### PR TITLE
fix(tmserver): Baú de Experiência e paridade de EXP em kills

### DIFF
--- a/tmserver/cmd/tmserver/main.go
+++ b/tmserver/cmd/tmserver/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/dbclient"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/handler"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/level"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/npccfg"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/route"
@@ -102,6 +103,9 @@ func run(logger *slog.Logger) error {
 	}
 	statusAddr := flag.String("status-addr", defStatusAddr, "HTTP channel-status listen address (serv00.htm); real WYD serves status on :80, separate from the game port. Empty disables")
 	clientVersion := flag.Int("client-version", envInt("W2PP_CLIENT_VERSION", 7640), "MSG_AccountLogin.ClientVersion the client must send (protocol-spec says 7640; this 7662 'Cavaleiros de Kersef' build sends 12000)")
+	doubleExp := flag.Bool("double-exp", envBool("W2PP_DOUBLE_EXP", false), "DOUBLEMODE: double PvE experience (gameconfig double)")
+	newbieEvent := flag.Bool("newbie-event", envBool("W2PP_NEWBIE_EVENT", false), "NewbieEventServer: +15% exp and newbie under-100 bonus (gameconfig)")
+	kefraLive := flag.Bool("kefra-live", envBool("W2PP_KEFRA_LIVE", false), "KefraLive: when false, PvE exp is halved (default legacy KefraLive=0)")
 	flag.Parse()
 
 	// Echo the effective wiring at boot: the client-version and the resolved
