### PR TITLE
fix: propagate AttackRun speed byte through CreateMob/score packets

### DIFF
--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -319,6 +319,7 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 		Level: int32(st.Level), Ac: st.AC, Damage: st.Damage,
 		MaxHp: st.MaxHP, MaxMp: st.MaxMP, Hp: st.HP, Mp: st.MP,
 		Str: st.Str, Int: st.Int, Dex: st.Dex, Con: st.Con,
+		AttackRun:  baseAttackRun,
 		ScoreBonus: st.ScoreBonus, GuildLevel: st.GuildLevel,
 		LearnedSkill: skill.LearnedSkill, SpecialBonus: skill.SpecialBonus,
 		SkillBonus: skill.SkillBonus, Special: skill.Special, SkillBar: skill.SkillBar,
@@ -411,6 +412,7 @@ func createMobFrom(e *world.Entity, createType uint16) protocol.CreateMobData {
 		Hp:              e.HP,
 		Str:             e.Str, Int: e.Int, Dex: e.Dex, Con: e.Con,
 		Merchant:   e.Merchant,
+		AttackRun:  attackRunOf(e),
 		Equip:      e.EquipVisual,
 		CreateType: createType,
 	}

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -601,7 +601,7 @@ func (d *Dispatcher) computeScore(e *world.Entity) protocol.ScoreData {
 		MaxHp: effectiveMaxHP(e), Hp: e.HP, MaxMp: effectiveMaxMP(e), Mp: e.MP,
 		Str: e.Str, Int: e.Int, Dex: e.Dex, Con: e.Con + e.AffCon,
 		Special:    special,
-		AttackRun:  baseAttackRun,
+		AttackRun:  attackRunOf(e),
 		SaveMana:   uint8(e.SaveMana),
 		Guild:      e.Guild,
 		GuildLevel: uint16(e.GuildLevel),
@@ -620,11 +620,24 @@ func (d *Dispatcher) computeScore(e *world.Entity) protocol.ScoreData {
 	for i := range sc.Resist {
 		sc.Resist[i] = int8(e.Resist[i] + e.AffResist[i])
 	}
-	// A mount in the mount slot raises the move-speed (low) nibble of AttackRun.
-	if !e.Equip[mountEquipSlot].Empty() {
-		sc.AttackRun = (baseAttackRun & 0xF0) | mountedMoveSpeed
-	}
 	return sc
+}
+
+// attackRunOf is the entity's live speed byte (run<<4 | move). Players get the
+// class base plus the mount bump; mobs carry their template's CurrentScore
+// value (set at spawn). Every S→C score/snapshot (UpdateScore, CreateMob, the
+// login MOB blob) must carry it: the client animates walks — its own and remote
+// entities' — at this speed, and a 0 here renders a crawling, rubber-banding
+// avatar.
+func attackRunOf(e *world.Entity) uint8 {
+	if !world.IsPlayer(e.ID) {
+		return e.AttackRun
+	}
+	// A mount in the mount slot raises the move-speed (low) nibble.
+	if !e.Equip[mountEquipSlot].Empty() {
+		return (baseAttackRun & 0xF0) | mountedMoveSpeed
+	}
+	return baseAttackRun
 }
 
 // sendScore pushes the recomputed CurrentScore to the player (_MSG_UpdateScore), so

--- a/tmserver/internal/handler/view_test.go
+++ b/tmserver/internal/handler/view_test.go
@@ -163,6 +163,14 @@ func TestMoveViewDelta(t *testing.T) {
 	if x, y, id := createMobFields(t, payload); id != 2 || x != 5 || y != 21 {
 		t.Errorf("A sees B = id %d at (%d,%d), want id 2 at (5,21)", id, x, y)
 	}
+	// The snapshot must carry the player's speed byte (Score.AttackRun @body137):
+	// a 0 here makes the remote client animate the avatar at crawl speed and
+	// rubber-band to catch up (the "anda devagar + teleporta" bug). Fresh test
+	// chars get the starter Shire mount, so the move nibble is the mounted 5:
+	// (82 & 0xF0) | 5 = 85.
+	if payload[124+13] != 85 {
+		t.Errorf("A sees B with AttackRun %d, want 85 (mounted starter char)", payload[124+13])
+	}
 	if ty, _, ok = readMaybeRaw(t, a); !ok || ty != protocol.MsgPKInfo {
 		t.Fatalf("A frame 2 = %#x ok=%v, want PKInfo", ty, ok)
 	}

--- a/tmserver/internal/protocol/createmob.go
+++ b/tmserver/internal/protocol/createmob.go
@@ -24,6 +24,7 @@ type CreateMobData struct {
 	MaxHp, MaxMp, Hp, Mp int32
 	Str, Int, Dex, Con   int16
 	Merchant             uint8 // NPC type (shop/bank/…); makes the name always-visible
+	AttackRun            uint8 // speed byte (run<<4 | move): the client animates this entity's walks with it — 0 = crawling avatar that rubber-bands
 	Direction            uint8
 	CreateType           uint16 // 0 normal, 2 "just entered"
 	Equip                [16]uint16
@@ -33,7 +34,8 @@ func writeCreateMobScore(b []byte, d CreateMobData) {
 	le.PutUint32(b[0:], uint32(d.Level))
 	le.PutUint32(b[4:], uint32(d.Ac))
 	le.PutUint32(b[8:], uint32(d.Damage))
-	b[12] = d.Merchant // STRUCT_SCORE.Merchant — NPC type
+	b[12] = d.Merchant  // STRUCT_SCORE.Merchant — NPC type
+	b[13] = d.AttackRun // STRUCT_SCORE.AttackRun — speed
 	b[14] = d.Direction
 	le.PutUint32(b[16:], uint32(d.MaxHp))
 	le.PutUint32(b[20:], uint32(d.MaxMp))

--- a/tmserver/internal/protocol/createmob_test.go
+++ b/tmserver/internal/protocol/createmob_test.go
@@ -13,7 +13,7 @@ func TestCreateMobBodyLayout(t *testing.T) {
 	d := CreateMobData{
 		MobID: 1001, Name: "Ciclope", PosX: 100, PosY: 200,
 		Guild: 7, GuildMemberType: 3, Level: 171, Hp: 15000, MaxHp: 15000,
-		Merchant: 1, CreateType: 2,
+		Merchant: 1, AttackRun: 82, CreateType: 2,
 	}
 	d.Equip[0] = 831
 	b := EncodeCreateMobBody(d)
@@ -33,6 +33,9 @@ func TestCreateMobBodyLayout(t *testing.T) {
 	}
 	if b[124+12] != 1 { // Score.Merchant @abs148 → body124+12 (name-visible NPC flag)
 		t.Errorf("Score.Merchant = %d, want 1", b[124+12])
+	}
+	if b[124+13] != 82 { // Score.AttackRun @abs149 → body124+13 (walk-animation speed)
+		t.Errorf("Score.AttackRun = %d, want 82", b[124+13])
 	}
 	if got := le.Uint32(b[124:]); got != 171 { // Score.Level @abs136 → body124
 		t.Errorf("Score.Level = %d, want 171", got)

--- a/tmserver/internal/protocol/mob.go
+++ b/tmserver/internal/protocol/mob.go
@@ -16,6 +16,7 @@ type MobBasics struct {
 	Clan               uint8 // STRUCT_MOB.Clan @16 — drives the g_pClanTable hostility check
 	Class              uint8
 	Merchant           uint8 // CurrentScore.Merchant — NPC type (shop/bank/…); 0 = monster
+	AttackRun          uint8 // CurrentScore.AttackRun — speed byte, echoed into CreateMob so clients animate the mob's walks
 	Level, Ac, Damage  int32
 	MaxHp, Hp          int32
 	Str, Int, Dex, Con int16
@@ -28,21 +29,22 @@ type MobBasics struct {
 func ParseMobBasics(mob816 []byte) MobBasics {
 	const cs = 92 // CurrentScore offset within STRUCT_MOB
 	return MobBasics{
-		Name:     cstr16(mob816[0:16]),
-		Clan:     mob816[16], // Clan @16 (same offset writeStructMob writes)
-		Class:    mob816[20],
-		Exp:      int64(le.Uint64(mob816[32:])), // STRUCT_MOB.Exp @32 (long long)
-		Merchant: mob816[cs+12],                 // CurrentScore.Merchant
-		Level:    int32(le.Uint32(mob816[cs+0:])),
-		Ac:       int32(le.Uint32(mob816[cs+4:])),
-		Damage:   int32(le.Uint32(mob816[cs+8:])),
-		MaxHp:    int32(le.Uint32(mob816[cs+16:])),
-		Hp:       int32(le.Uint32(mob816[cs+24:])),
-		Str:      int16(le.Uint16(mob816[cs+32:])),
-		Int:      int16(le.Uint16(mob816[cs+34:])),
-		Dex:      int16(le.Uint16(mob816[cs+36:])),
-		Con:      int16(le.Uint16(mob816[cs+38:])),
-		Resist:   [4]uint8(mob816[806:810]), // STRUCT_MOB.Resist @806 (skill mitigation)
+		Name:      cstr16(mob816[0:16]),
+		Clan:      mob816[16], // Clan @16 (same offset writeStructMob writes)
+		Class:     mob816[20],
+		Exp:       int64(le.Uint64(mob816[32:])), // STRUCT_MOB.Exp @32 (long long)
+		Merchant:  mob816[cs+12],                 // CurrentScore.Merchant
+		AttackRun: mob816[cs+13],                 // CurrentScore.AttackRun (speed)
+		Level:     int32(le.Uint32(mob816[cs+0:])),
+		Ac:        int32(le.Uint32(mob816[cs+4:])),
+		Damage:    int32(le.Uint32(mob816[cs+8:])),
+		MaxHp:     int32(le.Uint32(mob816[cs+16:])),
+		Hp:        int32(le.Uint32(mob816[cs+24:])),
+		Str:       int16(le.Uint16(mob816[cs+32:])),
+		Int:       int16(le.Uint16(mob816[cs+34:])),
+		Dex:       int16(le.Uint16(mob816[cs+36:])),
+		Con:       int16(le.Uint16(mob816[cs+38:])),
+		Resist:    [4]uint8(mob816[806:810]), // STRUCT_MOB.Resist @806 (skill mitigation)
 	}
 }
 
@@ -73,6 +75,7 @@ type MobSnapshot struct {
 	MaxHp, MaxMp, Hp, Mp int32
 	Str, Int, Dex, Con   int16
 	Special              [4]int16 // STRUCT_SCORE.Special @40 (skill-tree mastery)
+	AttackRun            uint8    // STRUCT_SCORE.AttackRun @13 — the client reads its own speed from here and stamps it into _MSG_Action.Speed
 	Direction            uint8
 	Equip                [16]SelItem
 	Carry                [64]SelItem
@@ -93,6 +96,8 @@ func writeMobScore(b []byte, m MobSnapshot) {
 	le.PutUint32(b[0:], uint32(m.Level))  // Level @0
 	le.PutUint32(b[4:], uint32(m.Ac))     // Ac @4
 	le.PutUint32(b[8:], uint32(m.Damage)) // Damage @8
+	b[12] = m.Merchant                    // Merchant @12
+	b[13] = m.AttackRun                   // AttackRun @13 (speed)
 	b[14] = m.Direction                   // Direction @14
 	le.PutUint32(b[16:], uint32(m.MaxHp)) // MaxHp @16
 	le.PutUint32(b[20:], uint32(m.MaxMp)) // MaxMp @20

--- a/tmserver/internal/world/api.go
+++ b/tmserver/internal/world/api.go
@@ -105,7 +105,8 @@ func (w *World) SpawnMobAt(sp MobSpawn) int {
 	b := protocol.ParseMobBasics(template)
 	e := &Entity{
 		ID: id, Mode: MobIdle, Name: b.Name, Clan: b.Clan, Class: b.Class, Merchant: b.Merchant,
-		X: x, Y: y, SpawnX: x, SpawnY: y, Level: b.Level, AC: b.Ac, Damage: b.Damage, Exp: b.Exp,
+		AttackRun: b.AttackRun,
+		X:         x, Y: y, SpawnX: x, SpawnY: y, Level: b.Level, AC: b.Ac, Damage: b.Damage, Exp: b.Exp,
 		MaxHP: b.MaxHp, HP: b.Hp, Str: b.Str, Int: b.Int, Dex: b.Dex, Con: b.Con,
 		Template:  template, // retained for runtime respawn (world/respawn.go)
 		RouteType: sp.RouteType, SegListX: sp.SegX, SegListY: sp.SegY, SegWait: sp.SegWait,

--- a/tmserver/internal/world/session.go
+++ b/tmserver/internal/world/session.go
@@ -120,6 +120,7 @@ type Entity struct {
 	Grade    uint8 // NPC sub-type for Merchant==100 quest NPCs (EF_GRADE0 of Equip[0])
 
 	Class       uint8    // character class (0=TK 1=FM 2=BM 3=HT); drives the visual model
+	AttackRun   uint8    // CurrentScore.AttackRun speed byte — mobs: template value (set at spawn); players: derived live (handler attackRunOf)
 	Route       [24]byte // last walk route from _MSG_Action (pMob.Route, MAX_ROUTE=24)
 	LastCity    int16    // last city visited (0..3); login spawn = its default area
 	Clan        uint8    // clan/race


### PR DESCRIPTION
## Summary
- The client reads its own and remote entities' walk-animation speed from `STRUCT_SCORE.AttackRun`, but `CreateMob`, mob snapshots, and login score data left this byte zeroed, causing the "anda devagar + teleporta" (crawling avatar that rubber-bands) bug.
- Add `AttackRun` to `CreateMobData`, `MobBasics`, `MobSnapshot`, and `Entity`, and wire it through spawn, login, and score computation via a new `attackRunOf` helper (players: class base + mount bump; mobs: template's `CurrentScore` value).

## Test plan
- [x] `go test ./tmserver/internal/protocol/...` — updated `createmob_test.go` asserts `Score.AttackRun` byte offset/value
- [x] `go test ./tmserver/internal/handler/...` — updated `view_test.go` asserts the mounted starter char's speed byte (85) appears in the cross-player CreateMob snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)