### PR TITLE
fix(npc): bump config version after default NPC seed migration

### DIFF
--- a/internal/migrations/0006_default_npc_seed.up.sql
+++ b/internal/migrations/0006_default_npc_seed.up.sql
@@ -2819,3 +2819,5 @@ INSERT INTO npc_shop_item (npc_id, slot, item_index, eff1, effv1, eff2, effv2, e
     SELECT id, 26, 4191, 0, 0, 0, 0, 0, 0 FROM npc_definition WHERE slug = 'Trajes2-6068'
     ON CONFLICT (npc_id, slot) DO NOTHING;
 
+UPDATE npc_config_meta SET version = version + 1 WHERE id = TRUE;
+


### PR DESCRIPTION
## Summary

- Adds `UPDATE npc_config_meta SET version = version + 1` at the end of migration `0006_default_npc_seed`, matching what `SeedNPCDefinitions` already does in Go.
- Fixes production issue where `W2PP_NPC_EDITING=true` skips 544 merchant blocks from `NPCGener.txt` but tm-server kept a stale DB snapshot (3 NPCs) after booting before db-server applied the seed migration — the version poll never detected the change.

## Test plan

- [ ] Fresh DB: apply migrations, confirm `npc_config_meta.version` increments after `0006`
- [ ] With `npc-editing` on, tm-server boot logs show `npcs=83` (or reload via poll within ~15s if tm-server boots first)
- [ ] Merchants visible in Armia after deploy without manual tm-server restart


Made with [Cursor](https://cursor.com)