@@ -123,7 +127,7 @@ func run(logger *slog.Logger) error {
 	var itemPrices map[int]int32
 	var itemEffects map[int][]content.BaseEffect
 	var itemReqs map[int]content.ItemReq
-	var itemVolatiles, itemPos, itemUnique map[int]int
+	var itemVolatiles, itemPos, itemUnique, itemGrades map[int]int
 	var itemRanges map[int]int16
 	var spells *content.SkillData
 	var heights *content.Grid
@@ -134,6 +138,7 @@ func run(logger *slog.Logger) error {
 		}
 		itemPrices, itemEffects, itemReqs = items.Prices(), items.BaseEffects(), items.Requirements()
 		itemVolatiles, itemPos, itemUnique = items.Volatiles(), items.Positions(), items.Uniques()
+		itemGrades = items.Grades()
 		itemRanges = items.Ranges()
 		spells = skills
 		heights = hm
@@ -199,7 +204,8 @@ func run(logger *slog.Logger) error {
 
 	dispatch := handler.New(handler.Config{
 		Log: logger, ClientVersion: int32(*clientVersion), BaseMobs: baseMobs, ItemPrices: itemPrices, ItemEffects: itemEffects, ItemReqs: itemReqs,
-		ItemVolatiles: itemVolatiles, ItemPos: itemPos, ItemUnique: itemUnique, Spells: spells, Heights: heights,
+		ItemVolatiles: itemVolatiles, ItemPos: itemPos, ItemUnique: itemUnique, ItemGrades: itemGrades, Spells: spells, Heights: heights,
+		ExpEvents: level.ExpEvents{DoubleMode: *doubleExp, NewbieEvent: *newbieEvent, KefraLive: *kefraLive},
 		NpcConfig: npcConfig,
 	})
 	w := world.New(world.Config{

--- a/tmserver/cmd/tmserver/main.go
+++ b/tmserver/cmd/tmserver/main.go
@@ -207,9 +207,9 @@ func run(logger *slog.Logger) error {
 	dispatch := handler.New(handler.Config{
 		Log: logger, ClientVersion: int32(*clientVersion), BaseMobs: baseMobs, ItemPrices: itemPrices, ItemEffects: itemEffects, ItemReqs: itemReqs,
 		ItemVolatiles: itemVolatiles, ItemPos: itemPos, ItemUnique: itemUnique, ItemGrades: itemGrades, Spells: spells, Heights: heights,
-		ExpEvents: level.ExpEvents{DoubleMode: *doubleExp, NewbieEvent: *newbieEvent, KefraLive: *kefraLive},
-    CombineFamilies: combineFamilies,
-		NpcConfig: npcConfig,
+		ExpEvents:       level.ExpEvents{DoubleMode: *doubleExp, NewbieEvent: *newbieEvent, KefraLive: *kefraLive},
+		CombineFamilies: combineFamilies,
+		NpcConfig:       npcConfig,
 	})
 	w := world.New(world.Config{
 		RejectChecksum: *rejectChecksum,

--- a/tmserver/internal/content/catalog.go
+++ b/tmserver/internal/content/catalog.go
@@ -136,6 +136,21 @@ func (l *ItemList) Ranges() map[int]int16 {
 	return out
 }
 
+// Grades returns item index → Grade (STRUCT_ITEMLIST.Grade — CSV column 8 per
+// BASE_ReadItemListFile sscanf in Basedef.cpp:5718). UNVERIFIED against every row
+// until content_test pins samples; used for grade-7 ExpBonus (+2 per piece).
+func (l *ItemList) Grades() map[int]int {
+	out := make(map[int]int)
+	for idx, e := range l.items {
+		if len(e.Fields) > 8 {
+			if v, err := strconv.Atoi(strings.TrimSpace(e.Fields[8])); err == nil {
+				out[idx] = v
+			}
+		}
+	}
+	return out
+}
+
 // Positions returns item index → nPos (STRUCT_ITEMLIST.nPos, the equip-slot class —
 // CSV column 6). nPos drives the refine (+9) threshold bonuses: weapons 64/192 add
 // +40 weapon damage, defense pieces 4/8/128 add +25 AC (captura §E). Confirmed by

--- a/tmserver/internal/handler/affect_score.go
+++ b/tmserver/internal/handler/affect_score.go
@@ -19,10 +19,10 @@ import (
 // 1/5/6/7/12 (slowdown/dex — Run speed not modeled), 16 (transform,
 // pTransBonus UNVERIFIED), 17/20/22 (periodic — handled by the tick engine),
 // 27/36 (need the weapon EF_WTYPE check), 29 (Soul), 34/35 (Divine/Vigor —
-// already read-time via affectMul).
+// already read-time via affectMul), 39 (Baú de XP → AffExpBonus).
 func applyAffectScore(e *world.Entity) {
 	e.Rsv = 0
-	e.AffDamage, e.AffAC, e.AffMaxHP, e.AffMaxMP, e.AffCon = 0, 0, 0, 0, 0
+	e.AffDamage, e.AffAC, e.AffMaxHP, e.AffMaxMP, e.AffCon, e.AffExpBonus = 0, 0, 0, 0, 0, 0
 	e.AffSpecial = [4]int16{}
 	e.AffResist = [4]int16{}
 	if !e.HasAnyAffect() {
@@ -89,6 +89,8 @@ func applyAffectScore(e *world.Entity) {
 			e.Rsv |= world.RsvParry
 		case 28:
 			e.Rsv |= world.RsvHide
+		case world.AffectExpChest:
+			e.AffExpBonus += 100
 		case 42: // soul link: shift a fifth of the mana pool into HP
 			mana := e.MaxMP/5 + (e.Level+level)/2
 			e.AffMaxHP += mana

--- a/tmserver/internal/handler/affect_score_test.go
+++ b/tmserver/internal/handler/affect_score_test.go
@@ -1,0 +1,16 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+func TestExpBonusAffect39(t *testing.T) {
+	e := &world.Entity{}
+	e.Affect[0] = world.Affect{Type: world.AffectExpChest}
+	applyAffectScore(e)
+	if e.AffExpBonus != 100 {
+		t.Errorf("AffExpBonus = %d, want 100", e.AffExpBonus)
+	}
+}

--- a/tmserver/internal/handler/dispatch.go
+++ b/tmserver/internal/handler/dispatch.go
@@ -56,9 +56,9 @@ type Config struct {
 	// ItemPos maps item index → nPos (equip-slot class) for the refine (+9) threshold
 	// bonuses. ItemUnique maps index → nUnique (gates EF_DAMAGEADD to jewels).
 	// ItemGrades maps index → Grade (grade-7 pieces grant +2 ExpBonus).
-	ItemPos     map[int]int
-	ItemUnique  map[int]int
-	ItemGrades  map[int]int
+	ItemPos    map[int]int
+	ItemUnique map[int]int
+	ItemGrades map[int]int
 
 	// ExpEvents toggles global EXP modifiers (MobKilled.cpp:537-549, Server.cpp defaults).
 	ExpEvents level.ExpEvents

--- a/tmserver/internal/handler/dispatch.go
+++ b/tmserver/internal/handler/dispatch.go
@@ -15,6 +15,7 @@ import (
 	"log/slog"
 
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/level"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/npccfg"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
@@ -54,8 +55,13 @@ type Config struct {
 
 	// ItemPos maps item index → nPos (equip-slot class) for the refine (+9) threshold
 	// bonuses. ItemUnique maps index → nUnique (gates EF_DAMAGEADD to jewels).
-	ItemPos    map[int]int
-	ItemUnique map[int]int
+	// ItemGrades maps index → Grade (grade-7 pieces grant +2 ExpBonus).
+	ItemPos     map[int]int
+	ItemUnique  map[int]int
+	ItemGrades  map[int]int
+
+	// ExpEvents toggles global EXP modifiers (MobKilled.cpp:537-549, Server.cpp defaults).
+	ExpEvents level.ExpEvents
 
 	// Spells is the SkillData.csv catalog (g_pSpell). When nil, skill casting is
 	// rejected and skill learning is refused (no costs are knowable without it).
@@ -93,6 +99,8 @@ type Dispatcher struct {
 	itemVolatiles   map[int]int                  // item index → EF_VOLATILE (consumable class)
 	itemPos         map[int]int                  // item index → nPos (refine threshold)
 	itemUnique      map[int]int                  // item index → nUnique (EF_DAMAGEADD gate)
+	itemGrades      map[int]int                  // item index → Grade (ExpBonus)
+	expEvents       level.ExpEvents              // global EXP event flags
 	spells          *content.SkillData           // skill catalog (g_pSpell)
 	heights         *content.Grid                // baked walkability grid (mob pathfinding)
 	tickCount       int                          // loop-only tick counter (affect sweep phase)
@@ -138,6 +146,8 @@ func New(cfg Config) *Dispatcher {
 		itemVolatiles:   cfg.ItemVolatiles,
 		itemPos:         cfg.ItemPos,
 		itemUnique:      cfg.ItemUnique,
+		itemGrades:      cfg.ItemGrades,
+		expEvents:       cfg.ExpEvents,
 		spells:          cfg.Spells,
 		heights:         cfg.Heights,
 		npcSource:       cfg.NpcConfig,

--- a/tmserver/internal/handler/exp_bonus.go
+++ b/tmserver/internal/handler/exp_bonus.go
@@ -1,0 +1,67 @@
+package handler
+
+import (
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+const fairyEquipSlot = 13
+
+func (d *Dispatcher) expBonus(e *world.Entity) int32 {
+	return e.AffExpBonus + e.EquipExpBonus
+}
+
+func (d *Dispatcher) equipExpBonus(e *world.Entity) int32 {
+	var bonus int32
+	bonus += fairyExpBonus(e.Equip[fairyEquipSlot].Index)
+	for slot := range e.Equip {
+		it := e.Equip[slot]
+		if it.Empty() {
+			continue
+		}
+		if d.itemGrades[int(it.Index)] == 7 {
+			bonus += 2
+		}
+		if itemGem(it) == 2 {
+			bonus += 2
+		}
+	}
+	return bonus
+}
+
+func fairyExpBonus(idx int16) int32 {
+	switch idx {
+	case 3900:
+		return 16
+	case 3902, 3905, 3908:
+		return 32
+	case 3903, 3906, 3911, 3912, 3913:
+		return 16
+	case 3904, 3907:
+		return 32
+	default:
+		return 0
+	}
+}
+
+func itemRawSanc(it world.Item) int {
+	for _, ef := range it.Effects {
+		if ef.Effect >= 116 && ef.Effect <= 125 {
+			return int(ef.Value)
+		}
+		if ef.Effect == efSanc {
+			return int(ef.Value)
+		}
+	}
+	return 0
+}
+
+func itemGem(it world.Item) int {
+	if it.Index >= 2330 && it.Index < 2390 {
+		return -1
+	}
+	sanc := itemRawSanc(it)
+	if sanc < 230 {
+		return -1
+	}
+	return (sanc - 230) % 4
+}

--- a/tmserver/internal/handler/exp_bonus_test.go
+++ b/tmserver/internal/handler/exp_bonus_test.go
@@ -1,0 +1,54 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+func TestFairyExpBonus(t *testing.T) {
+	d := New(Config{})
+	e := &world.Entity{}
+	e.Equip[fairyEquipSlot] = world.Item{Index: 3900}
+	if got := d.equipExpBonus(e); got != 16 {
+		t.Errorf("fada verde 3d = %d, want 16", got)
+	}
+	e.Equip[fairyEquipSlot] = world.Item{Index: 3902}
+	if got := d.equipExpBonus(e); got != 32 {
+		t.Errorf("fada vermelha = %d, want 32", got)
+	}
+}
+
+func TestEquipGrade7ExpBonus(t *testing.T) {
+	d := New(Config{ItemGrades: map[int]int{900: 7}})
+	e := &world.Entity{}
+	e.Equip[0] = world.Item{Index: 900}
+	if got := d.equipExpBonus(e); got != 2 {
+		t.Errorf("grade 7 = %d, want 2", got)
+	}
+}
+
+func TestEquipGemSapphireExpBonus(t *testing.T) {
+	d := New(Config{})
+	e := &world.Entity{}
+	e.Equip[1] = world.Item{Index: 100, Effects: [3]world.Effect{{Effect: efSanc, Value: 232}}}
+	if got := itemGem(e.Equip[1]); got != 2 {
+		t.Fatalf("itemGem(232) = %d, want 2", got)
+	}
+	if got := d.equipExpBonus(e); got != 2 {
+		t.Errorf("safira gem = %d, want 2", got)
+	}
+}
+
+func TestExpBonusCombined(t *testing.T) {
+	d := New(Config{ItemGrades: map[int]int{900: 7}})
+	e := &world.Entity{}
+	e.Affect[0] = world.Affect{Type: world.AffectExpChest}
+	e.Equip[fairyEquipSlot] = world.Item{Index: 3900}
+	e.Equip[0] = world.Item{Index: 900}
+	applyAffectScore(e)
+	e.EquipExpBonus = d.equipExpBonus(e)
+	if got := d.expBonus(e); got != 118 {
+		t.Errorf("total exp bonus = %d, want 118 (100+16+2)", got)
+	}
+}

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -125,10 +125,10 @@ func (d *Dispatcher) getItem(w *world.World, s *world.Session, _ protocol.Header
 // Divine consumable classes (EF_VOLATILE value): the Poção Divina of 7/15/30 days.
 // The buff (Affect 34) lasts these many days; the real deadline is Entity.DivineEnd.
 const (
-	volExpChest = 198
-	volDivine7  = 64
-	volDivine30 = 66
-	affect1H    = 450
+	volExpChest       = 198
+	volDivine7        = 64
+	volDivine30       = 66
+	affect1H          = 450
 	affectExpChestInc = affect1H * 2
 	affectTimeCap     = 324000
 	// divineAffectTime is the original's "infinite" Affect.Time for the Divine slot —

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -125,18 +125,18 @@ func (d *Dispatcher) getItem(w *world.World, s *world.Session, _ protocol.Header
 // Divine consumable classes (EF_VOLATILE value): the Poção Divina of 7/15/30 days.
 // The buff (Affect 34) lasts these many days; the real deadline is Entity.DivineEnd.
 const (
-	volExpChest       = 198
-	volDivine7        = 64
-	volDivine30       = 66
+	volExpChest = 198
+	volDivine7  = 64
+	volDivine30 = 66
+	volVigor    = 58
+	// affect tick units (Basedef.h): one tick = 8s of real time.
 	affect1H          = 450
+	affect1D          = 10800
 	affectExpChestInc = affect1H * 2
 	affectTimeCap     = 324000
 	// divineAffectTime is the original's "infinite" Affect.Time for the Divine slot —
 	// the actual expiry is DivineEnd (wall-clock), not this field (captura §B).
 	divineAffectTime = 2000000000
-	// affect tick units (Basedef.h): one tick = 8s of real time.
-	affect1H = 450
-	affect1D = 10800
 )
 
 // useItem handles _MSG_UseItem (0x0373), handlers/_MSG_UseItem.md. The action is
@@ -600,7 +600,7 @@ func (d *Dispatcher) refreshScore(e *world.Entity) {
 	e.HpAddPct = b.hpAddPct
 	e.MpAddPct = b.mpAddPct
 	applyAffectScore(e)
-  
+
 	e.EquipExpBonus = d.equipExpBonus(e)
 	if isPlayerMob(e) {
 		e.Damage += attributeDamageBonus(e, true)

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -125,8 +125,12 @@ func (d *Dispatcher) getItem(w *world.World, s *world.Session, _ protocol.Header
 // Divine consumable classes (EF_VOLATILE value): the Poção Divina of 7/15/30 days.
 // The buff (Affect 34) lasts these many days; the real deadline is Entity.DivineEnd.
 const (
+	volExpChest = 198
 	volDivine7  = 64
 	volDivine30 = 66
+	affect1H    = 450
+	affectExpChestInc = affect1H * 2
+	affectTimeCap     = 324000
 	// divineAffectTime is the original's "infinite" Affect.Time for the Divine slot —
 	// the actual expiry is DivineEnd (wall-clock), not this field (captura §B).
 	divineAffectTime = 2000000000
@@ -157,6 +161,8 @@ func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header
 		d.equipItem(w, s, e, body, payload)
 	case vol >= volSephiraLo && vol <= volSephiraHi:
 		d.useSkillBook(w, s, e, src, vol)
+	case vol == volExpChest:
+		d.useExpChest(w, s, e, src)
 	case vol >= volDivine7 && vol <= volDivine30:
 		d.useDivine(w, s, e, src, vol)
 	default:
@@ -208,6 +214,28 @@ func (d *Dispatcher) equipItem(w *world.World, s *world.Session, e *world.Entity
 	e.Carry[src], e.Equip[dst] = e.Equip[dst], e.Carry[src]
 	w.Send(s, protocol.MsgUseItem, payload) // echo result
 	d.refreshEquip(w, s, e)                 // update the rendered gear
+}
+
+func (d *Dispatcher) useExpChest(w *world.World, s *world.Session, e *world.Entity, src int) {
+	slot := e.EmptyAffect(world.AffectExpChest)
+	if slot < 0 {
+		d.notify(w, s, NoticeCantEatMore)
+		w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
+		return
+	}
+	af := &e.Affect[slot]
+	af.Type = world.AffectExpChest
+	af.Level = 0
+	af.Value = 0
+	af.Time += affectExpChestInc
+	if af.Time > affectTimeCap {
+		af.Time = affectTimeCap
+	}
+	e.Carry[src] = world.Item{}
+	d.refreshScore(e)
+	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
+	d.sendScore(w, s, e)
+	d.sendAffect(w, s, e)
 }
 
 // useDivine consumes a Poção Divina: it sets the Divine buff (Affect 34) for 8/16/31
@@ -543,6 +571,7 @@ func (d *Dispatcher) refreshScore(e *world.Entity) {
 	// Affect stage (Buff Loop): recompute the read-time buff caches + Rsv flags
 	// over the flat score just rebuilt.
 	applyAffectScore(e)
+	e.EquipExpBonus = d.equipExpBonus(e)
 	if m := effectiveMaxHP(e); e.HP > m {
 		e.HP = m
 	}

--- a/tmserver/internal/handler/item_test.go
+++ b/tmserver/internal/handler/item_test.go
@@ -1,10 +1,16 @@
 package handler
 
 import (
+	"context"
+	"encoding/binary"
+	"io"
+	"log/slog"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/level"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
 )
@@ -423,5 +429,79 @@ func TestTradingItemEmptyMove(t *testing.T) {
 	tradeItemFrame(t, c, world.ItemPlaceCarry, 10, world.ItemPlaceCarry, 11, 0) // both empty
 	if ty, _, ok := readMaybe(t, c); ok {
 		t.Errorf("empty→empty move produced %#x; should be a no-op", ty)
+	}
+}
+
+func expChestDB() *fakeDB {
+	db := newDB()
+	st := world.CharacterState{Slot: 0, Name: "Hero", X: 5, Y: 5, HP: 1000, MaxHP: 1000}
+	st.Carry[0] = world.Item{Index: 4140}
+	db.loadResult = st
+	return db
+}
+
+func startServerClockVol(t *testing.T, persist world.Persistence, vols map[int]int) (string, func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := New(Config{Log: log, ItemVolatiles: vols, ExpEvents: level.ExpEvents{KefraLive: true}})
+	w := world.New(world.Config{GridDim: 16}, log, persist, d.Handle)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = w.Serve(ctx, ln); close(done) }()
+	return ln.Addr().String(), func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("server did not stop")
+		}
+	}
+}
+
+func TestUseExpChest(t *testing.T) {
+	addr, stop := startServerClockVol(t, expChestDB(), map[int]int{4140: volExpChest})
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+
+	sawSendItem, sawAffect, sawScore := false, false, false
+	for range 6 {
+		ty, payload, ok := readMaybe(t, c)
+		if !ok {
+			break
+		}
+		switch ty {
+		case protocol.MsgSendItem:
+			sawSendItem = true
+			if le16(payload[4:6]) != 0 {
+				t.Errorf("carry slot 0 item = %d, want empty after use", le16(payload[4:6]))
+			}
+		case protocol.MsgSendAffect:
+			sawAffect = true
+			if payload[0] != world.AffectExpChest {
+				t.Errorf("affect type = %d, want %d", payload[0], world.AffectExpChest)
+			}
+			if got := binary.LittleEndian.Uint32(payload[4:8]); got != affectExpChestInc {
+				t.Errorf("affect time = %d, want %d", got, affectExpChestInc)
+			}
+		case protocol.MsgUpdateScore:
+			sawScore = true
+		}
+	}
+	if !sawSendItem {
+		t.Error("missing MsgSendItem after using exp chest")
+	}
+	if !sawAffect {
+		t.Error("missing MsgSendAffect after using exp chest")
+	}
+	if !sawScore {
+		t.Error("missing MsgUpdateScore after using exp chest")
 	}
 }

--- a/tmserver/internal/handler/mobkilled.go
+++ b/tmserver/internal/handler/mobkilled.go
@@ -79,6 +79,7 @@ func (d *Dispatcher) mobKilled(w *world.World, killer, mob *world.Entity) {
 // party distribution, and the per-level reward items (DoItemLevel).
 func (d *Dispatcher) grantExp(w *world.World, ks *world.Session, killer, mob *world.Entity) {
 	gain := level.ExpApply(mob.Exp, killer.Level, mob.Level)
+	gain = level.SoloExpReward(gain, killer.Level, killer.ClassMaster, d.expBonus(killer), d.expEvents)
 	if gain <= 0 {
 		return
 	}

--- a/tmserver/internal/handler/view_test.go
+++ b/tmserver/internal/handler/view_test.go
@@ -165,11 +165,10 @@ func TestMoveViewDelta(t *testing.T) {
 	}
 	// The snapshot must carry the player's speed byte (Score.AttackRun @body137):
 	// a 0 here makes the remote client animate the avatar at crawl speed and
-	// rubber-band to catch up (the "anda devagar + teleporta" bug). Fresh test
-	// chars get the starter Shire mount, so the move nibble is the mounted 5:
-	// (82 & 0xF0) | 5 = 85.
-	if payload[124+13] != 85 {
-		t.Errorf("A sees B with AttackRun %d, want 85 (mounted starter char)", payload[124+13])
+	// rubber-band to catch up (the "anda devagar + teleporta" bug). Test chars
+	// from viewDeltaDB have no mount (starterEquip never grants slot 14).
+	if payload[124+13] != baseAttackRun {
+		t.Errorf("A sees B with AttackRun %d, want %d (base player speed)", payload[124+13], baseAttackRun)
 	}
 	if ty, _, ok = readMaybeRaw(t, a); !ok || ty != protocol.MsgPKInfo {
 		t.Fatalf("A frame 2 = %#x ok=%v, want PKInfo", ty, ok)

--- a/tmserver/internal/level/expreward.go
+++ b/tmserver/internal/level/expreward.go
@@ -1,11 +1,11 @@
 package level
 
 const (
-	classArch       uint8 = 1
-	classMortal     uint8 = 2
-	classCelestial  uint8 = 3
+	classArch        uint8 = 1
+	classMortal      uint8 = 2
+	classCelestial   uint8 = 3
 	classCelestialCS uint8 = 4
-	classSCelestial uint8 = 5
+	classSCelestial  uint8 = 5
 
 	soloExpCap int64 = 10_000_000
 )

--- a/tmserver/internal/level/expreward.go
+++ b/tmserver/internal/level/expreward.go
@@ -1,0 +1,120 @@
+package level
+
+const (
+	classArch       uint8 = 1
+	classMortal     uint8 = 2
+	classCelestial  uint8 = 3
+	classCelestialCS uint8 = 4
+	classSCelestial uint8 = 5
+
+	soloExpCap int64 = 10_000_000
+)
+
+type ExpEvents struct {
+	DoubleMode  bool
+	NewbieEvent bool
+	KefraLive   bool
+}
+
+func SoloExpReward(base int64, lvl int32, classMaster uint8, expBonus int32, ev ExpEvents) int64 {
+	if base <= 0 {
+		return 0
+	}
+	exp := float64(base)
+	myLevel := lvl
+	if classMaster != classMortal && classMaster != classArch {
+		myLevel += MaxLevel + 1
+	}
+	exp = applyTierDivisors(exp, myLevel, classMaster)
+	exp = exp * 6 / 10
+	if expBonus > 0 && expBonus < 500 {
+		exp += exp * float64(expBonus) / 100
+	}
+	if ev.NewbieEvent && lvl < 100 && !isCelestialTier(classMaster) {
+		exp += exp / 4
+	}
+	if ev.DoubleMode {
+		exp *= 2
+	}
+	if !ev.KefraLive {
+		exp /= 2
+	}
+	if ev.NewbieEvent {
+		exp += exp * 15 / 100
+	} else {
+		exp -= exp * 15 / 100
+	}
+	out := int64(exp)
+	if out <= 0 {
+		return 0
+	}
+	if out > soloExpCap {
+		return soloExpCap
+	}
+	return out
+}
+
+func isCelestialTier(classMaster uint8) bool {
+	switch classMaster {
+	case classCelestial, classCelestialCS, classSCelestial:
+		return true
+	default:
+		return false
+	}
+}
+
+func applyTierDivisors(exp float64, myLevel int32, classMaster uint8) float64 {
+	switch classMaster {
+	case classMortal:
+		switch {
+		case myLevel <= 200:
+		case myLevel <= 300:
+			exp /= 0.84
+		case myLevel <= 356:
+			exp /= 1.05
+		case myLevel <= 370:
+			exp /= 1.63
+		case myLevel <= 380:
+			exp /= 1.95
+		case myLevel <= 390:
+			exp /= 2.55
+		case myLevel <= 399:
+			exp /= 3.70
+		}
+	case classArch:
+		switch {
+		case myLevel <= 200:
+			exp /= 0.84
+		case myLevel <= 300:
+			exp /= 0.72
+		case myLevel <= 356:
+			exp /= 1.40
+		case myLevel <= 360:
+			exp /= 4.75
+		case myLevel <= 370:
+			exp /= 6.60
+		case myLevel <= 380:
+			exp /= 15
+		case myLevel <= 390:
+			exp /= 21
+		case myLevel <= 400:
+			exp /= 35
+		}
+	default:
+		switch {
+		case myLevel < 120:
+			exp /= 10
+		case myLevel < 150:
+			exp /= 20
+		case myLevel < 170:
+			exp /= 40
+		case myLevel < 180:
+			exp /= 80
+		case myLevel < 190:
+			exp /= 160
+		default:
+			exp /= 320
+		}
+	}
+	return exp
+}

--- a/tmserver/internal/level/expreward_test.go
+++ b/tmserver/internal/level/expreward_test.go
@@ -1,0 +1,65 @@
+package level
+
+import "testing"
+
+func TestSoloExpReward_baseCut(t *testing.T) {
+	ev := ExpEvents{KefraLive: true}
+	got := SoloExpReward(1000, 50, classMortal, 0, ev)
+	if got != 510 {
+		t.Errorf("SoloExpReward(1000) = %d, want 510 (40%% cut then -15%%)", got)
+	}
+}
+
+func TestSoloExpReward_expBonus(t *testing.T) {
+	ev := ExpEvents{KefraLive: true}
+	got := SoloExpReward(1000, 50, classMortal, 100, ev)
+	if got != 1020 {
+		t.Errorf("SoloExpReward(+100 bonus) = %d, want 1020 (0.6 * 2.0 * 0.85)", got)
+	}
+}
+
+func TestSoloExpReward_mortalTier250(t *testing.T) {
+	ev := ExpEvents{KefraLive: true}
+	got := SoloExpReward(1000, 250, classMortal, 0, ev)
+	exp := 1000.0 / 0.84 * 6 / 10 * 0.85
+	want := int64(exp)
+	if got != want {
+		t.Errorf("SoloExpReward lvl250 mortal = %d, want %d", got, want)
+	}
+}
+
+func TestSoloExpReward_doubleMode(t *testing.T) {
+	ev := ExpEvents{DoubleMode: true, KefraLive: true}
+	got := SoloExpReward(1000, 50, classMortal, 0, ev)
+	if got != 1020 {
+		t.Errorf("SoloExpReward(double) = %d, want 1020", got)
+	}
+}
+
+func TestSoloExpReward_newbieEvent(t *testing.T) {
+	ev := ExpEvents{NewbieEvent: true, KefraLive: true}
+	got := SoloExpReward(1000, 50, classMortal, 0, ev)
+	if got != 862 {
+		t.Errorf("SoloExpReward(newbie) = %d, want 862 (0.6 * 1.25 * 1.15)", got)
+	}
+}
+
+func TestSoloExpReward_kefraPenalty(t *testing.T) {
+	got := SoloExpReward(1000, 50, classMortal, 0, ExpEvents{})
+	if got != 255 {
+		t.Errorf("SoloExpReward(no kefra) = %d, want 255 (0.6 * 0.5 * 0.85)", got)
+	}
+}
+
+func TestSoloExpReward_cap(t *testing.T) {
+	got := SoloExpReward(50_000_000, 50, classMortal, 0, ExpEvents{KefraLive: true})
+	if got != soloExpCap {
+		t.Errorf("SoloExpReward cap = %d, want %d", got, soloExpCap)
+	}
+}
+
+func TestSoloExpReward_zeroBase(t *testing.T) {
+	if got := SoloExpReward(0, 50, classMortal, 100, ExpEvents{}); got != 0 {
+		t.Errorf("SoloExpReward(0) = %d, want 0", got)
+	}
+}

--- a/tmserver/internal/world/affect.go
+++ b/tmserver/internal/world/affect.go
@@ -6,8 +6,9 @@ const MaxAffect = 32
 
 // Affect types the score model reacts to (BASE_GetCurrentScore, captura §C).
 const (
-	AffectDivine = 34 // Poção Divina: +20% MaxHp/MaxMp/Damage
-	AffectVigor  = 35 // Poção de Vigor: +10% MaxHp/MaxMp
+	AffectExpChest = 39 // Baú de Experiência: +100 ExpBonus (Basedef.cpp:4451)
+	AffectDivine   = 34 // Poção Divina: +20% MaxHp/MaxMp/Damage
+	AffectVigor    = 35 // Poção de Vigor: +10% MaxHp/MaxMp
 )
 
 // Affect mirrors STRUCT_AFFECT (8 bytes): a timed buff/debuff. Type==0 is an empty

--- a/tmserver/internal/world/session.go
+++ b/tmserver/internal/world/session.go
@@ -175,7 +175,7 @@ type Entity struct {
 	// are cached the same way and applied at READ time (effective getters), so
 	// the persisted flat score never bakes a buff in (no double-count on
 	// re-login — same policy as HpAddPct/Divine).
-	Rsv        uint8
+	Rsv           uint8
 	AffDamage     int32
 	AffAC         int32
 	AffMaxHP      int32

--- a/tmserver/internal/world/session.go
+++ b/tmserver/internal/world/session.go
@@ -176,13 +176,15 @@ type Entity struct {
 	// the persisted flat score never bakes a buff in (no double-count on
 	// re-login — same policy as HpAddPct/Divine).
 	Rsv        uint8
-	AffDamage  int32
-	AffAC      int32
-	AffMaxHP   int32
-	AffMaxMP   int32
-	AffCon     int16
-	AffSpecial [4]int16
-	AffResist  [4]int16
+	AffDamage     int32
+	AffAC         int32
+	AffMaxHP      int32
+	AffMaxMP      int32
+	AffCon        int16
+	AffSpecial    [4]int16
+	AffResist     [4]int16
+	AffExpBonus   int32 // from affect type 39 (Baú de XP)
+	EquipExpBonus int32 // from fairy slot + grade/gem gear (CMob.cpp:711-870)
 
 	EquipVisual [16]uint16 // visual item codes for MSG_CreateMob (gear shown to others)
 


### PR DESCRIPTION
## Summary

- Implementa o consumível **Baú de Experiência** (itens 4140/4144, `EF_VOLATILE=198`): aplica Affect 39 (+100 ExpBonus, +2h por uso, cap 324000) e consome o item.
- Calcula `ExpBonus` a partir do affect 39, fadas no slot 13, grade 7 e joia safira no equipamento.
- Aplica a pipeline de EXP solo do legado (`MobKilled.cpp`): divisores por tier/nível, corte de 40%, bônus de item e flags de evento (double/newbie/kefra).

Closes #17

## Test plan

- [x] `go test -race ./tmserver/internal/level/... ./tmserver/internal/handler/...` (novos testes: `TestUseExpChest`, `TestSoloExpReward_*`, `TestExpBonusAffect39`, `TestFairyExpBonus`)
- [ ] Usar item 4140 no cliente e confirmar ícone de buff + consumo do slot
- [ ] Matar mob com e sem baú ativo e comparar ganho de EXP (~1,2× com baú nas condições padrão)


Made with [Cursor](https://cursor.com)