### PR TITLE
feat(npc): sistema de edição de NPCs por moderadores (backend + dados)

### DIFF
--- a/api/db/v1/db.pb.go
+++ b/api/db/v1/db.pb.go
@@ -1498,6 +1498,460 @@ func (x *SaveCargoResponse) GetOk() bool {
 	return false
 }
 
+type NpcConfigVersionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NpcConfigVersionRequest) Reset() {
+	*x = NpcConfigVersionRequest{}
+	mi := &file_api_db_v1_db_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NpcConfigVersionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NpcConfigVersionRequest) ProtoMessage() {}
+
+func (x *NpcConfigVersionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_db_v1_db_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NpcConfigVersionRequest.ProtoReflect.Descriptor instead.
+func (*NpcConfigVersionRequest) Descriptor() ([]byte, []int) {
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{20}
+}
+
+type NpcConfigVersionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Version       int64                  `protobuf:"varint,1,opt,name=version,proto3" json:"version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NpcConfigVersionResponse) Reset() {
+	*x = NpcConfigVersionResponse{}
+	mi := &file_api_db_v1_db_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NpcConfigVersionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NpcConfigVersionResponse) ProtoMessage() {}
+
+func (x *NpcConfigVersionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_db_v1_db_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NpcConfigVersionResponse.ProtoReflect.Descriptor instead.
+func (*NpcConfigVersionResponse) Descriptor() ([]byte, []int) {
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *NpcConfigVersionResponse) GetVersion() int64 {
+	if x != nil {
+		return x.Version
+	}
+	return 0
+}
+
+type ListNpcDefinitionsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListNpcDefinitionsRequest) Reset() {
+	*x = ListNpcDefinitionsRequest{}
+	mi := &file_api_db_v1_db_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListNpcDefinitionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListNpcDefinitionsRequest) ProtoMessage() {}
+
+func (x *ListNpcDefinitionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_db_v1_db_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListNpcDefinitionsRequest.ProtoReflect.Descriptor instead.
+func (*ListNpcDefinitionsRequest) Descriptor() ([]byte, []int) {
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{22}
+}
+
+type ListNpcDefinitionsResponse struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Version        int64                  `protobuf:"varint,1,opt,name=version,proto3" json:"version,omitempty"`
+	Definitions    []*NpcDefinition       `protobuf:"bytes,2,rep,name=definitions,proto3" json:"definitions,omitempty"`
+	PriceOverrides []*ItemPrice           `protobuf:"bytes,3,rep,name=price_overrides,json=priceOverrides,proto3" json:"price_overrides,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *ListNpcDefinitionsResponse) Reset() {
+	*x = ListNpcDefinitionsResponse{}
+	mi := &file_api_db_v1_db_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListNpcDefinitionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListNpcDefinitionsResponse) ProtoMessage() {}
+
+func (x *ListNpcDefinitionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_db_v1_db_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListNpcDefinitionsResponse.ProtoReflect.Descriptor instead.
+func (*ListNpcDefinitionsResponse) Descriptor() ([]byte, []int) {
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *ListNpcDefinitionsResponse) GetVersion() int64 {
+	if x != nil {
+		return x.Version
+	}
+	return 0
+}
+
+func (x *ListNpcDefinitionsResponse) GetDefinitions() []*NpcDefinition {
+	if x != nil {
+		return x.Definitions
+	}
+	return nil
+}
+
+func (x *ListNpcDefinitionsResponse) GetPriceOverrides() []*ItemPrice {
+	if x != nil {
+		return x.PriceOverrides
+	}
+	return nil
+}
+
+// NpcShopItem is one merchant shop slot (overlays the template Carry[]). Effects
+// are the 3 STRUCT_ITEM effect pairs. Price is NOT here — it is global (ItemPrice).
+type NpcShopItem struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Slot          int32                  `protobuf:"varint,1,opt,name=slot,proto3" json:"slot,omitempty"`
+	ItemIndex     int32                  `protobuf:"varint,2,opt,name=item_index,json=itemIndex,proto3" json:"item_index,omitempty"`
+	Eff1          int32                  `protobuf:"varint,3,opt,name=eff1,proto3" json:"eff1,omitempty"`
+	Effv1         int32                  `protobuf:"varint,4,opt,name=effv1,proto3" json:"effv1,omitempty"`
+	Eff2          int32                  `protobuf:"varint,5,opt,name=eff2,proto3" json:"eff2,omitempty"`
+	Effv2         int32                  `protobuf:"varint,6,opt,name=effv2,proto3" json:"effv2,omitempty"`
+	Eff3          int32                  `protobuf:"varint,7,opt,name=eff3,proto3" json:"eff3,omitempty"`
+	Effv3         int32                  `protobuf:"varint,8,opt,name=effv3,proto3" json:"effv3,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NpcShopItem) Reset() {
+	*x = NpcShopItem{}
+	mi := &file_api_db_v1_db_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NpcShopItem) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NpcShopItem) ProtoMessage() {}
+
+func (x *NpcShopItem) ProtoReflect() protoreflect.Message {
+	mi := &file_api_db_v1_db_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NpcShopItem.ProtoReflect.Descriptor instead.
+func (*NpcShopItem) Descriptor() ([]byte, []int) {
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *NpcShopItem) GetSlot() int32 {
+	if x != nil {
+		return x.Slot
+	}
+	return 0
+}
+
+func (x *NpcShopItem) GetItemIndex() int32 {
+	if x != nil {
+		return x.ItemIndex
+	}
+	return 0
+}
+
+func (x *NpcShopItem) GetEff1() int32 {
+	if x != nil {
+		return x.Eff1
+	}
+	return 0
+}
+
+func (x *NpcShopItem) GetEffv1() int32 {
+	if x != nil {
+		return x.Effv1
+	}
+	return 0
+}
+
+func (x *NpcShopItem) GetEff2() int32 {
+	if x != nil {
+		return x.Eff2
+	}
+	return 0
+}
+
+func (x *NpcShopItem) GetEffv2() int32 {
+	if x != nil {
+		return x.Effv2
+	}
+	return 0
+}
+
+func (x *NpcShopItem) GetEff3() int32 {
+	if x != nil {
+		return x.Eff3
+	}
+	return 0
+}
+
+func (x *NpcShopItem) GetEffv3() int32 {
+	if x != nil {
+		return x.Effv3
+	}
+	return 0
+}
+
+type NpcDefinition struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Slug          string                 `protobuf:"bytes,2,opt,name=slug,proto3" json:"slug,omitempty"`
+	TemplateName  string                 `protobuf:"bytes,3,opt,name=template_name,json=templateName,proto3" json:"template_name,omitempty"`
+	DisplayName   string                 `protobuf:"bytes,4,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	Enabled       bool                   `protobuf:"varint,5,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	MapId         int32                  `protobuf:"varint,6,opt,name=map_id,json=mapId,proto3" json:"map_id,omitempty"`
+	PosX          int32                  `protobuf:"varint,7,opt,name=pos_x,json=posX,proto3" json:"pos_x,omitempty"`
+	PosY          int32                  `protobuf:"varint,8,opt,name=pos_y,json=posY,proto3" json:"pos_y,omitempty"`
+	RouteType     int32                  `protobuf:"varint,9,opt,name=route_type,json=routeType,proto3" json:"route_type,omitempty"`
+	Merchant      int32                  `protobuf:"varint,10,opt,name=merchant,proto3" json:"merchant,omitempty"`
+	Shop          []*NpcShopItem         `protobuf:"bytes,11,rep,name=shop,proto3" json:"shop,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NpcDefinition) Reset() {
+	*x = NpcDefinition{}
+	mi := &file_api_db_v1_db_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NpcDefinition) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NpcDefinition) ProtoMessage() {}
+
+func (x *NpcDefinition) ProtoReflect() protoreflect.Message {
+	mi := &file_api_db_v1_db_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NpcDefinition.ProtoReflect.Descriptor instead.
+func (*NpcDefinition) Descriptor() ([]byte, []int) {
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *NpcDefinition) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *NpcDefinition) GetSlug() string {
+	if x != nil {
+		return x.Slug
+	}
+	return ""
+}
+
+func (x *NpcDefinition) GetTemplateName() string {
+	if x != nil {
+		return x.TemplateName
+	}
+	return ""
+}
+
+func (x *NpcDefinition) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+func (x *NpcDefinition) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *NpcDefinition) GetMapId() int32 {
+	if x != nil {
+		return x.MapId
+	}
+	return 0
+}
+
+func (x *NpcDefinition) GetPosX() int32 {
+	if x != nil {
+		return x.PosX
+	}
+	return 0
+}
+
+func (x *NpcDefinition) GetPosY() int32 {
+	if x != nil {
+		return x.PosY
+	}
+	return 0
+}
+
+func (x *NpcDefinition) GetRouteType() int32 {
+	if x != nil {
+		return x.RouteType
+	}
+	return 0
+}
+
+func (x *NpcDefinition) GetMerchant() int32 {
+	if x != nil {
+		return x.Merchant
+	}
+	return 0
+}
+
+func (x *NpcDefinition) GetShop() []*NpcShopItem {
+	if x != nil {
+		return x.Shop
+	}
+	return nil
+}
+
+type ItemPrice struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ItemIndex     int32                  `protobuf:"varint,1,opt,name=item_index,json=itemIndex,proto3" json:"item_index,omitempty"`
+	Price         int64                  `protobuf:"varint,2,opt,name=price,proto3" json:"price,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ItemPrice) Reset() {
+	*x = ItemPrice{}
+	mi := &file_api_db_v1_db_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ItemPrice) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ItemPrice) ProtoMessage() {}
+
+func (x *ItemPrice) ProtoReflect() protoreflect.Message {
+	mi := &file_api_db_v1_db_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ItemPrice.ProtoReflect.Descriptor instead.
+func (*ItemPrice) Descriptor() ([]byte, []int) {
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *ItemPrice) GetItemIndex() int32 {
+	if x != nil {
+		return x.ItemIndex
+	}
+	return 0
+}
+
+func (x *ItemPrice) GetPrice() int64 {
+	if x != nil {
+		return x.Price
+	}
+	return 0
+}
+
 var File_api_db_v1_db_proto protoreflect.FileDescriptor
 
 const file_api_db_v1_db_proto_rawDesc = "" +
@@ -1624,7 +2078,43 @@ const file_api_db_v1_db_proto_rawDesc = "" +
 	"cargo_coin\x18\x02 \x01(\x05R\tcargoCoin\x12!\n" +
 	"\x05items\x18\x03 \x03(\v2\v.db.v1.ItemR\x05items\"#\n" +
 	"\x11SaveCargoResponse\x12\x0e\n" +
-	"\x02ok\x18\x01 \x01(\bR\x02ok*\xb8\x01\n" +
+	"\x02ok\x18\x01 \x01(\bR\x02ok\"\x19\n" +
+	"\x17NpcConfigVersionRequest\"4\n" +
+	"\x18NpcConfigVersionResponse\x12\x18\n" +
+	"\aversion\x18\x01 \x01(\x03R\aversion\"\x1b\n" +
+	"\x19ListNpcDefinitionsRequest\"\xa9\x01\n" +
+	"\x1aListNpcDefinitionsResponse\x12\x18\n" +
+	"\aversion\x18\x01 \x01(\x03R\aversion\x126\n" +
+	"\vdefinitions\x18\x02 \x03(\v2\x14.db.v1.NpcDefinitionR\vdefinitions\x129\n" +
+	"\x0fprice_overrides\x18\x03 \x03(\v2\x10.db.v1.ItemPriceR\x0epriceOverrides\"\xbe\x01\n" +
+	"\vNpcShopItem\x12\x12\n" +
+	"\x04slot\x18\x01 \x01(\x05R\x04slot\x12\x1d\n" +
+	"\n" +
+	"item_index\x18\x02 \x01(\x05R\titemIndex\x12\x12\n" +
+	"\x04eff1\x18\x03 \x01(\x05R\x04eff1\x12\x14\n" +
+	"\x05effv1\x18\x04 \x01(\x05R\x05effv1\x12\x12\n" +
+	"\x04eff2\x18\x05 \x01(\x05R\x04eff2\x12\x14\n" +
+	"\x05effv2\x18\x06 \x01(\x05R\x05effv2\x12\x12\n" +
+	"\x04eff3\x18\a \x01(\x05R\x04eff3\x12\x14\n" +
+	"\x05effv3\x18\b \x01(\x05R\x05effv3\"\xb9\x02\n" +
+	"\rNpcDefinition\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x12\n" +
+	"\x04slug\x18\x02 \x01(\tR\x04slug\x12#\n" +
+	"\rtemplate_name\x18\x03 \x01(\tR\ftemplateName\x12!\n" +
+	"\fdisplay_name\x18\x04 \x01(\tR\vdisplayName\x12\x18\n" +
+	"\aenabled\x18\x05 \x01(\bR\aenabled\x12\x15\n" +
+	"\x06map_id\x18\x06 \x01(\x05R\x05mapId\x12\x13\n" +
+	"\x05pos_x\x18\a \x01(\x05R\x04posX\x12\x13\n" +
+	"\x05pos_y\x18\b \x01(\x05R\x04posY\x12\x1d\n" +
+	"\n" +
+	"route_type\x18\t \x01(\x05R\trouteType\x12\x1a\n" +
+	"\bmerchant\x18\n" +
+	" \x01(\x05R\bmerchant\x12&\n" +
+	"\x04shop\x18\v \x03(\v2\x12.db.v1.NpcShopItemR\x04shop\"@\n" +
+	"\tItemPrice\x12\x1d\n" +
+	"\n" +
+	"item_index\x18\x01 \x01(\x05R\titemIndex\x12\x14\n" +
+	"\x05price\x18\x02 \x01(\x03R\x05price*\xb8\x01\n" +
 	"\vLoginResult\x12\x1c\n" +
 	"\x18LOGIN_RESULT_UNSPECIFIED\x10\x00\x12\x13\n" +
 	"\x0fLOGIN_RESULT_OK\x10\x01\x12\x1b\n" +
@@ -1640,7 +2130,10 @@ const file_api_db_v1_db_proto_rawDesc = "" +
 	"\x0fCreateCharacter\x12\x1d.db.v1.CreateCharacterRequest\x1a\x1e.db.v1.CreateCharacterResponse\x12P\n" +
 	"\x0fDeleteCharacter\x12\x1d.db.v1.DeleteCharacterRequest\x1a\x1e.db.v1.DeleteCharacterResponse\x12>\n" +
 	"\tLoadCargo\x12\x17.db.v1.LoadCargoRequest\x1a\x18.db.v1.LoadCargoResponse\x12>\n" +
-	"\tSaveCargo\x12\x17.db.v1.SaveCargoRequest\x1a\x18.db.v1.SaveCargoResponseB1Z/github.com/jeanluca/w2pp-openwyd/api/db/v1;dbv1b\x06proto3"
+	"\tSaveCargo\x12\x17.db.v1.SaveCargoRequest\x1a\x18.db.v1.SaveCargoResponse2\xc2\x01\n" +
+	"\x10NpcConfigService\x12S\n" +
+	"\x10NpcConfigVersion\x12\x1e.db.v1.NpcConfigVersionRequest\x1a\x1f.db.v1.NpcConfigVersionResponse\x12Y\n" +
+	"\x12ListNpcDefinitions\x12 .db.v1.ListNpcDefinitionsRequest\x1a!.db.v1.ListNpcDefinitionsResponseB1Z/github.com/jeanluca/w2pp-openwyd/api/db/v1;dbv1b\x06proto3"
 
 var (
 	file_api_db_v1_db_proto_rawDescOnce sync.Once
@@ -1655,29 +2148,36 @@ func file_api_db_v1_db_proto_rawDescGZIP() []byte {
 }
 
 var file_api_db_v1_db_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_api_db_v1_db_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
+var file_api_db_v1_db_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
 var file_api_db_v1_db_proto_goTypes = []any{
-	(LoginResult)(0),                // 0: db.v1.LoginResult
-	(*AccountLoginRequest)(nil),     // 1: db.v1.AccountLoginRequest
-	(*AccountLoginResponse)(nil),    // 2: db.v1.AccountLoginResponse
-	(*ListCharactersRequest)(nil),   // 3: db.v1.ListCharactersRequest
-	(*CharacterSummary)(nil),        // 4: db.v1.CharacterSummary
-	(*ListCharactersResponse)(nil),  // 5: db.v1.ListCharactersResponse
-	(*LoadCharacterRequest)(nil),    // 6: db.v1.LoadCharacterRequest
-	(*Character)(nil),               // 7: db.v1.Character
-	(*Item)(nil),                    // 8: db.v1.Item
-	(*Affect)(nil),                  // 9: db.v1.Affect
-	(*LoadCharacterResponse)(nil),   // 10: db.v1.LoadCharacterResponse
-	(*SaveCharacterRequest)(nil),    // 11: db.v1.SaveCharacterRequest
-	(*SaveCharacterResponse)(nil),   // 12: db.v1.SaveCharacterResponse
-	(*CreateCharacterRequest)(nil),  // 13: db.v1.CreateCharacterRequest
-	(*CreateCharacterResponse)(nil), // 14: db.v1.CreateCharacterResponse
-	(*DeleteCharacterRequest)(nil),  // 15: db.v1.DeleteCharacterRequest
-	(*DeleteCharacterResponse)(nil), // 16: db.v1.DeleteCharacterResponse
-	(*LoadCargoRequest)(nil),        // 17: db.v1.LoadCargoRequest
-	(*LoadCargoResponse)(nil),       // 18: db.v1.LoadCargoResponse
-	(*SaveCargoRequest)(nil),        // 19: db.v1.SaveCargoRequest
-	(*SaveCargoResponse)(nil),       // 20: db.v1.SaveCargoResponse
+	(LoginResult)(0),                   // 0: db.v1.LoginResult
+	(*AccountLoginRequest)(nil),        // 1: db.v1.AccountLoginRequest
+	(*AccountLoginResponse)(nil),       // 2: db.v1.AccountLoginResponse
+	(*ListCharactersRequest)(nil),      // 3: db.v1.ListCharactersRequest
+	(*CharacterSummary)(nil),           // 4: db.v1.CharacterSummary
+	(*ListCharactersResponse)(nil),     // 5: db.v1.ListCharactersResponse
+	(*LoadCharacterRequest)(nil),       // 6: db.v1.LoadCharacterRequest
+	(*Character)(nil),                  // 7: db.v1.Character
+	(*Item)(nil),                       // 8: db.v1.Item
+	(*Affect)(nil),                     // 9: db.v1.Affect
+	(*LoadCharacterResponse)(nil),      // 10: db.v1.LoadCharacterResponse
+	(*SaveCharacterRequest)(nil),       // 11: db.v1.SaveCharacterRequest
+	(*SaveCharacterResponse)(nil),      // 12: db.v1.SaveCharacterResponse
+	(*CreateCharacterRequest)(nil),     // 13: db.v1.CreateCharacterRequest
+	(*CreateCharacterResponse)(nil),    // 14: db.v1.CreateCharacterResponse
+	(*DeleteCharacterRequest)(nil),     // 15: db.v1.DeleteCharacterRequest
+	(*DeleteCharacterResponse)(nil),    // 16: db.v1.DeleteCharacterResponse
+	(*LoadCargoRequest)(nil),           // 17: db.v1.LoadCargoRequest
+	(*LoadCargoResponse)(nil),          // 18: db.v1.LoadCargoResponse
+	(*SaveCargoRequest)(nil),           // 19: db.v1.SaveCargoRequest
+	(*SaveCargoResponse)(nil),          // 20: db.v1.SaveCargoResponse
+	(*NpcConfigVersionRequest)(nil),    // 21: db.v1.NpcConfigVersionRequest
+	(*NpcConfigVersionResponse)(nil),   // 22: db.v1.NpcConfigVersionResponse
+	(*ListNpcDefinitionsRequest)(nil),  // 23: db.v1.ListNpcDefinitionsRequest
+	(*ListNpcDefinitionsResponse)(nil), // 24: db.v1.ListNpcDefinitionsResponse
+	(*NpcShopItem)(nil),                // 25: db.v1.NpcShopItem
+	(*NpcDefinition)(nil),              // 26: db.v1.NpcDefinition
+	(*ItemPrice)(nil),                  // 27: db.v1.ItemPrice
 }
 var file_api_db_v1_db_proto_depIdxs = []int32{
 	0,  // 0: db.v1.AccountLoginResponse.result:type_name -> db.v1.LoginResult
@@ -1689,27 +2189,34 @@ var file_api_db_v1_db_proto_depIdxs = []int32{
 	7,  // 6: db.v1.SaveCharacterRequest.character:type_name -> db.v1.Character
 	8,  // 7: db.v1.LoadCargoResponse.items:type_name -> db.v1.Item
 	8,  // 8: db.v1.SaveCargoRequest.items:type_name -> db.v1.Item
-	1,  // 9: db.v1.AccountService.AccountLogin:input_type -> db.v1.AccountLoginRequest
-	3,  // 10: db.v1.AccountService.ListCharacters:input_type -> db.v1.ListCharactersRequest
-	6,  // 11: db.v1.AccountService.LoadCharacter:input_type -> db.v1.LoadCharacterRequest
-	11, // 12: db.v1.AccountService.SaveCharacter:input_type -> db.v1.SaveCharacterRequest
-	13, // 13: db.v1.AccountService.CreateCharacter:input_type -> db.v1.CreateCharacterRequest
-	15, // 14: db.v1.AccountService.DeleteCharacter:input_type -> db.v1.DeleteCharacterRequest
-	17, // 15: db.v1.AccountService.LoadCargo:input_type -> db.v1.LoadCargoRequest
-	19, // 16: db.v1.AccountService.SaveCargo:input_type -> db.v1.SaveCargoRequest
-	2,  // 17: db.v1.AccountService.AccountLogin:output_type -> db.v1.AccountLoginResponse
-	5,  // 18: db.v1.AccountService.ListCharacters:output_type -> db.v1.ListCharactersResponse
-	10, // 19: db.v1.AccountService.LoadCharacter:output_type -> db.v1.LoadCharacterResponse
-	12, // 20: db.v1.AccountService.SaveCharacter:output_type -> db.v1.SaveCharacterResponse
-	14, // 21: db.v1.AccountService.CreateCharacter:output_type -> db.v1.CreateCharacterResponse
-	16, // 22: db.v1.AccountService.DeleteCharacter:output_type -> db.v1.DeleteCharacterResponse
-	18, // 23: db.v1.AccountService.LoadCargo:output_type -> db.v1.LoadCargoResponse
-	20, // 24: db.v1.AccountService.SaveCargo:output_type -> db.v1.SaveCargoResponse
-	17, // [17:25] is the sub-list for method output_type
-	9,  // [9:17] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	26, // 9: db.v1.ListNpcDefinitionsResponse.definitions:type_name -> db.v1.NpcDefinition
+	27, // 10: db.v1.ListNpcDefinitionsResponse.price_overrides:type_name -> db.v1.ItemPrice
+	25, // 11: db.v1.NpcDefinition.shop:type_name -> db.v1.NpcShopItem
+	1,  // 12: db.v1.AccountService.AccountLogin:input_type -> db.v1.AccountLoginRequest
+	3,  // 13: db.v1.AccountService.ListCharacters:input_type -> db.v1.ListCharactersRequest
+	6,  // 14: db.v1.AccountService.LoadCharacter:input_type -> db.v1.LoadCharacterRequest
+	11, // 15: db.v1.AccountService.SaveCharacter:input_type -> db.v1.SaveCharacterRequest
+	13, // 16: db.v1.AccountService.CreateCharacter:input_type -> db.v1.CreateCharacterRequest
+	15, // 17: db.v1.AccountService.DeleteCharacter:input_type -> db.v1.DeleteCharacterRequest
+	17, // 18: db.v1.AccountService.LoadCargo:input_type -> db.v1.LoadCargoRequest
+	19, // 19: db.v1.AccountService.SaveCargo:input_type -> db.v1.SaveCargoRequest
+	21, // 20: db.v1.NpcConfigService.NpcConfigVersion:input_type -> db.v1.NpcConfigVersionRequest
+	23, // 21: db.v1.NpcConfigService.ListNpcDefinitions:input_type -> db.v1.ListNpcDefinitionsRequest
+	2,  // 22: db.v1.AccountService.AccountLogin:output_type -> db.v1.AccountLoginResponse
+	5,  // 23: db.v1.AccountService.ListCharacters:output_type -> db.v1.ListCharactersResponse
+	10, // 24: db.v1.AccountService.LoadCharacter:output_type -> db.v1.LoadCharacterResponse
+	12, // 25: db.v1.AccountService.SaveCharacter:output_type -> db.v1.SaveCharacterResponse
+	14, // 26: db.v1.AccountService.CreateCharacter:output_type -> db.v1.CreateCharacterResponse
+	16, // 27: db.v1.AccountService.DeleteCharacter:output_type -> db.v1.DeleteCharacterResponse
+	18, // 28: db.v1.AccountService.LoadCargo:output_type -> db.v1.LoadCargoResponse
+	20, // 29: db.v1.AccountService.SaveCargo:output_type -> db.v1.SaveCargoResponse
+	22, // 30: db.v1.NpcConfigService.NpcConfigVersion:output_type -> db.v1.NpcConfigVersionResponse
+	24, // 31: db.v1.NpcConfigService.ListNpcDefinitions:output_type -> db.v1.ListNpcDefinitionsResponse
+	22, // [22:32] is the sub-list for method output_type
+	12, // [12:22] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_api_db_v1_db_proto_init() }
@@ -1723,9 +2230,9 @@ func file_api_db_v1_db_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_db_v1_db_proto_rawDesc), len(file_api_db_v1_db_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   20,
+			NumMessages:   27,
 			NumExtensions: 0,
-			NumServices:   1,
+			NumServices:   2,
 		},
 		GoTypes:           file_api_db_v1_db_proto_goTypes,
 		DependencyIndexes: file_api_db_v1_db_proto_depIdxs,

--- a/api/db/v1/db.proto
+++ b/api/db/v1/db.proto
@@ -177,3 +177,54 @@ message SaveCargoRequest {
   repeated Item items = 3;
 }
 message SaveCargoResponse { bool ok = 1; }
+
+// NpcConfigService serves the moderator-editable NPC configuration to tmServer
+// (npc-editing-plan.md). It is READ-ONLY from tmServer's side: the web-api writes
+// the definitions to Postgres; tmServer polls the version and reloads the full
+// snapshot when it changes, then materializes the live entities inside its
+// single-owner loop. Separate from AccountService, which mirrors legacy G↔DB.
+service NpcConfigService {
+  // NpcConfigVersion returns the monotonic config version (cheap poll).
+  rpc NpcConfigVersion(NpcConfigVersionRequest) returns (NpcConfigVersionResponse);
+  // ListNpcDefinitions returns the full definition snapshot + global price overrides.
+  rpc ListNpcDefinitions(ListNpcDefinitionsRequest) returns (ListNpcDefinitionsResponse);
+}
+
+message NpcConfigVersionRequest {}
+message NpcConfigVersionResponse { int64 version = 1; }
+
+message ListNpcDefinitionsRequest {}
+message ListNpcDefinitionsResponse {
+  int64 version = 1;
+  repeated NpcDefinition definitions = 2;
+  repeated ItemPrice price_overrides = 3;
+}
+
+// NpcShopItem is one merchant shop slot (overlays the template Carry[]). Effects
+// are the 3 STRUCT_ITEM effect pairs. Price is NOT here — it is global (ItemPrice).
+message NpcShopItem {
+  int32 slot = 1;
+  int32 item_index = 2;
+  int32 eff1 = 3;  int32 effv1 = 4;
+  int32 eff2 = 5;  int32 effv2 = 6;
+  int32 eff3 = 7;  int32 effv3 = 8;
+}
+
+message NpcDefinition {
+  int64 id = 1;
+  string slug = 2;
+  string template_name = 3;
+  string display_name = 4;
+  bool enabled = 5;
+  int32 map_id = 6;
+  int32 pos_x = 7;
+  int32 pos_y = 8;
+  int32 route_type = 9;
+  int32 merchant = 10;
+  repeated NpcShopItem shop = 11;
+}
+
+message ItemPrice {
+  int32 item_index = 1;
+  int64 price = 2;
+}

--- a/api/db/v1/db_grpc.pb.go
+++ b/api/db/v1/db_grpc.pb.go
@@ -415,3 +415,159 @@ var AccountService_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "api/db/v1/db.proto",
 }
+
+const (
+	NpcConfigService_NpcConfigVersion_FullMethodName   = "/db.v1.NpcConfigService/NpcConfigVersion"
+	NpcConfigService_ListNpcDefinitions_FullMethodName = "/db.v1.NpcConfigService/ListNpcDefinitions"
+)
+
+// NpcConfigServiceClient is the client API for NpcConfigService service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// NpcConfigService serves the moderator-editable NPC configuration to tmServer
+// (npc-editing-plan.md). It is READ-ONLY from tmServer's side: the web-api writes
+// the definitions to Postgres; tmServer polls the version and reloads the full
+// snapshot when it changes, then materializes the live entities inside its
+// single-owner loop. Separate from AccountService, which mirrors legacy G↔DB.
+type NpcConfigServiceClient interface {
+	// NpcConfigVersion returns the monotonic config version (cheap poll).
+	NpcConfigVersion(ctx context.Context, in *NpcConfigVersionRequest, opts ...grpc.CallOption) (*NpcConfigVersionResponse, error)
+	// ListNpcDefinitions returns the full definition snapshot + global price overrides.
+	ListNpcDefinitions(ctx context.Context, in *ListNpcDefinitionsRequest, opts ...grpc.CallOption) (*ListNpcDefinitionsResponse, error)
+}
+
+type npcConfigServiceClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewNpcConfigServiceClient(cc grpc.ClientConnInterface) NpcConfigServiceClient {
+	return &npcConfigServiceClient{cc}
+}
+
+func (c *npcConfigServiceClient) NpcConfigVersion(ctx context.Context, in *NpcConfigVersionRequest, opts ...grpc.CallOption) (*NpcConfigVersionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(NpcConfigVersionResponse)
+	err := c.cc.Invoke(ctx, NpcConfigService_NpcConfigVersion_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *npcConfigServiceClient) ListNpcDefinitions(ctx context.Context, in *ListNpcDefinitionsRequest, opts ...grpc.CallOption) (*ListNpcDefinitionsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListNpcDefinitionsResponse)
+	err := c.cc.Invoke(ctx, NpcConfigService_ListNpcDefinitions_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// NpcConfigServiceServer is the server API for NpcConfigService service.
+// All implementations must embed UnimplementedNpcConfigServiceServer
+// for forward compatibility.
+//
+// NpcConfigService serves the moderator-editable NPC configuration to tmServer
+// (npc-editing-plan.md). It is READ-ONLY from tmServer's side: the web-api writes
+// the definitions to Postgres; tmServer polls the version and reloads the full
+// snapshot when it changes, then materializes the live entities inside its
+// single-owner loop. Separate from AccountService, which mirrors legacy G↔DB.
+type NpcConfigServiceServer interface {
+	// NpcConfigVersion returns the monotonic config version (cheap poll).
+	NpcConfigVersion(context.Context, *NpcConfigVersionRequest) (*NpcConfigVersionResponse, error)
+	// ListNpcDefinitions returns the full definition snapshot + global price overrides.
+	ListNpcDefinitions(context.Context, *ListNpcDefinitionsRequest) (*ListNpcDefinitionsResponse, error)
+	mustEmbedUnimplementedNpcConfigServiceServer()
+}
+
+// UnimplementedNpcConfigServiceServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedNpcConfigServiceServer struct{}
+
+func (UnimplementedNpcConfigServiceServer) NpcConfigVersion(context.Context, *NpcConfigVersionRequest) (*NpcConfigVersionResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method NpcConfigVersion not implemented")
+}
+func (UnimplementedNpcConfigServiceServer) ListNpcDefinitions(context.Context, *ListNpcDefinitionsRequest) (*ListNpcDefinitionsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListNpcDefinitions not implemented")
+}
+func (UnimplementedNpcConfigServiceServer) mustEmbedUnimplementedNpcConfigServiceServer() {}
+func (UnimplementedNpcConfigServiceServer) testEmbeddedByValue()                          {}
+
+// UnsafeNpcConfigServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to NpcConfigServiceServer will
+// result in compilation errors.
+type UnsafeNpcConfigServiceServer interface {
+	mustEmbedUnimplementedNpcConfigServiceServer()
+}
+
+func RegisterNpcConfigServiceServer(s grpc.ServiceRegistrar, srv NpcConfigServiceServer) {
+	// If the following call panics, it indicates UnimplementedNpcConfigServiceServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&NpcConfigService_ServiceDesc, srv)
+}
+
+func _NpcConfigService_NpcConfigVersion_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(NpcConfigVersionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NpcConfigServiceServer).NpcConfigVersion(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: NpcConfigService_NpcConfigVersion_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NpcConfigServiceServer).NpcConfigVersion(ctx, req.(*NpcConfigVersionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _NpcConfigService_ListNpcDefinitions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListNpcDefinitionsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NpcConfigServiceServer).ListNpcDefinitions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: NpcConfigService_ListNpcDefinitions_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NpcConfigServiceServer).ListNpcDefinitions(ctx, req.(*ListNpcDefinitionsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// NpcConfigService_ServiceDesc is the grpc.ServiceDesc for NpcConfigService service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var NpcConfigService_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "db.v1.NpcConfigService",
+	HandlerType: (*NpcConfigServiceServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "NpcConfigVersion",
+			Handler:    _NpcConfigService_NpcConfigVersion_Handler,
+		},
+		{
+			MethodName: "ListNpcDefinitions",
+			Handler:    _NpcConfigService_ListNpcDefinitions_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "api/db/v1/db.proto",
+}

--- a/api/web/v1/web.pb.go
+++ b/api/web/v1/web.pb.go
@@ -307,10 +307,15 @@ func (x *VerifyCredentialsRequest) GetPassword() string {
 }
 
 type VerifyCredentialsResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Ok            bool                   `protobuf:"varint,1,opt,name=ok,proto3" json:"ok,omitempty"`                                // name exists and password matches
-	AccountId     int64                  `protobuf:"varint,2,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"` // set only when ok
-	Blocked       bool                   `protobuf:"varint,3,opt,name=blocked,proto3" json:"blocked,omitempty"`                      // account.is_blocked — caller decides how to surface it
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Ok        bool                   `protobuf:"varint,1,opt,name=ok,proto3" json:"ok,omitempty"`                                // name exists and password matches
+	AccountId int64                  `protobuf:"varint,2,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"` // set only when ok
+	Blocked   bool                   `protobuf:"varint,3,opt,name=blocked,proto3" json:"blocked,omitempty"`                      // account.is_blocked — caller decides how to surface it
+	// role is account.role ('player'/'moderator'/'admin'). The BFF stores it in the
+	// session to gate the moderator UI (page visibility only). It is NOT the
+	// authorization decision — NpcAdminService re-checks the role server-side on
+	// every call, so a tampered session flag still gets ADMIN_RESULT_FORBIDDEN.
+	Role          string `protobuf:"bytes,4,opt,name=role,proto3" json:"role,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -364,6 +369,13 @@ func (x *VerifyCredentialsResponse) GetBlocked() bool {
 		return x.Blocked
 	}
 	return false
+}
+
+func (x *VerifyCredentialsResponse) GetRole() string {
+	if x != nil {
+		return x.Role
+	}
+	return ""
 }
 
 type AdminAck struct {
@@ -1252,12 +1264,13 @@ const file_api_web_v1_web_proto_rawDesc = "" +
 	"account_id\x18\x02 \x01(\x03R\taccountId\"J\n" +
 	"\x18VerifyCredentialsRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
-	"\bpassword\x18\x02 \x01(\tR\bpassword\"d\n" +
+	"\bpassword\x18\x02 \x01(\tR\bpassword\"x\n" +
 	"\x19VerifyCredentialsResponse\x12\x0e\n" +
 	"\x02ok\x18\x01 \x01(\bR\x02ok\x12\x1d\n" +
 	"\n" +
 	"account_id\x18\x02 \x01(\x03R\taccountId\x12\x18\n" +
-	"\ablocked\x18\x03 \x01(\bR\ablocked\"7\n" +
+	"\ablocked\x18\x03 \x01(\bR\ablocked\x12\x12\n" +
+	"\x04role\x18\x04 \x01(\tR\x04role\"7\n" +
 	"\bAdminAck\x12+\n" +
 	"\x06result\x18\x01 \x01(\x0e2\x13.web.v1.AdminResultR\x06result\"\xc3\x01\n" +
 	"\x10AdminNpcShopItem\x12\x12\n" +

--- a/api/web/v1/web.pb.go
+++ b/api/web/v1/web.pb.go
@@ -85,6 +85,63 @@ func (CreateResult) EnumDescriptor() ([]byte, []int) {
 	return file_api_web_v1_web_proto_rawDescGZIP(), []int{0}
 }
 
+// AdminResult carries the business outcome of an admin write (authorization,
+// validation, missing target) in the body — only infra failures become gRPC errors.
+type AdminResult int32
+
+const (
+	AdminResult_ADMIN_RESULT_UNSPECIFIED AdminResult = 0
+	AdminResult_ADMIN_RESULT_OK          AdminResult = 1
+	AdminResult_ADMIN_RESULT_FORBIDDEN   AdminResult = 2 // caller is not a moderator/admin
+	AdminResult_ADMIN_RESULT_INVALID     AdminResult = 3 // validation failed (bad slot, unknown target, …)
+	AdminResult_ADMIN_RESULT_NOT_FOUND   AdminResult = 4 // target definition does not exist
+)
+
+// Enum value maps for AdminResult.
+var (
+	AdminResult_name = map[int32]string{
+		0: "ADMIN_RESULT_UNSPECIFIED",
+		1: "ADMIN_RESULT_OK",
+		2: "ADMIN_RESULT_FORBIDDEN",
+		3: "ADMIN_RESULT_INVALID",
+		4: "ADMIN_RESULT_NOT_FOUND",
+	}
+	AdminResult_value = map[string]int32{
+		"ADMIN_RESULT_UNSPECIFIED": 0,
+		"ADMIN_RESULT_OK":          1,
+		"ADMIN_RESULT_FORBIDDEN":   2,
+		"ADMIN_RESULT_INVALID":     3,
+		"ADMIN_RESULT_NOT_FOUND":   4,
+	}
+)
+
+func (x AdminResult) Enum() *AdminResult {
+	p := new(AdminResult)
+	*p = x
+	return p
+}
+
+func (x AdminResult) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (AdminResult) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_web_v1_web_proto_enumTypes[1].Descriptor()
+}
+
+func (AdminResult) Type() protoreflect.EnumType {
+	return &file_api_web_v1_web_proto_enumTypes[1]
+}
+
+func (x AdminResult) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use AdminResult.Descriptor instead.
+func (AdminResult) EnumDescriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{1}
+}
+
 type CreateAccountRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`         // canonicalized to lowercase server-side
@@ -309,6 +366,877 @@ func (x *VerifyCredentialsResponse) GetBlocked() bool {
 	return false
 }
 
+type AdminAck struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Result        AdminResult            `protobuf:"varint,1,opt,name=result,proto3,enum=web.v1.AdminResult" json:"result,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AdminAck) Reset() {
+	*x = AdminAck{}
+	mi := &file_api_web_v1_web_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AdminAck) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AdminAck) ProtoMessage() {}
+
+func (x *AdminAck) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AdminAck.ProtoReflect.Descriptor instead.
+func (*AdminAck) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *AdminAck) GetResult() AdminResult {
+	if x != nil {
+		return x.Result
+	}
+	return AdminResult_ADMIN_RESULT_UNSPECIFIED
+}
+
+// AdminNpcShopItem mirrors the DB shop slot; price is global, not per-slot.
+type AdminNpcShopItem struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Slot          int32                  `protobuf:"varint,1,opt,name=slot,proto3" json:"slot,omitempty"`
+	ItemIndex     int32                  `protobuf:"varint,2,opt,name=item_index,json=itemIndex,proto3" json:"item_index,omitempty"`
+	Eff1          int32                  `protobuf:"varint,3,opt,name=eff1,proto3" json:"eff1,omitempty"`
+	Effv1         int32                  `protobuf:"varint,4,opt,name=effv1,proto3" json:"effv1,omitempty"`
+	Eff2          int32                  `protobuf:"varint,5,opt,name=eff2,proto3" json:"eff2,omitempty"`
+	Effv2         int32                  `protobuf:"varint,6,opt,name=effv2,proto3" json:"effv2,omitempty"`
+	Eff3          int32                  `protobuf:"varint,7,opt,name=eff3,proto3" json:"eff3,omitempty"`
+	Effv3         int32                  `protobuf:"varint,8,opt,name=effv3,proto3" json:"effv3,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AdminNpcShopItem) Reset() {
+	*x = AdminNpcShopItem{}
+	mi := &file_api_web_v1_web_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AdminNpcShopItem) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AdminNpcShopItem) ProtoMessage() {}
+
+func (x *AdminNpcShopItem) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AdminNpcShopItem.ProtoReflect.Descriptor instead.
+func (*AdminNpcShopItem) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *AdminNpcShopItem) GetSlot() int32 {
+	if x != nil {
+		return x.Slot
+	}
+	return 0
+}
+
+func (x *AdminNpcShopItem) GetItemIndex() int32 {
+	if x != nil {
+		return x.ItemIndex
+	}
+	return 0
+}
+
+func (x *AdminNpcShopItem) GetEff1() int32 {
+	if x != nil {
+		return x.Eff1
+	}
+	return 0
+}
+
+func (x *AdminNpcShopItem) GetEffv1() int32 {
+	if x != nil {
+		return x.Effv1
+	}
+	return 0
+}
+
+func (x *AdminNpcShopItem) GetEff2() int32 {
+	if x != nil {
+		return x.Eff2
+	}
+	return 0
+}
+
+func (x *AdminNpcShopItem) GetEffv2() int32 {
+	if x != nil {
+		return x.Effv2
+	}
+	return 0
+}
+
+func (x *AdminNpcShopItem) GetEff3() int32 {
+	if x != nil {
+		return x.Eff3
+	}
+	return 0
+}
+
+func (x *AdminNpcShopItem) GetEffv3() int32 {
+	if x != nil {
+		return x.Effv3
+	}
+	return 0
+}
+
+type AdminNpc struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Slug          string                 `protobuf:"bytes,2,opt,name=slug,proto3" json:"slug,omitempty"`
+	TemplateName  string                 `protobuf:"bytes,3,opt,name=template_name,json=templateName,proto3" json:"template_name,omitempty"`
+	DisplayName   string                 `protobuf:"bytes,4,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	Enabled       bool                   `protobuf:"varint,5,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	MapId         int32                  `protobuf:"varint,6,opt,name=map_id,json=mapId,proto3" json:"map_id,omitempty"`
+	PosX          int32                  `protobuf:"varint,7,opt,name=pos_x,json=posX,proto3" json:"pos_x,omitempty"`
+	PosY          int32                  `protobuf:"varint,8,opt,name=pos_y,json=posY,proto3" json:"pos_y,omitempty"`
+	RouteType     int32                  `protobuf:"varint,9,opt,name=route_type,json=routeType,proto3" json:"route_type,omitempty"`
+	Merchant      int32                  `protobuf:"varint,10,opt,name=merchant,proto3" json:"merchant,omitempty"`
+	Shop          []*AdminNpcShopItem    `protobuf:"bytes,11,rep,name=shop,proto3" json:"shop,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AdminNpc) Reset() {
+	*x = AdminNpc{}
+	mi := &file_api_web_v1_web_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AdminNpc) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AdminNpc) ProtoMessage() {}
+
+func (x *AdminNpc) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AdminNpc.ProtoReflect.Descriptor instead.
+func (*AdminNpc) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *AdminNpc) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *AdminNpc) GetSlug() string {
+	if x != nil {
+		return x.Slug
+	}
+	return ""
+}
+
+func (x *AdminNpc) GetTemplateName() string {
+	if x != nil {
+		return x.TemplateName
+	}
+	return ""
+}
+
+func (x *AdminNpc) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+func (x *AdminNpc) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *AdminNpc) GetMapId() int32 {
+	if x != nil {
+		return x.MapId
+	}
+	return 0
+}
+
+func (x *AdminNpc) GetPosX() int32 {
+	if x != nil {
+		return x.PosX
+	}
+	return 0
+}
+
+func (x *AdminNpc) GetPosY() int32 {
+	if x != nil {
+		return x.PosY
+	}
+	return 0
+}
+
+func (x *AdminNpc) GetRouteType() int32 {
+	if x != nil {
+		return x.RouteType
+	}
+	return 0
+}
+
+func (x *AdminNpc) GetMerchant() int32 {
+	if x != nil {
+		return x.Merchant
+	}
+	return 0
+}
+
+func (x *AdminNpc) GetShop() []*AdminNpcShopItem {
+	if x != nil {
+		return x.Shop
+	}
+	return nil
+}
+
+type ListNpcsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId   int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListNpcsRequest) Reset() {
+	*x = ListNpcsRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListNpcsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListNpcsRequest) ProtoMessage() {}
+
+func (x *ListNpcsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListNpcsRequest.ProtoReflect.Descriptor instead.
+func (*ListNpcsRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *ListNpcsRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+type ListNpcsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Result        AdminResult            `protobuf:"varint,1,opt,name=result,proto3,enum=web.v1.AdminResult" json:"result,omitempty"`
+	Npcs          []*AdminNpc            `protobuf:"bytes,2,rep,name=npcs,proto3" json:"npcs,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListNpcsResponse) Reset() {
+	*x = ListNpcsResponse{}
+	mi := &file_api_web_v1_web_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListNpcsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListNpcsResponse) ProtoMessage() {}
+
+func (x *ListNpcsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListNpcsResponse.ProtoReflect.Descriptor instead.
+func (*ListNpcsResponse) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *ListNpcsResponse) GetResult() AdminResult {
+	if x != nil {
+		return x.Result
+	}
+	return AdminResult_ADMIN_RESULT_UNSPECIFIED
+}
+
+func (x *ListNpcsResponse) GetNpcs() []*AdminNpc {
+	if x != nil {
+		return x.Npcs
+	}
+	return nil
+}
+
+type GetNpcRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId   int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	NpcId         int64                  `protobuf:"varint,2,opt,name=npc_id,json=npcId,proto3" json:"npc_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetNpcRequest) Reset() {
+	*x = GetNpcRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetNpcRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetNpcRequest) ProtoMessage() {}
+
+func (x *GetNpcRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetNpcRequest.ProtoReflect.Descriptor instead.
+func (*GetNpcRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *GetNpcRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+func (x *GetNpcRequest) GetNpcId() int64 {
+	if x != nil {
+		return x.NpcId
+	}
+	return 0
+}
+
+type GetNpcResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Result        AdminResult            `protobuf:"varint,1,opt,name=result,proto3,enum=web.v1.AdminResult" json:"result,omitempty"`
+	Npc           *AdminNpc              `protobuf:"bytes,2,opt,name=npc,proto3" json:"npc,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetNpcResponse) Reset() {
+	*x = GetNpcResponse{}
+	mi := &file_api_web_v1_web_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetNpcResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetNpcResponse) ProtoMessage() {}
+
+func (x *GetNpcResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetNpcResponse.ProtoReflect.Descriptor instead.
+func (*GetNpcResponse) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *GetNpcResponse) GetResult() AdminResult {
+	if x != nil {
+		return x.Result
+	}
+	return AdminResult_ADMIN_RESULT_UNSPECIFIED
+}
+
+func (x *GetNpcResponse) GetNpc() *AdminNpc {
+	if x != nil {
+		return x.Npc
+	}
+	return nil
+}
+
+type UpsertNpcRequest struct {
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	// id is ignored on create; the slug is the stable key. Position/visibility/
+	// merchant fields are applied as given.
+	Slug          string `protobuf:"bytes,2,opt,name=slug,proto3" json:"slug,omitempty"`
+	TemplateName  string `protobuf:"bytes,3,opt,name=template_name,json=templateName,proto3" json:"template_name,omitempty"`
+	DisplayName   string `protobuf:"bytes,4,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	Enabled       bool   `protobuf:"varint,5,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	MapId         int32  `protobuf:"varint,6,opt,name=map_id,json=mapId,proto3" json:"map_id,omitempty"`
+	PosX          int32  `protobuf:"varint,7,opt,name=pos_x,json=posX,proto3" json:"pos_x,omitempty"`
+	PosY          int32  `protobuf:"varint,8,opt,name=pos_y,json=posY,proto3" json:"pos_y,omitempty"`
+	RouteType     int32  `protobuf:"varint,9,opt,name=route_type,json=routeType,proto3" json:"route_type,omitempty"`
+	Merchant      int32  `protobuf:"varint,10,opt,name=merchant,proto3" json:"merchant,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpsertNpcRequest) Reset() {
+	*x = UpsertNpcRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpsertNpcRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpsertNpcRequest) ProtoMessage() {}
+
+func (x *UpsertNpcRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpsertNpcRequest.ProtoReflect.Descriptor instead.
+func (*UpsertNpcRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *UpsertNpcRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+func (x *UpsertNpcRequest) GetSlug() string {
+	if x != nil {
+		return x.Slug
+	}
+	return ""
+}
+
+func (x *UpsertNpcRequest) GetTemplateName() string {
+	if x != nil {
+		return x.TemplateName
+	}
+	return ""
+}
+
+func (x *UpsertNpcRequest) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+func (x *UpsertNpcRequest) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *UpsertNpcRequest) GetMapId() int32 {
+	if x != nil {
+		return x.MapId
+	}
+	return 0
+}
+
+func (x *UpsertNpcRequest) GetPosX() int32 {
+	if x != nil {
+		return x.PosX
+	}
+	return 0
+}
+
+func (x *UpsertNpcRequest) GetPosY() int32 {
+	if x != nil {
+		return x.PosY
+	}
+	return 0
+}
+
+func (x *UpsertNpcRequest) GetRouteType() int32 {
+	if x != nil {
+		return x.RouteType
+	}
+	return 0
+}
+
+func (x *UpsertNpcRequest) GetMerchant() int32 {
+	if x != nil {
+		return x.Merchant
+	}
+	return 0
+}
+
+type UpsertNpcResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Result        AdminResult            `protobuf:"varint,1,opt,name=result,proto3,enum=web.v1.AdminResult" json:"result,omitempty"`
+	NpcId         int64                  `protobuf:"varint,2,opt,name=npc_id,json=npcId,proto3" json:"npc_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpsertNpcResponse) Reset() {
+	*x = UpsertNpcResponse{}
+	mi := &file_api_web_v1_web_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpsertNpcResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpsertNpcResponse) ProtoMessage() {}
+
+func (x *UpsertNpcResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpsertNpcResponse.ProtoReflect.Descriptor instead.
+func (*UpsertNpcResponse) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *UpsertNpcResponse) GetResult() AdminResult {
+	if x != nil {
+		return x.Result
+	}
+	return AdminResult_ADMIN_RESULT_UNSPECIFIED
+}
+
+func (x *UpsertNpcResponse) GetNpcId() int64 {
+	if x != nil {
+		return x.NpcId
+	}
+	return 0
+}
+
+type SetNpcVisibilityRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId   int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	NpcId         int64                  `protobuf:"varint,2,opt,name=npc_id,json=npcId,proto3" json:"npc_id,omitempty"`
+	Enabled       bool                   `protobuf:"varint,3,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetNpcVisibilityRequest) Reset() {
+	*x = SetNpcVisibilityRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetNpcVisibilityRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetNpcVisibilityRequest) ProtoMessage() {}
+
+func (x *SetNpcVisibilityRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetNpcVisibilityRequest.ProtoReflect.Descriptor instead.
+func (*SetNpcVisibilityRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *SetNpcVisibilityRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+func (x *SetNpcVisibilityRequest) GetNpcId() int64 {
+	if x != nil {
+		return x.NpcId
+	}
+	return 0
+}
+
+func (x *SetNpcVisibilityRequest) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+type SetNpcShopRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId   int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	NpcId         int64                  `protobuf:"varint,2,opt,name=npc_id,json=npcId,proto3" json:"npc_id,omitempty"`
+	Items         []*AdminNpcShopItem    `protobuf:"bytes,3,rep,name=items,proto3" json:"items,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetNpcShopRequest) Reset() {
+	*x = SetNpcShopRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetNpcShopRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetNpcShopRequest) ProtoMessage() {}
+
+func (x *SetNpcShopRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetNpcShopRequest.ProtoReflect.Descriptor instead.
+func (*SetNpcShopRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *SetNpcShopRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+func (x *SetNpcShopRequest) GetNpcId() int64 {
+	if x != nil {
+		return x.NpcId
+	}
+	return 0
+}
+
+func (x *SetNpcShopRequest) GetItems() []*AdminNpcShopItem {
+	if x != nil {
+		return x.Items
+	}
+	return nil
+}
+
+type SetItemPriceRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId   int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	ItemIndex     int32                  `protobuf:"varint,2,opt,name=item_index,json=itemIndex,proto3" json:"item_index,omitempty"`
+	Price         int64                  `protobuf:"varint,3,opt,name=price,proto3" json:"price,omitempty"` // < 0 clears the override
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetItemPriceRequest) Reset() {
+	*x = SetItemPriceRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetItemPriceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetItemPriceRequest) ProtoMessage() {}
+
+func (x *SetItemPriceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetItemPriceRequest.ProtoReflect.Descriptor instead.
+func (*SetItemPriceRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *SetItemPriceRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+func (x *SetItemPriceRequest) GetItemIndex() int32 {
+	if x != nil {
+		return x.ItemIndex
+	}
+	return 0
+}
+
+func (x *SetItemPriceRequest) GetPrice() int64 {
+	if x != nil {
+		return x.Price
+	}
+	return 0
+}
+
+type DeleteNpcRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId   int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	NpcId         int64                  `protobuf:"varint,2,opt,name=npc_id,json=npcId,proto3" json:"npc_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteNpcRequest) Reset() {
+	*x = DeleteNpcRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteNpcRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteNpcRequest) ProtoMessage() {}
+
+func (x *DeleteNpcRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteNpcRequest.ProtoReflect.Descriptor instead.
+func (*DeleteNpcRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *DeleteNpcRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+func (x *DeleteNpcRequest) GetNpcId() int64 {
+	if x != nil {
+		return x.NpcId
+	}
+	return 0
+}
+
 var File_api_web_v1_web_proto protoreflect.FileDescriptor
 
 const file_api_web_v1_web_proto_rawDesc = "" +
@@ -329,15 +1257,99 @@ const file_api_web_v1_web_proto_rawDesc = "" +
 	"\x02ok\x18\x01 \x01(\bR\x02ok\x12\x1d\n" +
 	"\n" +
 	"account_id\x18\x02 \x01(\x03R\taccountId\x12\x18\n" +
-	"\ablocked\x18\x03 \x01(\bR\ablocked*|\n" +
+	"\ablocked\x18\x03 \x01(\bR\ablocked\"7\n" +
+	"\bAdminAck\x12+\n" +
+	"\x06result\x18\x01 \x01(\x0e2\x13.web.v1.AdminResultR\x06result\"\xc3\x01\n" +
+	"\x10AdminNpcShopItem\x12\x12\n" +
+	"\x04slot\x18\x01 \x01(\x05R\x04slot\x12\x1d\n" +
+	"\n" +
+	"item_index\x18\x02 \x01(\x05R\titemIndex\x12\x12\n" +
+	"\x04eff1\x18\x03 \x01(\x05R\x04eff1\x12\x14\n" +
+	"\x05effv1\x18\x04 \x01(\x05R\x05effv1\x12\x12\n" +
+	"\x04eff2\x18\x05 \x01(\x05R\x04eff2\x12\x14\n" +
+	"\x05effv2\x18\x06 \x01(\x05R\x05effv2\x12\x12\n" +
+	"\x04eff3\x18\a \x01(\x05R\x04eff3\x12\x14\n" +
+	"\x05effv3\x18\b \x01(\x05R\x05effv3\"\xba\x02\n" +
+	"\bAdminNpc\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x12\n" +
+	"\x04slug\x18\x02 \x01(\tR\x04slug\x12#\n" +
+	"\rtemplate_name\x18\x03 \x01(\tR\ftemplateName\x12!\n" +
+	"\fdisplay_name\x18\x04 \x01(\tR\vdisplayName\x12\x18\n" +
+	"\aenabled\x18\x05 \x01(\bR\aenabled\x12\x15\n" +
+	"\x06map_id\x18\x06 \x01(\x05R\x05mapId\x12\x13\n" +
+	"\x05pos_x\x18\a \x01(\x05R\x04posX\x12\x13\n" +
+	"\x05pos_y\x18\b \x01(\x05R\x04posY\x12\x1d\n" +
+	"\n" +
+	"route_type\x18\t \x01(\x05R\trouteType\x12\x1a\n" +
+	"\bmerchant\x18\n" +
+	" \x01(\x05R\bmerchant\x12,\n" +
+	"\x04shop\x18\v \x03(\v2\x18.web.v1.AdminNpcShopItemR\x04shop\"4\n" +
+	"\x0fListNpcsRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\"e\n" +
+	"\x10ListNpcsResponse\x12+\n" +
+	"\x06result\x18\x01 \x01(\x0e2\x13.web.v1.AdminResultR\x06result\x12$\n" +
+	"\x04npcs\x18\x02 \x03(\v2\x10.web.v1.AdminNpcR\x04npcs\"I\n" +
+	"\rGetNpcRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\x12\x15\n" +
+	"\x06npc_id\x18\x02 \x01(\x03R\x05npcId\"a\n" +
+	"\x0eGetNpcResponse\x12+\n" +
+	"\x06result\x18\x01 \x01(\x0e2\x13.web.v1.AdminResultR\x06result\x12\"\n" +
+	"\x03npc\x18\x02 \x01(\v2\x10.web.v1.AdminNpcR\x03npc\"\xa7\x02\n" +
+	"\x10UpsertNpcRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\x12\x12\n" +
+	"\x04slug\x18\x02 \x01(\tR\x04slug\x12#\n" +
+	"\rtemplate_name\x18\x03 \x01(\tR\ftemplateName\x12!\n" +
+	"\fdisplay_name\x18\x04 \x01(\tR\vdisplayName\x12\x18\n" +
+	"\aenabled\x18\x05 \x01(\bR\aenabled\x12\x15\n" +
+	"\x06map_id\x18\x06 \x01(\x05R\x05mapId\x12\x13\n" +
+	"\x05pos_x\x18\a \x01(\x05R\x04posX\x12\x13\n" +
+	"\x05pos_y\x18\b \x01(\x05R\x04posY\x12\x1d\n" +
+	"\n" +
+	"route_type\x18\t \x01(\x05R\trouteType\x12\x1a\n" +
+	"\bmerchant\x18\n" +
+	" \x01(\x05R\bmerchant\"W\n" +
+	"\x11UpsertNpcResponse\x12+\n" +
+	"\x06result\x18\x01 \x01(\x0e2\x13.web.v1.AdminResultR\x06result\x12\x15\n" +
+	"\x06npc_id\x18\x02 \x01(\x03R\x05npcId\"m\n" +
+	"\x17SetNpcVisibilityRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\x12\x15\n" +
+	"\x06npc_id\x18\x02 \x01(\x03R\x05npcId\x12\x18\n" +
+	"\aenabled\x18\x03 \x01(\bR\aenabled\"}\n" +
+	"\x11SetNpcShopRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\x12\x15\n" +
+	"\x06npc_id\x18\x02 \x01(\x03R\x05npcId\x12.\n" +
+	"\x05items\x18\x03 \x03(\v2\x18.web.v1.AdminNpcShopItemR\x05items\"m\n" +
+	"\x13SetItemPriceRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\x12\x1d\n" +
+	"\n" +
+	"item_index\x18\x02 \x01(\x05R\titemIndex\x12\x14\n" +
+	"\x05price\x18\x03 \x01(\x03R\x05price\"L\n" +
+	"\x10DeleteNpcRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\x12\x15\n" +
+	"\x06npc_id\x18\x02 \x01(\x03R\x05npcId*|\n" +
 	"\fCreateResult\x12\x1d\n" +
 	"\x19CREATE_RESULT_UNSPECIFIED\x10\x00\x12\x14\n" +
 	"\x10CREATE_RESULT_OK\x10\x01\x12\x1c\n" +
 	"\x18CREATE_RESULT_NAME_TAKEN\x10\x02\x12\x19\n" +
-	"\x15CREATE_RESULT_INVALID\x10\x032\xbb\x01\n" +
+	"\x15CREATE_RESULT_INVALID\x10\x03*\x92\x01\n" +
+	"\vAdminResult\x12\x1c\n" +
+	"\x18ADMIN_RESULT_UNSPECIFIED\x10\x00\x12\x13\n" +
+	"\x0fADMIN_RESULT_OK\x10\x01\x12\x1a\n" +
+	"\x16ADMIN_RESULT_FORBIDDEN\x10\x02\x12\x18\n" +
+	"\x14ADMIN_RESULT_INVALID\x10\x03\x12\x1a\n" +
+	"\x16ADMIN_RESULT_NOT_FOUND\x10\x042\xbb\x01\n" +
 	"\x11AccountWebService\x12L\n" +
 	"\rCreateAccount\x12\x1c.web.v1.CreateAccountRequest\x1a\x1d.web.v1.CreateAccountResponse\x12X\n" +
-	"\x11VerifyCredentials\x12 .web.v1.VerifyCredentialsRequest\x1a!.web.v1.VerifyCredentialsResponseB3Z1github.com/jeanluca/w2pp-openwyd/api/web/v1;webv1b\x06proto3"
+	"\x11VerifyCredentials\x12 .web.v1.VerifyCredentialsRequest\x1a!.web.v1.VerifyCredentialsResponse2\xc5\x03\n" +
+	"\x0fNpcAdminService\x12=\n" +
+	"\bListNpcs\x12\x17.web.v1.ListNpcsRequest\x1a\x18.web.v1.ListNpcsResponse\x127\n" +
+	"\x06GetNpc\x12\x15.web.v1.GetNpcRequest\x1a\x16.web.v1.GetNpcResponse\x12@\n" +
+	"\tUpsertNpc\x12\x18.web.v1.UpsertNpcRequest\x1a\x19.web.v1.UpsertNpcResponse\x12E\n" +
+	"\x10SetNpcVisibility\x12\x1f.web.v1.SetNpcVisibilityRequest\x1a\x10.web.v1.AdminAck\x129\n" +
+	"\n" +
+	"SetNpcShop\x12\x19.web.v1.SetNpcShopRequest\x1a\x10.web.v1.AdminAck\x12=\n" +
+	"\fSetItemPrice\x12\x1b.web.v1.SetItemPriceRequest\x1a\x10.web.v1.AdminAck\x127\n" +
+	"\tDeleteNpc\x12\x18.web.v1.DeleteNpcRequest\x1a\x10.web.v1.AdminAckB3Z1github.com/jeanluca/w2pp-openwyd/api/web/v1;webv1b\x06proto3"
 
 var (
 	file_api_web_v1_web_proto_rawDescOnce sync.Once
@@ -351,26 +1363,62 @@ func file_api_web_v1_web_proto_rawDescGZIP() []byte {
 	return file_api_web_v1_web_proto_rawDescData
 }
 
-var file_api_web_v1_web_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_api_web_v1_web_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_api_web_v1_web_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_api_web_v1_web_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_api_web_v1_web_proto_goTypes = []any{
 	(CreateResult)(0),                 // 0: web.v1.CreateResult
-	(*CreateAccountRequest)(nil),      // 1: web.v1.CreateAccountRequest
-	(*CreateAccountResponse)(nil),     // 2: web.v1.CreateAccountResponse
-	(*VerifyCredentialsRequest)(nil),  // 3: web.v1.VerifyCredentialsRequest
-	(*VerifyCredentialsResponse)(nil), // 4: web.v1.VerifyCredentialsResponse
+	(AdminResult)(0),                  // 1: web.v1.AdminResult
+	(*CreateAccountRequest)(nil),      // 2: web.v1.CreateAccountRequest
+	(*CreateAccountResponse)(nil),     // 3: web.v1.CreateAccountResponse
+	(*VerifyCredentialsRequest)(nil),  // 4: web.v1.VerifyCredentialsRequest
+	(*VerifyCredentialsResponse)(nil), // 5: web.v1.VerifyCredentialsResponse
+	(*AdminAck)(nil),                  // 6: web.v1.AdminAck
+	(*AdminNpcShopItem)(nil),          // 7: web.v1.AdminNpcShopItem
+	(*AdminNpc)(nil),                  // 8: web.v1.AdminNpc
+	(*ListNpcsRequest)(nil),           // 9: web.v1.ListNpcsRequest
+	(*ListNpcsResponse)(nil),          // 10: web.v1.ListNpcsResponse
+	(*GetNpcRequest)(nil),             // 11: web.v1.GetNpcRequest
+	(*GetNpcResponse)(nil),            // 12: web.v1.GetNpcResponse
+	(*UpsertNpcRequest)(nil),          // 13: web.v1.UpsertNpcRequest
+	(*UpsertNpcResponse)(nil),         // 14: web.v1.UpsertNpcResponse
+	(*SetNpcVisibilityRequest)(nil),   // 15: web.v1.SetNpcVisibilityRequest
+	(*SetNpcShopRequest)(nil),         // 16: web.v1.SetNpcShopRequest
+	(*SetItemPriceRequest)(nil),       // 17: web.v1.SetItemPriceRequest
+	(*DeleteNpcRequest)(nil),          // 18: web.v1.DeleteNpcRequest
 }
 var file_api_web_v1_web_proto_depIdxs = []int32{
-	0, // 0: web.v1.CreateAccountResponse.result:type_name -> web.v1.CreateResult
-	1, // 1: web.v1.AccountWebService.CreateAccount:input_type -> web.v1.CreateAccountRequest
-	3, // 2: web.v1.AccountWebService.VerifyCredentials:input_type -> web.v1.VerifyCredentialsRequest
-	2, // 3: web.v1.AccountWebService.CreateAccount:output_type -> web.v1.CreateAccountResponse
-	4, // 4: web.v1.AccountWebService.VerifyCredentials:output_type -> web.v1.VerifyCredentialsResponse
-	3, // [3:5] is the sub-list for method output_type
-	1, // [1:3] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	0,  // 0: web.v1.CreateAccountResponse.result:type_name -> web.v1.CreateResult
+	1,  // 1: web.v1.AdminAck.result:type_name -> web.v1.AdminResult
+	7,  // 2: web.v1.AdminNpc.shop:type_name -> web.v1.AdminNpcShopItem
+	1,  // 3: web.v1.ListNpcsResponse.result:type_name -> web.v1.AdminResult
+	8,  // 4: web.v1.ListNpcsResponse.npcs:type_name -> web.v1.AdminNpc
+	1,  // 5: web.v1.GetNpcResponse.result:type_name -> web.v1.AdminResult
+	8,  // 6: web.v1.GetNpcResponse.npc:type_name -> web.v1.AdminNpc
+	1,  // 7: web.v1.UpsertNpcResponse.result:type_name -> web.v1.AdminResult
+	7,  // 8: web.v1.SetNpcShopRequest.items:type_name -> web.v1.AdminNpcShopItem
+	2,  // 9: web.v1.AccountWebService.CreateAccount:input_type -> web.v1.CreateAccountRequest
+	4,  // 10: web.v1.AccountWebService.VerifyCredentials:input_type -> web.v1.VerifyCredentialsRequest
+	9,  // 11: web.v1.NpcAdminService.ListNpcs:input_type -> web.v1.ListNpcsRequest
+	11, // 12: web.v1.NpcAdminService.GetNpc:input_type -> web.v1.GetNpcRequest
+	13, // 13: web.v1.NpcAdminService.UpsertNpc:input_type -> web.v1.UpsertNpcRequest
+	15, // 14: web.v1.NpcAdminService.SetNpcVisibility:input_type -> web.v1.SetNpcVisibilityRequest
+	16, // 15: web.v1.NpcAdminService.SetNpcShop:input_type -> web.v1.SetNpcShopRequest
+	17, // 16: web.v1.NpcAdminService.SetItemPrice:input_type -> web.v1.SetItemPriceRequest
+	18, // 17: web.v1.NpcAdminService.DeleteNpc:input_type -> web.v1.DeleteNpcRequest
+	3,  // 18: web.v1.AccountWebService.CreateAccount:output_type -> web.v1.CreateAccountResponse
+	5,  // 19: web.v1.AccountWebService.VerifyCredentials:output_type -> web.v1.VerifyCredentialsResponse
+	10, // 20: web.v1.NpcAdminService.ListNpcs:output_type -> web.v1.ListNpcsResponse
+	12, // 21: web.v1.NpcAdminService.GetNpc:output_type -> web.v1.GetNpcResponse
+	14, // 22: web.v1.NpcAdminService.UpsertNpc:output_type -> web.v1.UpsertNpcResponse
+	6,  // 23: web.v1.NpcAdminService.SetNpcVisibility:output_type -> web.v1.AdminAck
+	6,  // 24: web.v1.NpcAdminService.SetNpcShop:output_type -> web.v1.AdminAck
+	6,  // 25: web.v1.NpcAdminService.SetItemPrice:output_type -> web.v1.AdminAck
+	6,  // 26: web.v1.NpcAdminService.DeleteNpc:output_type -> web.v1.AdminAck
+	18, // [18:27] is the sub-list for method output_type
+	9,  // [9:18] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_api_web_v1_web_proto_init() }
@@ -383,10 +1431,10 @@ func file_api_web_v1_web_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_web_v1_web_proto_rawDesc), len(file_api_web_v1_web_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   4,
+			NumEnums:      2,
+			NumMessages:   17,
 			NumExtensions: 0,
-			NumServices:   1,
+			NumServices:   2,
 		},
 		GoTypes:           file_api_web_v1_web_proto_goTypes,
 		DependencyIndexes: file_api_web_v1_web_proto_depIdxs,

--- a/api/web/v1/web.proto
+++ b/api/web/v1/web.proto
@@ -54,3 +54,118 @@ message VerifyCredentialsResponse {
   int64 account_id = 2; // set only when ok
   bool blocked = 3;     // account.is_blocked — caller decides how to surface it
 }
+
+// NpcAdminService is the moderator-facing NPC editing surface (npc-editing-plan.md).
+// The Next.js BFF calls it server-side after establishing a moderator session;
+// every request carries the moderator's account_id, which the web-api authorizes
+// against account.role ('moderator'/'admin') and records in the audit trail. All
+// writes are cold config in Postgres — never live game state, which stays in
+// tmServer's single-owner loop.
+service NpcAdminService {
+  // ListNpcs returns every NPC definition (moderation table).
+  rpc ListNpcs(ListNpcsRequest) returns (ListNpcsResponse);
+  // GetNpc returns one definition with its shop stock.
+  rpc GetNpc(GetNpcRequest) returns (GetNpcResponse);
+  // UpsertNpc creates or updates a definition (position, visibility, merchant type).
+  rpc UpsertNpc(UpsertNpcRequest) returns (UpsertNpcResponse);
+  // SetNpcVisibility toggles whether the NPC appears ("aparece ou não").
+  rpc SetNpcVisibility(SetNpcVisibilityRequest) returns (AdminAck);
+  // SetNpcShop replaces a merchant NPC's shop stock.
+  rpc SetNpcShop(SetNpcShopRequest) returns (AdminAck);
+  // SetItemPrice sets (price>=0) or clears (price<0) the GLOBAL price of an item.
+  rpc SetItemPrice(SetItemPriceRequest) returns (AdminAck);
+  // DeleteNpc removes a definition.
+  rpc DeleteNpc(DeleteNpcRequest) returns (AdminAck);
+}
+
+// AdminResult carries the business outcome of an admin write (authorization,
+// validation, missing target) in the body — only infra failures become gRPC errors.
+enum AdminResult {
+  ADMIN_RESULT_UNSPECIFIED = 0;
+  ADMIN_RESULT_OK = 1;
+  ADMIN_RESULT_FORBIDDEN = 2;  // caller is not a moderator/admin
+  ADMIN_RESULT_INVALID = 3;    // validation failed (bad slot, unknown target, …)
+  ADMIN_RESULT_NOT_FOUND = 4;  // target definition does not exist
+}
+
+message AdminAck { AdminResult result = 1; }
+
+// AdminNpcShopItem mirrors the DB shop slot; price is global, not per-slot.
+message AdminNpcShopItem {
+  int32 slot = 1;
+  int32 item_index = 2;
+  int32 eff1 = 3;  int32 effv1 = 4;
+  int32 eff2 = 5;  int32 effv2 = 6;
+  int32 eff3 = 7;  int32 effv3 = 8;
+}
+
+message AdminNpc {
+  int64 id = 1;
+  string slug = 2;
+  string template_name = 3;
+  string display_name = 4;
+  bool enabled = 5;
+  int32 map_id = 6;
+  int32 pos_x = 7;
+  int32 pos_y = 8;
+  int32 route_type = 9;
+  int32 merchant = 10;
+  repeated AdminNpcShopItem shop = 11;
+}
+
+message ListNpcsRequest { int64 moderator_id = 1; }
+message ListNpcsResponse {
+  AdminResult result = 1;
+  repeated AdminNpc npcs = 2;
+}
+
+message GetNpcRequest {
+  int64 moderator_id = 1;
+  int64 npc_id = 2;
+}
+message GetNpcResponse {
+  AdminResult result = 1;
+  AdminNpc npc = 2;
+}
+
+message UpsertNpcRequest {
+  int64 moderator_id = 1;
+  // id is ignored on create; the slug is the stable key. Position/visibility/
+  // merchant fields are applied as given.
+  string slug = 2;
+  string template_name = 3;
+  string display_name = 4;
+  bool enabled = 5;
+  int32 map_id = 6;
+  int32 pos_x = 7;
+  int32 pos_y = 8;
+  int32 route_type = 9;
+  int32 merchant = 10;
+}
+message UpsertNpcResponse {
+  AdminResult result = 1;
+  int64 npc_id = 2;
+}
+
+message SetNpcVisibilityRequest {
+  int64 moderator_id = 1;
+  int64 npc_id = 2;
+  bool enabled = 3;
+}
+
+message SetNpcShopRequest {
+  int64 moderator_id = 1;
+  int64 npc_id = 2;
+  repeated AdminNpcShopItem items = 3;
+}
+
+message SetItemPriceRequest {
+  int64 moderator_id = 1;
+  int32 item_index = 2;
+  int64 price = 3; // < 0 clears the override
+}
+
+message DeleteNpcRequest {
+  int64 moderator_id = 1;
+  int64 npc_id = 2;
+}

--- a/api/web/v1/web.proto
+++ b/api/web/v1/web.proto
@@ -53,6 +53,11 @@ message VerifyCredentialsResponse {
   bool ok = 1;          // name exists and password matches
   int64 account_id = 2; // set only when ok
   bool blocked = 3;     // account.is_blocked — caller decides how to surface it
+  // role is account.role ('player'/'moderator'/'admin'). The BFF stores it in the
+  // session to gate the moderator UI (page visibility only). It is NOT the
+  // authorization decision — NpcAdminService re-checks the role server-side on
+  // every call, so a tampered session flag still gets ADMIN_RESULT_FORBIDDEN.
+  string role = 4;
 }
 
 // NpcAdminService is the moderator-facing NPC editing surface (npc-editing-plan.md).

--- a/api/web/v1/web_grpc.pb.go
+++ b/api/web/v1/web_grpc.pb.go
@@ -180,3 +180,361 @@ var AccountWebService_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "api/web/v1/web.proto",
 }
+
+const (
+	NpcAdminService_ListNpcs_FullMethodName         = "/web.v1.NpcAdminService/ListNpcs"
+	NpcAdminService_GetNpc_FullMethodName           = "/web.v1.NpcAdminService/GetNpc"
+	NpcAdminService_UpsertNpc_FullMethodName        = "/web.v1.NpcAdminService/UpsertNpc"
+	NpcAdminService_SetNpcVisibility_FullMethodName = "/web.v1.NpcAdminService/SetNpcVisibility"
+	NpcAdminService_SetNpcShop_FullMethodName       = "/web.v1.NpcAdminService/SetNpcShop"
+	NpcAdminService_SetItemPrice_FullMethodName     = "/web.v1.NpcAdminService/SetItemPrice"
+	NpcAdminService_DeleteNpc_FullMethodName        = "/web.v1.NpcAdminService/DeleteNpc"
+)
+
+// NpcAdminServiceClient is the client API for NpcAdminService service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// NpcAdminService is the moderator-facing NPC editing surface (npc-editing-plan.md).
+// The Next.js BFF calls it server-side after establishing a moderator session;
+// every request carries the moderator's account_id, which the web-api authorizes
+// against account.role ('moderator'/'admin') and records in the audit trail. All
+// writes are cold config in Postgres — never live game state, which stays in
+// tmServer's single-owner loop.
+type NpcAdminServiceClient interface {
+	// ListNpcs returns every NPC definition (moderation table).
+	ListNpcs(ctx context.Context, in *ListNpcsRequest, opts ...grpc.CallOption) (*ListNpcsResponse, error)
+	// GetNpc returns one definition with its shop stock.
+	GetNpc(ctx context.Context, in *GetNpcRequest, opts ...grpc.CallOption) (*GetNpcResponse, error)
+	// UpsertNpc creates or updates a definition (position, visibility, merchant type).
+	UpsertNpc(ctx context.Context, in *UpsertNpcRequest, opts ...grpc.CallOption) (*UpsertNpcResponse, error)
+	// SetNpcVisibility toggles whether the NPC appears ("aparece ou não").
+	SetNpcVisibility(ctx context.Context, in *SetNpcVisibilityRequest, opts ...grpc.CallOption) (*AdminAck, error)
+	// SetNpcShop replaces a merchant NPC's shop stock.
+	SetNpcShop(ctx context.Context, in *SetNpcShopRequest, opts ...grpc.CallOption) (*AdminAck, error)
+	// SetItemPrice sets (price>=0) or clears (price<0) the GLOBAL price of an item.
+	SetItemPrice(ctx context.Context, in *SetItemPriceRequest, opts ...grpc.CallOption) (*AdminAck, error)
+	// DeleteNpc removes a definition.
+	DeleteNpc(ctx context.Context, in *DeleteNpcRequest, opts ...grpc.CallOption) (*AdminAck, error)
+}
+
+type npcAdminServiceClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewNpcAdminServiceClient(cc grpc.ClientConnInterface) NpcAdminServiceClient {
+	return &npcAdminServiceClient{cc}
+}
+
+func (c *npcAdminServiceClient) ListNpcs(ctx context.Context, in *ListNpcsRequest, opts ...grpc.CallOption) (*ListNpcsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListNpcsResponse)
+	err := c.cc.Invoke(ctx, NpcAdminService_ListNpcs_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *npcAdminServiceClient) GetNpc(ctx context.Context, in *GetNpcRequest, opts ...grpc.CallOption) (*GetNpcResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetNpcResponse)
+	err := c.cc.Invoke(ctx, NpcAdminService_GetNpc_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *npcAdminServiceClient) UpsertNpc(ctx context.Context, in *UpsertNpcRequest, opts ...grpc.CallOption) (*UpsertNpcResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UpsertNpcResponse)
+	err := c.cc.Invoke(ctx, NpcAdminService_UpsertNpc_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *npcAdminServiceClient) SetNpcVisibility(ctx context.Context, in *SetNpcVisibilityRequest, opts ...grpc.CallOption) (*AdminAck, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AdminAck)
+	err := c.cc.Invoke(ctx, NpcAdminService_SetNpcVisibility_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *npcAdminServiceClient) SetNpcShop(ctx context.Context, in *SetNpcShopRequest, opts ...grpc.CallOption) (*AdminAck, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AdminAck)
+	err := c.cc.Invoke(ctx, NpcAdminService_SetNpcShop_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *npcAdminServiceClient) SetItemPrice(ctx context.Context, in *SetItemPriceRequest, opts ...grpc.CallOption) (*AdminAck, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AdminAck)
+	err := c.cc.Invoke(ctx, NpcAdminService_SetItemPrice_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *npcAdminServiceClient) DeleteNpc(ctx context.Context, in *DeleteNpcRequest, opts ...grpc.CallOption) (*AdminAck, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AdminAck)
+	err := c.cc.Invoke(ctx, NpcAdminService_DeleteNpc_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// NpcAdminServiceServer is the server API for NpcAdminService service.
+// All implementations must embed UnimplementedNpcAdminServiceServer
+// for forward compatibility.
+//
+// NpcAdminService is the moderator-facing NPC editing surface (npc-editing-plan.md).
+// The Next.js BFF calls it server-side after establishing a moderator session;
+// every request carries the moderator's account_id, which the web-api authorizes
+// against account.role ('moderator'/'admin') and records in the audit trail. All
+// writes are cold config in Postgres — never live game state, which stays in
+// tmServer's single-owner loop.
+type NpcAdminServiceServer interface {
+	// ListNpcs returns every NPC definition (moderation table).
+	ListNpcs(context.Context, *ListNpcsRequest) (*ListNpcsResponse, error)
+	// GetNpc returns one definition with its shop stock.
+	GetNpc(context.Context, *GetNpcRequest) (*GetNpcResponse, error)
+	// UpsertNpc creates or updates a definition (position, visibility, merchant type).
+	UpsertNpc(context.Context, *UpsertNpcRequest) (*UpsertNpcResponse, error)
+	// SetNpcVisibility toggles whether the NPC appears ("aparece ou não").
+	SetNpcVisibility(context.Context, *SetNpcVisibilityRequest) (*AdminAck, error)
+	// SetNpcShop replaces a merchant NPC's shop stock.
+	SetNpcShop(context.Context, *SetNpcShopRequest) (*AdminAck, error)
+	// SetItemPrice sets (price>=0) or clears (price<0) the GLOBAL price of an item.
+	SetItemPrice(context.Context, *SetItemPriceRequest) (*AdminAck, error)
+	// DeleteNpc removes a definition.
+	DeleteNpc(context.Context, *DeleteNpcRequest) (*AdminAck, error)
+	mustEmbedUnimplementedNpcAdminServiceServer()
+}
+
+// UnimplementedNpcAdminServiceServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedNpcAdminServiceServer struct{}
+
+func (UnimplementedNpcAdminServiceServer) ListNpcs(context.Context, *ListNpcsRequest) (*ListNpcsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListNpcs not implemented")
+}
+func (UnimplementedNpcAdminServiceServer) GetNpc(context.Context, *GetNpcRequest) (*GetNpcResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetNpc not implemented")
+}
+func (UnimplementedNpcAdminServiceServer) UpsertNpc(context.Context, *UpsertNpcRequest) (*UpsertNpcResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method UpsertNpc not implemented")
+}
+func (UnimplementedNpcAdminServiceServer) SetNpcVisibility(context.Context, *SetNpcVisibilityRequest) (*AdminAck, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetNpcVisibility not implemented")
+}
+func (UnimplementedNpcAdminServiceServer) SetNpcShop(context.Context, *SetNpcShopRequest) (*AdminAck, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetNpcShop not implemented")
+}
+func (UnimplementedNpcAdminServiceServer) SetItemPrice(context.Context, *SetItemPriceRequest) (*AdminAck, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetItemPrice not implemented")
+}
+func (UnimplementedNpcAdminServiceServer) DeleteNpc(context.Context, *DeleteNpcRequest) (*AdminAck, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteNpc not implemented")
+}
+func (UnimplementedNpcAdminServiceServer) mustEmbedUnimplementedNpcAdminServiceServer() {}
+func (UnimplementedNpcAdminServiceServer) testEmbeddedByValue()                         {}
+
+// UnsafeNpcAdminServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to NpcAdminServiceServer will
+// result in compilation errors.
+type UnsafeNpcAdminServiceServer interface {
+	mustEmbedUnimplementedNpcAdminServiceServer()
+}
+
+func RegisterNpcAdminServiceServer(s grpc.ServiceRegistrar, srv NpcAdminServiceServer) {
+	// If the following call panics, it indicates UnimplementedNpcAdminServiceServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&NpcAdminService_ServiceDesc, srv)
+}
+
+func _NpcAdminService_ListNpcs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListNpcsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NpcAdminServiceServer).ListNpcs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: NpcAdminService_ListNpcs_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NpcAdminServiceServer).ListNpcs(ctx, req.(*ListNpcsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _NpcAdminService_GetNpc_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetNpcRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NpcAdminServiceServer).GetNpc(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: NpcAdminService_GetNpc_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NpcAdminServiceServer).GetNpc(ctx, req.(*GetNpcRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _NpcAdminService_UpsertNpc_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpsertNpcRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NpcAdminServiceServer).UpsertNpc(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: NpcAdminService_UpsertNpc_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NpcAdminServiceServer).UpsertNpc(ctx, req.(*UpsertNpcRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _NpcAdminService_SetNpcVisibility_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetNpcVisibilityRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NpcAdminServiceServer).SetNpcVisibility(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: NpcAdminService_SetNpcVisibility_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NpcAdminServiceServer).SetNpcVisibility(ctx, req.(*SetNpcVisibilityRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _NpcAdminService_SetNpcShop_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetNpcShopRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NpcAdminServiceServer).SetNpcShop(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: NpcAdminService_SetNpcShop_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NpcAdminServiceServer).SetNpcShop(ctx, req.(*SetNpcShopRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _NpcAdminService_SetItemPrice_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetItemPriceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NpcAdminServiceServer).SetItemPrice(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: NpcAdminService_SetItemPrice_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NpcAdminServiceServer).SetItemPrice(ctx, req.(*SetItemPriceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _NpcAdminService_DeleteNpc_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteNpcRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NpcAdminServiceServer).DeleteNpc(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: NpcAdminService_DeleteNpc_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NpcAdminServiceServer).DeleteNpc(ctx, req.(*DeleteNpcRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// NpcAdminService_ServiceDesc is the grpc.ServiceDesc for NpcAdminService service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var NpcAdminService_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "web.v1.NpcAdminService",
+	HandlerType: (*NpcAdminServiceServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "ListNpcs",
+			Handler:    _NpcAdminService_ListNpcs_Handler,
+		},
+		{
+			MethodName: "GetNpc",
+			Handler:    _NpcAdminService_GetNpc_Handler,
+		},
+		{
+			MethodName: "UpsertNpc",
+			Handler:    _NpcAdminService_UpsertNpc_Handler,
+		},
+		{
+			MethodName: "SetNpcVisibility",
+			Handler:    _NpcAdminService_SetNpcVisibility_Handler,
+		},
+		{
+			MethodName: "SetNpcShop",
+			Handler:    _NpcAdminService_SetNpcShop_Handler,
+		},
+		{
+			MethodName: "SetItemPrice",
+			Handler:    _NpcAdminService_SetItemPrice_Handler,
+		},
+		{
+			MethodName: "DeleteNpc",
+			Handler:    _NpcAdminService_DeleteNpc_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "api/web/v1/web.proto",
+}

--- a/dbserver/cmd/dbserver/main.go
+++ b/dbserver/cmd/dbserver/main.go
@@ -15,6 +15,8 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"flag"
@@ -23,6 +25,8 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -33,6 +37,7 @@ import (
 	dbv1 "github.com/jeanluca/w2pp-openwyd/api/db/v1"
 	"github.com/jeanluca/w2pp-openwyd/dbserver/internal/convert"
 	"github.com/jeanluca/w2pp-openwyd/dbserver/internal/grpcsrv"
+	"github.com/jeanluca/w2pp-openwyd/dbserver/internal/savefmt"
 	"github.com/jeanluca/w2pp-openwyd/internal/domain"
 	"github.com/jeanluca/w2pp-openwyd/internal/secret"
 	"github.com/jeanluca/w2pp-openwyd/internal/secure"
@@ -61,6 +66,11 @@ func main() {
 			logger.Error("seed-account failed", "err", err)
 			os.Exit(1)
 		}
+	case "import-npcs":
+		if err := runImportNPCs(os.Args[2:], logger); err != nil {
+			logger.Error("import-npcs failed", "err", err)
+			os.Exit(1)
+		}
 	default:
 		usage()
 		os.Exit(2)
@@ -72,6 +82,198 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  dbserver convert -accounts <dir> [-dsn <postgres-url>]")
 	fmt.Fprintln(os.Stderr, "  dbserver serve [-addr :7514] -dsn <postgres-url> [-tls-cert -tls-key -tls-ca]")
 	fmt.Fprintln(os.Stderr, "  dbserver seed-account -name <login> -pass <password> [-dsn <postgres-url>]")
+	fmt.Fprintln(os.Stderr, "  dbserver import-npcs -content <Release/> [-dsn <postgres-url>]")
+}
+
+// runImportNPCs seeds npc_definition (+ npc_shop_item) from the NPCGener.txt
+// spawn blocks (npc-editing-plan.md §4.1). It imports only MERCHANT blocks — the
+// NPCs whose shop the moderator edits; monsters and non-shop NPCs keep spawning
+// from NPCGener.txt. Idempotent by slug, so re-running only adds new blocks.
+// Without -dsn it is a dry run that reports what it would import.
+func runImportNPCs(args []string, logger *slog.Logger) error {
+	fs := flag.NewFlagSet("import-npcs", flag.ExitOnError)
+	contentDir := fs.String("content", "", "path to the Release/ content tree")
+	dsn := fs.String("dsn", envOr("W2PP_DB_DSN", ""), "PostgreSQL DSN; if unset, dry run")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *contentDir == "" {
+		return fmt.Errorf("-content is required")
+	}
+
+	defs, err := buildNPCDefinitions(*contentDir, logger)
+	if err != nil {
+		return err
+	}
+	logger.Info("scanned NPC generators", "merchant_definitions", len(defs))
+
+	if *dsn == "" {
+		logger.Info("dry run (no -dsn) — not persisting")
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, *dsn)
+	if err != nil {
+		return fmt.Errorf("connect: %w", err)
+	}
+	defer pool.Close()
+	if err := store.Migrate(ctx, pool); err != nil {
+		return err
+	}
+	inserted, err := store.New(pool).SeedNPCDefinitions(ctx, defs)
+	if err != nil {
+		return fmt.Errorf("seed npc definitions: %w", err)
+	}
+	logger.Info("import complete", "inserted", inserted, "already_present", len(defs)-inserted)
+	return nil
+}
+
+// buildNPCDefinitions parses NPCGener.txt and returns one domain.NPCDefinition
+// per MERCHANT spawn block (leader template Merchant != 0), with its shop stock
+// read from the template's Carry[]. The slug is stable across re-imports:
+// "<template>-<blockIndex>". A block whose leader template is missing or is not a
+// merchant is skipped.
+func buildNPCDefinitions(contentDir string, logger *slog.Logger) ([]domain.NPCDefinition, error) {
+	blocks, err := parseNPCGener(filepath.Join(contentDir, "TMsrv", "run", "NPCGener.txt"))
+	if err != nil {
+		return nil, err
+	}
+	templates := make(map[string]*savefmt.Mob)
+	load := func(name string) *savefmt.Mob {
+		if name == "" {
+			return nil
+		}
+		if m, seen := templates[name]; seen {
+			return m
+		}
+		var m *savefmt.Mob
+		if b, terr := os.ReadFile(filepath.Join(contentDir, "TMsrv", "run", "npc", name)); terr == nil {
+			if mob, derr := savefmt.DecodeMob(b); derr == nil {
+				m = &mob
+			} else {
+				logger.Warn("npc template decode failed", "name", name, "err", derr)
+			}
+		}
+		templates[name] = m
+		return m
+	}
+
+	var out []domain.NPCDefinition
+	for i, b := range blocks {
+		mob := load(b.leader)
+		// The shop flag the tmServer honours is CurrentScore.Merchant (STRUCT_MOB
+		// offset 104), NOT the top-level Mob.Merchant (offset 17) — read the same
+		// field here so importer and runtime agree on what is a merchant.
+		if mob == nil || mob.CurrentScore.Merchant == 0 {
+			continue // missing template, or a monster / non-shop NPC (stays in NPCGener.txt)
+		}
+		def := domain.NPCDefinition{
+			Slug:         fmt.Sprintf("%s-%d", b.leader, i),
+			TemplateName: b.leader,
+			DisplayName:  cString(mob.Name[:]),
+			Enabled:      true,
+			PosX:         int32(b.startX),
+			PosY:         int32(b.startY),
+			RouteType:    int16(b.routeType),
+			Merchant:     int16(mob.CurrentScore.Merchant),
+		}
+		// Shop slots are positional (MSG_ShopList sends slots 0..26 verbatim), so
+		// keep each item at its template Carry index rather than compacting.
+		for ci := 0; ci < 27; ci++ {
+			c := mob.Carry[ci]
+			if c.Index == 0 {
+				continue
+			}
+			def.Shop = append(def.Shop, domain.NPCShopItem{
+				Slot:      int16(ci),
+				ItemIndex: int32(c.Index),
+				Eff1:      c.Effects[0].Effect, EffV1: c.Effects[0].Value,
+				Eff2: c.Effects[1].Effect, EffV2: c.Effects[1].Value,
+				Eff3: c.Effects[2].Effect, EffV3: c.Effects[2].Value,
+			})
+		}
+		out = append(out, def)
+	}
+	return out, nil
+}
+
+// npcGenerBlock is the subset of an NPCGener.txt spawn block the importer needs:
+// the leader template name, the Start waypoint (spawn point) and the route type.
+type npcGenerBlock struct {
+	leader         string
+	startX, startY int
+	routeType      int
+}
+
+// parseNPCGener reads NPCGener.txt. Blocks begin with '#'; lines are "Key:\tvalue";
+// '//' lines are comments. This is a minimal text parser for the import (the full
+// spawn semantics live in tmserver/internal/content, which the tmServer uses at
+// runtime; only the fields the seed needs are read here).
+func parseNPCGener(path string) ([]npcGenerBlock, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("import-npcs: open NPCGener: %w", err)
+	}
+	defer f.Close()
+
+	var out []npcGenerBlock
+	var cur *npcGenerBlock
+	flush := func() {
+		if cur != nil && cur.leader != "" {
+			out = append(out, *cur)
+		}
+	}
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 1024), 1<<20)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "//") {
+			continue
+		}
+		if strings.HasPrefix(line, "#") {
+			flush()
+			cur = &npcGenerBlock{}
+			continue
+		}
+		if cur == nil {
+			continue
+		}
+		key, val, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		key, val = strings.TrimSpace(key), strings.TrimSpace(val)
+		switch key {
+		case "Leader":
+			cur.leader = val
+		case "StartX":
+			cur.startX = atoiSafe(val)
+		case "StartY":
+			cur.startY = atoiSafe(val)
+		case "RouteType":
+			cur.routeType = atoiSafe(val)
+		}
+	}
+	flush()
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("import-npcs: scan NPCGener: %w", err)
+	}
+	return out, nil
+}
+
+// cString trims a fixed-size C string field at its first NUL.
+func cString(b []byte) string {
+	if i := bytes.IndexByte(b, 0); i >= 0 {
+		b = b[:i]
+	}
+	return string(b)
+}
+
+func atoiSafe(s string) int {
+	n, _ := strconv.Atoi(strings.TrimSpace(s))
+	return n
 }
 
 // runSeedAccount creates one password-only account for local testing. The name
@@ -161,7 +363,9 @@ func runServe(args []string, logger *slog.Logger) error {
 		return err
 	}
 	srv := grpc.NewServer(grpc.Creds(creds))
-	dbv1.RegisterAccountServiceServer(srv, grpcsrv.New(store.New(pool)))
+	st := store.New(pool)
+	dbv1.RegisterAccountServiceServer(srv, grpcsrv.New(st))
+	dbv1.RegisterNpcConfigServiceServer(srv, grpcsrv.NewNpcConfig(st))
 
 	ln, err := net.Listen("tcp", *addr)
 	if err != nil {

--- a/dbserver/cmd/dbserver/main.go
+++ b/dbserver/cmd/dbserver/main.go
@@ -179,15 +179,17 @@ func buildNPCDefinitions(contentDir string, logger *slog.Logger) ([]domain.NPCDe
 			RouteType:    int16(b.routeType),
 			Merchant:     int16(mob.CurrentScore.Merchant),
 		}
-		// Shop slots are positional (MSG_ShopList sends slots 0..26 verbatim), so
-		// keep each item at its template Carry index rather than compacting.
-		for ci := 0; ci < 27; ci++ {
-			c := mob.Carry[ci]
+		// Slot is the MSG_ShopList display index (0..26); it maps to the real Carry
+		// slot via shopCarrySlot (3 tabs of 9). Reading Carry directly would miss
+		// tabs 2/3 (Carry[27..35],[54..62]) — the same mapping the tmServer writes
+		// (applyShop) and reads back (reqShopList).
+		for i := 0; i < 27; i++ {
+			c := mob.Carry[shopCarrySlot(i)]
 			if c.Index == 0 {
 				continue
 			}
 			def.Shop = append(def.Shop, domain.NPCShopItem{
-				Slot:      int16(ci),
+				Slot:      int16(i),
 				ItemIndex: int32(c.Index),
 				Eff1:      c.Effects[0].Effect, EffV1: c.Effects[0].Value,
 				Eff2: c.Effects[1].Effect, EffV2: c.Effects[1].Value,
@@ -198,6 +200,11 @@ func buildNPCDefinitions(contentDir string, logger *slog.Logger) ([]domain.NPCDe
 	}
 	return out, nil
 }
+
+// shopCarrySlot maps a MSG_ShopList display index (0..26) to the NPC Carry slot
+// it occupies (3 tabs of 9: Carry[0..8],[27..35],[54..62]). Mirrors
+// protocol.ShopSlot, which dbserver cannot import (tmserver internal package).
+func shopCarrySlot(i int) int { return (i % 9) + (i/9)*27 }
 
 // npcGenerBlock is the subset of an NPCGener.txt spawn block the importer needs:
 // the leader template name, the Start waypoint (spawn point) and the route type.

--- a/dbserver/internal/grpcsrv/npcconfig.go
+++ b/dbserver/internal/grpcsrv/npcconfig.go
@@ -1,0 +1,93 @@
+package grpcsrv
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	dbv1 "github.com/jeanluca/w2pp-openwyd/api/db/v1"
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+)
+
+// NpcConfigStore is the read surface the NPC-config service needs (satisfied by
+// *store.Store). tmServer only reads NPC config through here; all writes go
+// through the web-api.
+type NpcConfigStore interface {
+	NPCConfigVersion(ctx context.Context) (int64, error)
+	ListNPCDefinitions(ctx context.Context) ([]domain.NPCDefinition, error)
+	ItemPriceOverrides(ctx context.Context) ([]domain.ItemPriceOverride, error)
+}
+
+// NpcConfigServer implements dbv1.NpcConfigServiceServer. It is the read-only
+// bridge tmServer polls to reload moderator-edited NPC config (npc-editing-plan.md).
+type NpcConfigServer struct {
+	dbv1.UnimplementedNpcConfigServiceServer
+	store NpcConfigStore
+}
+
+// NewNpcConfig builds the NPC-config service over the given store.
+func NewNpcConfig(s NpcConfigStore) *NpcConfigServer { return &NpcConfigServer{store: s} }
+
+// NpcConfigVersion returns the monotonic config version for the tmServer poll.
+func (s *NpcConfigServer) NpcConfigVersion(ctx context.Context, _ *dbv1.NpcConfigVersionRequest) (*dbv1.NpcConfigVersionResponse, error) {
+	v, err := s.store.NPCConfigVersion(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "npc config version: %v", err)
+	}
+	return &dbv1.NpcConfigVersionResponse{Version: v}, nil
+}
+
+// ListNpcDefinitions returns the full definition snapshot plus global price
+// overrides, tagged with the version they were read at.
+func (s *NpcConfigServer) ListNpcDefinitions(ctx context.Context, _ *dbv1.ListNpcDefinitionsRequest) (*dbv1.ListNpcDefinitionsResponse, error) {
+	// Read the version FIRST so a concurrent write can only make the snapshot look
+	// older than it is (the tmServer re-polls and reloads), never newer — which
+	// would let a stale snapshot masquerade as current and skip the next reload.
+	version, err := s.store.NPCConfigVersion(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "npc config version: %v", err)
+	}
+	defs, err := s.store.ListNPCDefinitions(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list npc definitions: %v", err)
+	}
+	prices, err := s.store.ItemPriceOverrides(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "item price overrides: %v", err)
+	}
+	return &dbv1.ListNpcDefinitionsResponse{
+		Version:        version,
+		Definitions:    npcDefinitionsToProto(defs),
+		PriceOverrides: itemPricesToProto(prices),
+	}, nil
+}
+
+func npcDefinitionsToProto(defs []domain.NPCDefinition) []*dbv1.NpcDefinition {
+	out := make([]*dbv1.NpcDefinition, 0, len(defs))
+	for _, d := range defs {
+		shop := make([]*dbv1.NpcShopItem, 0, len(d.Shop))
+		for _, it := range d.Shop {
+			shop = append(shop, &dbv1.NpcShopItem{
+				Slot: int32(it.Slot), ItemIndex: it.ItemIndex,
+				Eff1: int32(it.Eff1), Effv1: int32(it.EffV1),
+				Eff2: int32(it.Eff2), Effv2: int32(it.EffV2),
+				Eff3: int32(it.Eff3), Effv3: int32(it.EffV3),
+			})
+		}
+		out = append(out, &dbv1.NpcDefinition{
+			Id: d.ID, Slug: d.Slug, TemplateName: d.TemplateName, DisplayName: d.DisplayName,
+			Enabled: d.Enabled, MapId: d.MapID, PosX: d.PosX, PosY: d.PosY,
+			RouteType: int32(d.RouteType), Merchant: int32(d.Merchant), Shop: shop,
+		})
+	}
+	return out
+}
+
+func itemPricesToProto(prices []domain.ItemPriceOverride) []*dbv1.ItemPrice {
+	out := make([]*dbv1.ItemPrice, 0, len(prices))
+	for _, p := range prices {
+		out = append(out, &dbv1.ItemPrice{ItemIndex: p.ItemIndex, Price: p.Price})
+	}
+	return out
+}

--- a/dbserver/internal/savefmt/codec.go
+++ b/dbserver/internal/savefmt/codec.go
@@ -246,6 +246,15 @@ func encodeQuest(b []byte, q Quest) {
 	}
 }
 
+// DecodeMob parses a standalone 816-byte STRUCT_MOB blob (e.g. an NPC template in
+// Release/TMsrv/run/npc/). It returns an error unless b is exactly MobSize bytes.
+func DecodeMob(b []byte) (Mob, error) {
+	if len(b) != MobSize {
+		return Mob{}, fmt.Errorf("savefmt: DecodeMob: length %d != %d", len(b), MobSize)
+	}
+	return decodeMob(b), nil
+}
+
 // --- STRUCT_ACCOUNTFILE (7952) ---
 
 // Decode parses a current-format (7952-byte) account blob. It returns an error

--- a/docs/integrations/npc-admin-nextjs.md
+++ b/docs/integrations/npc-admin-nextjs.md
@@ -1,0 +1,250 @@
+# Integração Next.js ↔ web-api: edição de NPCs (moderação)
+
+> Guia de integração para o **projeto Next.js** consumir a funcionalidade de **edição de NPCs por
+> moderadores** (visibilidade, posição e loja/preço). Fonte da verdade do contrato:
+> `api/web/v1/web.proto` (serviço `NpcAdminService`). Contexto de arquitetura: `docs/migration/npc-editing-plan.md`
+> e `docs/migration/web-platform-plan.md`.
+
+## 1. Topologia (o que o Next.js fala com o quê)
+
+```
+Browser ──HTTPS──> Next.js (Route Handlers / Server Actions = BFF)
+                        │  só server-side; cookie de sessão httpOnly
+                        │ gRPC + mTLS
+                        ▼
+                     web-api (serviço Go, :7600)  ──> Postgres (escreve config fria de NPC)
+                                                   ──> (o tmServer lê e materializa no jogo)
+```
+
+Regras que **não** mudam:
+
+- **O browser nunca fala gRPC nem vê certificado mTLS.** Todas as chamadas ao `web-api` saem do
+  server-side do Next.js (Route Handlers / Server Actions).
+- O Next.js é **BFF puro**: guarda apenas um cookie de sessão `httpOnly` e traduz REST/HTTP ⇄ gRPC.
+- O `web-api` é a **autoridade** de autorização e validação. O front pode espelhar validações para UX,
+  mas nunca confiar nelas para segurança.
+
+## 2. Pré-requisitos
+
+1. **web-api no ar** (`webserver`, porta `:7600`) com mTLS — mesmos certs dos links internos
+   (`internal/secure`). O Next.js precisa do par cliente (cert/key) + CA para conectar.
+2. **Migrations aplicadas** (`0005_npc_editing`) — sobem automaticamente quando o `web-api`/`dbserver`
+   iniciam.
+3. **Conta de moderador**: a coluna `account.role` precisa ser `'moderator'` ou `'admin'`. **Não há RPC
+   para promover** — é operação de DBA/seed (ex.: `UPDATE account SET role='moderator' WHERE name=...`).
+   Contas normais têm `role='player'` e recebem `ADMIN_RESULT_FORBIDDEN`.
+4. **Seed dos NPCs** (uma vez): `dbserver import-npcs -content <Release/> -dsn <dsn>` popula os NPCs
+   merchant a partir do `NPCGener.txt`. Antes disso, `ListNpcs` volta vazio.
+5. **Overlay ligado no tmServer**: `W2PP_NPC_EDITING=true` (senão as edições ficam só no banco e não
+   aparecem no jogo). Ver §7.
+
+## 3. Autenticação e sessão do moderador
+
+Reaproveita o **mesmo `AccountWebService`** que o Next.js já usa para login web (ver
+`web-platform-plan.md`):
+
+- `VerifyCredentials(name, password)` → `{ ok, account_id, blocked }`.
+- Em caso de `ok`, o BFF cria o **cookie de sessão `httpOnly`** contendo (ou referenciando) o
+  `account_id`.
+
+**`account_id` da sessão = `moderator_id`** de toda RPC do `NpcAdminService`. Regras:
+
+- O BFF **sempre deriva `moderator_id` do cookie de sessão**, nunca do corpo enviado pelo browser.
+- A autorização (papel `moderator`/`admin`) é feita **server-side no `web-api`**; um `player` recebe
+  `ADMIN_RESULT_FORBIDDEN`.
+- Não reaproveitar o login CPSock do jogo — é outro mundo (`web-platform-plan.md §Autenticação`).
+
+## 4. Contrato — `web.v1.NpcAdminService`
+
+Todas as RPCs recebem `moderator_id` (int64). Resultados de negócio viajam **no corpo** via enum
+`AdminResult`; só falha de infraestrutura vira erro gRPC.
+
+### 4.1 Enum de resultado
+
+| `AdminResult`               | Significado                                   | HTTP sugerido no BFF |
+|-----------------------------|-----------------------------------------------|----------------------|
+| `ADMIN_RESULT_OK` (1)       | sucesso                                        | 200                  |
+| `ADMIN_RESULT_FORBIDDEN` (2)| chamador não é `moderator`/`admin`             | 403                  |
+| `ADMIN_RESULT_INVALID` (3)  | validação falhou (slot, merchant, campos…)     | 400 / 422            |
+| `ADMIN_RESULT_NOT_FOUND` (4)| NPC alvo não existe                            | 404                  |
+| `ADMIN_RESULT_UNSPECIFIED`(0)| não deve ocorrer                              | 500                  |
+
+Erros gRPC (ex.: `UNAVAILABLE`, `INTERNAL`) = falha de infraestrutura → 502/500 no BFF.
+
+### 4.2 RPCs
+
+| RPC | Request (campos além de `moderator_id`) | Response | Uso |
+|-----|------------------------------------------|----------|-----|
+| `ListNpcs` | — | `{ result, npcs: AdminNpc[] }` | tabela de moderação |
+| `GetNpc` | `npc_id` | `{ result, npc: AdminNpc }` | detalhe (com loja) |
+| `UpsertNpc` | `slug, template_name, display_name, enabled, map_id, pos_x, pos_y, route_type, merchant` | `{ result, npc_id }` | criar/editar definição |
+| `SetNpcVisibility` | `npc_id, enabled` | `AdminAck{ result }` | atalho "aparece ou não" |
+| `SetNpcShop` | `npc_id, items: AdminNpcShopItem[]` | `AdminAck{ result }` | substituir a loja inteira |
+| `SetItemPrice` | `item_index, price` | `AdminAck{ result }` | preço **global** do item |
+| `DeleteNpc` | `npc_id` | `AdminAck{ result }` | remover definição |
+
+### 4.3 Mensagens
+
+```proto
+message AdminNpc {
+  int64  id            = 1;  // id numérico da definição (use em npc_id)
+  string slug          = 2;  // chave humana estável (ex. "Karkarian-42")
+  string template_name = 3;  // arquivo do template em Release/TMsrv/run/npc/
+  string display_name  = 4;
+  bool   enabled       = 5;  // "aparece ou não"
+  int32  map_id        = 6;  // carregado, mas o jogo posiciona só por x/y (grid único)
+  int32  pos_x         = 7;  // "onde fica" (ponto de spawn)
+  int32  pos_y         = 8;
+  int32  route_type    = 9;  // 0 = parado
+  int32  merchant      = 10; // ver §5.1
+  repeated AdminNpcShopItem shop = 11; // preenchido em GetNpc/ListNpcs
+}
+
+message AdminNpcShopItem {
+  int32 slot       = 1;  // índice de loja 0..26 (ver §5.2)
+  int32 item_index = 2;  // índice no ItemList (> 0)
+  int32 eff1 = 3; int32 effv1 = 4;  // efeitos opcionais (0 = sem efeito)
+  int32 eff2 = 5; int32 effv2 = 6;
+  int32 eff3 = 7; int32 effv3 = 8;
+}
+```
+
+> `UpsertNpc` **não** edita a loja — use `SetNpcShop`. `SetItemPrice` é **global por item**, não por NPC.
+
+## 5. Semântica de domínio (o que a UI precisa saber)
+
+### 5.1 `merchant` (tipo do NPC)
+
+Conjunto aceito (outros → `ADMIN_RESULT_INVALID`):
+
+| valor | significado |
+|------:|-------------|
+| `0`   | não-merchant (sem loja) |
+| `1`   | loja normal |
+| `2`   | guarda-carga (abre o armazém, não uma lista de compra) |
+| `19`  | loja tipo 3 |
+| `100` | NPC de quest |
+
+A **loja** (`SetNpcShop`) só faz sentido para NPCs merchant (tipicamente `1`/`19`).
+
+### 5.2 Loja: slots 0..26 = **3 abas de 9**
+
+O `slot` é o **índice de exibição** do `MSG_ShopList`, de `0` a `26`, organizado em **3 abas de 9 itens**:
+
+- **Aba 1:** slots `0..8`
+- **Aba 2:** slots `9..17`
+- **Aba 3:** slots `18..26`
+
+A UI deve apresentar exatamente assim. O backend cuida do mapeamento interno para o inventário do NPC;
+o front trabalha só com `0..26`. Regras de validação (espelhe para UX):
+
+- `slot` único e em `[0, 26]`;
+- `item_index > 0`;
+- `SetNpcShop` **substitui a loja inteira** — envie **todos** os itens que devem existir; slots omitidos
+  ficam vazios (loja vazia = NPC não vende nada).
+
+### 5.3 Preço é **global por item**
+
+Não existe preço por-NPC. `SetItemPrice(item_index, price)`:
+
+- `price >= 0` → define o preço global daquele item (vale em **todos** os NPCs que o vendem);
+- `price < 0` → **limpa** o override e o item volta ao preço do catálogo do jogo.
+
+### 5.4 Propagação para o jogo (não é instantâneo)
+
+A escrita vai para o Postgres na hora, mas o mundo do jogo só reflete quando o **tmServer recarrega**:
+
+- **no boot**, e
+- por **poll periódico (~15s)** enquanto roda.
+
+Ou seja: comunique ao moderador algo como *"a alteração aparece no jogo em alguns segundos"*. Requer o
+overlay ligado (`W2PP_NPC_EDITING=true`). Sem isso, a edição fica só no banco.
+
+## 6. Camada BFF (Next.js) — como implementar
+
+O browser fala com **rotas REST do próprio Next.js**; essas rotas (server-side) chamam o `web-api` por
+gRPC+mTLS. Sugestão de mapeamento REST → RPC:
+
+| Método + rota (exemplo) | RPC |
+|-------------------------|-----|
+| `GET /api/admin/npcs` | `ListNpcs` |
+| `GET /api/admin/npcs/:id` | `GetNpc` |
+| `POST /api/admin/npcs` / `PUT /api/admin/npcs/:id` | `UpsertNpc` |
+| `PATCH /api/admin/npcs/:id/visibility` | `SetNpcVisibility` |
+| `PUT /api/admin/npcs/:id/shop` | `SetNpcShop` |
+| `PUT /api/admin/items/:index/price` | `SetItemPrice` |
+| `DELETE /api/admin/npcs/:id` | `DeleteNpc` |
+
+Esqueleto de um Route Handler (TypeScript, server-side; `@grpc/grpc-js` + stubs gerados do `.proto`):
+
+```ts
+// lib/npcAdminClient.ts  (SERVER-ONLY — nunca importar no client)
+import { credentials } from "@grpc/grpc-js";
+import fs from "node:fs";
+import { NpcAdminServiceClient } from "@/gen/web/v1/web_grpc_pb"; // gerado do web.proto
+
+const ssl = credentials.createSsl(
+  fs.readFileSync(process.env.WEB_API_CA!),      // CA
+  fs.readFileSync(process.env.WEB_API_CLIENT_KEY!),
+  fs.readFileSync(process.env.WEB_API_CLIENT_CERT!),
+);
+export const npcAdmin = new NpcAdminServiceClient(process.env.WEB_API_ADDR!, ssl); // ex. "web-api:7600"
+```
+
+```ts
+// app/api/admin/npcs/route.ts
+import { NextResponse } from "next/server";
+import { npcAdmin } from "@/lib/npcAdminClient";
+import { getSession } from "@/lib/session"; // lê o cookie httpOnly → { accountId }
+
+const httpFor = (r: number) => ({ 1: 200, 2: 403, 3: 422, 4: 404 } as const)[r] ?? 500;
+
+export async function GET() {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+
+  const resp = await new Promise<any>((resolve, reject) =>
+    npcAdmin.listNpcs({ moderatorId: session.accountId }, (err: unknown, r: unknown) =>
+      err ? reject(err) : resolve(r)),
+  ).catch(() => null);
+
+  if (!resp) return NextResponse.json({ error: "upstream" }, { status: 502 }); // erro gRPC = infra
+  const status = httpFor(resp.result);
+  if (status !== 200) return NextResponse.json({ result: resp.result }, { status });
+  return NextResponse.json({ npcs: resp.npcs });
+}
+```
+
+Pontos importantes do BFF:
+
+- **`moderatorId` vem SEMPRE da sessão** (`session.accountId`), nunca do corpo do request.
+- Mapear `AdminResult` → HTTP (tabela §4.1). Rejeição de gRPC (promise reject) = falha de infra → 502.
+- Cliente gRPC é **singleton server-side**; nunca exposto ao browser.
+- Cookie de sessão `httpOnly` + proteção CSRF nas rotas mutantes (POST/PUT/PATCH/DELETE).
+
+## 7. Geração dos stubs
+
+O time do Next.js gera os stubs a partir de **`api/web/v1/web.proto`** (peça o arquivo ou aponte para
+este repo). Pacote proto: `web.v1`; serviços: `AccountWebService` (login) e `NpcAdminService` (esta
+feature). Ferramentas usuais: `@grpc/grpc-js` + `grpc-tools`/`ts-proto`, ou `buf generate`.
+
+## 8. Variáveis de ambiente (Next.js server-side)
+
+| Var | Descrição |
+|-----|-----------|
+| `WEB_API_ADDR` | host:porta do web-api (ex. `web-api:7600`) |
+| `WEB_API_CA` | caminho do CA (PEM) que valida o web-api |
+| `WEB_API_CLIENT_CERT` / `WEB_API_CLIENT_KEY` | par cliente (PEM) para o mTLS |
+| `SESSION_SECRET` | assinatura/criptografia do cookie de sessão |
+
+## 9. Checklist de integração
+
+- [ ] Gerar stubs de `web.proto` (`web.v1.NpcAdminService`).
+- [ ] Cliente gRPC+mTLS server-side (singleton), certs via env.
+- [ ] Login do moderador via `AccountWebService.VerifyCredentials` → cookie `httpOnly`.
+- [ ] Toda rota admin deriva `moderator_id` da sessão (nunca do corpo).
+- [ ] Mapear `AdminResult` → HTTP; tratar reject de gRPC como 502.
+- [ ] UI da loja em 3 abas de 9 (slots 0..8 / 9..17 / 18..26); `SetNpcShop` envia a loja inteira.
+- [ ] Preço via `SetItemPrice` (global; `price < 0` limpa).
+- [ ] Avisar que a mudança aparece no jogo em ~alguns segundos (poll do tmServer).
+- [ ] Garantir que o operador setou `account.role` do moderador e rodou `import-npcs`.

--- a/docs/integrations/npc-admin-nextjs.md
+++ b/docs/integrations/npc-admin-nextjs.md
@@ -43,15 +43,21 @@ Regras que **não** mudam:
 Reaproveita o **mesmo `AccountWebService`** que o Next.js já usa para login web (ver
 `web-platform-plan.md`):
 
-- `VerifyCredentials(name, password)` → `{ ok, account_id, blocked }`.
-- Em caso de `ok`, o BFF cria o **cookie de sessão `httpOnly`** contendo (ou referenciando) o
-  `account_id`.
+- `VerifyCredentials(name, password)` → `{ ok, account_id, blocked, role }`.
+  - `role` é `account.role`: `"player"` | `"moderator"` | `"admin"`.
+- Em caso de `ok`, o BFF cria o **cookie de sessão `httpOnly`** guardando (ou referenciando) o
+  `account_id` **e** o `role`.
 
 **`account_id` da sessão = `moderator_id`** de toda RPC do `NpcAdminService`. Regras:
 
 - O BFF **sempre deriva `moderator_id` do cookie de sessão**, nunca do corpo enviado pelo browser.
-- A autorização (papel `moderator`/`admin`) é feita **server-side no `web-api`**; um `player` recebe
-  `ADMIN_RESULT_FORBIDDEN`.
+- **Gate da página de edição de NPC:** `role ∈ { "moderator", "admin" }`. Esse flag é **só para UX**
+  (mostrar/esconder o menu e a rota). **Não é a decisão de autorização** — o `NpcAdminService` revalida
+  o papel server-side em **toda** chamada, então uma sessão adulterada ainda recebe
+  `ADMIN_RESULT_FORBIDDEN`. Trate o `role` da sessão como uma dica de UI, nunca como permissão.
+- **Setar quem é moderador (fase inicial):** direto no banco — não há RPC de promoção. Ex.:
+  `UPDATE account SET role = 'moderator' WHERE name = 'fulano';`. O `role` só passa a valer no próximo
+  login (é lido no `VerifyCredentials`); se precisar refletir na hora, invalide a sessão do usuário.
 - Não reaproveitar o login CPSock do jogo — é outro mundo (`web-platform-plan.md §Autenticação`).
 
 ## 4. Contrato — `web.v1.NpcAdminService`
@@ -192,6 +198,28 @@ export const npcAdmin = new NpcAdminServiceClient(process.env.WEB_API_ADDR!, ssl
 ```
 
 ```ts
+// app/api/login/route.ts  — grava account_id + role na sessão
+import { NextResponse } from "next/server";
+import { accountWeb } from "@/lib/accountWebClient"; // AccountWebServiceClient (mesmo padrão mTLS)
+import { createSession } from "@/lib/session";
+
+export async function POST(req: Request) {
+  const { name, password } = await req.json();
+  const r = await new Promise<any>((resolve, reject) =>
+    accountWeb.verifyCredentials({ name, password }, (e: unknown, x: unknown) => (e ? reject(e) : resolve(x))),
+  ).catch(() => null);
+
+  if (!r) return NextResponse.json({ error: "upstream" }, { status: 502 });
+  if (!r.ok) return NextResponse.json({ error: "invalid_credentials" }, { status: 401 });
+  if (r.blocked) return NextResponse.json({ error: "blocked" }, { status: 403 });
+
+  await createSession({ accountId: r.accountId, role: r.role }); // cookie httpOnly
+  const isModerator = r.role === "moderator" || r.role === "admin";
+  return NextResponse.json({ accountId: r.accountId, role: r.role, isModerator });
+}
+```
+
+```ts
 // app/api/admin/npcs/route.ts
 import { NextResponse } from "next/server";
 import { npcAdmin } from "@/lib/npcAdminClient";
@@ -241,7 +269,8 @@ feature). Ferramentas usuais: `@grpc/grpc-js` + `grpc-tools`/`ts-proto`, ou `buf
 
 - [ ] Gerar stubs de `web.proto` (`web.v1.NpcAdminService`).
 - [ ] Cliente gRPC+mTLS server-side (singleton), certs via env.
-- [ ] Login do moderador via `AccountWebService.VerifyCredentials` → cookie `httpOnly`.
+- [ ] Login via `AccountWebService.VerifyCredentials` → cookie `httpOnly` guardando `account_id` **e** `role`.
+- [ ] Gate da página/menu de NPC por `role ∈ { moderator, admin }` (só UX — o web-api reautoriza).
 - [ ] Toda rota admin deriva `moderator_id` da sessão (nunca do corpo).
 - [ ] Mapear `AdminResult` → HTTP; tratar reject de gRPC como 502.
 - [ ] UI da loja em 3 abas de 9 (slots 0..8 / 9..17 / 18..26); `SetNpcShop` envia a loja inteira.

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -25,6 +25,8 @@
 | 9 | [migration-plan.md](migration-plan.md) | **COMPLETO** | NFRs, comparação de stacks + recomendação, sequência, riscos, DoD |
 | 10 | [glossary.md](glossary.md) | **COMPLETO** | termos WYD/PT-BR e do código |
 | — | [client-patch-hooks.md](client-patch-hooks.md) | **COMPLETO** | mapa dos hooks/patches da `ClientPatch_v7662.dll` por endereço (checksum off, força-gráficos, SkillDelay, título); 4 pontos de extensão p/ customizar o cliente fechado (ReadMessage/SendChat/UI/SendPack) |
+| — | [web-platform-plan.md](web-platform-plan.md) | **PLANO** | integração da plataforma web (contas, cash, recompensas, loja-web, ranking); web-api + `delivery_queue` (mailbox) preservando o single-owner |
+| — | [npc-editing-plan.md](npc-editing-plan.md) | **PLANO** | edição de NPCs por moderadores via web (aparece/não, posição, itens/preços da loja); overlay em Postgres + hot-reload no loop single-owner |
 
 ---
 

--- a/docs/migration/npc-editing-plan.md
+++ b/docs/migration/npc-editing-plan.md
@@ -1,0 +1,265 @@
+# Plano: Sistema de Edição de NPCs (painel de moderação)
+
+> Status: PLANO (não implementado). Origem: necessidade de **moderadores de jogo** editarem NPCs pela
+> web — se o NPC **aparece ou não**, **onde** ele fica, e **quais itens vende e por qual preço**. Este
+> doc é a fonte da verdade dessa decisão de arquitetura. Escopo pedido: **apenas estruturas de dados e
+> backend** (o front-end Next.js não faz parte deste plano; ele apenas consome a mesma borda `web-api`
+> descrita em `web-platform-plan.md`).
+
+## 1. O que existe hoje (ponto de partida)
+
+Os NPCs **não têm identidade estável nem configuração editável**. Eles nascem da **árvore de conteúdo
+read-only** montada no boot:
+
+- **`Release/TMsrv/run/NPCGener.txt`** — blocos de *spawn* (líder, seguidor, waypoints, `MinuteGenerate`,
+  `MaxNumMob`, `RouteType`). Parseado por `content.LoadNPCGenerators` (`tmserver/internal/content/npc.go`).
+- **`Release/TMsrv/run/npc/<nome>`** — o *template* cru de 816 bytes (`STRUCT_MOB`) de cada NPC/mob,
+  carregado por `content.LoadNPCTemplate`. É daqui que sai o **flag `Merchant`** e o **`Carry[]`** (a
+  vitrine da loja: `world/api.go:154-165`, `protocol.MobCarry`).
+- **`itemPrices`** — o preço de compra vem do **catálogo de itens** (`ItemList`), não do NPC:
+  `handler/shop.go:83` (`d.itemPrices[index]`). O NPC só decide **quais** itens aparecem (o `Carry[]`);
+  o **preço** é global por índice de item.
+- **Spawn no boot**, dentro do loop, por `spawnNPCs` (`tmserver/cmd/tmserver/main.go:222`): cada bloco
+  vira um `world.Generator` e dispara um `GenerateMob`.
+
+Limitações para o que os moderadores precisam:
+
+1. **Aparecer/não aparecer** — hoje só editando `NPCGener.txt` e reiniciando o servidor.
+2. **Onde fica** — idem: coordenadas estão no `.txt`; mudar exige editar arquivo + restart.
+3. **O que vende / por qual preço** — o `Carry[]` está *dentro* do template binário de 816 bytes
+   (nada amigável de editar); o preço é global no catálogo, não por-NPC.
+4. **Sem ID estável** — blocos são posicionais (índice no arquivo). Não dá pra referenciar "o NPC X"
+   de forma durável a partir de um banco.
+
+## 2. A restrição que decide tudo (a mesma do resto da plataforma web)
+
+Vale **integralmente** a regra de `web-platform-plan.md`:
+
+> O tmServer tem **um único goroutine dono de todo o estado do mundo**, em memória, sem locks
+> (`world/world.go`, `CLAUDE.md` §"single-owner game loop"). As **entidades NPC são estado vivo do
+> loop** (`w.entities[...]`, `pMob[MaxUser..MaxMob)`).
+
+Consequência direta:
+
+> ❌ A web **nunca** muta entidade NPC viva. Nem escreve direto num Postgres que o tmServer também
+> escreve para essas linhas. Isso reintroduziria exatamente o race que a arquitetura single-owner
+> existe para evitar.
+
+Mas há uma diferença importante em relação a inventário de personagem: **configuração de NPC é
+conteúdo/definição, não estado de jogador**. O tmServer **não persiste** definição de NPC de volta — ele
+só a **lê** e **materializa** entidades a partir dela. Isso torna o Postgres o **dono legítimo da
+definição** (o tmServer é dono só da *instância viva*), e elimina o risco de clobber que existe para
+`donate_balance`/inventário. O fluxo é **uma via**: `web-api → Postgres → dbServer → tmServer`.
+
+## 3. Topologia decidida
+
+```
+Moderador ──HTTPS──> Next.js BFF ──gRPC+mTLS──> web-api ──> Postgres  (ESCRITA da definição + auditoria)
+                                                              │
+                                                              ▼
+                                              dbServer (gRPC, api/db/v1)  ← tmServer LÊ a definição
+                                                              │                (boot + reload periódico)
+                                                              ▼
+                                                        tmServer (loop single-owner)
+                                                     aplica diff: spawn/despawn/mover/atualizar Carry
+```
+
+Decisões de posicionamento (todas seguindo os precedentes do repo):
+
+- **A escrita (CRUD de moderador) mora na `web-api`** (`api/web/v1`), um **novo serviço gRPC**
+  `NpcAdminService` ao lado de `AccountWebService`. Motivo: moderadores são usuários **web**; a `web-api`
+  já é a borda web sobre `internal/store` + `internal/secret`. Não estender `AccountService`
+  (`api/db/v1`) — aquele espelha as mensagens legadas G↔DB.
+- **A leitura pelo tmServer passa pelo dbServer** (`api/db/v1`, novo RPC `ListNpcDefinitions` /
+  `NpcConfigVersion`). Motivo: o tmServer **só tem cliente gRPC do dbServer** (`main.go:135`), nunca fala
+  Postgres direto, e degrada sem `-dbserver`. Manter isso: sem dbServer, o tmServer cai no fallback atual
+  (NPCs do `NPCGener.txt`), o que preserva o bring-up local.
+- **`internal/store`, `internal/migrations`, `internal/domain`** (repo-root) ganham o modelo de NPC,
+  reaproveitados por web-api (escrita) e dbServer (leitura), como já fazem para `account`.
+
+## 4. Como uma edição chega no loop que está rodando (o ponto central)
+
+Espelha o padrão *mailbox* do `delivery_queue`, mas para **configuração** em vez de concessão. Duas
+peças:
+
+1. **Versão monotônica de configuração.** Uma linha `npc_config_meta(version bigint)` incrementada em
+   **toda** escrita de moderador (na mesma transação). Barata de checar.
+2. **Poll dentro do loop.** O tmServer já tem um ticker de simulação (`world.onTick`, `world/tick.go`).
+   Adiciona-se um **tick lento de reconfiguração** (ex.: a cada N segundos) que:
+   - **fora do loop** (`World.Go`, como toda I/O bloqueante) chama `dbServer.NpcConfigVersion`; se
+     mudou, chama `ListNpcDefinitions`;
+   - **de volta no loop**, aplica o **diff** entre a definição nova e as entidades vivas, tudo no
+     goroutine dono — respeitando o single-owner:
+     - NPC **desabilitado / removido** → `DespawnMob` da(s) instância(s) daquele NPC.
+     - NPC **habilitado / novo** → spawn na posição configurada.
+     - NPC **movido** → despawn + respawn na nova célula (ou reposicionamento direto se estático).
+     - **Loja alterada** (itens/efeitos) → reescreve o `Carry[]` da entidade merchant viva.
+     - **Preço alterado** → atualiza o override de preço consultado pelos handlers `buy`/`sell`.
+
+Isso dá **hot-reload sem restart e sem race**: a web só escreve definição fria; o tmServer continua o
+**único** a criar/mutar/destruir entidade viva.
+
+> **Marco de corte:** o **milestone 1** pode aplicar a definição **só no boot** (ler a tabela em
+> `spawnNPCs` como *overlay* sobre o `NPCGener.txt`). O **milestone 3** adiciona o tick de reload. Assim
+> entrega-se valor cedo (moderar + restart) antes de construir o hot-reload.
+
+### 4.1 Identidade estável e *seed* inicial
+
+Cada NPC editável precisa de um **id durável**. Faz-se um **import one-shot** (subcomando novo no
+dbServer, no espírito do `dbserver convert`/`seed-account`) que lê `NPCGener.txt` + os templates e
+popula `npc_definition` — um id por bloco. A partir daí o `.txt` vira *bootstrap read-only* e o banco é a
+fonte da verdade. Merchants (`Merchant != 0`) são o subconjunto que ganha linhas em `npc_shop_item`.
+
+## 5. Modelo de dados (nova migration `internal/migrations/000N_npc_editing.up.sql`)
+
+Esboço (nomes/colunas a refinar na implementação; `snake_case`, seguindo o estilo das migrations
+existentes):
+
+```sql
+-- Definição editável de um NPC. Fonte da verdade da CONFIGURAÇÃO; o tmServer é
+-- dono só da INSTÂNCIA viva materializada a partir daqui.
+CREATE TABLE npc_definition (
+  id            bigserial PRIMARY KEY,
+  slug          text NOT NULL UNIQUE,        -- id humano estável (ex. "armia-merchant-1")
+  template_name text NOT NULL,               -- nome do arquivo em Release/TMsrv/run/npc/
+  display_name  text NOT NULL,
+  enabled       boolean NOT NULL DEFAULT true,   -- "aparece ou não"
+  map_id        integer NOT NULL,            -- mapa/cidade
+  pos_x         integer NOT NULL,            -- "onde fica"
+  pos_y         integer NOT NULL,
+  route_type    smallint NOT NULL DEFAULT 0, -- parado / patrulha
+  merchant      smallint NOT NULL DEFAULT 0, -- 0=não-merchant, 1=loja, 2=guarda-carga, 19=shop tipo 3 ...
+  updated_by    bigint,                      -- account.id do moderador
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+-- Estoque da loja de um NPC merchant. Sobrepõe o Carry[] do template binário.
+-- price_override NULL = usa o preço global do catálogo (itemPrices) — comportamento atual.
+CREATE TABLE npc_shop_item (
+  npc_id         bigint NOT NULL REFERENCES npc_definition(id) ON DELETE CASCADE,
+  slot           smallint NOT NULL,          -- 0..26 (MSG_ShopList tem 27 slots)
+  item_index     integer NOT NULL,           -- índice no ItemList
+  eff1_effect    smallint NOT NULL DEFAULT 0, eff1_value smallint NOT NULL DEFAULT 0,
+  eff2_effect    smallint NOT NULL DEFAULT 0, eff2_value smallint NOT NULL DEFAULT 0,
+  eff3_effect    smallint NOT NULL DEFAULT 0, eff3_value smallint NOT NULL DEFAULT 0,
+  price_override bigint,                      -- NULL = catálogo
+  PRIMARY KEY (npc_id, slot)
+);
+
+-- Sinal de hot-reload: incrementado em TODA escrita (mesma transação).
+CREATE TABLE npc_config_meta (
+  id      boolean PRIMARY KEY DEFAULT true CHECK (id),  -- single-row
+  version bigint NOT NULL DEFAULT 0
+);
+
+-- Trilha de auditoria: quem mudou o quê (moderação = ação privilegiada).
+CREATE TABLE npc_audit (
+  id         bigserial PRIMARY KEY,
+  npc_id     bigint,
+  account_id bigint NOT NULL,     -- moderador
+  action     text NOT NULL,       -- 'create' | 'update' | 'delete' | 'toggle'
+  before     jsonb,
+  after      jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+```
+
+Além disso: **papel de moderador**. Adicionar `account.role text NOT NULL DEFAULT 'player'` (ou uma
+tabela `account_role`) para a `web-api` autorizar as RPCs de admin. Ver §6.
+
+Modelo relacional correspondente em `internal/domain` (`NpcDefinition`, `NpcShopItem`), no mesmo estilo
+de `domain.Account`/`domain.Character`.
+
+## 6. Autenticação e autorização dos moderadores
+
+- **Sessão web** = o mesmo cookie `httpOnly` do `web-platform-plan.md` (login web via
+  `VerifyCredentials`). Não reaproveitar o login CPSock do jogo.
+- **Autorização** = `web-api` **exige `role in ('moderator','admin')`** em toda RPC de `NpcAdminService`.
+  A verificação é **server-side no Go**, nunca só no BFF. Toda mutação grava `npc_audit` com o
+  `account_id` do moderador na **mesma transação** que incrementa `npc_config_meta.version`.
+- Ponto em aberto herdado: relação com `is_blocked`/binServer — ver §9 de `web-platform-plan.md`. Não
+  bloqueia este plano.
+
+## 7. Contratos gRPC (novos)
+
+**`api/web/v1` — `NpcAdminService`** (borda do moderador; `make proto` regenera):
+
+```proto
+service NpcAdminService {
+  rpc ListNpcs(ListNpcsRequest) returns (ListNpcsResponse);          // vitrine de moderação
+  rpc GetNpc(GetNpcRequest) returns (NpcDefinition);
+  rpc UpsertNpc(UpsertNpcRequest) returns (UpsertNpcResponse);       // criar/editar posição, enabled, merchant
+  rpc SetNpcVisibility(SetNpcVisibilityRequest) returns (Ack);       // "aparece ou não" (atalho comum)
+  rpc SetNpcShop(SetNpcShopRequest) returns (Ack);                   // itens + efeitos + price_override
+  rpc DeleteNpc(DeleteNpcRequest) returns (Ack);
+}
+```
+
+Resultados de negócio (slug já existe, item inválido, sem permissão) viajam **no corpo** como enums/flags
+(padrão de `CreateResult` em `web.proto`), não como códigos de erro gRPC — só falha de infra vira `error`.
+Todo request de admin carrega o `account_id`/token do moderador para a checagem de papel + auditoria.
+
+**`api/db/v1` — leitura pelo tmServer** (dois RPCs enxutos):
+
+```proto
+rpc NpcConfigVersion(NpcConfigVersionRequest) returns (NpcConfigVersionResponse); // só o int; poll barato
+rpc ListNpcDefinitions(ListNpcDefinitionsRequest) returns (ListNpcDefinitionsResponse); // snapshot completo
+```
+
+## 8. Plano de execução por marcos
+
+**Milestone 0 — Modelo & seed (sem gameplay novo).**
+- Migration `000N_npc_editing` + tipos em `internal/domain`.
+- Queries em `internal/store` (CRUD de `npc_definition`/`npc_shop_item`, bump de versão, auditoria) com
+  testes `-tags=integration` no padrão de `store_integration_test.go`.
+- Subcomando `dbserver import-npcs`: lê `NPCGener.txt` + templates → popula `npc_definition`
+  (+`npc_shop_item` para merchants). Idempotente por `slug`.
+
+**Milestone 1 — Overlay no boot (valor imediato).**
+- `dbServer`: `ListNpcDefinitions`.
+- `tmServer`: em `spawnNPCs`, quando `-dbserver` está setado, **preferir** a definição do banco sobre o
+  `.txt` (posição, `enabled`, merchant Carry via `npc_shop_item`). Sem dbServer → comportamento atual.
+- Handlers `buy`/`sell`: consultar `price_override` do NPC antes de cair no `itemPrices` global.
+- Entrega: moderar exige restart, mas já é 100% via banco/web.
+
+**Milestone 2 — CRUD do moderador (web-api).**
+- `NpcAdminService` + autorização por papel + `npc_audit`.
+- Validação: item existe no catálogo; `slot` 0..26; coords dentro do mapa; `merchant` num conjunto
+  conhecido.
+
+**Milestone 3 — Hot-reload (sem restart).**
+- `dbServer`: `NpcConfigVersion`.
+- `tmServer`: tick lento de reconfiguração (`World.Go` para o poll fora do loop; aplicação do **diff**
+  dentro do loop: spawn/despawn/mover/atualizar `Carry`/preço). Testes de mundo (`-race`) cobrindo o
+  diff e a invariância single-owner (nenhuma mutação de entidade fora do loop).
+
+**Milestone 4 — Refinamentos.**
+- Preço **por-NPC** default (não só override por item).
+- Histórico/rollback via `npc_audit`.
+- Métricas/observabilidade das reconfigurações (contagem de spawn/despawn por reload).
+
+## 9. Pontos em aberto (decidir antes de construir)
+
+1. **Preço: global vs por-NPC.** Hoje o preço é global por índice de item (`itemPrices`). O plano
+   introduz `price_override` **por slot de NPC** — confirmar que é isso que os moderadores querem (vs.
+   editar o catálogo global). Recomendação: manter override por-NPC (mais localizado e reversível).
+2. **Granularidade de "onde fica".** `map_id + pos_x/pos_y` cobre NPC estático. Para NPCs **patrulhando**
+   (waypoints do `NPCGener.txt`), decidir se os moderadores editam waypoints ou só o ponto de spawn.
+   Recomendação: milestone inicial só ponto de spawn; waypoints depois.
+3. **Instância única vs grupo.** Um bloco `NPCGener` pode spawnar líder + seguidores. Definir se a
+   edição de moderador opera por **bloco** (grupo) ou por **entidade**. Recomendação: por definição
+   (bloco), que é a unidade natural do conteúdo.
+4. **Validação de `merchant` / tipos de loja.** O mapeamento `Merchant → ShopType` (1→1, 19→3, 2=guarda-
+   carga) está **UNVERIFIED** no código (`handler/shop.go:23`). Fixar o conjunto permitido antes de expor
+   na UI de moderação.
+5. **Autoridade de spawn no boot.** O boot atual popula tudo do `.txt` (divergência deliberada,
+   `main.go:216`). Com o overlay do banco, decidir a precedência exata quando um bloco existe no `.txt`
+   mas não no banco (e vice-versa). Recomendação: banco vence quando presente; `.txt` é só o seed.
+
+## 10. Relação com o resto da plataforma
+
+Este plano é **irmão** de `web-platform-plan.md` e reusa toda a sua infraestrutura (web-api, mTLS,
+`internal/store`, hashing/sessão, o padrão mailbox). A diferença conceitual — e por que é mais seguro que
+a loja-web — é que **definição de NPC não é estado de jogador**: o fluxo é de via única
+(web escreve config fria; tmServer materializa), sem o risco de clobber que exige o `delivery_queue` para
+concessões de item/cash.

--- a/docs/migration/npc-editing-plan.md
+++ b/docs/migration/npc-editing-plan.md
@@ -1,10 +1,19 @@
 # Plano: Sistema de Edição de NPCs (painel de moderação)
 
-> Status: PLANO (não implementado). Origem: necessidade de **moderadores de jogo** editarem NPCs pela
-> web — se o NPC **aparece ou não**, **onde** ele fica, e **quais itens vende e por qual preço**. Este
-> doc é a fonte da verdade dessa decisão de arquitetura. Escopo pedido: **apenas estruturas de dados e
-> backend** (o front-end Next.js não faz parte deste plano; ele apenas consome a mesma borda `web-api`
-> descrita em `web-platform-plan.md`).
+> Status: **IMPLEMENTADO** (backend + estruturas de dados; front-end Next.js fora de escopo). Origem:
+> necessidade de **moderadores de jogo** editarem NPCs pela web — se o NPC **aparece ou não**, **onde**
+> ele fica, e **quais itens vende e por qual preço**. Este doc é a fonte da verdade dessa decisão de
+> arquitetura. Escopo entregue: **apenas estruturas de dados e backend** (o front-end Next.js apenas
+> consome a mesma borda `web-api` descrita em `web-platform-plan.md`).
+>
+> **Decisões tomadas na implementação** (as perguntas em aberto de §9 foram respondidas assim):
+> - **Preço é GLOBAL por índice de item** (tabela `item_price` sobrepõe o catálogo), não override
+>   por-NPC — o mesmo item custa o mesmo em todo NPC (§9.1).
+> - **Posição = só ponto de spawn** (`map_id + x/y`); waypoints de patrulha ficam para depois (§9.2).
+> - **Unidade de edição = a definição/bloco** (uma linha `npc_definition`), não a entidade viva (§9.3).
+> - **NPCs geridos pelo banco = o subconjunto MERCHANT.** No boot, com o overlay ativo, os blocos
+>   merchant do `NPCGener.txt` são pulados (a definição do banco os materializa); monstros e NPCs
+>   sem loja continuam vindo do `NPCGener.txt`. Isso particiona limpo e evita spawn duplo.
 
 ## 1. O que existe hoje (ponto de partida)
 
@@ -110,40 +119,47 @@ dbServer, no espírito do `dbserver convert`/`seed-account`) que lê `NPCGener.t
 popula `npc_definition` — um id por bloco. A partir daí o `.txt` vira *bootstrap read-only* e o banco é a
 fonte da verdade. Merchants (`Merchant != 0`) são o subconjunto que ganha linhas em `npc_shop_item`.
 
-## 5. Modelo de dados (nova migration `internal/migrations/000N_npc_editing.up.sql`)
+## 5. Modelo de dados (migration `internal/migrations/0005_npc_editing.up.sql`)
 
-Esboço (nomes/colunas a refinar na implementação; `snake_case`, seguindo o estilo das migrations
-existentes):
+Como implementado (`snake_case`, seguindo o estilo das migrations existentes):
 
 ```sql
 -- Definição editável de um NPC. Fonte da verdade da CONFIGURAÇÃO; o tmServer é
 -- dono só da INSTÂNCIA viva materializada a partir daqui.
 CREATE TABLE npc_definition (
   id            bigserial PRIMARY KEY,
-  slug          text NOT NULL UNIQUE,        -- id humano estável (ex. "armia-merchant-1")
+  slug          text NOT NULL UNIQUE,        -- id humano estável (ex. "Karkarian-42")
   template_name text NOT NULL,               -- nome do arquivo em Release/TMsrv/run/npc/
-  display_name  text NOT NULL,
+  display_name  text NOT NULL DEFAULT '',
   enabled       boolean NOT NULL DEFAULT true,   -- "aparece ou não"
-  map_id        integer NOT NULL,            -- mapa/cidade
-  pos_x         integer NOT NULL,            -- "onde fica"
-  pos_y         integer NOT NULL,
-  route_type    smallint NOT NULL DEFAULT 0, -- parado / patrulha
-  merchant      smallint NOT NULL DEFAULT 0, -- 0=não-merchant, 1=loja, 2=guarda-carga, 19=shop tipo 3 ...
-  updated_by    bigint,                      -- account.id do moderador
+  map_id        integer NOT NULL DEFAULT 0,  -- carregado, mas o overlay usa só x/y (grid único)
+  pos_x         integer NOT NULL DEFAULT 0,  -- "onde fica" (ponto de spawn)
+  pos_y         integer NOT NULL DEFAULT 0,
+  route_type    smallint NOT NULL DEFAULT 0,
+  merchant      smallint NOT NULL DEFAULT 0, -- 0=não-merchant, 1=loja, 2=guarda-carga, 19=shop tipo 3
+  updated_by    bigint REFERENCES account(id) ON DELETE SET NULL,
   updated_at    timestamptz NOT NULL DEFAULT now()
 );
 
--- Estoque da loja de um NPC merchant. Sobrepõe o Carry[] do template binário.
--- price_override NULL = usa o preço global do catálogo (itemPrices) — comportamento atual.
+-- Estoque da loja de um NPC merchant. Sobrepõe o Carry[] do template binário. SEM
+-- preço aqui: o preço é GLOBAL (item_price), decisão desta feature.
 CREATE TABLE npc_shop_item (
-  npc_id         bigint NOT NULL REFERENCES npc_definition(id) ON DELETE CASCADE,
-  slot           smallint NOT NULL,          -- 0..26 (MSG_ShopList tem 27 slots)
-  item_index     integer NOT NULL,           -- índice no ItemList
-  eff1_effect    smallint NOT NULL DEFAULT 0, eff1_value smallint NOT NULL DEFAULT 0,
-  eff2_effect    smallint NOT NULL DEFAULT 0, eff2_value smallint NOT NULL DEFAULT 0,
-  eff3_effect    smallint NOT NULL DEFAULT 0, eff3_value smallint NOT NULL DEFAULT 0,
-  price_override bigint,                      -- NULL = catálogo
+  npc_id     bigint NOT NULL REFERENCES npc_definition(id) ON DELETE CASCADE,
+  slot       smallint NOT NULL CHECK (slot BETWEEN 0 AND 26), -- MSG_ShopList tem 27 slots
+  item_index integer NOT NULL,
+  eff1 smallint NOT NULL DEFAULT 0, effv1 smallint NOT NULL DEFAULT 0,
+  eff2 smallint NOT NULL DEFAULT 0, effv2 smallint NOT NULL DEFAULT 0,
+  eff3 smallint NOT NULL DEFAULT 0, effv3 smallint NOT NULL DEFAULT 0,
   PRIMARY KEY (npc_id, slot)
+);
+
+-- Override GLOBAL de preço por índice de item (sobrepõe o preço do catálogo/itemPrices
+-- em TODO NPC que vende o item). Ausente = preço do catálogo.
+CREATE TABLE item_price (
+  item_index integer PRIMARY KEY,
+  price      bigint NOT NULL,
+  updated_by bigint REFERENCES account(id) ON DELETE SET NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
 );
 
 -- Sinal de hot-reload: incrementado em TODA escrita (mesma transação).
@@ -155,13 +171,16 @@ CREATE TABLE npc_config_meta (
 -- Trilha de auditoria: quem mudou o quê (moderação = ação privilegiada).
 CREATE TABLE npc_audit (
   id         bigserial PRIMARY KEY,
-  npc_id     bigint,
-  account_id bigint NOT NULL,     -- moderador
-  action     text NOT NULL,       -- 'create' | 'update' | 'delete' | 'toggle'
+  npc_id     bigint,             -- sem FK: sobrevive ao delete da definição
+  account_id bigint NOT NULL,    -- moderador
+  action     text NOT NULL,      -- 'create'|'update'|'delete'|'set_shop'|'set_price'|'set_visibility'
   before     jsonb,
   after      jsonb,
   created_at timestamptz NOT NULL DEFAULT now()
 );
+
+-- Papel de moderação (autorização das RPCs de admin na web-api).
+ALTER TABLE account ADD COLUMN role text NOT NULL DEFAULT 'player';
 ```
 
 Além disso: **papel de moderador**. Adicionar `account.role text NOT NULL DEFAULT 'player'` (ou uma
@@ -187,11 +206,12 @@ de `domain.Account`/`domain.Character`.
 ```proto
 service NpcAdminService {
   rpc ListNpcs(ListNpcsRequest) returns (ListNpcsResponse);          // vitrine de moderação
-  rpc GetNpc(GetNpcRequest) returns (NpcDefinition);
+  rpc GetNpc(GetNpcRequest) returns (GetNpcResponse);
   rpc UpsertNpc(UpsertNpcRequest) returns (UpsertNpcResponse);       // criar/editar posição, enabled, merchant
-  rpc SetNpcVisibility(SetNpcVisibilityRequest) returns (Ack);       // "aparece ou não" (atalho comum)
-  rpc SetNpcShop(SetNpcShopRequest) returns (Ack);                   // itens + efeitos + price_override
-  rpc DeleteNpc(DeleteNpcRequest) returns (Ack);
+  rpc SetNpcVisibility(SetNpcVisibilityRequest) returns (AdminAck);  // "aparece ou não" (atalho comum)
+  rpc SetNpcShop(SetNpcShopRequest) returns (AdminAck);              // itens + efeitos (slots 0..26)
+  rpc SetItemPrice(SetItemPriceRequest) returns (AdminAck);          // preço GLOBAL do item (price<0 limpa)
+  rpc DeleteNpc(DeleteNpcRequest) returns (AdminAck);
 }
 ```
 
@@ -219,7 +239,7 @@ rpc ListNpcDefinitions(ListNpcDefinitionsRequest) returns (ListNpcDefinitionsRes
 - `dbServer`: `ListNpcDefinitions`.
 - `tmServer`: em `spawnNPCs`, quando `-dbserver` está setado, **preferir** a definição do banco sobre o
   `.txt` (posição, `enabled`, merchant Carry via `npc_shop_item`). Sem dbServer → comportamento atual.
-- Handlers `buy`/`sell`: consultar `price_override` do NPC antes de cair no `itemPrices` global.
+- Handlers `buy`/`sell`: usam `itemPrices` efetivo (catálogo + `item_price` global sobreposto no reload).
 - Entrega: moderar exige restart, mas já é 100% via banco/web.
 
 **Milestone 2 — CRUD do moderador (web-api).**
@@ -238,25 +258,42 @@ rpc ListNpcDefinitions(ListNpcDefinitionsRequest) returns (ListNpcDefinitionsRes
 - Histórico/rollback via `npc_audit`.
 - Métricas/observabilidade das reconfigurações (contagem de spawn/despawn por reload).
 
-## 9. Pontos em aberto (decidir antes de construir)
+## 9. Pontos em aberto — resolvidos na implementação
 
-1. **Preço: global vs por-NPC.** Hoje o preço é global por índice de item (`itemPrices`). O plano
-   introduz `price_override` **por slot de NPC** — confirmar que é isso que os moderadores querem (vs.
-   editar o catálogo global). Recomendação: manter override por-NPC (mais localizado e reversível).
-2. **Granularidade de "onde fica".** `map_id + pos_x/pos_y` cobre NPC estático. Para NPCs **patrulhando**
-   (waypoints do `NPCGener.txt`), decidir se os moderadores editam waypoints ou só o ponto de spawn.
-   Recomendação: milestone inicial só ponto de spawn; waypoints depois.
-3. **Instância única vs grupo.** Um bloco `NPCGener` pode spawnar líder + seguidores. Definir se a
-   edição de moderador opera por **bloco** (grupo) ou por **entidade**. Recomendação: por definição
-   (bloco), que é a unidade natural do conteúdo.
-4. **Validação de `merchant` / tipos de loja.** O mapeamento `Merchant → ShopType` (1→1, 19→3, 2=guarda-
-   carga) está **UNVERIFIED** no código (`handler/shop.go:23`). Fixar o conjunto permitido antes de expor
-   na UI de moderação.
-5. **Autoridade de spawn no boot.** O boot atual popula tudo do `.txt` (divergência deliberada,
-   `main.go:216`). Com o overlay do banco, decidir a precedência exata quando um bloco existe no `.txt`
-   mas não no banco (e vice-versa). Recomendação: banco vence quando presente; `.txt` é só o seed.
+1. **Preço: global vs por-NPC.** ✅ **Global** (tabela `item_price`; sem `price_override` por-NPC). O
+   moderador edita o preço global do item; vale em todo NPC. O tmServer mescla `item_price` sobre o
+   `itemPrices` do catálogo no reload.
+2. **Granularidade de "onde fica".** ✅ **Só ponto de spawn** (`map_id + pos_x/pos_y`; `map_id` carregado
+   mas o grid é único, então o overlay usa x/y). Waypoints de patrulha ficam para depois.
+3. **Instância única vs grupo.** ✅ **Por definição/bloco** (uma linha `npc_definition` = um NPC gerido).
+4. **Validação de `merchant` / tipos de loja.** ✅ Conjunto permitido fixado em `{0,1,2,19,100}`
+   (`npcadmin.validMerchant`). O mapeamento `Merchant → ShopType` segue **UNVERIFIED** em `handler/shop.go`.
+5. **Autoridade de spawn no boot.** ✅ **Banco vence para merchants:** com o overlay ativo, os blocos
+   merchant do `NPCGener.txt` são pulados (`spawnNPCs`, `skipMerchants`) e materializados do banco;
+   monstros/NPCs sem loja continuam vindo do `.txt`. Partição limpa, sem spawn duplo.
 
-## 10. Relação com o resto da plataforma
+Ainda em aberto (não bloqueiam): waypoints editáveis; preço-base por-NPC; rollback via `npc_audit`;
+verificação do mapeamento `Merchant → ShopType` por captura.
+
+## 10. Implementação — mapa de arquivos
+
+- **Migration/modelo:** `internal/migrations/0005_npc_editing.{up,down}.sql`, tipos em
+  `internal/domain/domain.go` (`NPCDefinition`, `NPCShopItem`, `ItemPriceOverride`).
+- **Store:** `internal/store/npc.go` (CRUD + `SeedNPCDefinitions` + bump de versão + auditoria);
+  integração em `internal/store/npc_integration_test.go` (`-tags=integration`).
+- **Protos:** `api/db/v1` (`NpcConfigService`: `NpcConfigVersion`, `ListNpcDefinitions`);
+  `api/web/v1` (`NpcAdminService`).
+- **dbServer:** `dbserver/internal/grpcsrv/npcconfig.go` (serve leitura); subcomando
+  `dbserver import-npcs` (`dbserver/cmd/dbserver/main.go`, usa `savefmt.DecodeMob` +
+  `CurrentScore.Merchant`).
+- **web-api:** `webserver/internal/npcadmin/service.go` (papel + validação; testes em
+  `service_test.go`), `webserver/internal/grpcsrv/npcadmin.go`.
+- **tmServer:** `tmserver/internal/npccfg` (tipos + `Source`), `tmserver/internal/dbclient/npcconfig.go`
+  (fonte gRPC + resolução de template), `tmserver/internal/world` (`GoDetached` + `worldCallbackEvent`),
+  `tmserver/internal/handler/npcconfig.go` (boot overlay + poll + `applyNPCConfig`, testes em
+  `npcconfig_test.go`), wiring em `tmserver/cmd/tmserver/main.go`.
+
+## 11. Relação com o resto da plataforma
 
 Este plano é **irmão** de `web-platform-plan.md` e reusa toda a sua infraestrutura (web-api, mTLS,
 `internal/store`, hashing/sessão, o padrão mailbox). A diferença conceitual — e por que é mais seguro que

--- a/docs/migration/npc-editing-plan.md
+++ b/docs/migration/npc-editing-plan.md
@@ -293,6 +293,18 @@ verificação do mapeamento `Merchant → ShopType` por captura.
   `tmserver/internal/handler/npcconfig.go` (boot overlay + poll + `applyNPCConfig`, testes em
   `npcconfig_test.go`), wiring em `tmserver/cmd/tmserver/main.go`.
 
+### Feature flag (opt-in) e ordem de ativação
+
+O overlay é **desligado por padrão** — habilite com `-npc-editing` (ou `W2PP_NPC_EDITING=true`), e só faz
+efeito com `-dbserver` **e** `-content` presentes. Motivo de segurança: com o overlay ligado, os blocos
+merchant do `NPCGener.txt` são pulados e materializados do banco; se `npc_definition` estiver **vazia**
+(seed não rodou), os NPCs de loja **sumiriam**. Ordem correta de ativação:
+
+1. `dbserver import-npcs -content <Release/> -dsn <dsn>` — seeda os merchants no banco.
+2. Suba o tmServer com `-npc-editing` (`W2PP_NPC_EDITING=true`).
+
+Sem a flag, o comportamento é o de antes (NPCs 100% do `NPCGener.txt`).
+
 ## 11. Relação com o resto da plataforma
 
 Este plano é **irmão** de `web-platform-plan.md` e reusa toda a sua infraestrutura (web-api, mTLS,

--- a/docs/migration/npc-editing-plan.md
+++ b/docs/migration/npc-editing-plan.md
@@ -295,10 +295,12 @@ verificação do mapeamento `Merchant → ShopType` por captura.
 
 ### Feature flag (opt-in) e ordem de ativação
 
-O overlay é **desligado por padrão** — habilite com `-npc-editing` (ou `W2PP_NPC_EDITING=true`), e só faz
-efeito com `-dbserver` **e** `-content` presentes. Motivo de segurança: com o overlay ligado, os blocos
-merchant do `NPCGener.txt` são pulados e materializados do banco; se `npc_definition` estiver **vazia**
-(seed não rodou), os NPCs de loja **sumiriam**. Ordem correta de ativação:
+O overlay é **desligado por padrão** — a chave única é `-npc-editing` (ou `W2PP_NPC_EDITING=true`). Ligado,
+ele **exige** `-dbserver` (fonte da config) **e** `-content` (para resolver os templates); faltando
+qualquer um, o tmServer **falha no boot** com erro claro (não sobe um overlay que não teria de onde ler
+nem como spawnar). Motivo do default OFF: com o overlay ligado, os blocos merchant do `NPCGener.txt` são
+pulados e materializados do banco; se `npc_definition` estiver **vazia** (seed não rodou), os NPCs de loja
+**sumiriam**. Ordem correta de ativação:
 
 1. `dbserver import-npcs -content <Release/> -dsn <dsn>` — seeda os merchants no banco.
 2. Suba o tmServer com `-npc-editing` (`W2PP_NPC_EDITING=true`).

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -96,3 +96,41 @@ type Affect struct {
 	Level uint16
 	Time  uint32
 }
+
+// NPCDefinition is a moderator-editable NPC/spawn block (npc-editing-plan.md).
+// It is cold configuration owned by Postgres, materialized into a live entity by
+// tmServer's single-owner loop — never the reverse. Slug is the stable id;
+// TemplateName points at the 816-byte STRUCT_MOB in Release/TMsrv/run/npc/.
+type NPCDefinition struct {
+	ID           int64
+	Slug         string
+	TemplateName string
+	DisplayName  string
+	Enabled      bool
+	MapID        int32
+	PosX         int32
+	PosY         int32
+	RouteType    int16
+	Merchant     int16
+	Shop         []NPCShopItem // merchant stock; overlays the template Carry[]
+}
+
+// NPCShopItem is one shop slot of a merchant NPC. Prices are NOT stored here —
+// the moderator edits the global catalog price (ItemPriceOverride).
+type NPCShopItem struct {
+	Slot      int16
+	ItemIndex int32
+	Eff1      uint8
+	EffV1     uint8
+	Eff2      uint8
+	EffV2     uint8
+	Eff3      uint8
+	EffV3     uint8
+}
+
+// ItemPriceOverride is a global per-item price set by a moderator. It overlays
+// the content catalog price for every NPC that sells the item.
+type ItemPriceOverride struct {
+	ItemIndex int32
+	Price     int64
+}

--- a/internal/migrations/0005_npc_editing.down.sql
+++ b/internal/migrations/0005_npc_editing.down.sql
@@ -1,0 +1,6 @@
+DROP TABLE IF EXISTS npc_audit;
+DROP TABLE IF EXISTS npc_config_meta;
+DROP TABLE IF EXISTS item_price;
+DROP TABLE IF EXISTS npc_shop_item;
+DROP TABLE IF EXISTS npc_definition;
+ALTER TABLE account DROP COLUMN IF EXISTS role;

--- a/internal/migrations/0005_npc_editing.up.sql
+++ b/internal/migrations/0005_npc_editing.up.sql
@@ -1,0 +1,79 @@
+-- 0005_npc_editing — moderator-editable NPC configuration (npc-editing-plan.md).
+--
+-- Postgres is the source of truth for the NPC *definition* (a one-way flow: the
+-- web writes cold config; tmServer materializes the live entity). This is NOT
+-- live player state, so there is no clobber hazard like inventory/donate_balance.
+-- The tmServer only reads these tables (via dbServer); it never writes them.
+
+-- Moderator role gate. 'player' is the default; the web-api authorizes NPC-admin
+-- RPCs on role in ('moderator','admin'). Kept as a column (not a separate table)
+-- to match the flat `account` model.
+ALTER TABLE account ADD COLUMN IF NOT EXISTS role TEXT NOT NULL DEFAULT 'player';
+
+-- Editable definition of one NPC/spawn block. `slug` is the stable human id
+-- (seeded from NPCGener.txt by `dbserver import-npcs`); `template_name` points at
+-- the 816-byte STRUCT_MOB in Release/TMsrv/run/npc/. Position is the spawn point
+-- (single global grid — map_id is carried for clarity but the world overlays by
+-- x/y only for now, npc-editing-plan.md §9).
+CREATE TABLE npc_definition (
+    id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    slug          TEXT NOT NULL UNIQUE,
+    template_name TEXT NOT NULL,
+    display_name  TEXT NOT NULL DEFAULT '',
+    enabled       BOOLEAN NOT NULL DEFAULT TRUE,   -- "aparece ou não"
+    map_id        INTEGER NOT NULL DEFAULT 0,
+    pos_x         INTEGER NOT NULL DEFAULT 0,      -- "onde fica"
+    pos_y         INTEGER NOT NULL DEFAULT 0,
+    route_type    SMALLINT NOT NULL DEFAULT 0,
+    merchant      SMALLINT NOT NULL DEFAULT 0,     -- 0=none, 1=shop, 2=cargo guard, 19=shop type 3
+    updated_by    BIGINT REFERENCES account(id) ON DELETE SET NULL,
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Shop stock of a merchant NPC — overlays the template's Carry[]. Prices are NOT
+-- here: the moderator edits the GLOBAL catalog price (item_price), so the same
+-- item costs the same at every NPC (npc-editing-plan decision).
+CREATE TABLE npc_shop_item (
+    npc_id     BIGINT NOT NULL REFERENCES npc_definition(id) ON DELETE CASCADE,
+    slot       SMALLINT NOT NULL CHECK (slot BETWEEN 0 AND 26),  -- MSG_ShopList has 27 slots
+    item_index INTEGER NOT NULL,
+    eff1       SMALLINT NOT NULL DEFAULT 0,
+    effv1      SMALLINT NOT NULL DEFAULT 0,
+    eff2       SMALLINT NOT NULL DEFAULT 0,
+    effv2      SMALLINT NOT NULL DEFAULT 0,
+    eff3       SMALLINT NOT NULL DEFAULT 0,
+    effv3      SMALLINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (npc_id, slot)
+);
+
+-- Global per-item price override. NULL/absent = use the content catalog price
+-- (itemPrices). The tmServer merges these over its base price map on reload.
+CREATE TABLE item_price (
+    item_index INTEGER PRIMARY KEY,
+    price      BIGINT NOT NULL,
+    updated_by BIGINT REFERENCES account(id) ON DELETE SET NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Single-row hot-reload signal. Bumped in the SAME transaction as every write so
+-- the tmServer's cheap version poll detects a change without diffing full state.
+CREATE TABLE npc_config_meta (
+    id      BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (id),
+    version BIGINT NOT NULL DEFAULT 0
+);
+INSERT INTO npc_config_meta (id, version) VALUES (TRUE, 0);
+
+-- Audit trail: moderation is a privileged action, so every mutation records who
+-- did what (before/after snapshots as JSON).
+CREATE TABLE npc_audit (
+    id         BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    npc_id     BIGINT,                 -- not an FK: survives npc_definition deletes
+    account_id BIGINT NOT NULL,        -- the moderator
+    action     TEXT NOT NULL,          -- 'create' | 'update' | 'delete' | 'set_shop' | 'set_price' | 'set_visibility'
+    before     JSONB,
+    after      JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX npc_shop_item_npc_id_idx ON npc_shop_item(npc_id);
+CREATE INDEX npc_audit_npc_id_idx ON npc_audit(npc_id);

--- a/internal/store/npc.go
+++ b/internal/store/npc.go
@@ -1,0 +1,419 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+)
+
+// NPC editing persistence (npc-editing-plan.md). Postgres owns the NPC
+// *definition*; the tmServer only ever reads it (via dbServer). Every mutation
+// runs in a transaction that also writes an audit row and bumps
+// npc_config_meta.version so the tmServer's cheap version poll detects the
+// change.
+
+// NPCConfigVersion returns the monotonically increasing config version. The
+// tmServer polls this to decide whether to reload the full definition set.
+func (s *Store) NPCConfigVersion(ctx context.Context) (int64, error) {
+	var v int64
+	err := s.pool.QueryRow(ctx, `SELECT version FROM npc_config_meta WHERE id = TRUE`).Scan(&v)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, nil // meta row not seeded yet (pre-0005 or empty) — treat as version 0
+	}
+	if err != nil {
+		return 0, fmt.Errorf("store: npc config version: %w", err)
+	}
+	return v, nil
+}
+
+// ListNPCDefinitions returns every NPC definition with its shop items, ordered by
+// id. This is the full snapshot the tmServer materializes into live entities.
+func (s *Store) ListNPCDefinitions(ctx context.Context) ([]domain.NPCDefinition, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, slug, template_name, display_name, enabled, map_id, pos_x, pos_y, route_type, merchant
+		FROM npc_definition ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("store: list npc definitions: %w", err)
+	}
+	defer rows.Close()
+
+	byID := make(map[int64]int) // id → index in out (to attach shop items)
+	var out []domain.NPCDefinition
+	for rows.Next() {
+		var d domain.NPCDefinition
+		if err := rows.Scan(&d.ID, &d.Slug, &d.TemplateName, &d.DisplayName, &d.Enabled,
+			&d.MapID, &d.PosX, &d.PosY, &d.RouteType, &d.Merchant); err != nil {
+			return nil, fmt.Errorf("store: scan npc definition: %w", err)
+		}
+		byID[d.ID] = len(out)
+		out = append(out, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("store: iterate npc definitions: %w", err)
+	}
+
+	shopRows, err := s.pool.Query(ctx, `
+		SELECT npc_id, slot, item_index, eff1, effv1, eff2, effv2, eff3, effv3
+		FROM npc_shop_item ORDER BY npc_id, slot`)
+	if err != nil {
+		return nil, fmt.Errorf("store: list npc shop items: %w", err)
+	}
+	defer shopRows.Close()
+	for shopRows.Next() {
+		var npcID int64
+		var it domain.NPCShopItem
+		if err := shopRows.Scan(&npcID, &it.Slot, &it.ItemIndex,
+			&it.Eff1, &it.EffV1, &it.Eff2, &it.EffV2, &it.Eff3, &it.EffV3); err != nil {
+			return nil, fmt.Errorf("store: scan npc shop item: %w", err)
+		}
+		if idx, ok := byID[npcID]; ok {
+			out[idx].Shop = append(out[idx].Shop, it)
+		}
+	}
+	if err := shopRows.Err(); err != nil {
+		return nil, fmt.Errorf("store: iterate npc shop items: %w", err)
+	}
+	return out, nil
+}
+
+// GetNPCDefinition loads one definition (with shop items) by id. Returns
+// ErrNotFound when absent.
+func (s *Store) GetNPCDefinition(ctx context.Context, id int64) (domain.NPCDefinition, error) {
+	var d domain.NPCDefinition
+	err := s.pool.QueryRow(ctx, `
+		SELECT id, slug, template_name, display_name, enabled, map_id, pos_x, pos_y, route_type, merchant
+		FROM npc_definition WHERE id = $1`, id).
+		Scan(&d.ID, &d.Slug, &d.TemplateName, &d.DisplayName, &d.Enabled,
+			&d.MapID, &d.PosX, &d.PosY, &d.RouteType, &d.Merchant)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return domain.NPCDefinition{}, ErrNotFound
+	}
+	if err != nil {
+		return domain.NPCDefinition{}, fmt.Errorf("store: get npc definition %d: %w", id, err)
+	}
+	shop, err := s.loadShopItems(ctx, s.pool, id)
+	if err != nil {
+		return domain.NPCDefinition{}, err
+	}
+	d.Shop = shop
+	return d, nil
+}
+
+// ItemPriceOverrides returns every global price override. The tmServer merges
+// these over its content-catalog base prices.
+func (s *Store) ItemPriceOverrides(ctx context.Context) ([]domain.ItemPriceOverride, error) {
+	rows, err := s.pool.Query(ctx, `SELECT item_index, price FROM item_price ORDER BY item_index`)
+	if err != nil {
+		return nil, fmt.Errorf("store: list item prices: %w", err)
+	}
+	defer rows.Close()
+	var out []domain.ItemPriceOverride
+	for rows.Next() {
+		var p domain.ItemPriceOverride
+		if err := rows.Scan(&p.ItemIndex, &p.Price); err != nil {
+			return nil, fmt.Errorf("store: scan item price: %w", err)
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// AccountRole returns the account's role ('player'/'moderator'/'admin'). The
+// web-api uses it to authorize NPC-admin RPCs. Returns ErrNotFound if absent.
+func (s *Store) AccountRole(ctx context.Context, id int64) (string, error) {
+	var role string
+	err := s.pool.QueryRow(ctx, `SELECT role FROM account WHERE id = $1`, id).Scan(&role)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", ErrNotFound
+	}
+	if err != nil {
+		return "", fmt.Errorf("store: account role %d: %w", id, err)
+	}
+	return role, nil
+}
+
+// UpsertNPCDefinition inserts a new definition or updates the existing one with
+// the same slug (position, visibility, template, merchant type). Shop items are
+// managed separately via SetNPCShop. Returns the definition id. Bumps the config
+// version and writes an audit row, all in one transaction.
+func (s *Store) UpsertNPCDefinition(ctx context.Context, d domain.NPCDefinition, moderatorID int64) (int64, error) {
+	var id int64
+	err := s.inTx(ctx, func(tx pgx.Tx) error {
+		before, _ := fetchDefJSON(ctx, tx, d.Slug)
+		qerr := tx.QueryRow(ctx, `
+			INSERT INTO npc_definition
+				(slug, template_name, display_name, enabled, map_id, pos_x, pos_y, route_type, merchant, updated_by, updated_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10, now())
+			ON CONFLICT (slug) DO UPDATE SET
+				template_name = EXCLUDED.template_name,
+				display_name  = EXCLUDED.display_name,
+				enabled       = EXCLUDED.enabled,
+				map_id        = EXCLUDED.map_id,
+				pos_x         = EXCLUDED.pos_x,
+				pos_y         = EXCLUDED.pos_y,
+				route_type    = EXCLUDED.route_type,
+				merchant      = EXCLUDED.merchant,
+				updated_by    = EXCLUDED.updated_by,
+				updated_at    = now()
+			RETURNING id`,
+			d.Slug, d.TemplateName, d.DisplayName, d.Enabled, d.MapID, d.PosX, d.PosY,
+			d.RouteType, d.Merchant, nullableID(moderatorID),
+		).Scan(&id)
+		if qerr != nil {
+			return fmt.Errorf("store: upsert npc definition %q: %w", d.Slug, qerr)
+		}
+		action := "update"
+		if before == nil {
+			action = "create"
+		}
+		after, _ := fetchDefJSONByID(ctx, tx, id)
+		if err := auditAndBump(ctx, tx, &id, moderatorID, action, before, after); err != nil {
+			return err
+		}
+		return nil
+	})
+	return id, err
+}
+
+// SetNPCShop replaces a merchant NPC's shop stock. Returns ErrNotFound if the
+// definition does not exist.
+func (s *Store) SetNPCShop(ctx context.Context, npcID int64, items []domain.NPCShopItem, moderatorID int64) error {
+	return s.inTx(ctx, func(tx pgx.Tx) error {
+		if err := ensureDefExists(ctx, tx, npcID); err != nil {
+			return err
+		}
+		before, _ := fetchShopJSON(ctx, tx, npcID)
+		if _, err := tx.Exec(ctx, `DELETE FROM npc_shop_item WHERE npc_id = $1`, npcID); err != nil {
+			return fmt.Errorf("store: clear npc shop %d: %w", npcID, err)
+		}
+		for _, it := range items {
+			if _, err := tx.Exec(ctx, `
+				INSERT INTO npc_shop_item (npc_id, slot, item_index, eff1, effv1, eff2, effv2, eff3, effv3)
+				VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
+				npcID, it.Slot, it.ItemIndex, it.Eff1, it.EffV1, it.Eff2, it.EffV2, it.Eff3, it.EffV3,
+			); err != nil {
+				return fmt.Errorf("store: insert npc shop item (npc %d slot %d): %w", npcID, it.Slot, err)
+			}
+		}
+		after, _ := fetchShopJSON(ctx, tx, npcID)
+		return auditAndBump(ctx, tx, &npcID, moderatorID, "set_shop", before, after)
+	})
+}
+
+// SetNPCVisibility toggles whether an NPC appears in the world. Returns
+// ErrNotFound if the definition does not exist.
+func (s *Store) SetNPCVisibility(ctx context.Context, npcID int64, enabled bool, moderatorID int64) error {
+	return s.inTx(ctx, func(tx pgx.Tx) error {
+		if err := ensureDefExists(ctx, tx, npcID); err != nil {
+			return err
+		}
+		before, _ := fetchDefJSONByID(ctx, tx, npcID)
+		if _, err := tx.Exec(ctx,
+			`UPDATE npc_definition SET enabled = $2, updated_by = $3, updated_at = now() WHERE id = $1`,
+			npcID, enabled, nullableID(moderatorID)); err != nil {
+			return fmt.Errorf("store: set npc visibility %d: %w", npcID, err)
+		}
+		after, _ := fetchDefJSONByID(ctx, tx, npcID)
+		return auditAndBump(ctx, tx, &npcID, moderatorID, "set_visibility", before, after)
+	})
+}
+
+// SetItemPrice sets (or clears, when price < 0) the global override price for an
+// item index.
+func (s *Store) SetItemPrice(ctx context.Context, itemIndex int32, price int64, moderatorID int64) error {
+	return s.inTx(ctx, func(tx pgx.Tx) error {
+		if price < 0 {
+			if _, err := tx.Exec(ctx, `DELETE FROM item_price WHERE item_index = $1`, itemIndex); err != nil {
+				return fmt.Errorf("store: clear item price %d: %w", itemIndex, err)
+			}
+		} else if _, err := tx.Exec(ctx, `
+			INSERT INTO item_price (item_index, price, updated_by, updated_at)
+			VALUES ($1,$2,$3, now())
+			ON CONFLICT (item_index) DO UPDATE SET price = EXCLUDED.price, updated_by = EXCLUDED.updated_by, updated_at = now()`,
+			itemIndex, price, nullableID(moderatorID)); err != nil {
+			return fmt.Errorf("store: set item price %d: %w", itemIndex, err)
+		}
+		after, _ := json.Marshal(domain.ItemPriceOverride{ItemIndex: itemIndex, Price: price})
+		return auditAndBump(ctx, tx, nil, moderatorID, "set_price", nil, after)
+	})
+}
+
+// DeleteNPCDefinition removes a definition (its shop items cascade). Returns
+// ErrNotFound if absent.
+func (s *Store) DeleteNPCDefinition(ctx context.Context, npcID int64, moderatorID int64) error {
+	return s.inTx(ctx, func(tx pgx.Tx) error {
+		before, err := fetchDefJSONByID(ctx, tx, npcID)
+		if err != nil {
+			return err
+		}
+		if before == nil {
+			return ErrNotFound
+		}
+		if _, err := tx.Exec(ctx, `DELETE FROM npc_definition WHERE id = $1`, npcID); err != nil {
+			return fmt.Errorf("store: delete npc definition %d: %w", npcID, err)
+		}
+		return auditAndBump(ctx, tx, &npcID, moderatorID, "delete", before, nil)
+	})
+}
+
+// SeedNPCDefinitions bulk-imports definitions (with shop items) in one
+// transaction, skipping any slug that already exists (idempotent — safe to
+// re-run). It bumps the config version once at the end and writes no per-row
+// audit (this is a system import, not moderator activity). Returns the number of
+// definitions actually inserted.
+func (s *Store) SeedNPCDefinitions(ctx context.Context, defs []domain.NPCDefinition) (int, error) {
+	inserted := 0
+	err := s.inTx(ctx, func(tx pgx.Tx) error {
+		for _, d := range defs {
+			var id int64
+			err := tx.QueryRow(ctx, `
+				INSERT INTO npc_definition
+					(slug, template_name, display_name, enabled, map_id, pos_x, pos_y, route_type, merchant)
+				VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+				ON CONFLICT (slug) DO NOTHING
+				RETURNING id`,
+				d.Slug, d.TemplateName, d.DisplayName, d.Enabled, d.MapID, d.PosX, d.PosY, d.RouteType, d.Merchant,
+			).Scan(&id)
+			if errors.Is(err, pgx.ErrNoRows) {
+				continue // slug already present — leave it untouched
+			}
+			if err != nil {
+				return fmt.Errorf("store: seed npc definition %q: %w", d.Slug, err)
+			}
+			for _, it := range d.Shop {
+				if _, err := tx.Exec(ctx, `
+					INSERT INTO npc_shop_item (npc_id, slot, item_index, eff1, effv1, eff2, effv2, eff3, effv3)
+					VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
+					id, it.Slot, it.ItemIndex, it.Eff1, it.EffV1, it.Eff2, it.EffV2, it.Eff3, it.EffV3,
+				); err != nil {
+					return fmt.Errorf("store: seed shop item (%q slot %d): %w", d.Slug, it.Slot, err)
+				}
+			}
+			inserted++
+		}
+		if inserted > 0 {
+			if _, err := tx.Exec(ctx, `UPDATE npc_config_meta SET version = version + 1 WHERE id = TRUE`); err != nil {
+				return fmt.Errorf("store: bump npc config version: %w", err)
+			}
+		}
+		return nil
+	})
+	return inserted, err
+}
+
+// --- helpers ---
+
+// inTx runs fn in a transaction, rolling back on error.
+func (s *Store) inTx(ctx context.Context, fn func(pgx.Tx) error) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("store: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func (s *Store) loadShopItems(ctx context.Context, q pgxQuerier, npcID int64) ([]domain.NPCShopItem, error) {
+	rows, err := q.Query(ctx, `
+		SELECT slot, item_index, eff1, effv1, eff2, effv2, eff3, effv3
+		FROM npc_shop_item WHERE npc_id = $1 ORDER BY slot`, npcID)
+	if err != nil {
+		return nil, fmt.Errorf("store: load shop items %d: %w", npcID, err)
+	}
+	defer rows.Close()
+	var out []domain.NPCShopItem
+	for rows.Next() {
+		var it domain.NPCShopItem
+		if err := rows.Scan(&it.Slot, &it.ItemIndex, &it.Eff1, &it.EffV1, &it.Eff2, &it.EffV2, &it.Eff3, &it.EffV3); err != nil {
+			return nil, fmt.Errorf("store: scan shop item: %w", err)
+		}
+		out = append(out, it)
+	}
+	return out, rows.Err()
+}
+
+// pgxQuerier is the read surface shared by *pgxpool.Pool and pgx.Tx.
+type pgxQuerier interface {
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+}
+
+// auditAndBump writes the audit row and increments the config version. Called at
+// the end of every mutating transaction.
+func auditAndBump(ctx context.Context, tx pgx.Tx, npcID *int64, moderatorID int64, action string, before, after []byte) error {
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO npc_audit (npc_id, account_id, action, before, after)
+		VALUES ($1,$2,$3,$4,$5)`,
+		npcID, moderatorID, action, nullableJSON(before), nullableJSON(after)); err != nil {
+		return fmt.Errorf("store: write npc audit: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `UPDATE npc_config_meta SET version = version + 1 WHERE id = TRUE`); err != nil {
+		return fmt.Errorf("store: bump npc config version: %w", err)
+	}
+	return nil
+}
+
+func ensureDefExists(ctx context.Context, tx pgx.Tx, npcID int64) error {
+	var exists bool
+	if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM npc_definition WHERE id = $1)`, npcID).Scan(&exists); err != nil {
+		return fmt.Errorf("store: check npc definition %d: %w", npcID, err)
+	}
+	if !exists {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// fetchDefJSON returns the definition row as JSON keyed by slug (nil if absent),
+// used to snapshot the "before" state for the audit trail.
+func fetchDefJSON(ctx context.Context, tx pgx.Tx, slug string) ([]byte, error) {
+	var js []byte
+	err := tx.QueryRow(ctx, `SELECT to_jsonb(d) FROM npc_definition d WHERE slug = $1`, slug).Scan(&js)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return js, err
+}
+
+func fetchDefJSONByID(ctx context.Context, tx pgx.Tx, id int64) ([]byte, error) {
+	var js []byte
+	err := tx.QueryRow(ctx, `SELECT to_jsonb(d) FROM npc_definition d WHERE id = $1`, id).Scan(&js)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return js, err
+}
+
+func fetchShopJSON(ctx context.Context, tx pgx.Tx, npcID int64) ([]byte, error) {
+	var js []byte
+	err := tx.QueryRow(ctx,
+		`SELECT coalesce(jsonb_agg(to_jsonb(si) ORDER BY si.slot), '[]'::jsonb)
+		 FROM npc_shop_item si WHERE npc_id = $1`, npcID).Scan(&js)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return js, err
+}
+
+// nullableID renders a zero moderator id as SQL NULL (system/seed writes).
+func nullableID(id int64) any {
+	if id == 0 {
+		return nil
+	}
+	return id
+}
+
+// nullableJSON renders empty JSON bytes as SQL NULL.
+func nullableJSON(b []byte) any {
+	if len(b) == 0 {
+		return nil
+	}
+	return b
+}

--- a/internal/store/npc_integration_test.go
+++ b/internal/store/npc_integration_test.go
@@ -1,0 +1,137 @@
+//go:build integration
+
+// Integration tests for the NPC-editing store (npc-editing-plan.md). They require
+// a real database and are excluded from the default build. Run with:
+//
+//	W2PP_TEST_DSN=postgres://postgres:dev@localhost:5432/postgres go test -tags=integration ./internal/store/
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+)
+
+// TestNPCConfigCRUD exercises the full moderator write path: upsert a definition,
+// set its shop, toggle visibility, override a price, and delete — asserting the
+// config version bumps on every write and reads reflect the writes.
+func TestNPCConfigCRUD(t *testing.T) {
+	ctx := context.Background()
+	pool := testPool(t)
+	if err := Migrate(ctx, pool); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	// Clean slate for the NPC tables (leave account schema alone).
+	_, _ = pool.Exec(ctx, `DELETE FROM npc_audit; DELETE FROM npc_shop_item; DELETE FROM npc_definition; DELETE FROM item_price; UPDATE npc_config_meta SET version = 0 WHERE id = TRUE`)
+
+	s := New(pool)
+
+	v0, err := s.NPCConfigVersion(ctx)
+	if err != nil {
+		t.Fatalf("version: %v", err)
+	}
+
+	// A moderator account to satisfy the updated_by FK / audit account_id.
+	var modID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO account (name, pass_hash, role) VALUES ('mod_npc_test','x','moderator') RETURNING id`).
+		Scan(&modID); err != nil {
+		t.Fatalf("seed moderator: %v", err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM account WHERE id = $1`, modID) })
+
+	id, err := s.UpsertNPCDefinition(ctx, domain.NPCDefinition{
+		Slug: "shop-int-1", TemplateName: "Keeper", DisplayName: "Keeper",
+		Enabled: true, PosX: 100, PosY: 200, Merchant: 1,
+	}, modID)
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	if err := s.SetNPCShop(ctx, id, []domain.NPCShopItem{
+		{Slot: 0, ItemIndex: 1100}, {Slot: 5, ItemIndex: 1101, Eff1: 1, EffV1: 9},
+	}, modID); err != nil {
+		t.Fatalf("set shop: %v", err)
+	}
+	if err := s.SetNPCVisibility(ctx, id, false, modID); err != nil {
+		t.Fatalf("set visibility: %v", err)
+	}
+	if err := s.SetItemPrice(ctx, 1100, 777, modID); err != nil {
+		t.Fatalf("set item price: %v", err)
+	}
+
+	// Read back the full snapshot.
+	defs, err := s.ListNPCDefinitions(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(defs) != 1 {
+		t.Fatalf("definitions = %d, want 1", len(defs))
+	}
+	got := defs[0]
+	if got.Slug != "shop-int-1" || got.Enabled || got.PosX != 100 || got.Merchant != 1 {
+		t.Errorf("definition mismatch: %+v", got)
+	}
+	if len(got.Shop) != 2 || got.Shop[1].ItemIndex != 1101 || got.Shop[1].EffV1 != 9 {
+		t.Errorf("shop mismatch: %+v", got.Shop)
+	}
+
+	prices, err := s.ItemPriceOverrides(ctx)
+	if err != nil {
+		t.Fatalf("prices: %v", err)
+	}
+	if len(prices) != 1 || prices[0].ItemIndex != 1100 || prices[0].Price != 777 {
+		t.Errorf("price override mismatch: %+v", prices)
+	}
+
+	// Version must have advanced by the four writes.
+	vN, err := s.NPCConfigVersion(ctx)
+	if err != nil {
+		t.Fatalf("version: %v", err)
+	}
+	if vN != v0+4 {
+		t.Errorf("version = %d, want %d (4 writes)", vN, v0+4)
+	}
+
+	// Delete cascades the shop rows.
+	if err := s.DeleteNPCDefinition(ctx, id, modID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	defs, _ = s.ListNPCDefinitions(ctx)
+	if len(defs) != 0 {
+		t.Errorf("definitions after delete = %d, want 0", len(defs))
+	}
+}
+
+// TestSeedNPCDefinitionsIdempotent checks the bulk import inserts once and skips
+// existing slugs on a re-run.
+func TestSeedNPCDefinitionsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	pool := testPool(t)
+	if err := Migrate(ctx, pool); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	_, _ = pool.Exec(ctx, `DELETE FROM npc_shop_item; DELETE FROM npc_definition WHERE slug LIKE 'seed-int-%'`)
+
+	s := New(pool)
+	defs := []domain.NPCDefinition{
+		{Slug: "seed-int-1", TemplateName: "A", Enabled: true, Merchant: 1,
+			Shop: []domain.NPCShopItem{{Slot: 0, ItemIndex: 10}}},
+		{Slug: "seed-int-2", TemplateName: "B", Enabled: true, Merchant: 1},
+	}
+	n, err := s.SeedNPCDefinitions(ctx, defs)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("first seed inserted %d, want 2", n)
+	}
+	n, err = s.SeedNPCDefinitions(ctx, defs)
+	if err != nil {
+		t.Fatalf("seed (2nd): %v", err)
+	}
+	if n != 0 {
+		t.Errorf("second seed inserted %d, want 0 (idempotent)", n)
+	}
+}

--- a/internal/store/store_live.go
+++ b/internal/store/store_live.go
@@ -21,6 +21,7 @@ type AccountAuth struct {
 	ID        int64
 	PassHash  string
 	IsBlocked bool
+	Role      string // account.role ('player'/'moderator'/'admin'); web-only UI gate
 }
 
 // AccountByName fetches the auth row for a canonical (lowercase) account name.
@@ -28,8 +29,8 @@ type AccountAuth struct {
 func (s *Store) AccountByName(ctx context.Context, name string) (AccountAuth, error) {
 	var a AccountAuth
 	err := s.pool.QueryRow(ctx,
-		`SELECT id, pass_hash, is_blocked FROM account WHERE name = $1`, name).
-		Scan(&a.ID, &a.PassHash, &a.IsBlocked)
+		`SELECT id, pass_hash, is_blocked, role FROM account WHERE name = $1`, name).
+		Scan(&a.ID, &a.PassHash, &a.IsBlocked, &a.Role)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return AccountAuth{}, ErrNotFound
 	}

--- a/tmserver/cmd/tmserver/main.go
+++ b/tmserver/cmd/tmserver/main.go
@@ -28,6 +28,8 @@ import (
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/dbclient"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/handler"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/npccfg"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/route"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
 )
@@ -129,14 +131,17 @@ func run(logger *slog.Logger) error {
 		return err
 	}
 
-	// Persistence: real dbServer adapter when -dbserver is set, else no-op.
+	// Persistence: real dbServer adapter when -dbserver is set, else no-op. The
+	// connection is retained (dbConn) so the NPC-config overlay can share it.
 	var persist world.Persistence = world.NopPersistence{}
+	var dbConn *grpc.ClientConn
 	if *dbAddr != "" {
 		conn, err := grpc.NewClient(*dbAddr, grpc.WithTransportCredentials(clientCreds))
 		if err != nil {
 			return err
 		}
 		defer func() { _ = conn.Close() }()
+		dbConn = conn
 		persist = dbclient.New(conn)
 		logger.Info("dbServer wired", "addr", *dbAddr)
 	} else {
@@ -157,9 +162,20 @@ func run(logger *slog.Logger) error {
 		}
 	}
 
+	// Moderator NPC-editing overlay (npc-editing-plan.md): available only with both
+	// a dbServer (config source) and a content tree (to resolve template bytes).
+	var npcConfig npccfg.Source
+	if dbConn != nil && *contentDir != "" {
+		npcConfig = dbclient.NewNpcConfig(dbConn, func(name string) ([]byte, error) {
+			return content.LoadNPCTemplate(*contentDir, name)
+		})
+		logger.Info("npc config overlay enabled (moderator editing)")
+	}
+
 	dispatch := handler.New(handler.Config{
 		Log: logger, ClientVersion: int32(*clientVersion), BaseMobs: baseMobs, ItemPrices: itemPrices, ItemEffects: itemEffects, ItemReqs: itemReqs,
 		ItemVolatiles: itemVolatiles, ItemPos: itemPos, ItemUnique: itemUnique, Spells: spells, Heights: heights,
+		NpcConfig: npcConfig,
 	})
 	w := world.New(world.Config{
 		RejectChecksum: *rejectChecksum,
@@ -192,9 +208,14 @@ func run(logger *slog.Logger) error {
 	}
 
 	// Populate the world with NPCs/monsters from NPCGener.txt (before Serve starts
-	// the loop, so spawning is single-threaded). Capped to fit the mob slots.
+	// the loop, so spawning is single-threaded). Capped to fit the mob slots. When
+	// the DB overlay is active, merchant blocks are skipped here (owned by
+	// npc_definition) and applied from the config snapshot instead.
 	if *contentDir != "" {
-		spawnNPCs(w, *contentDir, logger)
+		spawnNPCs(w, *contentDir, npcConfig != nil, logger)
+	}
+	if npcConfig != nil {
+		dispatch.ApplyNPCConfigBoot(w)
 	}
 
 	ln, err := net.Listen("tcp", *addr)
@@ -219,7 +240,7 @@ func run(logger *slog.Logger) error {
 // front so the world is playable immediately. This burns the LCG at boot (one
 // stream for all spawns, like the original's global rand()); there is no legacy
 // boot rand order to diverge from.
-func spawnNPCs(w *world.World, dir string, logger *slog.Logger) {
+func spawnNPCs(w *world.World, dir string, skipMerchants bool, logger *slog.Logger) {
 	gens, err := content.LoadNPCGenerators(filepath.Join(dir, "TMsrv", "run", "NPCGener.txt"))
 	if err != nil {
 		logger.Warn("NPC generators not loaded", "err", err)
@@ -241,10 +262,18 @@ func spawnNPCs(w *world.World, dir string, logger *slog.Logger) {
 	}
 
 	wgens := make([]*world.Generator, len(gens))
+	skipped := 0
 	for i, g := range gens {
 		leader := load(g.Leader)
 		if leader == nil {
 			continue // block unusable without its Leader template (~1400 miss files)
+		}
+		// When DB-managed NPC config is active, merchant blocks are owned by
+		// npc_definition (materialized by the dispatcher overlay), so skip them here
+		// to avoid double-spawning. Monsters / non-shop NPCs stay on NPCGener.txt.
+		if skipMerchants && protocol.ParseMobBasics(leader).Merchant != 0 {
+			skipped++
+			continue
 		}
 		wg := &world.Generator{
 			MinuteGenerate: g.MinuteGenerate,
@@ -271,7 +300,8 @@ func spawnNPCs(w *world.World, dir string, logger *slog.Logger) {
 			total += len(w.GenerateMob(i))
 		}
 	}
-	logger.Info("NPCs spawned", "generators", len(gens), "mobs", total, "templates", len(templates))
+	logger.Info("NPCs spawned", "generators", len(gens), "mobs", total, "templates", len(templates),
+		"merchant_blocks_skipped", skipped)
 }
 
 // serveStatusHTTP runs the channel-status web server (serv00.htm). It answers any

--- a/tmserver/cmd/tmserver/main.go
+++ b/tmserver/cmd/tmserver/main.go
@@ -193,7 +193,7 @@ func run(logger *slog.Logger) error {
 		}
 		npcConfig = dbclient.NewNpcConfig(dbConn, func(name string) ([]byte, error) {
 			return content.LoadNPCTemplate(*contentDir, name)
-		})
+		}, logger)
 		logger.Info("npc config overlay enabled (moderator editing)")
 	}
 

--- a/tmserver/cmd/tmserver/main.go
+++ b/tmserver/cmd/tmserver/main.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -179,21 +180,21 @@ func run(logger *slog.Logger) error {
 		}
 	}
 
-	// Moderator NPC-editing overlay (npc-editing-plan.md): opt-in via -npc-editing
-	// (W2PP_NPC_EDITING), and only usable with both a dbServer (config source) and a
-	// content tree (to resolve template bytes). Off by default so an unseeded DB
-	// never makes the NPCGener.txt merchants vanish.
+	// Moderator NPC-editing overlay (npc-editing-plan.md): the single switch is
+	// -npc-editing (W2PP_NPC_EDITING), off by default so an unseeded DB never makes
+	// the NPCGener.txt merchants vanish. When on, it MUST have a dbServer (the config
+	// source) and a content tree (to resolve template bytes into the 816-byte
+	// STRUCT_MOB) — both are hard dependencies, not optional, so fail fast with a
+	// clear error rather than booting an overlay that can't read or spawn anything.
 	var npcConfig npccfg.Source
 	if *npcEditing {
-		switch {
-		case dbConn == nil || *contentDir == "":
-			logger.Warn("npc-editing requested but disabled: it needs both -dbserver and -content")
-		default:
-			npcConfig = dbclient.NewNpcConfig(dbConn, func(name string) ([]byte, error) {
-				return content.LoadNPCTemplate(*contentDir, name)
-			})
-			logger.Info("npc config overlay enabled (moderator editing)")
+		if dbConn == nil || *contentDir == "" {
+			return fmt.Errorf("-npc-editing requires both -dbserver (config source) and -content (NPC templates)")
 		}
+		npcConfig = dbclient.NewNpcConfig(dbConn, func(name string) ([]byte, error) {
+			return content.LoadNPCTemplate(*contentDir, name)
+		})
+		logger.Info("npc config overlay enabled (moderator editing)")
 	}
 
 	dispatch := handler.New(handler.Config{

--- a/tmserver/cmd/tmserver/main.go
+++ b/tmserver/cmd/tmserver/main.go
@@ -58,6 +58,21 @@ func envInt(key string, def int) int {
 	return n
 }
 
+// envBool reads a boolean flag default from the environment (Railway-style knob),
+// accepting the usual truthy spellings; a missing or malformed value falls back to
+// def.
+func envBool(key string, def bool) bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return def
+	}
+	return b
+}
+
 // addrOrNone renders an empty flag value as "(none)" so the boot log reads
 // clearly when an optional address (dbServer/binServer/content) is unset.
 func addrOrNone(v string) string {
@@ -79,6 +94,7 @@ func run(logger *slog.Logger) error {
 	maxMsgPerSec := flag.Float64("max-msg-per-sec", 200, "per-connection inbound message rate limit (0 = disabled)")
 	msgBurst := flag.Int("msg-burst", 400, "per-connection message burst depth")
 	contentDir := flag.String("content", os.Getenv("W2PP_CONTENT"), "path to the Release/ content tree (empty = skip; validates rates/catalogs/maps at boot)")
+	npcEditing := flag.Bool("npc-editing", envBool("W2PP_NPC_EDITING", false), "enable the moderator NPC-editing overlay (npc-editing-plan.md); needs -dbserver and -content. OFF by default: turn it on only after `dbserver import-npcs` has seeded npc_definition, else DB-managed merchant NPCs would be skipped from NPCGener.txt with nothing to replace them")
 	defStatusAddr := os.Getenv("W2PP_STATUS_ADDR")
 	if defStatusAddr == "" {
 		defStatusAddr = ":80"
@@ -95,7 +111,8 @@ func run(logger *slog.Logger) error {
 		"client_version", *clientVersion,
 		"dbserver", addrOrNone(*dbAddr),
 		"binserver", addrOrNone(*binAddr),
-		"content", addrOrNone(*contentDir))
+		"content", addrOrNone(*contentDir),
+		"npc_editing", *npcEditing)
 
 	// When -content is set, load and validate the content tree up front so a
 	// missing/corrupt mount fails fast instead of surfacing mid-session. The
@@ -162,14 +179,21 @@ func run(logger *slog.Logger) error {
 		}
 	}
 
-	// Moderator NPC-editing overlay (npc-editing-plan.md): available only with both
-	// a dbServer (config source) and a content tree (to resolve template bytes).
+	// Moderator NPC-editing overlay (npc-editing-plan.md): opt-in via -npc-editing
+	// (W2PP_NPC_EDITING), and only usable with both a dbServer (config source) and a
+	// content tree (to resolve template bytes). Off by default so an unseeded DB
+	// never makes the NPCGener.txt merchants vanish.
 	var npcConfig npccfg.Source
-	if dbConn != nil && *contentDir != "" {
-		npcConfig = dbclient.NewNpcConfig(dbConn, func(name string) ([]byte, error) {
-			return content.LoadNPCTemplate(*contentDir, name)
-		})
-		logger.Info("npc config overlay enabled (moderator editing)")
+	if *npcEditing {
+		switch {
+		case dbConn == nil || *contentDir == "":
+			logger.Warn("npc-editing requested but disabled: it needs both -dbserver and -content")
+		default:
+			npcConfig = dbclient.NewNpcConfig(dbConn, func(name string) ([]byte, error) {
+				return content.LoadNPCTemplate(*contentDir, name)
+			})
+			logger.Info("npc config overlay enabled (moderator editing)")
+		}
 	}
 
 	dispatch := handler.New(handler.Config{

--- a/tmserver/internal/dbclient/npcconfig.go
+++ b/tmserver/internal/dbclient/npcconfig.go
@@ -1,0 +1,89 @@
+package dbclient
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc"
+
+	dbv1 "github.com/jeanluca/w2pp-openwyd/api/db/v1"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/npccfg"
+)
+
+// TemplateLoader resolves an NPC template name to its raw 816-byte STRUCT_MOB.
+// The dbServer stores only the template NAME (not the bytes), so the tmServer
+// resolves it against its local content tree at snapshot time.
+type TemplateLoader func(name string) ([]byte, error)
+
+// NpcConfig adapts the dbServer NpcConfigService to the npccfg.Source port. It
+// fetches the moderator-edited definitions over gRPC and resolves each template
+// name to bytes so the loop can materialize the NPC directly.
+type NpcConfig struct {
+	api      dbv1.NpcConfigServiceClient
+	template TemplateLoader
+}
+
+// NewNpcConfig wraps a gRPC connection + template loader as an npccfg.Source.
+func NewNpcConfig(conn grpc.ClientConnInterface, loader TemplateLoader) *NpcConfig {
+	return &NpcConfig{api: dbv1.NewNpcConfigServiceClient(conn), template: loader}
+}
+
+var _ npccfg.Source = (*NpcConfig)(nil)
+
+// Version returns the current config version (cheap poll).
+func (c *NpcConfig) Version(ctx context.Context) (int64, error) {
+	resp, err := c.api.NpcConfigVersion(ctx, &dbv1.NpcConfigVersionRequest{})
+	if err != nil {
+		return 0, fmt.Errorf("dbclient: npc config version: %w", err)
+	}
+	return resp.GetVersion(), nil
+}
+
+// Snapshot fetches the full definition set + price overrides and resolves each
+// definition's template bytes. A template that fails to load leaves Template nil
+// (the applier skips it) rather than failing the whole reload.
+func (c *NpcConfig) Snapshot(ctx context.Context) (npccfg.Snapshot, error) {
+	resp, err := c.api.ListNpcDefinitions(ctx, &dbv1.ListNpcDefinitionsRequest{})
+	if err != nil {
+		return npccfg.Snapshot{}, fmt.Errorf("dbclient: list npc definitions: %w", err)
+	}
+	snap := npccfg.Snapshot{Version: resp.GetVersion()}
+	cache := make(map[string][]byte)
+	for _, d := range resp.GetDefinitions() {
+		tmpl, ok := cache[d.GetTemplateName()]
+		if !ok {
+			if b, lerr := c.template(d.GetTemplateName()); lerr == nil {
+				tmpl = b
+			}
+			cache[d.GetTemplateName()] = tmpl
+		}
+		def := npccfg.Definition{
+			Slug:      d.GetSlug(),
+			Template:  tmpl,
+			Enabled:   d.GetEnabled(),
+			X:         int16(d.GetPosX()),
+			Y:         int16(d.GetPosY()),
+			RouteType: uint8(d.GetRouteType()),
+			Merchant:  uint8(d.GetMerchant()),
+		}
+		for _, it := range d.GetShop() {
+			def.Shop = append(def.Shop, npccfg.ShopItem{
+				Slot:  int(it.GetSlot()),
+				Index: uint16(it.GetItemIndex()),
+				Eff: [3][2]uint8{
+					{uint8(it.GetEff1()), uint8(it.GetEffv1())},
+					{uint8(it.GetEff2()), uint8(it.GetEffv2())},
+					{uint8(it.GetEff3()), uint8(it.GetEffv3())},
+				},
+			})
+		}
+		snap.Defs = append(snap.Defs, def)
+	}
+	if prices := resp.GetPriceOverrides(); len(prices) > 0 {
+		snap.PriceOverrides = make(map[int]int32, len(prices))
+		for _, p := range prices {
+			snap.PriceOverrides[int(p.GetItemIndex())] = int32(p.GetPrice())
+		}
+	}
+	return snap, nil
+}

--- a/tmserver/internal/dbclient/npcconfig.go
+++ b/tmserver/internal/dbclient/npcconfig.go
@@ -3,6 +3,7 @@ package dbclient
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"google.golang.org/grpc"
 
@@ -21,11 +22,17 @@ type TemplateLoader func(name string) ([]byte, error)
 type NpcConfig struct {
 	api      dbv1.NpcConfigServiceClient
 	template TemplateLoader
+	log      *slog.Logger
 }
 
-// NewNpcConfig wraps a gRPC connection + template loader as an npccfg.Source.
-func NewNpcConfig(conn grpc.ClientConnInterface, loader TemplateLoader) *NpcConfig {
-	return &NpcConfig{api: dbv1.NewNpcConfigServiceClient(conn), template: loader}
+// NewNpcConfig wraps a gRPC connection + template loader as an npccfg.Source. log
+// receives a warning whenever a template fails to resolve (nil defaults to the
+// slog default), so a missing/corrupt NPC file is never silently dropped.
+func NewNpcConfig(conn grpc.ClientConnInterface, loader TemplateLoader, log *slog.Logger) *NpcConfig {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &NpcConfig{api: dbv1.NewNpcConfigServiceClient(conn), template: loader, log: log}
 }
 
 var _ npccfg.Source = (*NpcConfig)(nil)
@@ -52,7 +59,12 @@ func (c *NpcConfig) Snapshot(ctx context.Context) (npccfg.Snapshot, error) {
 	for _, d := range resp.GetDefinitions() {
 		tmpl, ok := cache[d.GetTemplateName()]
 		if !ok {
-			if b, lerr := c.template(d.GetTemplateName()); lerr == nil {
+			b, lerr := c.template(d.GetTemplateName())
+			if lerr != nil {
+				// Don't fail the whole reload for one bad template; leave it nil (the
+				// applier skips + warns) but surface why here.
+				c.log.Warn("npc template resolve failed", "template", d.GetTemplateName(), "slug", d.GetSlug(), "err", lerr)
+			} else {
 				tmpl = b
 			}
 			cache[d.GetTemplateName()] = tmpl

--- a/tmserver/internal/handler/dispatch.go
+++ b/tmserver/internal/handler/dispatch.go
@@ -15,6 +15,7 @@ import (
 	"log/slog"
 
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/npccfg"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
 )
@@ -66,6 +67,11 @@ type Config struct {
 	// safe. When nil (maps not mounted, or tests) mobs fall back to the blind
 	// one-tile Chebyshev step.
 	Heights *content.Grid
+
+	// NpcConfig is the moderator-edited NPC configuration source (npc-editing-plan.md).
+	// When set, the dispatcher overlays DB-defined merchant NPCs on boot and polls
+	// for changes each tick (hot-reload). When nil, NPCs come only from NPCGener.txt.
+	NpcConfig npccfg.Source
 }
 
 type handlerFunc func(w *world.World, s *world.Session, h protocol.Header, payload []byte)
@@ -90,6 +96,18 @@ type Dispatcher struct {
 	spells          *content.SkillData           // skill catalog (g_pSpell)
 	heights         *content.Grid                // baked walkability grid (mob pathfinding)
 	tickCount       int                          // loop-only tick counter (affect sweep phase)
+
+	// NPC-config overlay (npc-editing-plan.md). All loop-only. baseItemPrices is the
+	// immutable content catalog; itemPrices is the effective map (base + global
+	// overrides), rebuilt on reload. managedNPCs maps a definition slug → its live
+	// entity id. npcVersion is the last applied config version; npcPolling guards a
+	// single in-flight version poll; npcPollTick phases the poll cadence.
+	npcSource      npccfg.Source
+	baseItemPrices map[int]int32
+	managedNPCs    map[string]int
+	npcVersion     int64
+	npcPolling     bool
+	npcPollTick    int
 
 	// playersX/Y are per-tick scratch snapshots of in-play player positions
 	// (mob-AI dormancy gate, mobai.go). Loop-only, reused to avoid allocation.
@@ -122,7 +140,14 @@ func New(cfg Config) *Dispatcher {
 		itemUnique:      cfg.ItemUnique,
 		spells:          cfg.Spells,
 		heights:         cfg.Heights,
+		npcSource:       cfg.NpcConfig,
+		managedNPCs:     make(map[string]int),
 	}
+	// The effective price map starts as the content catalog and is later overlaid
+	// with moderator overrides; keep the base immutable so an override can be
+	// cleared. When there is no catalog both stay nil (buy/sell simply find no price).
+	d.baseItemPrices = cfg.ItemPrices
+	d.itemPrices = cloneInt32Map(cfg.ItemPrices)
 	if d.combineFamilies == nil {
 		d.combineFamilies = make(map[protocol.Type]CombineFamily)
 	}

--- a/tmserver/internal/handler/mobai.go
+++ b/tmserver/internal/handler/mobai.go
@@ -79,6 +79,7 @@ func (d *Dispatcher) Tick(w *world.World) {
 	d.sweepAffects(w)
 	d.respawnMobs(w)
 	d.generateMobs(w)
+	d.pollNPCConfig(w) // hot-reload moderator NPC edits (npc-editing-plan.md)
 }
 
 // battleDragBox is the SetBattle engage box: a group member joins the fight only

--- a/tmserver/internal/handler/npcconfig.go
+++ b/tmserver/internal/handler/npcconfig.go
@@ -1,0 +1,178 @@
+package handler
+
+import (
+	"context"
+	"time"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/npccfg"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// Moderator-edited NPC overlay (npc-editing-plan.md). The web writes cold config
+// to Postgres; the tmServer reads it (via dbServer) and MATERIALIZES the live
+// entities inside the single-owner loop — the web never touches live state.
+//
+// DB-managed NPCs are the MERCHANT subset: at boot the NPCGener.txt merchant
+// blocks are skipped (main.spawnNPCs) and these definitions own them instead, so
+// there is no double-spawn. Monsters and non-shop NPCs keep coming from
+// NPCGener.txt untouched.
+
+const (
+	// npcPollPeriod is how many mob-AI ticks (1s each) between config version
+	// polls. Moderator edits are rare, so ~15s keeps the DB load negligible while
+	// still feeling live.
+	npcPollPeriod = 15
+	// npcFetchTimeout bounds the off-loop version/snapshot gRPC calls.
+	npcFetchTimeout = 5 * time.Second
+)
+
+// ApplyNPCConfigBoot fetches the definition snapshot synchronously and applies it
+// once at boot (no reveal — no players are connected yet). It runs before the
+// loop starts, so it is single-threaded like spawnNPCs. A fetch error is logged
+// and left for the periodic poll to retry once the loop is running.
+func (d *Dispatcher) ApplyNPCConfigBoot(w *world.World) {
+	if d.npcSource == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), npcFetchTimeout)
+	defer cancel()
+	snap, err := d.npcSource.Snapshot(ctx)
+	if err != nil {
+		d.log.Warn("npc config boot load failed (will retry via poll)", "err", err)
+		return
+	}
+	d.applyNPCConfig(w, snap, false)
+	d.log.Info("npc config applied at boot", "version", snap.Version, "npcs", len(d.managedNPCs))
+}
+
+// pollNPCConfig checks the config version off the loop each npcPollPeriod ticks
+// and, when it changed, reloads the snapshot and applies it inside the loop. Only
+// one poll is in flight at a time (npcPolling). Called from the mob-AI Tick.
+func (d *Dispatcher) pollNPCConfig(w *world.World) {
+	if d.npcSource == nil || d.npcPolling {
+		return
+	}
+	d.npcPollTick++
+	if d.npcPollTick%npcPollPeriod != 0 {
+		return
+	}
+	known := d.npcVersion // captured in-loop; the off-loop goroutine never reads loop state
+	d.npcPolling = true
+	w.GoDetached(func() func(*world.World) {
+		ctx, cancel := context.WithTimeout(context.Background(), npcFetchTimeout)
+		defer cancel()
+		version, err := d.npcSource.Version(ctx)
+		if err != nil {
+			return func(w *world.World) { d.npcPolling = false; d.log.Warn("npc config version poll failed", "err", err) }
+		}
+		if version == known {
+			return func(w *world.World) { d.npcPolling = false }
+		}
+		snap, err := d.npcSource.Snapshot(ctx)
+		if err != nil {
+			return func(w *world.World) { d.npcPolling = false; d.log.Warn("npc config reload failed", "err", err) }
+		}
+		return func(w *world.World) {
+			d.applyNPCConfig(w, snap, true)
+			d.npcPolling = false
+			d.log.Info("npc config reloaded", "version", snap.Version, "npcs", len(d.managedNPCs))
+		}
+	})
+}
+
+// applyNPCConfig reconciles the live world with a config snapshot, inside the
+// loop. It fully re-materializes the managed set: despawn every currently managed
+// NPC, then spawn each enabled definition. Merchant count is small and reloads
+// are rare (moderator-driven), so a full reconcile is simplest and obviously
+// correct. It also refreshes the global item-price overlay. reveal announces new
+// spawns to in-view players (true on hot-reload, false at boot).
+func (d *Dispatcher) applyNPCConfig(w *world.World, snap npccfg.Snapshot, reveal bool) {
+	d.rebuildItemPrices(snap.PriceOverrides)
+
+	for slug, id := range d.managedNPCs {
+		w.DespawnMob(id, 0) // removeType 0 = out-of-view removal, never queues a respawn
+		delete(d.managedNPCs, slug)
+	}
+
+	for _, def := range snap.Defs {
+		if !def.Enabled || def.Template == nil {
+			continue
+		}
+		if def.X <= 0 || def.Y <= 0 {
+			d.log.Warn("npc definition has no valid position — skipped", "slug", def.Slug, "x", def.X, "y", def.Y)
+			continue
+		}
+		id := w.SpawnMobAt(world.MobSpawn{
+			Template:  def.Template,
+			X:         def.X,
+			Y:         def.Y,
+			RouteType: def.RouteType,
+			GenIndex:  -1, // not owned by an NPCGener block (no CurrentNumMob accounting)
+		})
+		if id < 0 {
+			d.log.Warn("npc spawn failed (no free slot)", "slug", def.Slug)
+			continue
+		}
+		if def.Merchant != 0 {
+			applyShop(w.Entity(id), def.Shop)
+		}
+		d.managedNPCs[def.Slug] = id
+		if reveal {
+			d.revealSpawned(w, []int{id})
+		}
+	}
+	d.npcVersion = snap.Version
+}
+
+// applyShop overwrites a merchant entity's shop stock (its Carry[]) with the
+// moderator-defined slots. The shop is authoritative: slots not listed are
+// cleared, so emptying the shop in the web sells nothing.
+func applyShop(e *world.Entity, shop []npccfg.ShopItem) {
+	if e == nil {
+		return
+	}
+	for i := range e.Carry {
+		e.Carry[i] = world.Item{}
+	}
+	for _, it := range shop {
+		if it.Slot < 0 || it.Slot >= world.MaxCarry {
+			continue
+		}
+		e.Carry[it.Slot] = world.Item{
+			Index: int16(it.Index),
+			Effects: [3]world.Effect{
+				{Effect: it.Eff[0][0], Value: it.Eff[0][1]},
+				{Effect: it.Eff[1][0], Value: it.Eff[1][1]},
+				{Effect: it.Eff[2][0], Value: it.Eff[2][1]},
+			},
+		}
+	}
+}
+
+// rebuildItemPrices resets the effective price map to the content catalog, then
+// applies the moderator's global overrides on top. Loop-only, so handlers reading
+// d.itemPrices never race it.
+func (d *Dispatcher) rebuildItemPrices(overrides map[int]int32) {
+	if len(overrides) == 0 && d.baseItemPrices == nil {
+		return
+	}
+	d.itemPrices = cloneInt32Map(d.baseItemPrices)
+	if d.itemPrices == nil {
+		d.itemPrices = make(map[int]int32, len(overrides))
+	}
+	for idx, price := range overrides {
+		d.itemPrices[idx] = price
+	}
+}
+
+// cloneInt32Map returns a shallow copy of m (nil for a nil input).
+func cloneInt32Map(m map[int]int32) map[int]int32 {
+	if m == nil {
+		return nil
+	}
+	out := make(map[int]int32, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/tmserver/internal/handler/npcconfig.go
+++ b/tmserver/internal/handler/npcconfig.go
@@ -63,14 +63,14 @@ func (d *Dispatcher) pollNPCConfig(w *world.World) {
 		defer cancel()
 		version, err := d.npcSource.Version(ctx)
 		if err != nil {
-			return func(w *world.World) { d.npcPolling = false; d.log.Warn("npc config version poll failed", "err", err) }
+			return func(*world.World) { d.npcPolling = false; d.log.Warn("npc config version poll failed", "err", err) }
 		}
 		if version == known {
-			return func(w *world.World) { d.npcPolling = false }
+			return func(*world.World) { d.npcPolling = false }
 		}
 		snap, err := d.npcSource.Snapshot(ctx)
 		if err != nil {
-			return func(w *world.World) { d.npcPolling = false; d.log.Warn("npc config reload failed", "err", err) }
+			return func(*world.World) { d.npcPolling = false; d.log.Warn("npc config reload failed", "err", err) }
 		}
 		return func(w *world.World) {
 			d.applyNPCConfig(w, snap, true)

--- a/tmserver/internal/handler/npcconfig.go
+++ b/tmserver/internal/handler/npcconfig.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/npccfg"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
 )
 
@@ -95,7 +96,14 @@ func (d *Dispatcher) applyNPCConfig(w *world.World, snap npccfg.Snapshot, reveal
 	}
 
 	for _, def := range snap.Defs {
-		if !def.Enabled || def.Template == nil {
+		if !def.Enabled {
+			continue
+		}
+		if def.Template == nil {
+			// Template failed to resolve (missing/corrupt file) — logged in the
+			// dbclient source too, but warn here so the skip is visible alongside
+			// the other skip branches (bad position, no free slot).
+			d.log.Warn("npc definition has no template — skipped", "slug", def.Slug)
 			continue
 		}
 		if def.X <= 0 || def.Y <= 0 {
@@ -125,8 +133,11 @@ func (d *Dispatcher) applyNPCConfig(w *world.World, snap npccfg.Snapshot, reveal
 }
 
 // applyShop overwrites a merchant entity's shop stock (its Carry[]) with the
-// moderator-defined slots. The shop is authoritative: slots not listed are
-// cleared, so emptying the shop in the web sells nothing.
+// moderator-defined slots. Slot is the MSG_ShopList index (0..26); it is mapped
+// to the real Carry index via protocol.ShopSlot (3 tabs of 9: Carry[0..8],
+// [27..35], [54..62]) — the same mapping reqShopList reads back, so an item in
+// tab 2/3 (slot >= 9) actually reaches the client. The shop is authoritative:
+// slots not listed are cleared, so emptying the shop in the web sells nothing.
 func applyShop(e *world.Entity, shop []npccfg.ShopItem) {
 	if e == nil {
 		return
@@ -135,10 +146,10 @@ func applyShop(e *world.Entity, shop []npccfg.ShopItem) {
 		e.Carry[i] = world.Item{}
 	}
 	for _, it := range shop {
-		if it.Slot < 0 || it.Slot >= world.MaxCarry {
+		if it.Slot < 0 || it.Slot >= maxShopSlots {
 			continue
 		}
-		e.Carry[it.Slot] = world.Item{
+		e.Carry[protocol.ShopSlot(it.Slot)] = world.Item{
 			Index: int16(it.Index),
 			Effects: [3]world.Effect{
 				{Effect: it.Eff[0][0], Value: it.Eff[0][1]},
@@ -148,6 +159,10 @@ func applyShop(e *world.Entity, shop []npccfg.ShopItem) {
 		}
 	}
 }
+
+// maxShopSlots is the number of MSG_ShopList slots (3 tabs of 9); a shop item's
+// Slot is a display index in [0, maxShopSlots).
+const maxShopSlots = 27
 
 // rebuildItemPrices resets the effective price map to the content catalog, then
 // applies the moderator's global overrides on top. Loop-only, so handlers reading

--- a/tmserver/internal/handler/npcconfig_test.go
+++ b/tmserver/internal/handler/npcconfig_test.go
@@ -1,0 +1,135 @@
+package handler
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/npccfg"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// merchantTemplate builds a minimal 816-byte STRUCT_MOB with CurrentScore.Merchant
+// set (the shop flag the tmServer honours, offset 104) and non-zero HP so
+// SpawnMobAt keeps it alive.
+func merchantTemplate(name string) []byte {
+	tmpl := make([]byte, 816)
+	copy(tmpl[0:16], name)
+	tmpl[92+12] = 1                                  // CurrentScore.Merchant = normal shop
+	binary.LittleEndian.PutUint32(tmpl[92+16:], 100) // MaxHp
+	binary.LittleEndian.PutUint32(tmpl[92+24:], 100) // Hp
+	return tmpl
+}
+
+// staticSource is a fixed npccfg.Source for driving applyNPCConfig directly.
+type staticSource struct{ snap npccfg.Snapshot }
+
+func (s staticSource) Version(context.Context) (int64, error)            { return s.snap.Version, nil }
+func (s staticSource) Snapshot(context.Context) (npccfg.Snapshot, error) { return s.snap, nil }
+
+func newNPCDispatcher(base map[int]int32) (*Dispatcher, *world.World) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := New(Config{Log: log, ItemPrices: base, NpcConfig: staticSource{}})
+	w := world.New(world.Config{GridDim: 32}, log, world.NopPersistence{}, d.Handle)
+	return d, w
+}
+
+// TestApplyNPCConfigSpawnsMerchant checks a boot apply materializes an enabled
+// merchant definition: the entity exists at its position, is a merchant, carries
+// the moderator shop stock, and the global price override lands.
+func TestApplyNPCConfigSpawnsMerchant(t *testing.T) {
+	d, w := newNPCDispatcher(map[int]int32{1100: 999})
+	snap := npccfg.Snapshot{
+		Version: 1,
+		Defs: []npccfg.Definition{{
+			Slug: "shop-1", Template: merchantTemplate("Keeper"), Enabled: true,
+			X: 8, Y: 8, Merchant: 1,
+			Shop: []npccfg.ShopItem{{Slot: 0, Index: 1100}, {Slot: 2, Index: 1101}},
+		}},
+		PriceOverrides: map[int]int32{1100: 500},
+	}
+	d.applyNPCConfig(w, snap, false)
+
+	id, ok := d.managedNPCs["shop-1"]
+	if !ok {
+		t.Fatal("managed NPC not registered")
+	}
+	e := w.Entity(id)
+	if e == nil {
+		t.Fatal("managed NPC entity missing")
+	}
+	if e.Merchant == 0 {
+		t.Errorf("entity Merchant = 0, want merchant")
+	}
+	if e.X != 8 || e.Y != 8 {
+		t.Errorf("entity at (%d,%d), want (8,8)", e.X, e.Y)
+	}
+	if e.Carry[0].Index != 1100 || e.Carry[2].Index != 1101 {
+		t.Errorf("shop stock = [0]=%d [2]=%d, want 1100/1101", e.Carry[0].Index, e.Carry[2].Index)
+	}
+	if e.Carry[1].Index != 0 {
+		t.Errorf("slot 1 = %d, want empty", e.Carry[1].Index)
+	}
+	if d.itemPrices[1100] != 500 {
+		t.Errorf("price[1100] = %d, want overridden 500", d.itemPrices[1100])
+	}
+	if d.npcVersion != 1 {
+		t.Errorf("npcVersion = %d, want 1", d.npcVersion)
+	}
+}
+
+// TestApplyNPCConfigReconcile checks a second snapshot that disables the NPC and
+// clears the price override despawns the entity and restores the base price.
+func TestApplyNPCConfigReconcile(t *testing.T) {
+	d, w := newNPCDispatcher(map[int]int32{1100: 999})
+	tmpl := merchantTemplate("Keeper")
+	d.applyNPCConfig(w, npccfg.Snapshot{
+		Version: 1,
+		Defs: []npccfg.Definition{{
+			Slug: "shop-1", Template: tmpl, Enabled: true, X: 8, Y: 8, Merchant: 1,
+			Shop: []npccfg.ShopItem{{Slot: 0, Index: 1100}},
+		}},
+		PriceOverrides: map[int]int32{1100: 500},
+	}, false)
+	id := d.managedNPCs["shop-1"]
+
+	// Reload: NPC disabled, override gone.
+	d.applyNPCConfig(w, npccfg.Snapshot{
+		Version: 2,
+		Defs: []npccfg.Definition{{
+			Slug: "shop-1", Template: tmpl, Enabled: false, X: 8, Y: 8, Merchant: 1,
+		}},
+	}, false)
+
+	if _, ok := d.managedNPCs["shop-1"]; ok {
+		t.Error("disabled NPC still managed")
+	}
+	if w.Entity(id) != nil {
+		t.Error("disabled NPC entity not despawned")
+	}
+	if d.itemPrices[1100] != 999 {
+		t.Errorf("price[1100] = %d, want base 999 after override cleared", d.itemPrices[1100])
+	}
+	if d.npcVersion != 2 {
+		t.Errorf("npcVersion = %d, want 2", d.npcVersion)
+	}
+}
+
+// TestApplyNPCConfigSkipsInvalid checks definitions with no template or no
+// position are skipped rather than spawned.
+func TestApplyNPCConfigSkipsInvalid(t *testing.T) {
+	d, w := newNPCDispatcher(nil)
+	d.applyNPCConfig(w, npccfg.Snapshot{
+		Version: 1,
+		Defs: []npccfg.Definition{
+			{Slug: "no-template", Enabled: true, X: 5, Y: 5, Merchant: 1},
+			{Slug: "no-pos", Template: merchantTemplate("X"), Enabled: true, X: 0, Y: 0, Merchant: 1},
+		},
+	}, false)
+	if len(d.managedNPCs) != 0 {
+		t.Errorf("managed = %d, want 0 (both invalid)", len(d.managedNPCs))
+	}
+	_ = w
+}

--- a/tmserver/internal/handler/npcconfig_test.go
+++ b/tmserver/internal/handler/npcconfig_test.go
@@ -46,7 +46,12 @@ func TestApplyNPCConfigSpawnsMerchant(t *testing.T) {
 		Defs: []npccfg.Definition{{
 			Slug: "shop-1", Template: merchantTemplate("Keeper"), Enabled: true,
 			X: 8, Y: 8, Merchant: 1,
-			Shop: []npccfg.ShopItem{{Slot: 0, Index: 1100}, {Slot: 2, Index: 1101}},
+			// Slots 0/2 are tab 1 (identity); slot 9 is tab 2 → Carry[27]; slot 18
+			// is tab 3 → Carry[54]. Proves the ShopSlot mapping is applied.
+			Shop: []npccfg.ShopItem{
+				{Slot: 0, Index: 1100}, {Slot: 2, Index: 1101},
+				{Slot: 9, Index: 1102}, {Slot: 18, Index: 1103},
+			},
 		}},
 		PriceOverrides: map[int]int32{1100: 500},
 	}
@@ -68,6 +73,16 @@ func TestApplyNPCConfigSpawnsMerchant(t *testing.T) {
 	}
 	if e.Carry[0].Index != 1100 || e.Carry[2].Index != 1101 {
 		t.Errorf("shop stock = [0]=%d [2]=%d, want 1100/1101", e.Carry[0].Index, e.Carry[2].Index)
+	}
+	// Tabs 2/3 map through ShopSlot: slot 9 → Carry[27], slot 18 → Carry[54].
+	if e.Carry[27].Index != 1102 {
+		t.Errorf("tab-2 slot 9 landed at Carry[27]=%d, want 1102", e.Carry[27].Index)
+	}
+	if e.Carry[54].Index != 1103 {
+		t.Errorf("tab-3 slot 18 landed at Carry[54]=%d, want 1103", e.Carry[54].Index)
+	}
+	if e.Carry[9].Index != 0 || e.Carry[18].Index != 0 {
+		t.Errorf("gap slots written: Carry[9]=%d Carry[18]=%d, want empty", e.Carry[9].Index, e.Carry[18].Index)
 	}
 	if e.Carry[1].Index != 0 {
 		t.Errorf("slot 1 = %d, want empty", e.Carry[1].Index)

--- a/tmserver/internal/npccfg/npccfg.go
+++ b/tmserver/internal/npccfg/npccfg.go
@@ -1,0 +1,46 @@
+// Package npccfg carries the moderator-edited NPC configuration into the
+// tmServer (npc-editing-plan.md). It is a leaf type package: the dbclient
+// implements Source (fetching over gRPC + resolving templates), and the handler
+// applies a Snapshot inside the single-owner loop. The world never writes this
+// back — the flow is one-way (web → Postgres → dbServer → tmServer).
+package npccfg
+
+import "context"
+
+// ShopItem is one merchant shop slot (overlays the template Carry[]). Slot is the
+// positional MSG_ShopList index (0..26). Prices are NOT here — they are global
+// (Snapshot.PriceOverrides).
+type ShopItem struct {
+	Slot  int
+	Index uint16
+	Eff   [3][2]uint8
+}
+
+// Definition is a fully resolved NPC ready to materialize: the raw 816-byte
+// STRUCT_MOB template plus the moderator's overrides (visibility, position, shop).
+// Template is nil when the referenced file could not be loaded — such a
+// definition is skipped by the applier.
+type Definition struct {
+	Slug      string
+	Template  []byte
+	Enabled   bool
+	X, Y      int16
+	RouteType uint8
+	Merchant  uint8
+	Shop      []ShopItem // nil = use the template's own Carry[] as the shop
+}
+
+// Snapshot is the full config at a given version: the definition set plus the
+// global per-item price overrides (item index → price).
+type Snapshot struct {
+	Version        int64
+	Defs           []Definition
+	PriceOverrides map[int]int32
+}
+
+// Source is the tmServer's read side of the NPC config. Version is a cheap poll;
+// Snapshot fetches the full set (only called when the version changed).
+type Source interface {
+	Version(ctx context.Context) (int64, error)
+	Snapshot(ctx context.Context) (Snapshot, error)
+}

--- a/tmserver/internal/world/api.go
+++ b/tmserver/internal/world/api.go
@@ -465,3 +465,21 @@ func (w *World) Go(s *Session, work func() func(*World, *Session)) {
 		}
 	}()
 }
+
+// GoDetached runs blocking work off the loop (like Go) but re-enters with a
+// world-scoped callback — for background maintenance not bound to any session,
+// such as polling the NPC config. The callback runs in the loop goroutine and
+// may mutate world state directly. A nil callback does nothing. It rides the
+// callbacks queue so a slow mob-AI tick never delays it.
+func (w *World) GoDetached(work func() func(*World)) {
+	go func() {
+		cb := work()
+		if cb == nil {
+			return
+		}
+		select {
+		case w.callbacks <- worldCallbackEvent{cb: cb}:
+		case <-w.done:
+		}
+	}()
+}

--- a/tmserver/internal/world/event.go
+++ b/tmserver/internal/world/event.go
@@ -112,6 +112,16 @@ func (e callbackEvent) apply(w *World) {
 	e.cb(w, e.sess)
 }
 
+// worldCallbackEvent carries the result of off-loop work that is NOT tied to a
+// session (World.GoDetached) — e.g. an NPC-config reload. It always applies (no
+// session-liveness guard), so its callback runs inside the loop goroutine and
+// may mutate world state directly.
+type worldCallbackEvent struct {
+	cb func(*World)
+}
+
+func (e worldCallbackEvent) apply(w *World) { e.cb(w) }
+
 // --- disconnect ---
 
 type disconnectEvent struct {

--- a/tmserver/internal/world/world.go
+++ b/tmserver/internal/world/world.go
@@ -128,8 +128,8 @@ type World struct {
 	cargo map[int64]*CargoState
 
 	events    chan event
-	callbacks chan callbackEvent // async handler results (World.Go); separate from
-	// events so a long mob-AI tick cannot block login/db callbacks on the main queue.
+	callbacks chan event // async handler results (World.Go / World.GoDetached); separate
+	// from events so a long mob-AI tick cannot block login/db callbacks on the main queue.
 	done   chan struct{}  // closed when the loop stops; unblocks conn goroutines
 	saveWG sync.WaitGroup // tracks in-flight async character saves (logout/disconnect)
 
@@ -183,7 +183,7 @@ func New(cfg Config, log *slog.Logger, persist Persistence, handler Handler) *Wo
 		grid:      newGrid(cfg.GridDim),
 		rng:       rng.New(),
 		events:    make(chan event, cfg.EventQueue),
-		callbacks: make(chan callbackEvent, 256),
+		callbacks: make(chan event, 256),
 		done:      make(chan struct{}),
 	}
 }

--- a/webserver/cmd/webserver/main.go
+++ b/webserver/cmd/webserver/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jeanluca/w2pp-openwyd/internal/store"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/account"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/grpcsrv"
+	"github.com/jeanluca/w2pp-openwyd/webserver/internal/npcadmin"
 )
 
 func main() {
@@ -69,7 +70,9 @@ func run(logger *slog.Logger) error {
 		return err
 	}
 	srv := grpc.NewServer(grpc.Creds(creds))
-	webv1.RegisterAccountWebServiceServer(srv, grpcsrv.New(account.New(store.New(pool))))
+	st := store.New(pool)
+	webv1.RegisterAccountWebServiceServer(srv, grpcsrv.New(account.New(st)))
+	webv1.RegisterNpcAdminServiceServer(srv, grpcsrv.NewNpcAdmin(npcadmin.New(st)))
 
 	ln, err := net.Listen("tcp", *addr)
 	if err != nil {

--- a/webserver/internal/account/service.go
+++ b/webserver/internal/account/service.go
@@ -97,24 +97,26 @@ func (s *Service) Create(ctx context.Context, name, password, email string) (Cre
 // Verify reports whether name+password match a stored account. A missing account
 // or wrong password both return ok=false (no account enumeration via timing is
 // attempted here beyond the constant-time hash compare). blocked reflects
-// account.is_blocked so the caller can decide how to surface a banned login.
-func (s *Service) Verify(ctx context.Context, name, password string) (ok bool, accountID int64, blocked bool, err error) {
+// account.is_blocked; role is account.role ('player'/'moderator'/'admin') so the
+// BFF can gate the moderator UI — authorization itself stays server-side in the
+// NpcAdminService, this is only a UI hint.
+func (s *Service) Verify(ctx context.Context, name, password string) (ok bool, accountID int64, blocked bool, role string, err error) {
 	canonical := strings.ToLower(strings.TrimSpace(name))
 	auth, err := s.store.AccountByName(ctx, canonical)
 	if errors.Is(err, store.ErrNotFound) {
-		return false, 0, false, nil
+		return false, 0, false, "", nil
 	}
 	if err != nil {
-		return false, 0, false, fmt.Errorf("account: lookup %q: %w", canonical, err)
+		return false, 0, false, "", fmt.Errorf("account: lookup %q: %w", canonical, err)
 	}
 	match, err := secret.VerifySecret(password, auth.PassHash)
 	if err != nil {
-		return false, 0, false, fmt.Errorf("account: verify password: %w", err)
+		return false, 0, false, "", fmt.Errorf("account: verify password: %w", err)
 	}
 	if !match {
-		return false, 0, false, nil
+		return false, 0, false, "", nil
 	}
-	return true, auth.ID, auth.IsBlocked, nil
+	return true, auth.ID, auth.IsBlocked, auth.Role, nil
 }
 
 // validName enforces the 4–12 ASCII-alphanumeric login rule on an already

--- a/webserver/internal/account/service_test.go
+++ b/webserver/internal/account/service_test.go
@@ -102,7 +102,7 @@ func TestVerify(t *testing.T) {
 		t.Fatalf("hash: %v", err)
 	}
 	fs := &fakeStore{byName: map[string]store.AccountAuth{
-		"alice":  {ID: 1, PassHash: hash},
+		"alice":  {ID: 1, PassHash: hash, Role: "moderator"},
 		"banned": {ID: 2, PassHash: hash, IsBlocked: true},
 	}}
 	s := New(fs)
@@ -111,21 +111,22 @@ func TestVerify(t *testing.T) {
 		name, login, pass string
 		wantOK, wantBlk   bool
 		wantID            int64
+		wantRole          string
 	}{
-		{"ok", "Alice", pw, true, false, 1},
-		{"wrong password", "alice", "nope", false, false, 0},
-		{"no account", "ghost", pw, false, false, 0},
-		{"blocked but valid", "banned", pw, true, true, 2},
+		{"ok moderator", "Alice", pw, true, false, 1, "moderator"},
+		{"wrong password", "alice", "nope", false, false, 0, ""},
+		{"no account", "ghost", pw, false, false, 0, ""},
+		{"blocked but valid", "banned", pw, true, true, 2, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			ok, id, blocked, err := s.Verify(context.Background(), tc.login, tc.pass)
+			ok, id, blocked, role, err := s.Verify(context.Background(), tc.login, tc.pass)
 			if err != nil {
 				t.Fatalf("Verify: %v", err)
 			}
-			if ok != tc.wantOK || blocked != tc.wantBlk || id != tc.wantID {
-				t.Fatalf("got ok=%v blocked=%v id=%d; want ok=%v blocked=%v id=%d",
-					ok, blocked, id, tc.wantOK, tc.wantBlk, tc.wantID)
+			if ok != tc.wantOK || blocked != tc.wantBlk || id != tc.wantID || role != tc.wantRole {
+				t.Fatalf("got ok=%v blocked=%v id=%d role=%q; want ok=%v blocked=%v id=%d role=%q",
+					ok, blocked, id, role, tc.wantOK, tc.wantBlk, tc.wantID, tc.wantRole)
 			}
 		})
 	}

--- a/webserver/internal/grpcsrv/npcadmin.go
+++ b/webserver/internal/grpcsrv/npcadmin.go
@@ -1,0 +1,158 @@
+package grpcsrv
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	webv1 "github.com/jeanluca/w2pp-openwyd/api/web/v1"
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+	"github.com/jeanluca/w2pp-openwyd/webserver/internal/npcadmin"
+)
+
+// NpcAdmin is the moderator NPC-editing surface the server depends on (satisfied
+// by *npcadmin.Service). Kept as an interface so the server is unit-testable.
+type NpcAdmin interface {
+	List(ctx context.Context, moderatorID int64) (npcadmin.Result, []domain.NPCDefinition, error)
+	Get(ctx context.Context, moderatorID, npcID int64) (npcadmin.Result, domain.NPCDefinition, error)
+	Upsert(ctx context.Context, moderatorID int64, d domain.NPCDefinition) (npcadmin.Result, int64, error)
+	SetVisibility(ctx context.Context, moderatorID, npcID int64, enabled bool) (npcadmin.Result, error)
+	SetShop(ctx context.Context, moderatorID, npcID int64, items []domain.NPCShopItem) (npcadmin.Result, error)
+	SetItemPrice(ctx context.Context, moderatorID int64, itemIndex int32, price int64) (npcadmin.Result, error)
+	Delete(ctx context.Context, moderatorID, npcID int64) (npcadmin.Result, error)
+}
+
+// NpcAdminServer implements webv1.NpcAdminServiceServer.
+type NpcAdminServer struct {
+	webv1.UnimplementedNpcAdminServiceServer
+	admin NpcAdmin
+}
+
+// NewNpcAdmin builds the NpcAdminService over the given admin logic.
+func NewNpcAdmin(a NpcAdmin) *NpcAdminServer { return &NpcAdminServer{admin: a} }
+
+// ListNpcs returns every NPC definition (after authorization).
+func (s *NpcAdminServer) ListNpcs(ctx context.Context, req *webv1.ListNpcsRequest) (*webv1.ListNpcsResponse, error) {
+	res, defs, err := s.admin.List(ctx, req.GetModeratorId())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list npcs: %v", err)
+	}
+	out := make([]*webv1.AdminNpc, 0, len(defs))
+	for _, d := range defs {
+		out = append(out, adminNpcToProto(d))
+	}
+	return &webv1.ListNpcsResponse{Result: resultToProto(res), Npcs: out}, nil
+}
+
+// GetNpc returns one definition with its shop stock.
+func (s *NpcAdminServer) GetNpc(ctx context.Context, req *webv1.GetNpcRequest) (*webv1.GetNpcResponse, error) {
+	res, def, err := s.admin.Get(ctx, req.GetModeratorId(), req.GetNpcId())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "get npc: %v", err)
+	}
+	resp := &webv1.GetNpcResponse{Result: resultToProto(res)}
+	if res == npcadmin.OK {
+		resp.Npc = adminNpcToProto(def)
+	}
+	return resp, nil
+}
+
+// UpsertNpc creates or updates a definition.
+func (s *NpcAdminServer) UpsertNpc(ctx context.Context, req *webv1.UpsertNpcRequest) (*webv1.UpsertNpcResponse, error) {
+	def := domain.NPCDefinition{
+		Slug:         req.GetSlug(),
+		TemplateName: req.GetTemplateName(),
+		DisplayName:  req.GetDisplayName(),
+		Enabled:      req.GetEnabled(),
+		MapID:        req.GetMapId(),
+		PosX:         req.GetPosX(),
+		PosY:         req.GetPosY(),
+		RouteType:    int16(req.GetRouteType()),
+		Merchant:     int16(req.GetMerchant()),
+	}
+	res, id, err := s.admin.Upsert(ctx, req.GetModeratorId(), def)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "upsert npc: %v", err)
+	}
+	return &webv1.UpsertNpcResponse{Result: resultToProto(res), NpcId: id}, nil
+}
+
+// SetNpcVisibility toggles whether the NPC appears.
+func (s *NpcAdminServer) SetNpcVisibility(ctx context.Context, req *webv1.SetNpcVisibilityRequest) (*webv1.AdminAck, error) {
+	res, err := s.admin.SetVisibility(ctx, req.GetModeratorId(), req.GetNpcId(), req.GetEnabled())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "set visibility: %v", err)
+	}
+	return &webv1.AdminAck{Result: resultToProto(res)}, nil
+}
+
+// SetNpcShop replaces a merchant NPC's shop stock.
+func (s *NpcAdminServer) SetNpcShop(ctx context.Context, req *webv1.SetNpcShopRequest) (*webv1.AdminAck, error) {
+	items := make([]domain.NPCShopItem, 0, len(req.GetItems()))
+	for _, it := range req.GetItems() {
+		items = append(items, protoToShopItem(it))
+	}
+	res, err := s.admin.SetShop(ctx, req.GetModeratorId(), req.GetNpcId(), items)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "set shop: %v", err)
+	}
+	return &webv1.AdminAck{Result: resultToProto(res)}, nil
+}
+
+// SetItemPrice sets or clears the global price of an item.
+func (s *NpcAdminServer) SetItemPrice(ctx context.Context, req *webv1.SetItemPriceRequest) (*webv1.AdminAck, error) {
+	res, err := s.admin.SetItemPrice(ctx, req.GetModeratorId(), req.GetItemIndex(), req.GetPrice())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "set item price: %v", err)
+	}
+	return &webv1.AdminAck{Result: resultToProto(res)}, nil
+}
+
+// DeleteNpc removes a definition.
+func (s *NpcAdminServer) DeleteNpc(ctx context.Context, req *webv1.DeleteNpcRequest) (*webv1.AdminAck, error) {
+	res, err := s.admin.Delete(ctx, req.GetModeratorId(), req.GetNpcId())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "delete npc: %v", err)
+	}
+	return &webv1.AdminAck{Result: resultToProto(res)}, nil
+}
+
+func adminNpcToProto(d domain.NPCDefinition) *webv1.AdminNpc {
+	shop := make([]*webv1.AdminNpcShopItem, 0, len(d.Shop))
+	for _, it := range d.Shop {
+		shop = append(shop, &webv1.AdminNpcShopItem{
+			Slot: int32(it.Slot), ItemIndex: it.ItemIndex,
+			Eff1: int32(it.Eff1), Effv1: int32(it.EffV1),
+			Eff2: int32(it.Eff2), Effv2: int32(it.EffV2),
+			Eff3: int32(it.Eff3), Effv3: int32(it.EffV3),
+		})
+	}
+	return &webv1.AdminNpc{
+		Id: d.ID, Slug: d.Slug, TemplateName: d.TemplateName, DisplayName: d.DisplayName,
+		Enabled: d.Enabled, MapId: d.MapID, PosX: d.PosX, PosY: d.PosY,
+		RouteType: int32(d.RouteType), Merchant: int32(d.Merchant), Shop: shop,
+	}
+}
+
+func protoToShopItem(it *webv1.AdminNpcShopItem) domain.NPCShopItem {
+	return domain.NPCShopItem{
+		Slot: int16(it.GetSlot()), ItemIndex: it.GetItemIndex(),
+		Eff1: uint8(it.GetEff1()), EffV1: uint8(it.GetEffv1()),
+		Eff2: uint8(it.GetEff2()), EffV2: uint8(it.GetEffv2()),
+		Eff3: uint8(it.GetEff3()), EffV3: uint8(it.GetEffv3()),
+	}
+}
+
+func resultToProto(r npcadmin.Result) webv1.AdminResult {
+	switch r {
+	case npcadmin.OK:
+		return webv1.AdminResult_ADMIN_RESULT_OK
+	case npcadmin.Forbidden:
+		return webv1.AdminResult_ADMIN_RESULT_FORBIDDEN
+	case npcadmin.NotFound:
+		return webv1.AdminResult_ADMIN_RESULT_NOT_FOUND
+	default:
+		return webv1.AdminResult_ADMIN_RESULT_INVALID
+	}
+}

--- a/webserver/internal/grpcsrv/server.go
+++ b/webserver/internal/grpcsrv/server.go
@@ -17,7 +17,7 @@ import (
 // *account.Service). Kept as an interface so the server is unit-testable.
 type Accounts interface {
 	Create(ctx context.Context, name, password, email string) (account.CreateResult, int64, error)
-	Verify(ctx context.Context, name, password string) (ok bool, accountID int64, blocked bool, err error)
+	Verify(ctx context.Context, name, password string) (ok bool, accountID int64, blocked bool, role string, err error)
 }
 
 // Server implements webv1.AccountWebServiceServer.
@@ -41,11 +41,11 @@ func (s *Server) CreateAccount(ctx context.Context, req *webv1.CreateAccountRequ
 
 // VerifyCredentials validates name + password for the BFF session cookie.
 func (s *Server) VerifyCredentials(ctx context.Context, req *webv1.VerifyCredentialsRequest) (*webv1.VerifyCredentialsResponse, error) {
-	ok, id, blocked, err := s.accounts.Verify(ctx, req.GetName(), req.GetPassword())
+	ok, id, blocked, role, err := s.accounts.Verify(ctx, req.GetName(), req.GetPassword())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "verify credentials: %v", err)
 	}
-	return &webv1.VerifyCredentialsResponse{Ok: ok, AccountId: id, Blocked: blocked}, nil
+	return &webv1.VerifyCredentialsResponse{Ok: ok, AccountId: id, Blocked: blocked, Role: role}, nil
 }
 
 // createResultToProto maps the domain outcome to the wire enum.

--- a/webserver/internal/grpcsrv/server_test.go
+++ b/webserver/internal/grpcsrv/server_test.go
@@ -15,18 +15,19 @@ type fakeAccounts struct {
 	createID  int64
 	createErr error
 
-	verifyOK  bool
-	verifyID  int64
-	verifyBlk bool
-	verifyErr error
+	verifyOK   bool
+	verifyID   int64
+	verifyBlk  bool
+	verifyRole string
+	verifyErr  error
 }
 
 func (f *fakeAccounts) Create(context.Context, string, string, string) (account.CreateResult, int64, error) {
 	return f.createRes, f.createID, f.createErr
 }
 
-func (f *fakeAccounts) Verify(context.Context, string, string) (bool, int64, bool, error) {
-	return f.verifyOK, f.verifyID, f.verifyBlk, f.verifyErr
+func (f *fakeAccounts) Verify(context.Context, string, string) (bool, int64, bool, string, error) {
+	return f.verifyOK, f.verifyID, f.verifyBlk, f.verifyRole, f.verifyErr
 }
 
 func TestCreateAccountMapping(t *testing.T) {

--- a/webserver/internal/npcadmin/service.go
+++ b/webserver/internal/npcadmin/service.go
@@ -1,0 +1,188 @@
+// Package npcadmin holds the web platform's moderator NPC-editing logic
+// (npc-editing-plan.md): CRUD over the cold NPC definition in Postgres, gated by
+// account.role and recorded in the audit trail by the store. It never touches
+// live game state — that stays in tmServer's single-owner loop; the tmServer
+// polls the config version and materializes the definitions.
+package npcadmin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+	"github.com/jeanluca/w2pp-openwyd/internal/store"
+)
+
+// Store is the persistence surface the service needs (satisfied by *store.Store).
+type Store interface {
+	AccountRole(ctx context.Context, id int64) (string, error)
+	ListNPCDefinitions(ctx context.Context) ([]domain.NPCDefinition, error)
+	GetNPCDefinition(ctx context.Context, id int64) (domain.NPCDefinition, error)
+	UpsertNPCDefinition(ctx context.Context, d domain.NPCDefinition, moderatorID int64) (int64, error)
+	SetNPCShop(ctx context.Context, npcID int64, items []domain.NPCShopItem, moderatorID int64) error
+	SetNPCVisibility(ctx context.Context, npcID int64, enabled bool, moderatorID int64) error
+	SetItemPrice(ctx context.Context, itemIndex int32, price int64, moderatorID int64) error
+	DeleteNPCDefinition(ctx context.Context, npcID int64, moderatorID int64) error
+}
+
+// Result is the business outcome of an admin operation. Only infra failures are
+// returned as errors; these ride in the response body.
+type Result int
+
+const (
+	// OK means the operation succeeded.
+	OK Result = iota
+	// Forbidden means the caller is not a moderator/admin.
+	Forbidden
+	// Invalid means the request failed validation.
+	Invalid
+	// NotFound means the target definition does not exist.
+	NotFound
+)
+
+// Shop slots mirror MSG_ShopList's 27 entries; a merchant NPC's stock lives in
+// slots 0..26. maxSlot bounds shop-item validation.
+const maxSlot = 26
+
+// Service implements the moderator NPC-editing operations.
+type Service struct {
+	store Store
+}
+
+// New builds the service over the given store.
+func New(s Store) *Service { return &Service{store: s} }
+
+// List returns every NPC definition, after authorizing the caller.
+func (s *Service) List(ctx context.Context, moderatorID int64) (Result, []domain.NPCDefinition, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, nil, err
+	}
+	defs, err := s.store.ListNPCDefinitions(ctx)
+	if err != nil {
+		return Invalid, nil, fmt.Errorf("npcadmin: list: %w", err)
+	}
+	return OK, defs, nil
+}
+
+// Get returns one definition by id.
+func (s *Service) Get(ctx context.Context, moderatorID, npcID int64) (Result, domain.NPCDefinition, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, domain.NPCDefinition{}, err
+	}
+	def, err := s.store.GetNPCDefinition(ctx, npcID)
+	if errors.Is(err, store.ErrNotFound) {
+		return NotFound, domain.NPCDefinition{}, nil
+	}
+	if err != nil {
+		return Invalid, domain.NPCDefinition{}, fmt.Errorf("npcadmin: get %d: %w", npcID, err)
+	}
+	return OK, def, nil
+}
+
+// Upsert creates or updates a definition (position, visibility, merchant type).
+func (s *Service) Upsert(ctx context.Context, moderatorID int64, d domain.NPCDefinition) (Result, int64, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, 0, err
+	}
+	if d.Slug == "" || d.TemplateName == "" || !validMerchant(d.Merchant) {
+		return Invalid, 0, nil
+	}
+	id, err := s.store.UpsertNPCDefinition(ctx, d, moderatorID)
+	if err != nil {
+		return Invalid, 0, fmt.Errorf("npcadmin: upsert %q: %w", d.Slug, err)
+	}
+	return OK, id, nil
+}
+
+// SetVisibility toggles whether the NPC appears in the world.
+func (s *Service) SetVisibility(ctx context.Context, moderatorID, npcID int64, enabled bool) (Result, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, err
+	}
+	err := s.store.SetNPCVisibility(ctx, npcID, enabled, moderatorID)
+	return classifyWrite(err, "set visibility")
+}
+
+// SetShop replaces a merchant NPC's shop stock after validating the slots.
+func (s *Service) SetShop(ctx context.Context, moderatorID, npcID int64, items []domain.NPCShopItem) (Result, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, err
+	}
+	seen := make(map[int16]bool, len(items))
+	for _, it := range items {
+		if it.Slot < 0 || it.Slot > maxSlot || it.ItemIndex <= 0 || seen[it.Slot] {
+			return Invalid, nil
+		}
+		seen[it.Slot] = true
+	}
+	err := s.store.SetNPCShop(ctx, npcID, items, moderatorID)
+	return classifyWrite(err, "set shop")
+}
+
+// SetItemPrice sets (price>=0) or clears (price<0) the global item price.
+func (s *Service) SetItemPrice(ctx context.Context, moderatorID int64, itemIndex int32, price int64) (Result, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, err
+	}
+	if itemIndex <= 0 {
+		return Invalid, nil
+	}
+	if err := s.store.SetItemPrice(ctx, itemIndex, price, moderatorID); err != nil {
+		return Invalid, fmt.Errorf("npcadmin: set item price %d: %w", itemIndex, err)
+	}
+	return OK, nil
+}
+
+// Delete removes a definition.
+func (s *Service) Delete(ctx context.Context, moderatorID, npcID int64) (Result, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, err
+	}
+	err := s.store.DeleteNPCDefinition(ctx, npcID, moderatorID)
+	return classifyWrite(err, "delete")
+}
+
+// authorize checks the caller has a moderator/admin role. A missing account or a
+// plain-player role yields Forbidden (never leaks whether the account exists).
+func (s *Service) authorize(ctx context.Context, moderatorID int64) (Result, error) {
+	if moderatorID <= 0 {
+		return Forbidden, nil
+	}
+	role, err := s.store.AccountRole(ctx, moderatorID)
+	if errors.Is(err, store.ErrNotFound) {
+		return Forbidden, nil
+	}
+	if err != nil {
+		return Invalid, fmt.Errorf("npcadmin: role lookup %d: %w", moderatorID, err)
+	}
+	if role != "moderator" && role != "admin" {
+		return Forbidden, nil
+	}
+	return OK, nil
+}
+
+// classifyWrite maps a store write error to a Result: ErrNotFound → NotFound,
+// nil → OK, anything else → Invalid (wrapped).
+func classifyWrite(err error, op string) (Result, error) {
+	switch {
+	case err == nil:
+		return OK, nil
+	case errors.Is(err, store.ErrNotFound):
+		return NotFound, nil
+	default:
+		return Invalid, fmt.Errorf("npcadmin: %s: %w", op, err)
+	}
+}
+
+// validMerchant accepts the merchant sub-types the game knows: 0 (none/monster),
+// 1 (shop), 2 (cargo guard), 19 (shop type 3), 100 (quest NPC). Others are
+// rejected until confirmed by capture (npc-editing-plan.md §9.4).
+func validMerchant(m int16) bool {
+	switch m {
+	case 0, 1, 2, 19, 100:
+		return true
+	default:
+		return false
+	}
+}

--- a/webserver/internal/npcadmin/service_test.go
+++ b/webserver/internal/npcadmin/service_test.go
@@ -1,0 +1,185 @@
+package npcadmin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+	"github.com/jeanluca/w2pp-openwyd/internal/store"
+)
+
+// fakeStore is an in-memory Store for exercising the service's authorization and
+// validation without a database.
+type fakeStore struct {
+	roles      map[int64]string
+	defs       map[int64]domain.NPCDefinition
+	upsertErr  error
+	lastShop   []domain.NPCShopItem
+	lastPrice  *int64
+	deletedID  int64
+	visibility *bool
+}
+
+func (f *fakeStore) AccountRole(_ context.Context, id int64) (string, error) {
+	r, ok := f.roles[id]
+	if !ok {
+		return "", store.ErrNotFound
+	}
+	return r, nil
+}
+func (f *fakeStore) ListNPCDefinitions(context.Context) ([]domain.NPCDefinition, error) {
+	out := make([]domain.NPCDefinition, 0, len(f.defs))
+	for _, d := range f.defs {
+		out = append(out, d)
+	}
+	return out, nil
+}
+func (f *fakeStore) GetNPCDefinition(_ context.Context, id int64) (domain.NPCDefinition, error) {
+	d, ok := f.defs[id]
+	if !ok {
+		return domain.NPCDefinition{}, store.ErrNotFound
+	}
+	return d, nil
+}
+func (f *fakeStore) UpsertNPCDefinition(_ context.Context, _ domain.NPCDefinition, _ int64) (int64, error) {
+	if f.upsertErr != nil {
+		return 0, f.upsertErr
+	}
+	return 42, nil
+}
+func (f *fakeStore) SetNPCShop(_ context.Context, id int64, items []domain.NPCShopItem, _ int64) error {
+	if _, ok := f.defs[id]; !ok {
+		return store.ErrNotFound
+	}
+	f.lastShop = items
+	return nil
+}
+func (f *fakeStore) SetNPCVisibility(_ context.Context, id int64, enabled bool, _ int64) error {
+	if _, ok := f.defs[id]; !ok {
+		return store.ErrNotFound
+	}
+	f.visibility = &enabled
+	return nil
+}
+func (f *fakeStore) SetItemPrice(_ context.Context, _ int32, price int64, _ int64) error {
+	f.lastPrice = &price
+	return nil
+}
+func (f *fakeStore) DeleteNPCDefinition(_ context.Context, id int64, _ int64) error {
+	if _, ok := f.defs[id]; !ok {
+		return store.ErrNotFound
+	}
+	f.deletedID = id
+	return nil
+}
+
+func newFake() *fakeStore {
+	return &fakeStore{
+		roles: map[int64]string{1: "moderator", 2: "admin", 3: "player"},
+		defs:  map[int64]domain.NPCDefinition{10: {ID: 10, Slug: "shop-10", Merchant: 1}},
+	}
+}
+
+// TestAuthorization checks every operation refuses non-moderators. A player, a
+// missing account, and a zero id all yield Forbidden; a moderator/admin passes.
+func TestAuthorization(t *testing.T) {
+	tests := []struct {
+		name       string
+		moderator  int64
+		wantResult Result
+	}{
+		{"moderator ok", 1, OK},
+		{"admin ok", 2, OK},
+		{"player forbidden", 3, Forbidden},
+		{"missing account forbidden", 99, Forbidden},
+		{"zero id forbidden", 0, Forbidden},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := New(newFake())
+			got, _, err := s.List(context.Background(), tt.moderator)
+			if err != nil {
+				t.Fatalf("List: %v", err)
+			}
+			if got != tt.wantResult {
+				t.Errorf("List result = %v, want %v", got, tt.wantResult)
+			}
+		})
+	}
+}
+
+func TestUpsertValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		def  domain.NPCDefinition
+		want Result
+	}{
+		{"ok", domain.NPCDefinition{Slug: "s", TemplateName: "t", Merchant: 1}, OK},
+		{"empty slug", domain.NPCDefinition{TemplateName: "t"}, Invalid},
+		{"empty template", domain.NPCDefinition{Slug: "s"}, Invalid},
+		{"bad merchant", domain.NPCDefinition{Slug: "s", TemplateName: "t", Merchant: 7}, Invalid},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := New(newFake())
+			got, _, err := s.Upsert(context.Background(), 1, tt.def)
+			if err != nil {
+				t.Fatalf("Upsert: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Upsert result = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetShopValidation(t *testing.T) {
+	tests := []struct {
+		name  string
+		items []domain.NPCShopItem
+		want  Result
+	}{
+		{"ok", []domain.NPCShopItem{{Slot: 0, ItemIndex: 1100}, {Slot: 1, ItemIndex: 1101}}, OK},
+		{"slot too high", []domain.NPCShopItem{{Slot: 27, ItemIndex: 1100}}, Invalid},
+		{"negative slot", []domain.NPCShopItem{{Slot: -1, ItemIndex: 1100}}, Invalid},
+		{"zero item", []domain.NPCShopItem{{Slot: 0, ItemIndex: 0}}, Invalid},
+		{"duplicate slot", []domain.NPCShopItem{{Slot: 0, ItemIndex: 1100}, {Slot: 0, ItemIndex: 1101}}, Invalid},
+		{"empty shop ok", nil, OK},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := New(newFake())
+			got, err := s.SetShop(context.Background(), 1, 10, tt.items)
+			if err != nil {
+				t.Fatalf("SetShop: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("SetShop result = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSetShopNotFound checks a write to a missing definition surfaces NotFound.
+func TestSetShopNotFound(t *testing.T) {
+	s := New(newFake())
+	got, err := s.SetShop(context.Background(), 1, 999, []domain.NPCShopItem{{Slot: 0, ItemIndex: 1100}})
+	if err != nil {
+		t.Fatalf("SetShop: %v", err)
+	}
+	if got != NotFound {
+		t.Errorf("SetShop result = %v, want NotFound", got)
+	}
+}
+
+// TestDeleteNotFound checks deleting a missing definition surfaces NotFound.
+func TestDeleteNotFound(t *testing.T) {
+	s := New(newFake())
+	got, err := s.Delete(context.Background(), 1, 999)
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if got != NotFound {
+		t.Errorf("Delete result = %v, want NotFound", got)
+	}
+}


### PR DESCRIPTION
## Resumo

Backend + estruturas de dados para **moderadores de jogo editarem NPCs pela web** (`docs/migration/npc-editing-plan.md`): se o NPC **aparece ou não**, **onde** fica, e **quais itens vende** (preço é **global** por item). Sem front-end — a mesma borda `web-api` do `web-platform-plan.md`.

Inclui o documento de plano (aprovado) e a implementação completa (M0–M3: modelo → seed → leitura no dbServer → overlay + hot-reload no tmServer → CRUD web).

## Invariante preservada

Fluxo de **via única** — a web escreve config fria no Postgres, o dbServer serve leituras, o tmServer **materializa** as entidades vivas dentro do loop single-owner. A web **nunca** toca estado vivo, então não há o risco de clobber que exige `delivery_queue` para concessões.

## Mudanças

**Modelo (migration `0005_npc_editing`)**
- `npc_definition`, `npc_shop_item`, `item_price` (override global de preço), `npc_config_meta` (versão p/ hot-reload), `npc_audit`; `account.role` p/ autorização.
- Tipos em `internal/domain`; CRUD transacional em `internal/store/npc.go` (auditoria + bump de versão na mesma tx), `SeedNPCDefinitions`, teste de integração.

**Serviços gRPC**
- `api/db/v1` `NpcConfigService` (`NpcConfigVersion`, `ListNpcDefinitions`) servido pelo dbServer.
- `dbserver import-npcs`: seeda blocos merchant do `NPCGener.txt` (lê `CurrentScore.Merchant` via `savefmt.DecodeMob`).
- `api/web/v1` `NpcAdminService` na web-api: CRUD com papel (`moderator`/`admin`), validação e auditoria.

**tmServer — overlay no boot + hot-reload**
- `npccfg` (tipos + `Source`), `dbclient` resolve bytes do template, `World.GoDetached` (trabalho off-loop sem sessão re-entrando no loop).
- No boot, materializa os merchants do banco e **pula** os blocos merchant do `NPCGener.txt` (sem spawn duplo); monstros continuam do `.txt`.
- Poll de versão recarrega e reconcilia dentro do loop (spawn/despawn/mover/`Carry`) + mescla overrides globais de preço.

## Decisões (perguntas em aberto resolvidas)

- Preço **global** por item (não override por-NPC).
- Posição **só ponto de spawn** (`map_id + x/y`).
- Edição **por definição/bloco**.
- NPCs geridos pelo banco = subconjunto **merchant**.

## Testes

- `go build ./...`, `go vet ./...`, `gofmt`, `golangci-lint` (sem novos issues) — limpos.
- `go test -race ./...` — verde. Novos: `npcadmin` (authz/validação), `handler` (apply/reconcile de NPC + preço), store (`-tags=integration`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TdmtCVxY41stkF5k3eghn