### PR TITLE
Fix NPC display name overrides

### DIFF
--- a/tmserver/internal/dbclient/npcconfig.go
+++ b/tmserver/internal/dbclient/npcconfig.go
@@ -70,13 +70,14 @@ func (c *NpcConfig) Snapshot(ctx context.Context) (npccfg.Snapshot, error) {
 			cache[d.GetTemplateName()] = tmpl
 		}
 		def := npccfg.Definition{
-			Slug:      d.GetSlug(),
-			Template:  tmpl,
-			Enabled:   d.GetEnabled(),
-			X:         int16(d.GetPosX()),
-			Y:         int16(d.GetPosY()),
-			RouteType: uint8(d.GetRouteType()),
-			Merchant:  uint8(d.GetMerchant()),
+			Slug:        d.GetSlug(),
+			Template:    tmpl,
+			DisplayName: d.GetDisplayName(),
+			Enabled:     d.GetEnabled(),
+			X:           int16(d.GetPosX()),
+			Y:           int16(d.GetPosY()),
+			RouteType:   uint8(d.GetRouteType()),
+			Merchant:    uint8(d.GetMerchant()),
 		}
 		for _, it := range d.GetShop() {
 			def.Shop = append(def.Shop, npccfg.ShopItem{

--- a/tmserver/internal/dbclient/npcconfig_test.go
+++ b/tmserver/internal/dbclient/npcconfig_test.go
@@ -1,0 +1,69 @@
+package dbclient
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"google.golang.org/grpc"
+
+	dbv1 "github.com/jeanluca/w2pp-openwyd/api/db/v1"
+)
+
+type fakeNpcConfigAPI struct {
+	version int64
+	list    *dbv1.ListNpcDefinitionsResponse
+}
+
+func (f *fakeNpcConfigAPI) NpcConfigVersion(context.Context, *dbv1.NpcConfigVersionRequest, ...grpc.CallOption) (*dbv1.NpcConfigVersionResponse, error) {
+	return &dbv1.NpcConfigVersionResponse{Version: f.version}, nil
+}
+
+func (f *fakeNpcConfigAPI) ListNpcDefinitions(context.Context, *dbv1.ListNpcDefinitionsRequest, ...grpc.CallOption) (*dbv1.ListNpcDefinitionsResponse, error) {
+	return f.list, nil
+}
+
+func TestNpcConfigSnapshotMapsDisplayName(t *testing.T) {
+	template := merchantTemplateBytes("Default")
+	src := &NpcConfig{
+		api: &fakeNpcConfigAPI{list: &dbv1.ListNpcDefinitionsResponse{
+			Version: 7,
+			Definitions: []*dbv1.NpcDefinition{{
+				Slug: "shop-1", TemplateName: "Keeper", DisplayName: "Ferreiro",
+				Enabled: true, PosX: 8, PosY: 9, RouteType: 2, Merchant: 1,
+			}},
+		}},
+		template: func(name string) ([]byte, error) {
+			if name != "Keeper" {
+				t.Fatalf("template name = %q, want Keeper", name)
+			}
+			return template, nil
+		},
+		log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	snap, err := src.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if snap.Version != 7 || len(snap.Defs) != 1 {
+		t.Fatalf("snapshot = version %d defs %d, want version 7 defs 1", snap.Version, len(snap.Defs))
+	}
+	def := snap.Defs[0]
+	if def.DisplayName != "Ferreiro" {
+		t.Fatalf("DisplayName = %q, want Ferreiro", def.DisplayName)
+	}
+	if def.Template == nil {
+		t.Fatal("template not resolved")
+	}
+	if got := string(def.Template[:7]); got != "Default" {
+		t.Fatalf("template name = %q, want Default", got)
+	}
+}
+
+func merchantTemplateBytes(name string) []byte {
+	tmpl := make([]byte, 816)
+	copy(tmpl[:16], name)
+	return tmpl
+}

--- a/tmserver/internal/handler/npcconfig.go
+++ b/tmserver/internal/handler/npcconfig.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/npccfg"
@@ -110,8 +111,9 @@ func (d *Dispatcher) applyNPCConfig(w *world.World, snap npccfg.Snapshot, reveal
 			d.log.Warn("npc definition has no valid position — skipped", "slug", def.Slug, "x", def.X, "y", def.Y)
 			continue
 		}
+		template := npcTemplateWithDisplayName(def.Template, def.DisplayName)
 		id := w.SpawnMobAt(world.MobSpawn{
-			Template:  def.Template,
+			Template:  template,
 			X:         def.X,
 			Y:         def.Y,
 			RouteType: def.RouteType,
@@ -130,6 +132,21 @@ func (d *Dispatcher) applyNPCConfig(w *world.World, snap npccfg.Snapshot, reveal
 		}
 	}
 	d.npcVersion = snap.Version
+}
+
+// npcTemplateWithDisplayName overlays the moderator display name onto a copy of
+// the raw STRUCT_MOB. Templates are shared by the dbclient cache, so mutating the
+// input would leak one NPC's translated name into every NPC using that template.
+func npcTemplateWithDisplayName(template []byte, displayName string) []byte {
+	if strings.TrimSpace(displayName) == "" {
+		return template
+	}
+	out := append([]byte(nil), template...)
+	for i := 0; i < 16 && i < len(out); i++ {
+		out[i] = 0
+	}
+	copy(out[0:min(16, len(out))], displayName)
+	return out
 }
 
 // applyShop overwrites a merchant entity's shop stock (its Carry[]) with the

--- a/tmserver/internal/handler/npcconfig_test.go
+++ b/tmserver/internal/handler/npcconfig_test.go
@@ -44,7 +44,7 @@ func TestApplyNPCConfigSpawnsMerchant(t *testing.T) {
 	snap := npccfg.Snapshot{
 		Version: 1,
 		Defs: []npccfg.Definition{{
-			Slug: "shop-1", Template: merchantTemplate("Keeper"), Enabled: true,
+			Slug: "shop-1", Template: merchantTemplate("Keeper"), DisplayName: "Ferreiro", Enabled: true,
 			X: 8, Y: 8, Merchant: 1,
 			// Slots 0/2 are tab 1 (identity); slot 9 is tab 2 → Carry[27]; slot 18
 			// is tab 3 → Carry[54]. Proves the ShopSlot mapping is applied.
@@ -71,6 +71,9 @@ func TestApplyNPCConfigSpawnsMerchant(t *testing.T) {
 	if e.X != 8 || e.Y != 8 {
 		t.Errorf("entity at (%d,%d), want (8,8)", e.X, e.Y)
 	}
+	if e.Name != "Ferreiro" {
+		t.Errorf("entity Name = %q, want Ferreiro", e.Name)
+	}
 	if e.Carry[0].Index != 1100 || e.Carry[2].Index != 1101 {
 		t.Errorf("shop stock = [0]=%d [2]=%d, want 1100/1101", e.Carry[0].Index, e.Carry[2].Index)
 	}
@@ -92,6 +95,36 @@ func TestApplyNPCConfigSpawnsMerchant(t *testing.T) {
 	}
 	if d.npcVersion != 1 {
 		t.Errorf("npcVersion = %d, want 1", d.npcVersion)
+	}
+}
+
+func TestApplyNPCConfigDisplayNameFallbackAndSharedTemplate(t *testing.T) {
+	d, w := newNPCDispatcher(nil)
+	tmpl := merchantTemplate("Default")
+	d.applyNPCConfig(w, npccfg.Snapshot{
+		Version: 1,
+		Defs: []npccfg.Definition{
+			{Slug: "named-a", Template: tmpl, DisplayName: "Armeiro", Enabled: true, X: 7, Y: 7, Merchant: 1},
+			{Slug: "named-b", Template: tmpl, DisplayName: "Alquimista", Enabled: true, X: 8, Y: 8, Merchant: 1},
+			{Slug: "fallback", Template: tmpl, DisplayName: " ", Enabled: true, X: 9, Y: 9, Merchant: 1},
+		},
+	}, false)
+
+	for slug, want := range map[string]string{
+		"named-a":  "Armeiro",
+		"named-b":  "Alquimista",
+		"fallback": "Default",
+	} {
+		id, ok := d.managedNPCs[slug]
+		if !ok {
+			t.Fatalf("%s not spawned", slug)
+		}
+		if got := w.Entity(id).Name; got != want {
+			t.Errorf("%s name = %q, want %q", slug, got, want)
+		}
+	}
+	if got := string(tmpl[:7]); got != "Default" {
+		t.Errorf("shared template mutated to %q, want Default", got)
 	}
 }
 

--- a/tmserver/internal/npccfg/npccfg.go
+++ b/tmserver/internal/npccfg/npccfg.go
@@ -21,13 +21,14 @@ type ShopItem struct {
 // Template is nil when the referenced file could not be loaded — such a
 // definition is skipped by the applier.
 type Definition struct {
-	Slug      string
-	Template  []byte
-	Enabled   bool
-	X, Y      int16
-	RouteType uint8
-	Merchant  uint8
-	Shop      []ShopItem // nil = use the template's own Carry[] as the shop
+	Slug        string
+	Template    []byte
+	DisplayName string
+	Enabled     bool
+	X, Y        int16
+	RouteType   uint8
+	Merchant    uint8
+	Shop        []ShopItem // nil = use the template's own Carry[] as the shop
 }
 
 // Snapshot is the full config at a given version: the definition set plus the


### PR DESCRIPTION
## Summary
- carry NPC display_name through the tmserver config snapshot
- overlay display names onto copied STRUCT_MOB template bytes before spawning
- add regression coverage for shared templates and dbclient mapping

## Tests
- make test

Fixes #40