### PR TITLE
Mount Release content into webserver for merchant template scanning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,10 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/app ./${SVC}/cmd/$
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=build /out/app /app
 # Bake the game content tree so tmServer (W2PP_CONTENT=/Release) can load
-# rates/catalogs/BaseMob templates at boot. Without it the char-login handler
-# falls back to a template-less CNFCharacterLogin that the real client rejects
-# (crash on entering the world). Only tmServer reads it; other services ignore it.
+# rates/catalogs/BaseMob templates at boot and webserver can scan merchant
+# templates + ItemList.csv for the moderator UI. Without it the char-login
+# handler falls back to a template-less CNFCharacterLogin that the real client
+# rejects (crash on entering the world). dbserver/binserver ignore it.
 # The heavy legacy artifacts are stripped by .dockerignore.
 COPY --from=build /src/Release /Release
 ENTRYPOINT ["/app"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,6 +52,7 @@ services:
         SVC: webserver
     environment:
       W2PP_DB_DSN: postgres://postgres:${POSTGRES_PASSWORD:-dev}@db:5432/postgres
+      W2PP_CONTENT: /Release
     command: ["-addr", ":7600", "-content", "/Release"]
     volumes:
       - ./Release:/Release:ro   # merchant NPC templates for ListMerchantTemplates


### PR DESCRIPTION
## Summary
- webserver needs `W2PP_CONTENT=/Release` to scan merchant NPC templates and `ItemList.csv` for the moderator UI
- Dockerfile now bakes the `Release/` content tree for webserver too (previously only documented for tmServer)
- docker-compose sets `W2PP_CONTENT: /Release` for the webserver service

## Test plan
- [ ] `docker compose up --build` and confirm webserver moderator UI lists merchant templates without errors