### PR TITLE
feat(web): expose my characters endpoint

### DIFF
--- a/api/web/v1/web.pb.go
+++ b/api/web/v1/web.pb.go
@@ -378,6 +378,242 @@ func (x *VerifyCredentialsResponse) GetRole() string {
 	return ""
 }
 
+type ListMyCharactersRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	AccountId     int64                  `protobuf:"varint,1,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"` // from the BFF session, never from browser input
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListMyCharactersRequest) Reset() {
+	*x = ListMyCharactersRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListMyCharactersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListMyCharactersRequest) ProtoMessage() {}
+
+func (x *ListMyCharactersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListMyCharactersRequest.ProtoReflect.Descriptor instead.
+func (*ListMyCharactersRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ListMyCharactersRequest) GetAccountId() int64 {
+	if x != nil {
+		return x.AccountId
+	}
+	return 0
+}
+
+type WebCharacterSummary struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Slot          int32                  `protobuf:"varint,1,opt,name=slot,proto3" json:"slot,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Class         int32                  `protobuf:"varint,3,opt,name=class,proto3" json:"class,omitempty"`
+	Level         int32                  `protobuf:"varint,4,opt,name=level,proto3" json:"level,omitempty"`
+	Exp           int64                  `protobuf:"varint,5,opt,name=exp,proto3" json:"exp,omitempty"`
+	Coin          int32                  `protobuf:"varint,6,opt,name=coin,proto3" json:"coin,omitempty"`
+	MaxHp         int32                  `protobuf:"varint,7,opt,name=max_hp,json=maxHp,proto3" json:"max_hp,omitempty"`
+	Hp            int32                  `protobuf:"varint,8,opt,name=hp,proto3" json:"hp,omitempty"`
+	MaxMp         int32                  `protobuf:"varint,9,opt,name=max_mp,json=maxMp,proto3" json:"max_mp,omitempty"`
+	Mp            int32                  `protobuf:"varint,10,opt,name=mp,proto3" json:"mp,omitempty"`
+	Str           int32                  `protobuf:"varint,11,opt,name=str,proto3" json:"str,omitempty"`
+	Int           int32                  `protobuf:"varint,12,opt,name=int,proto3" json:"int,omitempty"`
+	Dex           int32                  `protobuf:"varint,13,opt,name=dex,proto3" json:"dex,omitempty"`
+	Con           int32                  `protobuf:"varint,14,opt,name=con,proto3" json:"con,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WebCharacterSummary) Reset() {
+	*x = WebCharacterSummary{}
+	mi := &file_api_web_v1_web_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WebCharacterSummary) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WebCharacterSummary) ProtoMessage() {}
+
+func (x *WebCharacterSummary) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WebCharacterSummary.ProtoReflect.Descriptor instead.
+func (*WebCharacterSummary) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *WebCharacterSummary) GetSlot() int32 {
+	if x != nil {
+		return x.Slot
+	}
+	return 0
+}
+
+func (x *WebCharacterSummary) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *WebCharacterSummary) GetClass() int32 {
+	if x != nil {
+		return x.Class
+	}
+	return 0
+}
+
+func (x *WebCharacterSummary) GetLevel() int32 {
+	if x != nil {
+		return x.Level
+	}
+	return 0
+}
+
+func (x *WebCharacterSummary) GetExp() int64 {
+	if x != nil {
+		return x.Exp
+	}
+	return 0
+}
+
+func (x *WebCharacterSummary) GetCoin() int32 {
+	if x != nil {
+		return x.Coin
+	}
+	return 0
+}
+
+func (x *WebCharacterSummary) GetMaxHp() int32 {
+	if x != nil {
+		return x.MaxHp
+	}
+	return 0
+}
+
+func (x *WebCharacterSummary) GetHp() int32 {
+	if x != nil {
+		return x.Hp
+	}
+	return 0
+}
+
+func (x *WebCharacterSummary) GetMaxMp() int32 {
+	if x != nil {
+		return x.MaxMp
+	}
+	return 0
+}
+
+func (x *WebCharacterSummary) GetMp() int32 {
+	if x != nil {
+		return x.Mp
+	}
+	return 0
+}
+
+func (x *WebCharacterSummary) GetStr() int32 {
+	if x != nil {
+		return x.Str
+	}
+	return 0
+}
+
+func (x *WebCharacterSummary) GetInt() int32 {
+	if x != nil {
+		return x.Int
+	}
+	return 0
+}
+
+func (x *WebCharacterSummary) GetDex() int32 {
+	if x != nil {
+		return x.Dex
+	}
+	return 0
+}
+
+func (x *WebCharacterSummary) GetCon() int32 {
+	if x != nil {
+		return x.Con
+	}
+	return 0
+}
+
+type ListMyCharactersResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Characters    []*WebCharacterSummary `protobuf:"bytes,1,rep,name=characters,proto3" json:"characters,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListMyCharactersResponse) Reset() {
+	*x = ListMyCharactersResponse{}
+	mi := &file_api_web_v1_web_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListMyCharactersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListMyCharactersResponse) ProtoMessage() {}
+
+func (x *ListMyCharactersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListMyCharactersResponse.ProtoReflect.Descriptor instead.
+func (*ListMyCharactersResponse) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *ListMyCharactersResponse) GetCharacters() []*WebCharacterSummary {
+	if x != nil {
+		return x.Characters
+	}
+	return nil
+}
+
 type AdminAck struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Result        AdminResult            `protobuf:"varint,1,opt,name=result,proto3,enum=web.v1.AdminResult" json:"result,omitempty"`
@@ -387,7 +623,7 @@ type AdminAck struct {
 
 func (x *AdminAck) Reset() {
 	*x = AdminAck{}
-	mi := &file_api_web_v1_web_proto_msgTypes[4]
+	mi := &file_api_web_v1_web_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -399,7 +635,7 @@ func (x *AdminAck) String() string {
 func (*AdminAck) ProtoMessage() {}
 
 func (x *AdminAck) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[4]
+	mi := &file_api_web_v1_web_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -412,7 +648,7 @@ func (x *AdminAck) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminAck.ProtoReflect.Descriptor instead.
 func (*AdminAck) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{4}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *AdminAck) GetResult() AdminResult {
@@ -439,7 +675,7 @@ type AdminNpcShopItem struct {
 
 func (x *AdminNpcShopItem) Reset() {
 	*x = AdminNpcShopItem{}
-	mi := &file_api_web_v1_web_proto_msgTypes[5]
+	mi := &file_api_web_v1_web_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -451,7 +687,7 @@ func (x *AdminNpcShopItem) String() string {
 func (*AdminNpcShopItem) ProtoMessage() {}
 
 func (x *AdminNpcShopItem) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[5]
+	mi := &file_api_web_v1_web_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -464,7 +700,7 @@ func (x *AdminNpcShopItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminNpcShopItem.ProtoReflect.Descriptor instead.
 func (*AdminNpcShopItem) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{5}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *AdminNpcShopItem) GetSlot() int32 {
@@ -542,7 +778,7 @@ type AdminNpc struct {
 
 func (x *AdminNpc) Reset() {
 	*x = AdminNpc{}
-	mi := &file_api_web_v1_web_proto_msgTypes[6]
+	mi := &file_api_web_v1_web_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -554,7 +790,7 @@ func (x *AdminNpc) String() string {
 func (*AdminNpc) ProtoMessage() {}
 
 func (x *AdminNpc) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[6]
+	mi := &file_api_web_v1_web_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -567,7 +803,7 @@ func (x *AdminNpc) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminNpc.ProtoReflect.Descriptor instead.
 func (*AdminNpc) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{6}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *AdminNpc) GetId() int64 {
@@ -656,7 +892,7 @@ type ListNpcsRequest struct {
 
 func (x *ListNpcsRequest) Reset() {
 	*x = ListNpcsRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[7]
+	mi := &file_api_web_v1_web_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -668,7 +904,7 @@ func (x *ListNpcsRequest) String() string {
 func (*ListNpcsRequest) ProtoMessage() {}
 
 func (x *ListNpcsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[7]
+	mi := &file_api_web_v1_web_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -681,7 +917,7 @@ func (x *ListNpcsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNpcsRequest.ProtoReflect.Descriptor instead.
 func (*ListNpcsRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{7}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ListNpcsRequest) GetModeratorId() int64 {
@@ -701,7 +937,7 @@ type ListNpcsResponse struct {
 
 func (x *ListNpcsResponse) Reset() {
 	*x = ListNpcsResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[8]
+	mi := &file_api_web_v1_web_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -713,7 +949,7 @@ func (x *ListNpcsResponse) String() string {
 func (*ListNpcsResponse) ProtoMessage() {}
 
 func (x *ListNpcsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[8]
+	mi := &file_api_web_v1_web_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -726,7 +962,7 @@ func (x *ListNpcsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNpcsResponse.ProtoReflect.Descriptor instead.
 func (*ListNpcsResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{8}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ListNpcsResponse) GetResult() AdminResult {
@@ -753,7 +989,7 @@ type GetNpcRequest struct {
 
 func (x *GetNpcRequest) Reset() {
 	*x = GetNpcRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[9]
+	mi := &file_api_web_v1_web_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -765,7 +1001,7 @@ func (x *GetNpcRequest) String() string {
 func (*GetNpcRequest) ProtoMessage() {}
 
 func (x *GetNpcRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[9]
+	mi := &file_api_web_v1_web_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -778,7 +1014,7 @@ func (x *GetNpcRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNpcRequest.ProtoReflect.Descriptor instead.
 func (*GetNpcRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{9}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *GetNpcRequest) GetModeratorId() int64 {
@@ -805,7 +1041,7 @@ type GetNpcResponse struct {
 
 func (x *GetNpcResponse) Reset() {
 	*x = GetNpcResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[10]
+	mi := &file_api_web_v1_web_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -817,7 +1053,7 @@ func (x *GetNpcResponse) String() string {
 func (*GetNpcResponse) ProtoMessage() {}
 
 func (x *GetNpcResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[10]
+	mi := &file_api_web_v1_web_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -830,7 +1066,7 @@ func (x *GetNpcResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNpcResponse.ProtoReflect.Descriptor instead.
 func (*GetNpcResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{10}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *GetNpcResponse) GetResult() AdminResult {
@@ -867,7 +1103,7 @@ type UpsertNpcRequest struct {
 
 func (x *UpsertNpcRequest) Reset() {
 	*x = UpsertNpcRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[11]
+	mi := &file_api_web_v1_web_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -879,7 +1115,7 @@ func (x *UpsertNpcRequest) String() string {
 func (*UpsertNpcRequest) ProtoMessage() {}
 
 func (x *UpsertNpcRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[11]
+	mi := &file_api_web_v1_web_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -892,7 +1128,7 @@ func (x *UpsertNpcRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpsertNpcRequest.ProtoReflect.Descriptor instead.
 func (*UpsertNpcRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{11}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *UpsertNpcRequest) GetModeratorId() int64 {
@@ -975,7 +1211,7 @@ type UpsertNpcResponse struct {
 
 func (x *UpsertNpcResponse) Reset() {
 	*x = UpsertNpcResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[12]
+	mi := &file_api_web_v1_web_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -987,7 +1223,7 @@ func (x *UpsertNpcResponse) String() string {
 func (*UpsertNpcResponse) ProtoMessage() {}
 
 func (x *UpsertNpcResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[12]
+	mi := &file_api_web_v1_web_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1000,7 +1236,7 @@ func (x *UpsertNpcResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpsertNpcResponse.ProtoReflect.Descriptor instead.
 func (*UpsertNpcResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{12}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *UpsertNpcResponse) GetResult() AdminResult {
@@ -1028,7 +1264,7 @@ type SetNpcVisibilityRequest struct {
 
 func (x *SetNpcVisibilityRequest) Reset() {
 	*x = SetNpcVisibilityRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[13]
+	mi := &file_api_web_v1_web_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1040,7 +1276,7 @@ func (x *SetNpcVisibilityRequest) String() string {
 func (*SetNpcVisibilityRequest) ProtoMessage() {}
 
 func (x *SetNpcVisibilityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[13]
+	mi := &file_api_web_v1_web_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1053,7 +1289,7 @@ func (x *SetNpcVisibilityRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetNpcVisibilityRequest.ProtoReflect.Descriptor instead.
 func (*SetNpcVisibilityRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{13}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *SetNpcVisibilityRequest) GetModeratorId() int64 {
@@ -1088,7 +1324,7 @@ type SetNpcShopRequest struct {
 
 func (x *SetNpcShopRequest) Reset() {
 	*x = SetNpcShopRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[14]
+	mi := &file_api_web_v1_web_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1100,7 +1336,7 @@ func (x *SetNpcShopRequest) String() string {
 func (*SetNpcShopRequest) ProtoMessage() {}
 
 func (x *SetNpcShopRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[14]
+	mi := &file_api_web_v1_web_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1113,7 +1349,7 @@ func (x *SetNpcShopRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetNpcShopRequest.ProtoReflect.Descriptor instead.
 func (*SetNpcShopRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{14}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *SetNpcShopRequest) GetModeratorId() int64 {
@@ -1148,7 +1384,7 @@ type SetItemPriceRequest struct {
 
 func (x *SetItemPriceRequest) Reset() {
 	*x = SetItemPriceRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[15]
+	mi := &file_api_web_v1_web_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1160,7 +1396,7 @@ func (x *SetItemPriceRequest) String() string {
 func (*SetItemPriceRequest) ProtoMessage() {}
 
 func (x *SetItemPriceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[15]
+	mi := &file_api_web_v1_web_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1173,7 +1409,7 @@ func (x *SetItemPriceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetItemPriceRequest.ProtoReflect.Descriptor instead.
 func (*SetItemPriceRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{15}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *SetItemPriceRequest) GetModeratorId() int64 {
@@ -1207,7 +1443,7 @@ type DeleteNpcRequest struct {
 
 func (x *DeleteNpcRequest) Reset() {
 	*x = DeleteNpcRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[16]
+	mi := &file_api_web_v1_web_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1219,7 +1455,7 @@ func (x *DeleteNpcRequest) String() string {
 func (*DeleteNpcRequest) ProtoMessage() {}
 
 func (x *DeleteNpcRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[16]
+	mi := &file_api_web_v1_web_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1232,7 +1468,7 @@ func (x *DeleteNpcRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteNpcRequest.ProtoReflect.Descriptor instead.
 func (*DeleteNpcRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{16}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *DeleteNpcRequest) GetModeratorId() int64 {
@@ -1262,7 +1498,7 @@ type MerchantTemplate struct {
 
 func (x *MerchantTemplate) Reset() {
 	*x = MerchantTemplate{}
-	mi := &file_api_web_v1_web_proto_msgTypes[17]
+	mi := &file_api_web_v1_web_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1274,7 +1510,7 @@ func (x *MerchantTemplate) String() string {
 func (*MerchantTemplate) ProtoMessage() {}
 
 func (x *MerchantTemplate) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[17]
+	mi := &file_api_web_v1_web_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1287,7 +1523,7 @@ func (x *MerchantTemplate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MerchantTemplate.ProtoReflect.Descriptor instead.
 func (*MerchantTemplate) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{17}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *MerchantTemplate) GetTemplateName() string {
@@ -1320,7 +1556,7 @@ type ListMerchantTemplatesRequest struct {
 
 func (x *ListMerchantTemplatesRequest) Reset() {
 	*x = ListMerchantTemplatesRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[18]
+	mi := &file_api_web_v1_web_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1332,7 +1568,7 @@ func (x *ListMerchantTemplatesRequest) String() string {
 func (*ListMerchantTemplatesRequest) ProtoMessage() {}
 
 func (x *ListMerchantTemplatesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[18]
+	mi := &file_api_web_v1_web_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1345,7 +1581,7 @@ func (x *ListMerchantTemplatesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMerchantTemplatesRequest.ProtoReflect.Descriptor instead.
 func (*ListMerchantTemplatesRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{18}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ListMerchantTemplatesRequest) GetModeratorId() int64 {
@@ -1365,7 +1601,7 @@ type ListMerchantTemplatesResponse struct {
 
 func (x *ListMerchantTemplatesResponse) Reset() {
 	*x = ListMerchantTemplatesResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[19]
+	mi := &file_api_web_v1_web_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1377,7 +1613,7 @@ func (x *ListMerchantTemplatesResponse) String() string {
 func (*ListMerchantTemplatesResponse) ProtoMessage() {}
 
 func (x *ListMerchantTemplatesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[19]
+	mi := &file_api_web_v1_web_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1390,7 +1626,7 @@ func (x *ListMerchantTemplatesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMerchantTemplatesResponse.ProtoReflect.Descriptor instead.
 func (*ListMerchantTemplatesResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{19}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ListMerchantTemplatesResponse) GetResult() AdminResult {
@@ -1420,7 +1656,7 @@ type ItemCatalogEntry struct {
 
 func (x *ItemCatalogEntry) Reset() {
 	*x = ItemCatalogEntry{}
-	mi := &file_api_web_v1_web_proto_msgTypes[20]
+	mi := &file_api_web_v1_web_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1432,7 +1668,7 @@ func (x *ItemCatalogEntry) String() string {
 func (*ItemCatalogEntry) ProtoMessage() {}
 
 func (x *ItemCatalogEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[20]
+	mi := &file_api_web_v1_web_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1445,7 +1681,7 @@ func (x *ItemCatalogEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ItemCatalogEntry.ProtoReflect.Descriptor instead.
 func (*ItemCatalogEntry) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{20}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ItemCatalogEntry) GetItemIndex() int32 {
@@ -1471,7 +1707,7 @@ type ListItemCatalogRequest struct {
 
 func (x *ListItemCatalogRequest) Reset() {
 	*x = ListItemCatalogRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[21]
+	mi := &file_api_web_v1_web_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1483,7 +1719,7 @@ func (x *ListItemCatalogRequest) String() string {
 func (*ListItemCatalogRequest) ProtoMessage() {}
 
 func (x *ListItemCatalogRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[21]
+	mi := &file_api_web_v1_web_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1496,7 +1732,7 @@ func (x *ListItemCatalogRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListItemCatalogRequest.ProtoReflect.Descriptor instead.
 func (*ListItemCatalogRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{21}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ListItemCatalogRequest) GetModeratorId() int64 {
@@ -1516,7 +1752,7 @@ type ListItemCatalogResponse struct {
 
 func (x *ListItemCatalogResponse) Reset() {
 	*x = ListItemCatalogResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[22]
+	mi := &file_api_web_v1_web_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1528,7 +1764,7 @@ func (x *ListItemCatalogResponse) String() string {
 func (*ListItemCatalogResponse) ProtoMessage() {}
 
 func (x *ListItemCatalogResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[22]
+	mi := &file_api_web_v1_web_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1541,7 +1777,7 @@ func (x *ListItemCatalogResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListItemCatalogResponse.ProtoReflect.Descriptor instead.
 func (*ListItemCatalogResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{22}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ListItemCatalogResponse) GetResult() AdminResult {
@@ -1571,7 +1807,7 @@ type MapZone struct {
 
 func (x *MapZone) Reset() {
 	*x = MapZone{}
-	mi := &file_api_web_v1_web_proto_msgTypes[23]
+	mi := &file_api_web_v1_web_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1583,7 +1819,7 @@ func (x *MapZone) String() string {
 func (*MapZone) ProtoMessage() {}
 
 func (x *MapZone) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[23]
+	mi := &file_api_web_v1_web_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1596,7 +1832,7 @@ func (x *MapZone) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MapZone.ProtoReflect.Descriptor instead.
 func (*MapZone) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{23}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *MapZone) GetId() int32 {
@@ -1622,7 +1858,7 @@ type ListMapZonesRequest struct {
 
 func (x *ListMapZonesRequest) Reset() {
 	*x = ListMapZonesRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[24]
+	mi := &file_api_web_v1_web_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1634,7 +1870,7 @@ func (x *ListMapZonesRequest) String() string {
 func (*ListMapZonesRequest) ProtoMessage() {}
 
 func (x *ListMapZonesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[24]
+	mi := &file_api_web_v1_web_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1647,7 +1883,7 @@ func (x *ListMapZonesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMapZonesRequest.ProtoReflect.Descriptor instead.
 func (*ListMapZonesRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{24}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ListMapZonesRequest) GetModeratorId() int64 {
@@ -1667,7 +1903,7 @@ type ListMapZonesResponse struct {
 
 func (x *ListMapZonesResponse) Reset() {
 	*x = ListMapZonesResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[25]
+	mi := &file_api_web_v1_web_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1679,7 +1915,7 @@ func (x *ListMapZonesResponse) String() string {
 func (*ListMapZonesResponse) ProtoMessage() {}
 
 func (x *ListMapZonesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[25]
+	mi := &file_api_web_v1_web_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1692,7 +1928,7 @@ func (x *ListMapZonesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMapZonesResponse.ProtoReflect.Descriptor instead.
 func (*ListMapZonesResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{25}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ListMapZonesResponse) GetResult() AdminResult {
@@ -1730,7 +1966,30 @@ const file_api_web_v1_web_proto_rawDesc = "" +
 	"\n" +
 	"account_id\x18\x02 \x01(\x03R\taccountId\x12\x18\n" +
 	"\ablocked\x18\x03 \x01(\bR\ablocked\x12\x12\n" +
-	"\x04role\x18\x04 \x01(\tR\x04role\"7\n" +
+	"\x04role\x18\x04 \x01(\tR\x04role\"8\n" +
+	"\x17ListMyCharactersRequest\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x01 \x01(\x03R\taccountId\"\xa5\x02\n" +
+	"\x13WebCharacterSummary\x12\x12\n" +
+	"\x04slot\x18\x01 \x01(\x05R\x04slot\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
+	"\x05class\x18\x03 \x01(\x05R\x05class\x12\x14\n" +
+	"\x05level\x18\x04 \x01(\x05R\x05level\x12\x10\n" +
+	"\x03exp\x18\x05 \x01(\x03R\x03exp\x12\x12\n" +
+	"\x04coin\x18\x06 \x01(\x05R\x04coin\x12\x15\n" +
+	"\x06max_hp\x18\a \x01(\x05R\x05maxHp\x12\x0e\n" +
+	"\x02hp\x18\b \x01(\x05R\x02hp\x12\x15\n" +
+	"\x06max_mp\x18\t \x01(\x05R\x05maxMp\x12\x0e\n" +
+	"\x02mp\x18\n" +
+	" \x01(\x05R\x02mp\x12\x10\n" +
+	"\x03str\x18\v \x01(\x05R\x03str\x12\x10\n" +
+	"\x03int\x18\f \x01(\x05R\x03int\x12\x10\n" +
+	"\x03dex\x18\r \x01(\x05R\x03dex\x12\x10\n" +
+	"\x03con\x18\x0e \x01(\x05R\x03con\"W\n" +
+	"\x18ListMyCharactersResponse\x12;\n" +
+	"\n" +
+	"characters\x18\x01 \x03(\v2\x1b.web.v1.WebCharacterSummaryR\n" +
+	"characters\"7\n" +
 	"\bAdminAck\x12+\n" +
 	"\x06result\x18\x01 \x01(\x0e2\x13.web.v1.AdminResultR\x06result\"\xc3\x01\n" +
 	"\x10AdminNpcShopItem\x12\x12\n" +
@@ -1839,7 +2098,9 @@ const file_api_web_v1_web_proto_rawDesc = "" +
 	"\x16ADMIN_RESULT_NOT_FOUND\x10\x042\xbb\x01\n" +
 	"\x11AccountWebService\x12L\n" +
 	"\rCreateAccount\x12\x1c.web.v1.CreateAccountRequest\x1a\x1d.web.v1.CreateAccountResponse\x12X\n" +
-	"\x11VerifyCredentials\x12 .web.v1.VerifyCredentialsRequest\x1a!.web.v1.VerifyCredentialsResponse2\xca\x05\n" +
+	"\x11VerifyCredentials\x12 .web.v1.VerifyCredentialsRequest\x1a!.web.v1.VerifyCredentialsResponse2l\n" +
+	"\x13CharacterWebService\x12U\n" +
+	"\x10ListMyCharacters\x12\x1f.web.v1.ListMyCharactersRequest\x1a .web.v1.ListMyCharactersResponse2\xca\x05\n" +
 	"\x0fNpcAdminService\x12=\n" +
 	"\bListNpcs\x12\x17.web.v1.ListNpcsRequest\x1a\x18.web.v1.ListNpcsResponse\x127\n" +
 	"\x06GetNpc\x12\x15.web.v1.GetNpcRequest\x1a\x16.web.v1.GetNpcResponse\x12@\n" +
@@ -1866,7 +2127,7 @@ func file_api_web_v1_web_proto_rawDescGZIP() []byte {
 }
 
 var file_api_web_v1_web_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_api_web_v1_web_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
+var file_api_web_v1_web_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
 var file_api_web_v1_web_proto_goTypes = []any{
 	(CreateResult)(0),                     // 0: web.v1.CreateResult
 	(AdminResult)(0),                      // 1: web.v1.AdminResult
@@ -1874,74 +2135,80 @@ var file_api_web_v1_web_proto_goTypes = []any{
 	(*CreateAccountResponse)(nil),         // 3: web.v1.CreateAccountResponse
 	(*VerifyCredentialsRequest)(nil),      // 4: web.v1.VerifyCredentialsRequest
 	(*VerifyCredentialsResponse)(nil),     // 5: web.v1.VerifyCredentialsResponse
-	(*AdminAck)(nil),                      // 6: web.v1.AdminAck
-	(*AdminNpcShopItem)(nil),              // 7: web.v1.AdminNpcShopItem
-	(*AdminNpc)(nil),                      // 8: web.v1.AdminNpc
-	(*ListNpcsRequest)(nil),               // 9: web.v1.ListNpcsRequest
-	(*ListNpcsResponse)(nil),              // 10: web.v1.ListNpcsResponse
-	(*GetNpcRequest)(nil),                 // 11: web.v1.GetNpcRequest
-	(*GetNpcResponse)(nil),                // 12: web.v1.GetNpcResponse
-	(*UpsertNpcRequest)(nil),              // 13: web.v1.UpsertNpcRequest
-	(*UpsertNpcResponse)(nil),             // 14: web.v1.UpsertNpcResponse
-	(*SetNpcVisibilityRequest)(nil),       // 15: web.v1.SetNpcVisibilityRequest
-	(*SetNpcShopRequest)(nil),             // 16: web.v1.SetNpcShopRequest
-	(*SetItemPriceRequest)(nil),           // 17: web.v1.SetItemPriceRequest
-	(*DeleteNpcRequest)(nil),              // 18: web.v1.DeleteNpcRequest
-	(*MerchantTemplate)(nil),              // 19: web.v1.MerchantTemplate
-	(*ListMerchantTemplatesRequest)(nil),  // 20: web.v1.ListMerchantTemplatesRequest
-	(*ListMerchantTemplatesResponse)(nil), // 21: web.v1.ListMerchantTemplatesResponse
-	(*ItemCatalogEntry)(nil),              // 22: web.v1.ItemCatalogEntry
-	(*ListItemCatalogRequest)(nil),        // 23: web.v1.ListItemCatalogRequest
-	(*ListItemCatalogResponse)(nil),       // 24: web.v1.ListItemCatalogResponse
-	(*MapZone)(nil),                       // 25: web.v1.MapZone
-	(*ListMapZonesRequest)(nil),           // 26: web.v1.ListMapZonesRequest
-	(*ListMapZonesResponse)(nil),          // 27: web.v1.ListMapZonesResponse
+	(*ListMyCharactersRequest)(nil),       // 6: web.v1.ListMyCharactersRequest
+	(*WebCharacterSummary)(nil),           // 7: web.v1.WebCharacterSummary
+	(*ListMyCharactersResponse)(nil),      // 8: web.v1.ListMyCharactersResponse
+	(*AdminAck)(nil),                      // 9: web.v1.AdminAck
+	(*AdminNpcShopItem)(nil),              // 10: web.v1.AdminNpcShopItem
+	(*AdminNpc)(nil),                      // 11: web.v1.AdminNpc
+	(*ListNpcsRequest)(nil),               // 12: web.v1.ListNpcsRequest
+	(*ListNpcsResponse)(nil),              // 13: web.v1.ListNpcsResponse
+	(*GetNpcRequest)(nil),                 // 14: web.v1.GetNpcRequest
+	(*GetNpcResponse)(nil),                // 15: web.v1.GetNpcResponse
+	(*UpsertNpcRequest)(nil),              // 16: web.v1.UpsertNpcRequest
+	(*UpsertNpcResponse)(nil),             // 17: web.v1.UpsertNpcResponse
+	(*SetNpcVisibilityRequest)(nil),       // 18: web.v1.SetNpcVisibilityRequest
+	(*SetNpcShopRequest)(nil),             // 19: web.v1.SetNpcShopRequest
+	(*SetItemPriceRequest)(nil),           // 20: web.v1.SetItemPriceRequest
+	(*DeleteNpcRequest)(nil),              // 21: web.v1.DeleteNpcRequest
+	(*MerchantTemplate)(nil),              // 22: web.v1.MerchantTemplate
+	(*ListMerchantTemplatesRequest)(nil),  // 23: web.v1.ListMerchantTemplatesRequest
+	(*ListMerchantTemplatesResponse)(nil), // 24: web.v1.ListMerchantTemplatesResponse
+	(*ItemCatalogEntry)(nil),              // 25: web.v1.ItemCatalogEntry
+	(*ListItemCatalogRequest)(nil),        // 26: web.v1.ListItemCatalogRequest
+	(*ListItemCatalogResponse)(nil),       // 27: web.v1.ListItemCatalogResponse
+	(*MapZone)(nil),                       // 28: web.v1.MapZone
+	(*ListMapZonesRequest)(nil),           // 29: web.v1.ListMapZonesRequest
+	(*ListMapZonesResponse)(nil),          // 30: web.v1.ListMapZonesResponse
 }
 var file_api_web_v1_web_proto_depIdxs = []int32{
 	0,  // 0: web.v1.CreateAccountResponse.result:type_name -> web.v1.CreateResult
-	1,  // 1: web.v1.AdminAck.result:type_name -> web.v1.AdminResult
-	7,  // 2: web.v1.AdminNpc.shop:type_name -> web.v1.AdminNpcShopItem
-	1,  // 3: web.v1.ListNpcsResponse.result:type_name -> web.v1.AdminResult
-	8,  // 4: web.v1.ListNpcsResponse.npcs:type_name -> web.v1.AdminNpc
-	1,  // 5: web.v1.GetNpcResponse.result:type_name -> web.v1.AdminResult
-	8,  // 6: web.v1.GetNpcResponse.npc:type_name -> web.v1.AdminNpc
-	1,  // 7: web.v1.UpsertNpcResponse.result:type_name -> web.v1.AdminResult
-	7,  // 8: web.v1.SetNpcShopRequest.items:type_name -> web.v1.AdminNpcShopItem
-	1,  // 9: web.v1.ListMerchantTemplatesResponse.result:type_name -> web.v1.AdminResult
-	19, // 10: web.v1.ListMerchantTemplatesResponse.templates:type_name -> web.v1.MerchantTemplate
-	1,  // 11: web.v1.ListItemCatalogResponse.result:type_name -> web.v1.AdminResult
-	22, // 12: web.v1.ListItemCatalogResponse.items:type_name -> web.v1.ItemCatalogEntry
-	1,  // 13: web.v1.ListMapZonesResponse.result:type_name -> web.v1.AdminResult
-	25, // 14: web.v1.ListMapZonesResponse.zones:type_name -> web.v1.MapZone
-	2,  // 15: web.v1.AccountWebService.CreateAccount:input_type -> web.v1.CreateAccountRequest
-	4,  // 16: web.v1.AccountWebService.VerifyCredentials:input_type -> web.v1.VerifyCredentialsRequest
-	9,  // 17: web.v1.NpcAdminService.ListNpcs:input_type -> web.v1.ListNpcsRequest
-	11, // 18: web.v1.NpcAdminService.GetNpc:input_type -> web.v1.GetNpcRequest
-	13, // 19: web.v1.NpcAdminService.UpsertNpc:input_type -> web.v1.UpsertNpcRequest
-	15, // 20: web.v1.NpcAdminService.SetNpcVisibility:input_type -> web.v1.SetNpcVisibilityRequest
-	16, // 21: web.v1.NpcAdminService.SetNpcShop:input_type -> web.v1.SetNpcShopRequest
-	17, // 22: web.v1.NpcAdminService.SetItemPrice:input_type -> web.v1.SetItemPriceRequest
-	18, // 23: web.v1.NpcAdminService.DeleteNpc:input_type -> web.v1.DeleteNpcRequest
-	20, // 24: web.v1.NpcAdminService.ListMerchantTemplates:input_type -> web.v1.ListMerchantTemplatesRequest
-	23, // 25: web.v1.NpcAdminService.ListItemCatalog:input_type -> web.v1.ListItemCatalogRequest
-	26, // 26: web.v1.NpcAdminService.ListMapZones:input_type -> web.v1.ListMapZonesRequest
-	3,  // 27: web.v1.AccountWebService.CreateAccount:output_type -> web.v1.CreateAccountResponse
-	5,  // 28: web.v1.AccountWebService.VerifyCredentials:output_type -> web.v1.VerifyCredentialsResponse
-	10, // 29: web.v1.NpcAdminService.ListNpcs:output_type -> web.v1.ListNpcsResponse
-	12, // 30: web.v1.NpcAdminService.GetNpc:output_type -> web.v1.GetNpcResponse
-	14, // 31: web.v1.NpcAdminService.UpsertNpc:output_type -> web.v1.UpsertNpcResponse
-	6,  // 32: web.v1.NpcAdminService.SetNpcVisibility:output_type -> web.v1.AdminAck
-	6,  // 33: web.v1.NpcAdminService.SetNpcShop:output_type -> web.v1.AdminAck
-	6,  // 34: web.v1.NpcAdminService.SetItemPrice:output_type -> web.v1.AdminAck
-	6,  // 35: web.v1.NpcAdminService.DeleteNpc:output_type -> web.v1.AdminAck
-	21, // 36: web.v1.NpcAdminService.ListMerchantTemplates:output_type -> web.v1.ListMerchantTemplatesResponse
-	24, // 37: web.v1.NpcAdminService.ListItemCatalog:output_type -> web.v1.ListItemCatalogResponse
-	27, // 38: web.v1.NpcAdminService.ListMapZones:output_type -> web.v1.ListMapZonesResponse
-	27, // [27:39] is the sub-list for method output_type
-	15, // [15:27] is the sub-list for method input_type
-	15, // [15:15] is the sub-list for extension type_name
-	15, // [15:15] is the sub-list for extension extendee
-	0,  // [0:15] is the sub-list for field type_name
+	7,  // 1: web.v1.ListMyCharactersResponse.characters:type_name -> web.v1.WebCharacterSummary
+	1,  // 2: web.v1.AdminAck.result:type_name -> web.v1.AdminResult
+	10, // 3: web.v1.AdminNpc.shop:type_name -> web.v1.AdminNpcShopItem
+	1,  // 4: web.v1.ListNpcsResponse.result:type_name -> web.v1.AdminResult
+	11, // 5: web.v1.ListNpcsResponse.npcs:type_name -> web.v1.AdminNpc
+	1,  // 6: web.v1.GetNpcResponse.result:type_name -> web.v1.AdminResult
+	11, // 7: web.v1.GetNpcResponse.npc:type_name -> web.v1.AdminNpc
+	1,  // 8: web.v1.UpsertNpcResponse.result:type_name -> web.v1.AdminResult
+	10, // 9: web.v1.SetNpcShopRequest.items:type_name -> web.v1.AdminNpcShopItem
+	1,  // 10: web.v1.ListMerchantTemplatesResponse.result:type_name -> web.v1.AdminResult
+	22, // 11: web.v1.ListMerchantTemplatesResponse.templates:type_name -> web.v1.MerchantTemplate
+	1,  // 12: web.v1.ListItemCatalogResponse.result:type_name -> web.v1.AdminResult
+	25, // 13: web.v1.ListItemCatalogResponse.items:type_name -> web.v1.ItemCatalogEntry
+	1,  // 14: web.v1.ListMapZonesResponse.result:type_name -> web.v1.AdminResult
+	28, // 15: web.v1.ListMapZonesResponse.zones:type_name -> web.v1.MapZone
+	2,  // 16: web.v1.AccountWebService.CreateAccount:input_type -> web.v1.CreateAccountRequest
+	4,  // 17: web.v1.AccountWebService.VerifyCredentials:input_type -> web.v1.VerifyCredentialsRequest
+	6,  // 18: web.v1.CharacterWebService.ListMyCharacters:input_type -> web.v1.ListMyCharactersRequest
+	12, // 19: web.v1.NpcAdminService.ListNpcs:input_type -> web.v1.ListNpcsRequest
+	14, // 20: web.v1.NpcAdminService.GetNpc:input_type -> web.v1.GetNpcRequest
+	16, // 21: web.v1.NpcAdminService.UpsertNpc:input_type -> web.v1.UpsertNpcRequest
+	18, // 22: web.v1.NpcAdminService.SetNpcVisibility:input_type -> web.v1.SetNpcVisibilityRequest
+	19, // 23: web.v1.NpcAdminService.SetNpcShop:input_type -> web.v1.SetNpcShopRequest
+	20, // 24: web.v1.NpcAdminService.SetItemPrice:input_type -> web.v1.SetItemPriceRequest
+	21, // 25: web.v1.NpcAdminService.DeleteNpc:input_type -> web.v1.DeleteNpcRequest
+	23, // 26: web.v1.NpcAdminService.ListMerchantTemplates:input_type -> web.v1.ListMerchantTemplatesRequest
+	26, // 27: web.v1.NpcAdminService.ListItemCatalog:input_type -> web.v1.ListItemCatalogRequest
+	29, // 28: web.v1.NpcAdminService.ListMapZones:input_type -> web.v1.ListMapZonesRequest
+	3,  // 29: web.v1.AccountWebService.CreateAccount:output_type -> web.v1.CreateAccountResponse
+	5,  // 30: web.v1.AccountWebService.VerifyCredentials:output_type -> web.v1.VerifyCredentialsResponse
+	8,  // 31: web.v1.CharacterWebService.ListMyCharacters:output_type -> web.v1.ListMyCharactersResponse
+	13, // 32: web.v1.NpcAdminService.ListNpcs:output_type -> web.v1.ListNpcsResponse
+	15, // 33: web.v1.NpcAdminService.GetNpc:output_type -> web.v1.GetNpcResponse
+	17, // 34: web.v1.NpcAdminService.UpsertNpc:output_type -> web.v1.UpsertNpcResponse
+	9,  // 35: web.v1.NpcAdminService.SetNpcVisibility:output_type -> web.v1.AdminAck
+	9,  // 36: web.v1.NpcAdminService.SetNpcShop:output_type -> web.v1.AdminAck
+	9,  // 37: web.v1.NpcAdminService.SetItemPrice:output_type -> web.v1.AdminAck
+	9,  // 38: web.v1.NpcAdminService.DeleteNpc:output_type -> web.v1.AdminAck
+	24, // 39: web.v1.NpcAdminService.ListMerchantTemplates:output_type -> web.v1.ListMerchantTemplatesResponse
+	27, // 40: web.v1.NpcAdminService.ListItemCatalog:output_type -> web.v1.ListItemCatalogResponse
+	30, // 41: web.v1.NpcAdminService.ListMapZones:output_type -> web.v1.ListMapZonesResponse
+	29, // [29:42] is the sub-list for method output_type
+	16, // [16:29] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_api_web_v1_web_proto_init() }
@@ -1955,9 +2222,9 @@ func file_api_web_v1_web_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_web_v1_web_proto_rawDesc), len(file_api_web_v1_web_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   26,
+			NumMessages:   29,
 			NumExtensions: 0,
-			NumServices:   2,
+			NumServices:   3,
 		},
 		GoTypes:           file_api_web_v1_web_proto_goTypes,
 		DependencyIndexes: file_api_web_v1_web_proto_depIdxs,

--- a/api/web/v1/web.proto
+++ b/api/web/v1/web.proto
@@ -60,6 +60,41 @@ message VerifyCredentialsResponse {
   string role = 4;
 }
 
+// CharacterWebService exposes player-facing, read-only character summaries for
+// the Next.js BFF. The BFF must pass the account_id from its httpOnly session;
+// the browser must never provide account_id directly.
+service CharacterWebService {
+  // ListMyCharacters returns the character-selection projection for the logged
+  // account. It is cold-storage data and can be slightly stale while a character
+  // is online; live state remains owned by tmServer's single goroutine.
+  rpc ListMyCharacters(ListMyCharactersRequest) returns (ListMyCharactersResponse);
+}
+
+message ListMyCharactersRequest {
+  int64 account_id = 1; // from the BFF session, never from browser input
+}
+
+message WebCharacterSummary {
+  int32 slot = 1;
+  string name = 2;
+  int32 class = 3;
+  int32 level = 4;
+  int64 exp = 5;
+  int32 coin = 6;
+  int32 max_hp = 7;
+  int32 hp = 8;
+  int32 max_mp = 9;
+  int32 mp = 10;
+  int32 str = 11;
+  int32 int = 12;
+  int32 dex = 13;
+  int32 con = 14;
+}
+
+message ListMyCharactersResponse {
+  repeated WebCharacterSummary characters = 1;
+}
+
 // NpcAdminService is the moderator-facing NPC editing surface (npc-editing-plan.md).
 // The Next.js BFF calls it server-side after establishing a moderator session;
 // every request carries the moderator's account_id, which the web-api authorizes

--- a/api/web/v1/web_grpc.pb.go
+++ b/api/web/v1/web_grpc.pb.go
@@ -182,6 +182,122 @@ var AccountWebService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
+	CharacterWebService_ListMyCharacters_FullMethodName = "/web.v1.CharacterWebService/ListMyCharacters"
+)
+
+// CharacterWebServiceClient is the client API for CharacterWebService service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// CharacterWebService exposes player-facing, read-only character summaries for
+// the Next.js BFF. The BFF must pass the account_id from its httpOnly session;
+// the browser must never provide account_id directly.
+type CharacterWebServiceClient interface {
+	// ListMyCharacters returns the character-selection projection for the logged
+	// account. It is cold-storage data and can be slightly stale while a character
+	// is online; live state remains owned by tmServer's single goroutine.
+	ListMyCharacters(ctx context.Context, in *ListMyCharactersRequest, opts ...grpc.CallOption) (*ListMyCharactersResponse, error)
+}
+
+type characterWebServiceClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewCharacterWebServiceClient(cc grpc.ClientConnInterface) CharacterWebServiceClient {
+	return &characterWebServiceClient{cc}
+}
+
+func (c *characterWebServiceClient) ListMyCharacters(ctx context.Context, in *ListMyCharactersRequest, opts ...grpc.CallOption) (*ListMyCharactersResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListMyCharactersResponse)
+	err := c.cc.Invoke(ctx, CharacterWebService_ListMyCharacters_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// CharacterWebServiceServer is the server API for CharacterWebService service.
+// All implementations must embed UnimplementedCharacterWebServiceServer
+// for forward compatibility.
+//
+// CharacterWebService exposes player-facing, read-only character summaries for
+// the Next.js BFF. The BFF must pass the account_id from its httpOnly session;
+// the browser must never provide account_id directly.
+type CharacterWebServiceServer interface {
+	// ListMyCharacters returns the character-selection projection for the logged
+	// account. It is cold-storage data and can be slightly stale while a character
+	// is online; live state remains owned by tmServer's single goroutine.
+	ListMyCharacters(context.Context, *ListMyCharactersRequest) (*ListMyCharactersResponse, error)
+	mustEmbedUnimplementedCharacterWebServiceServer()
+}
+
+// UnimplementedCharacterWebServiceServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedCharacterWebServiceServer struct{}
+
+func (UnimplementedCharacterWebServiceServer) ListMyCharacters(context.Context, *ListMyCharactersRequest) (*ListMyCharactersResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListMyCharacters not implemented")
+}
+func (UnimplementedCharacterWebServiceServer) mustEmbedUnimplementedCharacterWebServiceServer() {}
+func (UnimplementedCharacterWebServiceServer) testEmbeddedByValue()                             {}
+
+// UnsafeCharacterWebServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to CharacterWebServiceServer will
+// result in compilation errors.
+type UnsafeCharacterWebServiceServer interface {
+	mustEmbedUnimplementedCharacterWebServiceServer()
+}
+
+func RegisterCharacterWebServiceServer(s grpc.ServiceRegistrar, srv CharacterWebServiceServer) {
+	// If the following call panics, it indicates UnimplementedCharacterWebServiceServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&CharacterWebService_ServiceDesc, srv)
+}
+
+func _CharacterWebService_ListMyCharacters_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListMyCharactersRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CharacterWebServiceServer).ListMyCharacters(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CharacterWebService_ListMyCharacters_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CharacterWebServiceServer).ListMyCharacters(ctx, req.(*ListMyCharactersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// CharacterWebService_ServiceDesc is the grpc.ServiceDesc for CharacterWebService service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var CharacterWebService_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "web.v1.CharacterWebService",
+	HandlerType: (*CharacterWebServiceServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "ListMyCharacters",
+			Handler:    _CharacterWebService_ListMyCharacters_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "api/web/v1/web.proto",
+}
+
+const (
 	NpcAdminService_ListNpcs_FullMethodName              = "/web.v1.NpcAdminService/ListNpcs"
 	NpcAdminService_GetNpc_FullMethodName                = "/web.v1.NpcAdminService/GetNpc"
 	NpcAdminService_UpsertNpc_FullMethodName             = "/web.v1.NpcAdminService/UpsertNpc"

--- a/docs/integrations/my-characters-nextjs.md
+++ b/docs/integrations/my-characters-nextjs.md
@@ -1,0 +1,63 @@
+# Integração Next.js ↔ web-api: meus personagens
+
+> Contrato: `api/web/v1/web.proto`, serviço `CharacterWebService`.
+
+## Fluxo
+
+O browser chama uma rota REST do próprio Next.js. Essa rota roda server-side, lê o cookie `httpOnly`
+da sessão criada por `AccountWebService.VerifyCredentials`, e chama o `web-api` por gRPC+mTLS.
+
+```
+Browser ──HTTPS──> Next.js BFF ──gRPC+mTLS──> web-api ──> Postgres
+```
+
+O browser nunca envia `account_id`. A rota usa sempre `session.accountId`.
+
+## RPC
+
+```proto
+service CharacterWebService {
+  rpc ListMyCharacters(ListMyCharactersRequest) returns (ListMyCharactersResponse);
+}
+
+message ListMyCharactersRequest {
+  int64 account_id = 1;
+}
+```
+
+`ListMyCharacters` retorna um resumo seguro de cada personagem da conta: `slot`, `name`, `class`,
+`level`, `exp`, `coin`, `hp/mp` e atributos básicos. Inventário, equipamentos e buffs ficam fora
+desta API.
+
+## Rota BFF sugerida
+
+| Método + rota | RPC |
+|---------------|-----|
+| `GET /api/me/characters` | `CharacterWebService.ListMyCharacters` |
+
+```ts
+// app/api/me/characters/route.ts
+import { NextResponse } from "next/server";
+import { characterWeb } from "@/lib/characterWebClient";
+import { getSession } from "@/lib/session";
+
+export async function GET() {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+
+  const resp = await new Promise<any>((resolve, reject) =>
+    characterWeb.listMyCharacters({ accountId: session.accountId }, (err: unknown, r: unknown) =>
+      err ? reject(err) : resolve(r)),
+  ).catch(() => null);
+
+  if (!resp) return NextResponse.json({ error: "upstream" }, { status: 502 });
+  return NextResponse.json({ characters: resp.characters ?? [] });
+}
+```
+
+## Observações
+
+- Os dados vêm do Postgres e podem estar levemente atrasados enquanto o personagem está online; o
+  estado vivo continua pertencendo ao tmServer.
+- Essa API é somente leitura. Qualquer escrita futura em personagem deve respeitar a regra do
+  single-owner game loop e passar pelo tmServer ou por uma fila de entrega.

--- a/webserver/cmd/webserver/main.go
+++ b/webserver/cmd/webserver/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jeanluca/w2pp-openwyd/internal/secure"
 	"github.com/jeanluca/w2pp-openwyd/internal/store"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/account"
+	"github.com/jeanluca/w2pp-openwyd/webserver/internal/characters"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/grpcsrv"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/itemcatalog"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/npcadmin"
@@ -93,6 +94,7 @@ func run(logger *slog.Logger) error {
 		}
 	}
 	webv1.RegisterAccountWebServiceServer(srv, grpcsrv.New(account.New(st)))
+	webv1.RegisterCharacterWebServiceServer(srv, grpcsrv.NewCharacters(characters.New(st)))
 	webv1.RegisterNpcAdminServiceServer(srv, grpcsrv.NewNpcAdmin(npcAdmin))
 
 	ln, err := net.Listen("tcp", *addr)

--- a/webserver/internal/characters/service.go
+++ b/webserver/internal/characters/service.go
@@ -1,0 +1,33 @@
+// Package characters holds the player-facing, read-only character queries used
+// by the web panel. It reads cold storage only; live state remains owned by
+// tmServer's single-owner loop.
+package characters
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+)
+
+// Store is the persistence surface the service needs (satisfied by *store.Store).
+type Store interface {
+	ListCharacters(ctx context.Context, accountID int64) ([]domain.Character, error)
+}
+
+// Service exposes read-only character summaries for web sessions.
+type Service struct {
+	store Store
+}
+
+// New builds the character query service over the given store.
+func New(s Store) *Service { return &Service{store: s} }
+
+// ListMyCharacters returns the character-selection projection for one account.
+func (s *Service) ListMyCharacters(ctx context.Context, accountID int64) ([]domain.Character, error) {
+	chars, err := s.store.ListCharacters(ctx, accountID)
+	if err != nil {
+		return nil, fmt.Errorf("characters: list account %d: %w", accountID, err)
+	}
+	return chars, nil
+}

--- a/webserver/internal/characters/service_test.go
+++ b/webserver/internal/characters/service_test.go
@@ -1,0 +1,45 @@
+package characters
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+)
+
+type fakeStore struct {
+	chars []domain.Character
+	err   error
+	gotID int64
+}
+
+func (f *fakeStore) ListCharacters(_ context.Context, accountID int64) ([]domain.Character, error) {
+	f.gotID = accountID
+	return f.chars, f.err
+}
+
+func TestListMyCharacters(t *testing.T) {
+	fs := &fakeStore{chars: []domain.Character{
+		{Slot: 0, Name: "Hero", Level: 10},
+		{Slot: 2, Name: "Mage", Level: 20},
+	}}
+	got, err := New(fs).ListMyCharacters(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ListMyCharacters: %v", err)
+	}
+	if fs.gotID != 42 {
+		t.Fatalf("accountID = %d, want 42", fs.gotID)
+	}
+	if len(got) != 2 || got[0].Slot != 0 || got[1].Slot != 2 {
+		t.Fatalf("characters = %+v", got)
+	}
+}
+
+func TestListMyCharactersError(t *testing.T) {
+	want := errors.New("db down")
+	_, err := New(&fakeStore{err: want}).ListMyCharacters(context.Background(), 7)
+	if !errors.Is(err, want) {
+		t.Fatalf("err = %v, want wrapping %v", err, want)
+	}
+}

--- a/webserver/internal/grpcsrv/characters.go
+++ b/webserver/internal/grpcsrv/characters.go
@@ -1,0 +1,57 @@
+package grpcsrv
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	webv1 "github.com/jeanluca/w2pp-openwyd/api/web/v1"
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+)
+
+// Characters is the player-facing character query surface the server depends on.
+type Characters interface {
+	ListMyCharacters(ctx context.Context, accountID int64) ([]domain.Character, error)
+}
+
+// CharacterServer implements webv1.CharacterWebServiceServer.
+type CharacterServer struct {
+	webv1.UnimplementedCharacterWebServiceServer
+	characters Characters
+}
+
+// NewCharacters builds the CharacterWebService over the given query logic.
+func NewCharacters(c Characters) *CharacterServer { return &CharacterServer{characters: c} }
+
+// ListMyCharacters returns read-only character summaries for the logged account.
+func (s *CharacterServer) ListMyCharacters(ctx context.Context, req *webv1.ListMyCharactersRequest) (*webv1.ListMyCharactersResponse, error) {
+	chars, err := s.characters.ListMyCharacters(ctx, req.GetAccountId())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list my characters: %v", err)
+	}
+	out := make([]*webv1.WebCharacterSummary, 0, len(chars))
+	for _, ch := range chars {
+		out = append(out, characterSummaryToProto(ch))
+	}
+	return &webv1.ListMyCharactersResponse{Characters: out}, nil
+}
+
+func characterSummaryToProto(ch domain.Character) *webv1.WebCharacterSummary {
+	return &webv1.WebCharacterSummary{
+		Slot:  int32(ch.Slot),
+		Name:  ch.Name,
+		Class: int32(ch.Class),
+		Level: ch.Level,
+		Exp:   ch.Exp,
+		Coin:  ch.Coin,
+		MaxHp: ch.MaxHp,
+		Hp:    ch.Hp,
+		MaxMp: ch.MaxMp,
+		Mp:    ch.Mp,
+		Str:   int32(ch.Str),
+		Int:   int32(ch.Int),
+		Dex:   int32(ch.Dex),
+		Con:   int32(ch.Con),
+	}
+}

--- a/webserver/internal/grpcsrv/characters_test.go
+++ b/webserver/internal/grpcsrv/characters_test.go
@@ -1,0 +1,63 @@
+package grpcsrv
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	webv1 "github.com/jeanluca/w2pp-openwyd/api/web/v1"
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+)
+
+type fakeCharacters struct {
+	chars []domain.Character
+	err   error
+	gotID int64
+}
+
+func (f *fakeCharacters) ListMyCharacters(_ context.Context, accountID int64) ([]domain.Character, error) {
+	f.gotID = accountID
+	return f.chars, f.err
+}
+
+func TestListMyCharactersMapping(t *testing.T) {
+	f := &fakeCharacters{chars: []domain.Character{{
+		Slot: 2, Name: "Hero", Class: 1, Level: 49, Exp: 123456, Coin: 987,
+		MaxHp: 800, Hp: 700, MaxMp: 300, Mp: 250, Str: 50, Int: 10, Dex: 20, Con: 30,
+	}}}
+	resp, err := NewCharacters(f).ListMyCharacters(context.Background(), &webv1.ListMyCharactersRequest{AccountId: 99})
+	if err != nil {
+		t.Fatalf("ListMyCharacters: %v", err)
+	}
+	if f.gotID != 99 {
+		t.Fatalf("accountID = %d, want 99", f.gotID)
+	}
+	if len(resp.GetCharacters()) != 1 {
+		t.Fatalf("characters = %d, want 1", len(resp.GetCharacters()))
+	}
+	got := resp.GetCharacters()[0]
+	if got.GetSlot() != 2 || got.GetName() != "Hero" || got.GetClass() != 1 || got.GetLevel() != 49 ||
+		got.GetExp() != 123456 || got.GetCoin() != 987 || got.GetMaxHp() != 800 || got.GetHp() != 700 ||
+		got.GetMaxMp() != 300 || got.GetMp() != 250 || got.GetStr() != 50 || got.GetInt() != 10 ||
+		got.GetDex() != 20 || got.GetCon() != 30 {
+		t.Fatalf("mapped character = %+v", got)
+	}
+}
+
+func TestListMyCharactersEmpty(t *testing.T) {
+	resp, err := NewCharacters(&fakeCharacters{}).ListMyCharacters(context.Background(), &webv1.ListMyCharactersRequest{AccountId: 1})
+	if err != nil {
+		t.Fatalf("ListMyCharacters: %v", err)
+	}
+	if len(resp.GetCharacters()) != 0 {
+		t.Fatalf("characters = %+v, want empty", resp.GetCharacters())
+	}
+}
+
+func TestListMyCharactersInfraError(t *testing.T) {
+	_, err := NewCharacters(&fakeCharacters{err: errors.New("db down")}).
+		ListMyCharacters(context.Background(), &webv1.ListMyCharactersRequest{AccountId: 1})
+	if err == nil {
+		t.Fatal("expected gRPC error")
+	}
+}


### PR DESCRIPTION
## Summary
- add CharacterWebService.ListMyCharacters to the web gRPC contract
- expose read-only character summaries for the logged account via webserver
- document the Next.js BFF route for GET /api/me/characters

Closes #31.

## Tests
- go test ./webserver/internal/...
- go test ./webserver/cmd/webserver
- go test ./...
- make build