### PR TITLE
Add /noatun teleport command

### DIFF
--- a/docs/game.md
+++ b/docs/game.md
@@ -10,6 +10,7 @@
 ✅ /azran: se teleportará para a cidade de Azran <br/>
 ✅ /gelo: se teleportará para a cidade de Gelo <br/>
 ✅ /kefra: se teleportará para a cidade de Kefra <br/>
+✅ /noatun: se teleportará para Noatun <br/>
 ✅ /red: se teleportará para o rei de Akelonia <br/>
 ✅ /blue: se teleportará para o rei de Hekalotia <br/>
 ✅ /arch: se teleportará para a cidade dos reinos (apenas o teleporte; o destrave do Arch é ⏳) <br/>

--- a/tmserver/internal/handler/chat.go
+++ b/tmserver/internal/handler/chat.go
@@ -71,6 +71,7 @@ var teleportCmds = map[string][2]int16{
 	"gelo": {3650, 3130}, "kefra": {2365, 3884}, "torre": {2506, 1878},
 	"red": {1744, 1880}, "blue": {1745, 1573}, "arch": {1706, 1723},
 	"selados": {1843, 3652}, "amagos": {3910, 2878}, "agua": {1966, 1770},
+	"noatun": {1052, 1726},
 }
 
 // runCommand executes a chat slash command delivered as a whisper whose target name is

--- a/tmserver/internal/handler/chat_test.go
+++ b/tmserver/internal/handler/chat_test.go
@@ -44,6 +44,28 @@ func TestCommandTeleport(t *testing.T) {
 	}
 }
 
+// TestCommandNoatunTeleport verifies /noatun teleports to Noatun with the same
+// rand%3 spread used by the other free teleport commands.
+func TestCommandNoatunTeleport(t *testing.T) {
+	addr, stop, _ := startServerClock(t, chatDB())
+	defer stop()
+	a := enterWorldAs(t, addr, "tester")
+	defer a.Close()
+
+	whisperFrame(t, a, "noatun", "")
+	ty, payload, ok := readMaybe(t, a)
+	if !ok || ty != protocol.MsgAction {
+		t.Fatalf("got %#x ok=%v, want MsgAction (teleport)", ty, ok)
+	}
+	var body protocol.MsgActionBody
+	if err := body.Decode(payload); err != nil {
+		t.Fatalf("decode MsgAction: %v", err)
+	}
+	if body.TargetX < 1052 || body.TargetX > 1054 || body.TargetY < 1726 || body.TargetY > 1728 {
+		t.Errorf("/noatun target = %d,%d, want within 1052..1054,1726..1728", body.TargetX, body.TargetY)
+	}
+}
+
 // TestCommandBuffs verifies /buffs clears affects and pushes a fresh score.
 func TestCommandBuffs(t *testing.T) {
 	addr, stop, _ := startServerClock(t, chatDB())


### PR DESCRIPTION
## Summary
- add /noatun to the chat teleport command map
- document /noatun in the game commands list
- cover the command with a handler test that validates the Noatun destination spread

## Tests
- go test ./tmserver/internal/handler

Closes #45