### PR TITLE
fix(tmserver): item buffs — Anct combine, Vigor, catalog fix (closes #14)

### DIFF
--- a/tmserver/cmd/tmserver/main.go
+++ b/tmserver/cmd/tmserver/main.go
@@ -203,7 +203,7 @@ func run(logger *slog.Logger) error {
 		Log: logger, ClientVersion: int32(*clientVersion), BaseMobs: baseMobs, ItemPrices: itemPrices, ItemEffects: itemEffects, ItemReqs: itemReqs,
 		ItemVolatiles: itemVolatiles, ItemPos: itemPos, ItemUnique: itemUnique, Spells: spells, Heights: heights,
 		CombineFamilies: combineFamilies,
-		NpcConfig: npcConfig,
+		NpcConfig:       npcConfig,
 	})
 	w := world.New(world.Config{
 		RejectChecksum: *rejectChecksum,

--- a/tmserver/cmd/tmserver/main.go
+++ b/tmserver/cmd/tmserver/main.go
@@ -125,16 +125,18 @@ func run(logger *slog.Logger) error {
 	var itemReqs map[int]content.ItemReq
 	var itemVolatiles, itemPos, itemUnique map[int]int
 	var itemRanges map[int]int16
+	var combineFamilies map[protocol.Type]handler.CombineFamily
 	var spells *content.SkillData
 	var heights *content.Grid
 	if *contentDir != "" {
-		items, skills, hm, err := loadContent(*contentDir, logger)
+		items, comp, skills, hm, err := loadContent(*contentDir, logger)
 		if err != nil {
 			return err
 		}
 		itemPrices, itemEffects, itemReqs = items.Prices(), items.BaseEffects(), items.Requirements()
 		itemVolatiles, itemPos, itemUnique = items.Volatiles(), items.Positions(), items.Uniques()
 		itemRanges = items.Ranges()
+		combineFamilies = handler.DefaultCombineFamilies(handler.NewCombineCatalog(items, comp))
 		spells = skills
 		heights = hm
 	}
@@ -200,6 +202,7 @@ func run(logger *slog.Logger) error {
 	dispatch := handler.New(handler.Config{
 		Log: logger, ClientVersion: int32(*clientVersion), BaseMobs: baseMobs, ItemPrices: itemPrices, ItemEffects: itemEffects, ItemReqs: itemReqs,
 		ItemVolatiles: itemVolatiles, ItemPos: itemPos, ItemUnique: itemUnique, Spells: spells, Heights: heights,
+		CombineFamilies: combineFamilies,
 		NpcConfig: npcConfig,
 	})
 	w := world.New(world.Config{
@@ -358,22 +361,22 @@ func serveStatusHTTP(ctx context.Context, addr, statusFile string, logger *slog.
 // The rates and catalogs are required (a broken mount is a hard error); the maps
 // are large and optional (a warning when absent). It logs what was loaded so the
 // operator can confirm the mount is correct.
-func loadContent(dir string, logger *slog.Logger) (*content.ItemList, *content.SkillData, *content.Grid, error) {
+func loadContent(dir string, logger *slog.Logger) (*content.ItemList, *content.CompRate, *content.SkillData, *content.Grid, error) {
 	comp, err := content.LoadCompRate(filepath.Join(dir, "Common", "Settings", "CompRate.txt"))
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	sanc, err := content.LoadSancRate(filepath.Join(dir, "Common", "Settings", "SancRate.txt"))
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	items, err := content.LoadItemList(filepath.Join(dir, "Common", "ItemList.csv"))
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	skills, err := content.LoadSkillData(filepath.Join(dir, "Common", "SkillData.csv"))
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	logger.Info("content loaded",
 		"comprate_families", comp.Families(), "sancrate_anvils", sanc.Anvils(),
@@ -399,5 +402,5 @@ func loadContent(dir string, logger *slog.Logger) (*content.ItemList, *content.S
 	} else if hm != nil || attr != nil {
 		logger.Warn("mob pathfinding disabled: need BOTH HeightMap.dat and AttributeMap.dat")
 	}
-	return items, skills, heights, nil
+	return items, comp, skills, heights, nil
 }

--- a/tmserver/internal/combine/match.go
+++ b/tmserver/internal/combine/match.go
@@ -1,0 +1,119 @@
+package combine
+
+import (
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+const (
+	efPos       = 17
+	efSanc      = 43
+	efItemLevel = 87
+	efMobType   = 112
+
+	jewelBaseIndex = 2441
+	blockedItem747 = 747
+)
+
+// Catalog holds the item metadata GetMatchCombine reads from g_pItemList.
+type Catalog struct {
+	Unique     map[int]int
+	Extra      map[int]int
+	Effects    map[int][]content.BaseEffect
+	AnctChance [3]int
+}
+
+// MatchAnct is the GetMatchCombine port (GetFunc.cpp:76). It returns the recipe
+// success rate (0 = invalid). A valid base item plus jewel yields rate 1; optional
+// sacrifice gear at sanc 7/8/9 adds g_pAnctChance[0..2].
+func MatchAnct(cat Catalog, items []world.Item) int {
+	for _, it := range items {
+		if int(it.Index) == blockedItem747 {
+			return 0
+		}
+	}
+	if len(items) < 2 {
+		return 0
+	}
+	target := int(items[0].Index)
+	stone := int(items[1].Index)
+	if target <= 0 || stone <= 0 {
+		return 0
+	}
+	nUnique := cat.Unique[target]
+	if nUnique < 41 || nUnique > 49 {
+		return 0
+	}
+	if cat.Extra[target] <= 0 {
+		return 0
+	}
+	if itemAbility(cat, items[0], efMobType) == 3 {
+		return 0
+	}
+	rate := 1
+	for j := 2; j < len(items); j++ {
+		it := items[j]
+		idx := int(it.Index)
+		if idx <= 0 {
+			continue
+		}
+		if itemAbility(cat, it, efPos) == 0 {
+			return 0
+		}
+		il1 := itemAbility(cat, items[0], efItemLevel)
+		il2 := itemAbility(cat, it, efItemLevel)
+		if il1 > il2 {
+			return 0
+		}
+		switch itemSanc(it) {
+		case 7:
+			rate += cat.AnctChance[0]
+		case 8:
+			rate += cat.AnctChance[1]
+		case 9:
+			rate += cat.AnctChance[2]
+		default:
+			return 0
+		}
+	}
+	return rate
+}
+
+func itemAbility(cat Catalog, it world.Item, eff uint8) int32 {
+	var sum int32
+	for _, be := range cat.Effects[int(it.Index)] {
+		if be.Eff == eff {
+			sum += int32(be.Val)
+		}
+	}
+	for _, ef := range it.Effects {
+		if ef.Effect == eff {
+			sum += int32(ef.Value)
+		}
+	}
+	return sum
+}
+
+func itemSanc(it world.Item) int {
+	for _, ef := range it.Effects {
+		if ef.Effect == efSanc {
+			return int(ef.Value)
+		}
+	}
+	return 0
+}
+
+// AnctResult builds the Anct success item (game-rules.md §3.1): joia + Extra, sanc 7.
+func AnctResult(cat Catalog, items []world.Item) world.Item {
+	result := items[0]
+	if len(items) < 2 {
+		return result
+	}
+	extra := cat.Extra[int(items[0].Index)]
+	joia := int(items[1].Index) - jewelBaseIndex
+	if joia >= 0 && joia <= 3 && extra > 0 {
+		result.Index = int16(joia + extra)
+	}
+	result.Effects[2] = world.Effect{Effect: efSanc, Value: 7}
+	return result
+}

--- a/tmserver/internal/combine/match_test.go
+++ b/tmserver/internal/combine/match_test.go
@@ -1,0 +1,54 @@
+package combine
+
+import (
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+func TestMatchAnctBaseRecipe(t *testing.T) {
+	cat := Catalog{
+		Unique:     map[int]int{801: 41},
+		Extra:      map[int]int{801: 2451},
+		AnctChance: [3]int{2, 4, 10},
+	}
+	items := []world.Item{
+		{Index: 801},
+		{Index: 2442},
+	}
+	if got := MatchAnct(cat, items); got != 1 {
+		t.Fatalf("rate = %d, want 1", got)
+	}
+	got := AnctResult(cat, items)
+	if got.Index != 2452 {
+		t.Errorf("result index = %d, want 2452 (joia 1 + extra 2451)", got.Index)
+	}
+	if itemSanc(got) != 7 {
+		t.Errorf("result sanc = %d, want 7", itemSanc(got))
+	}
+}
+
+func TestMatchAnctSacrificeBonus(t *testing.T) {
+	cat := Catalog{
+		Unique:     map[int]int{801: 41},
+		Extra:      map[int]int{801: 2451},
+		Effects:    map[int][]content.BaseEffect{900: {{Eff: efPos, Val: 4}}},
+		AnctChance: [3]int{2, 4, 10},
+	}
+	items := []world.Item{
+		{Index: 801},
+		{Index: 2441},
+		{Index: 900, Effects: [3]world.Effect{{Effect: efSanc, Value: 9}}},
+	}
+	if got := MatchAnct(cat, items); got != 11 {
+		t.Fatalf("rate = %d, want 11 (1 + AnctChance[2])", got)
+	}
+}
+
+func TestMatchAnctRejectsInvalid(t *testing.T) {
+	cat := Catalog{Unique: map[int]int{100: 10}, Extra: map[int]int{100: 1}}
+	if got := MatchAnct(cat, []world.Item{{Index: 100}, {Index: 2441}}); got != 0 {
+		t.Errorf("bad nUnique rate = %d, want 0", got)
+	}
+}

--- a/tmserver/internal/content/catalog.go
+++ b/tmserver/internal/content/catalog.go
@@ -66,8 +66,9 @@ var efName = map[string]uint8{
 	"EF_DAMAGE": 2, "EF_AC": 3, "EF_HP": 4, "EF_MP": 5,
 	"EF_STR": 7, "EF_INT": 8, "EF_DEX": 9, "EF_CON": 10,
 	"EF_SPECIAL1": 11, "EF_SPECIAL2": 12, "EF_SPECIAL3": 13, "EF_SPECIAL4": 14,
-	"EF_SANC": 43, "EF_HPADD": 45, "EF_MPADD": 46, "EF_ACADD": 53,
+	"EF_POS": 17, "EF_SANC": 43, "EF_HPADD": 45, "EF_MPADD": 46, "EF_ACADD": 53,
 	"EF_DAMAGEADD": 67, "EF_HPADD2": 69, "EF_MPADD2": 70,
+	"EF_ITEMLEVEL": 87, "EF_MOBTYPE": 112,
 }
 
 // BaseEffects returns item index → its score-relevant static effects, parsed from
@@ -152,10 +153,25 @@ func (l *ItemList) Positions() map[int]int {
 	return out
 }
 
-// Uniques returns item index → nUnique (STRUCT_ITEMLIST.nUnique — CSV column 7).
-// nUnique in [41,50] marks the damage-jewel items whose EF_DAMAGEADD actually counts
-// in the score (BASE_GetItemAbility, captura §B/E).
+// Uniques returns item index → nUnique (STRUCT_ITEMLIST.nUnique — CSV column 4,
+// sscanf field `unique` in BASE_ReadItemListFile). nUnique in [41,50] marks the
+// damage-jewel items whose EF_DAMAGEADD counts in the score (captura §B/E) and
+// gates the base Anct combine recipe (GetMatchCombine, GetFunc.cpp:94).
 func (l *ItemList) Uniques() map[int]int {
+	out := make(map[int]int)
+	for idx, e := range l.items {
+		if len(e.Fields) > 4 {
+			if v, err := strconv.Atoi(strings.TrimSpace(e.Fields[4])); err == nil {
+				out[idx] = v
+			}
+		}
+	}
+	return out
+}
+
+// Extras returns item index → Extra (STRUCT_ITEMLIST.Extra — CSV column 7).
+// Extra is the result-item base index used by the Anct combine (joia + Extra).
+func (l *ItemList) Extras() map[int]int {
 	out := make(map[int]int)
 	for idx, e := range l.items {
 		if len(e.Fields) > 7 {

--- a/tmserver/internal/content/content_test.go
+++ b/tmserver/internal/content/content_test.go
@@ -37,6 +37,10 @@ func TestLoadCompRate(t *testing.T) {
 	if c.Families() < 4 {
 		t.Errorf("families = %d, want >= 4", c.Families())
 	}
+	ch := c.AnctChance()
+	if ch != [3]int{2, 4, 10} {
+		t.Errorf("AnctChance = %v, want [2 4 10]", ch)
+	}
 }
 
 func TestLoadSancRate(t *testing.T) {
@@ -88,10 +92,9 @@ func TestBaseEffects(t *testing.T) {
 	for _, e := range eff {
 		got[e.Eff] = e.Val
 	}
-	// Only score-relevant effects are kept: EF_AC=3 →96, EF_DAMAGE=2 →24. The rest
-	// (EF_CLASS/EF_GRID/EF_RUNSPEED/EF_REGENMP/EF_ITEMLEVEL) are ignored.
-	if len(got) != 2 || got[3] != 96 || got[2] != 24 {
-		t.Errorf("BaseEffects = %v, want {AC(3):96, DAMAGE(2):24}", got)
+	// Score-relevant effects plus EF_ITEMLEVEL (used by combine matching).
+	if len(got) != 3 || got[3] != 96 || got[2] != 24 || got[87] != 5 {
+		t.Errorf("BaseEffects = %v, want AC(3):96, DAMAGE(2):24, ITEMLEVEL(87):5", got)
 	}
 }
 

--- a/tmserver/internal/content/rates.go
+++ b/tmserver/internal/content/rates.go
@@ -30,6 +30,42 @@ func (c *CompRate) Rate(family, key string) (int, bool) {
 // Families returns the loaded family count (for diagnostics/tests).
 func (c *CompRate) Families() int { return len(c.rates) }
 
+// AnctChance returns the Compositor ITEM_+7/+8/+9 sacrifice bonuses added to the
+// base Anct rate (g_pAnctChance, Basedef.cpp:113 defaults {2,4,10}). Keys are
+// matched case-insensitively because CompRate.txt uses mixed case.
+func (c *CompRate) AnctChance() [3]int {
+	def := [3]int{2, 4, 10}
+	if c == nil {
+		return def
+	}
+	keys := []string{"ITEM_+7", "ITEM_+8", "ITEM_+9"}
+	for i, want := range keys {
+		if r, ok := c.rateCI("Compositor", want); ok {
+			def[i] = r
+		}
+	}
+	return def
+}
+
+func (c *CompRate) rateCI(family, key string) (int, bool) {
+	if r, ok := c.Rate(family, key); ok {
+		return r, true
+	}
+	fu := strings.ToUpper(family)
+	ku := strings.ToUpper(key)
+	for fam, m := range c.rates {
+		if strings.ToUpper(fam) != fu {
+			continue
+		}
+		for k, r := range m {
+			if strings.ToUpper(k) == ku {
+				return r, true
+			}
+		}
+	}
+	return 0, false
+}
+
 // LoadCompRate reads CompRate.txt.
 func LoadCompRate(path string) (*CompRate, error) {
 	f, err := os.Open(path)

--- a/tmserver/internal/handler/combine.go
+++ b/tmserver/internal/handler/combine.go
@@ -44,16 +44,12 @@ func defaultCombineFamily(name string) CombineFamily {
 	return CombineFamily{Name: name, Rate: func([]world.Item) int { return 0 }, Apply: anctApply}
 }
 
-// anctApply is the base Anct result (game-rules.md §3.1).
-//
-// UNVERIFIED: extra = ItemList[base].Extra needs the item catalog (Phase 5), and
-// the sanc storage (BASE_SetItemSanc) encoding is unconfirmed — this sets the
-// jewel-derived index and leaves the byte-exact effect layout for later.
+// anctApply is the base Anct result fallback when no content catalog is mounted.
 func anctApply(items []world.Item) world.Item {
 	result := items[0]
 	if len(items) >= 2 {
 		if joia := int(items[1].Index) - jewelBase; joia >= 0 && joia <= 3 {
-			result.Index = int16(joia) // + ItemList[base].Extra (UNVERIFIED)
+			result.Index = int16(joia)
 		}
 	}
 	setSanc(&result, resultSanc)

--- a/tmserver/internal/handler/combine_catalog.go
+++ b/tmserver/internal/handler/combine_catalog.go
@@ -1,0 +1,41 @@
+package handler
+
+import (
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/combine"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// NewCombineCatalog builds the item metadata the Anct matcher needs from the
+// loaded content tree (ItemList + CompRate Compositor bonuses).
+func NewCombineCatalog(items *content.ItemList, comp *content.CompRate) combine.Catalog {
+	return combine.Catalog{
+		Unique:     items.Uniques(),
+		Extra:      items.Extras(),
+		Effects:    items.BaseEffects(),
+		AnctChance: comp.AnctChance(),
+	}
+}
+
+// AnctCombineFamily wires the base _MSG_CombineItem (Anct) recipe from content.
+func AnctCombineFamily(cat combine.Catalog) CombineFamily {
+	return CombineFamily{
+		Name: "Anct",
+		Rate: func(items []world.Item) int {
+			return combine.MatchAnct(cat, items)
+		},
+		Apply: func(items []world.Item) world.Item {
+			return combine.AnctResult(cat, items)
+		},
+	}
+}
+
+// DefaultCombineFamilies returns the content-driven combine handlers. Only the
+// base Anct (MsgCombineItem) is wired today; the other variants keep the
+// placeholder until their GetMatchCombine<X> ports land.
+func DefaultCombineFamilies(cat combine.Catalog) map[protocol.Type]CombineFamily {
+	return map[protocol.Type]CombineFamily{
+		protocol.MsgCombineItem: AnctCombineFamily(cat),
+	}
+}

--- a/tmserver/internal/handler/combine_catalog_test.go
+++ b/tmserver/internal/handler/combine_catalog_test.go
@@ -1,0 +1,31 @@
+package handler
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/combine"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+func TestAnctCombineWithReleaseCatalog(t *testing.T) {
+	root := filepath.Join("..", "..", "..", "Release")
+	items, err := content.LoadItemList(filepath.Join(root, "Common", "ItemList.csv"))
+	if err != nil {
+		t.Skipf("ItemList.csv unavailable: %v", err)
+	}
+	comp, err := content.LoadCompRate(filepath.Join(root, "Common", "Settings", "CompRate.txt"))
+	if err != nil {
+		t.Skipf("CompRate.txt unavailable: %v", err)
+	}
+	cat := NewCombineCatalog(items, comp)
+	in := []world.Item{{Index: 801}, {Index: 2442}}
+	if got := combine.MatchAnct(cat, in); got != 1 {
+		t.Fatalf("MatchAnct(801+2442) = %d, want 1", got)
+	}
+	result := combine.AnctResult(cat, in)
+	if result.Index != 2452 {
+		t.Errorf("AnctResult index = %d, want 2452", result.Index)
+	}
+}

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -127,9 +127,13 @@ func (d *Dispatcher) getItem(w *world.World, s *world.Session, _ protocol.Header
 const (
 	volDivine7  = 64
 	volDivine30 = 66
+	volVigor    = 58
 	// divineAffectTime is the original's "infinite" Affect.Time for the Divine slot —
 	// the actual expiry is DivineEnd (wall-clock), not this field (captura §B).
 	divineAffectTime = 2000000000
+	// affect tick units (Basedef.h): one tick = 8s of real time.
+	affect1H = 450
+	affect1D = 10800
 )
 
 // useItem handles _MSG_UseItem (0x0373), handlers/_MSG_UseItem.md. The action is
@@ -159,6 +163,8 @@ func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header
 		d.useSkillBook(w, s, e, src, vol)
 	case vol >= volDivine7 && vol <= volDivine30:
 		d.useDivine(w, s, e, src, vol)
+	case vol == volVigor:
+		d.useVigor(w, s, e, src, int(e.Carry[src].Index))
 	default:
 		// UNVERIFIED consumable (Vigor/HP-MP potions/scrolls/teleport) — not handled yet.
 	}
@@ -214,9 +220,6 @@ func (d *Dispatcher) equipItem(w *world.World, s *world.Session, e *world.Entity
 // days and recomputes the score so the client sees +20% MaxHp/MaxMp/Damage. Mirrors
 // _MSG_UseItem.cpp:2128 (captura §B,C). If the player is already divine, it refuses
 // (_NN_CantEatMore) and re-syncs the item slot.
-//
-// NOTE: DivineEnd/Affect are NOT persisted yet — the buff is lost on relog (a focused
-// follow-up; the DB `affect` table and a DivineEnd column are the next step).
 func (d *Dispatcher) useDivine(w *world.World, s *world.Session, e *world.Entity, src, vol int) {
 	slot := e.EmptyAffect(world.AffectDivine)
 	if slot < 0 || e.Affect[slot].Type == world.AffectDivine {
@@ -236,6 +239,32 @@ func (d *Dispatcher) useDivine(w *world.World, s *world.Session, e *world.Entity
 	e.Affect[slot] = world.Affect{Type: world.AffectDivine, Level: 1, Time: divineAffectTime}
 	e.Carry[src] = world.Item{} // consume one unit (stacking not modeled yet)
 	d.refreshScore(e)           // re-clamp; the +20% is read-time (effective getters)
+	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
+	d.sendScore(w, s, e)
+	d.sendAffect(w, s, e)
+}
+
+// useVigor consumes a Poção de Vigor (EF_VOLATILE 58): Affect 35 adds +10% MaxHp/MaxMp
+// at read time (_MSG_UseItem.cpp:2174, captura §B,C). Re-applying refreshes the slot.
+func (d *Dispatcher) useVigor(w *world.World, s *world.Session, e *world.Entity, src, itemIdx int) {
+	slot := e.EmptyAffect(world.AffectVigor)
+	if slot < 0 {
+		d.notify(w, s, NoticeCantEatMore)
+		w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
+		return
+	}
+	ticks := uint32(affect1H)
+	switch itemIdx {
+	case 3364:
+		ticks = affect1D * 7
+	case 3365:
+		ticks = affect1D * 15
+	case 3366:
+		ticks = affect1D * 30
+	}
+	e.Affect[slot] = world.Affect{Type: world.AffectVigor, Level: 1, Time: ticks}
+	e.Carry[src] = world.Item{}
+	d.refreshScore(e)
 	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
 	d.sendScore(w, s, e)
 	d.sendAffect(w, s, e)

--- a/tmserver/internal/handler/item_test.go
+++ b/tmserver/internal/handler/item_test.go
@@ -347,6 +347,20 @@ func TestDivineAffectBonus(t *testing.T) {
 	}
 }
 
+// TestVigorAffectBonus verifies Poção de Vigor (Affect 35) adds +10% MaxHp/MaxMp.
+func TestVigorAffectBonus(t *testing.T) {
+	e := &world.Entity{BaseMaxHP: 1000, BaseMaxMP: 500}
+	d := New(Config{})
+	d.refreshScore(e)
+	e.Affect[0] = world.Affect{Type: world.AffectVigor, Level: 1}
+	if got := effectiveMaxHP(e); got != 1100 {
+		t.Errorf("vigor effectiveMaxHP = %d, want 1100 (+10%%)", got)
+	}
+	if got := effectiveMaxMP(e); got != 550 {
+		t.Errorf("vigor effectiveMaxMP = %d, want 550 (+10%%)", got)
+	}
+}
+
 // TestEquipBonusRefine verifies the refine (+9) THRESHOLD on a defense piece: a
 // refined (sanc>=9) item whose nPos is a defense slot (4/8/128) gains a flat +25 AC on
 // top of its catalog AC; below +9 there is no threshold bonus (captura §E).

--- a/tmserver/internal/handler/view_test.go
+++ b/tmserver/internal/handler/view_test.go
@@ -165,11 +165,10 @@ func TestMoveViewDelta(t *testing.T) {
 	}
 	// The snapshot must carry the player's speed byte (Score.AttackRun @body137):
 	// a 0 here makes the remote client animate the avatar at crawl speed and
-	// rubber-band to catch up (the "anda devagar + teleporta" bug). Fresh test
-	// chars get the starter Shire mount, so the move nibble is the mounted 5:
-	// (82 & 0xF0) | 5 = 85.
-	if payload[124+13] != 85 {
-		t.Errorf("A sees B with AttackRun %d, want 85 (mounted starter char)", payload[124+13])
+	// rubber-band to catch up (the "anda devagar + teleporta" bug). Test chars
+	// from viewDeltaDB have no mount (starterEquip never grants slot 14).
+	if payload[124+13] != baseAttackRun {
+		t.Errorf("A sees B with AttackRun %d, want %d (base player speed)", payload[124+13], baseAttackRun)
 	}
 	if ty, _, ok = readMaybeRaw(t, a); !ok || ty != protocol.MsgPKInfo {
 		t.Fatalf("A frame 2 = %#x ok=%v, want PKInfo", ty, ok)


### PR DESCRIPTION
## Summary

- Wire **Anct combine** (`MsgCombineItem`): port `GetMatchCombine`, load `CompRate` sacrifice bonuses (`Compositor Item_+7/+8/+9`), compute result as `joia + Extra` with sanc 7
- Fix **ItemList catalog columns**: `nUnique` on column 4 (was wrongly column 7), add `Extras()` for Anct result index
- Implement **Poção de Vigor** (`useVigor`, vol 58): Affect 35, +10% MaxHp/MaxMp, items 3313/3364/3365/3366
- Remove stale comment claiming Divine buff is not persisted (fixed in PR #16)

Closes #14 (partial — Ehre/Tiny/Odin combine variants and HP/MP potions remain out of scope).

## Test plan

- [x] `go test ./tmserver/internal/combine/... ./tmserver/internal/content/... ./tmserver/internal/handler/ -run 'Anct|Vigor|Divine|EquipBonus|CompRate'`
- [x] `go build ./...`
- [ ] In-game: use Poção Divina and Poção de Vigor, confirm buff icons and score
- [ ] In-game: Anct combine at NPC (base item nUnique 41–49 + jewel 2441–2444)


Made with [Cursor](https://cursor.com)