### PR TITLE
Fix Poeira de Fada XP

### DIFF
--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"time"
 
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/level"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
 )
@@ -125,10 +126,11 @@ func (d *Dispatcher) getItem(w *world.World, s *world.Session, _ protocol.Header
 // Divine consumable classes (EF_VOLATILE value): the Poção Divina of 7/15/30 days.
 // The buff (Affect 34) lasts these many days; the real deadline is Entity.DivineEnd.
 const (
-	volExpChest = 198
-	volDivine7  = 64
-	volDivine30 = 66
-	volVigor    = 58
+	volExpChest  = 198
+	volFairyDust = 7
+	volDivine7   = 64
+	volDivine30  = 66
+	volVigor     = 58
 	// affect tick units (Basedef.h): one tick = 8s of real time.
 	affect1H          = 450
 	affect1D          = 10800
@@ -164,6 +166,8 @@ func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header
 		d.equipItem(w, s, e, body, payload)
 	case vol >= volSephiraLo && vol <= volSephiraHi:
 		d.useSkillBook(w, s, e, src, vol)
+	case vol == volFairyDust:
+		d.useFairyDust(w, s, e, src)
 	case vol == volExpChest:
 		d.useExpChest(w, s, e, src)
 	case vol >= volDivine7 && vol <= volDivine30:
@@ -172,6 +176,30 @@ func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header
 		d.useVigor(w, s, e, src, int(e.Carry[src].Index))
 	default:
 		// UNVERIFIED consumable (Vigor/HP-MP potions/scrolls/teleport) — not handled yet.
+	}
+}
+
+const efAmount = 61
+
+func itemAmount(it world.Item) int {
+	for _, ef := range it.Effects {
+		if ef.Effect == efAmount {
+			return int(ef.Value)
+		}
+	}
+	return 1
+}
+
+func consumeOneItem(it *world.Item) {
+	if itemAmount(*it) <= 1 {
+		*it = world.Item{}
+		return
+	}
+	for i := range it.Effects {
+		if it.Effects[i].Effect == efAmount {
+			it.Effects[i].Value--
+			return
+		}
 	}
 }
 
@@ -241,6 +269,26 @@ func (d *Dispatcher) useExpChest(w *world.World, s *world.Session, e *world.Enti
 	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
 	d.sendScore(w, s, e)
 	d.sendAffect(w, s, e)
+}
+
+// useFairyDust consumes Poeira de Fada (EF_VOLATILE 7). The legacy handler sets
+// Exp directly to the next curve threshold, then calls CheckGetLevel; both sides
+// of its rand()%2 branch do the same in this fork.
+func (d *Dispatcher) useFairyDust(w *world.World, s *world.Session, e *world.Entity, src int) {
+	if e.Level < 0 {
+		return
+	}
+	if e.Level >= level.MaxLevel {
+		e.Exp = level.MaxExp
+	} else {
+		e.Exp = level.NextLevelExp(e.Level)
+	}
+	consumeOneItem(&e.Carry[src])
+	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
+	if !d.applyMortalLevelUps(w, s, e) {
+		d.sendEtc(w, s, e)
+	}
+	d.log.Info("fairy dust used", "conn", s.Conn, "classmaster", e.ClassMaster, "level", e.Level)
 }
 
 // useDivine consumes a Poção Divina: it sets the Divine buff (Affect 34) for 8/16/31

--- a/tmserver/internal/handler/item_test.go
+++ b/tmserver/internal/handler/item_test.go
@@ -454,6 +454,17 @@ func expChestDB() *fakeDB {
 	return db
 }
 
+func fairyDustDB(levelValue int, item world.Item) *fakeDB {
+	db := newDB()
+	st := world.CharacterState{
+		Slot: 0, Name: "Hero", Class: 1, Level: levelValue,
+		X: 5, Y: 5, HP: 1000, MaxHP: 1000, MP: 100, MaxMP: 100,
+	}
+	st.Carry[0] = item
+	db.loadResult = st
+	return db
+}
+
 func startServerClockVol(t *testing.T, persist world.Persistence, vols map[int]int) (string, func()) {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -517,5 +528,114 @@ func TestUseExpChest(t *testing.T) {
 	}
 	if !sawScore {
 		t.Error("missing MsgUpdateScore after using exp chest")
+	}
+}
+
+func TestUseFairyDust(t *testing.T) {
+	const dust = 5001
+	addr, stop := startServerClockVol(t, fairyDustDB(0, world.Item{Index: dust}), map[int]int{dust: volFairyDust})
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+
+	sawSendItem, sawScore, sawEtc, sawMotion := false, false, false, false
+	for range 6 {
+		ty, payload, ok := readMaybe(t, c)
+		if !ok {
+			break
+		}
+		switch ty {
+		case protocol.MsgSendItem:
+			sawSendItem = true
+			if le16(payload[4:6]) != 0 {
+				t.Errorf("carry slot 0 item = %d, want empty after use", le16(payload[4:6]))
+			}
+		case protocol.MsgUpdateScore:
+			sawScore = true
+		case protocol.MsgUpdateEtc:
+			sawEtc = true
+			if got := int64(binary.LittleEndian.Uint64(payload[4:12])); got != level.NextLevelExp(0) {
+				t.Errorf("UpdateEtc.Exp = %d, want %d", got, level.NextLevelExp(0))
+			}
+		case protocol.MsgMotion:
+			sawMotion = true
+			if got := le16(payload[0:2]); got != motionLevelUp {
+				t.Errorf("motion = %d, want %d", got, motionLevelUp)
+			}
+		}
+	}
+	if !sawSendItem {
+		t.Error("missing MsgSendItem after using fairy dust")
+	}
+	if !sawScore {
+		t.Error("missing MsgUpdateScore after using fairy dust")
+	}
+	if !sawEtc {
+		t.Error("missing MsgUpdateEtc after using fairy dust")
+	}
+	if !sawMotion {
+		t.Error("missing MsgMotion after using fairy dust")
+	}
+}
+
+func TestUseFairyDustStack(t *testing.T) {
+	const dust = 5001
+	item := world.Item{Index: dust, Effects: [3]world.Effect{{Effect: efAmount, Value: 3}}}
+	addr, stop := startServerClockVol(t, fairyDustDB(0, item), map[int]int{dust: volFairyDust})
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+
+	payload := expect(t, c, protocol.MsgSendItem)
+	if got := le16(payload[4:6]); got != dust {
+		t.Fatalf("carry slot 0 item = %d, want stacked dust", got)
+	}
+	if payload[6] != efAmount || payload[7] != 2 {
+		t.Errorf("effect0 = %d.%d, want %d.2", payload[6], payload[7], efAmount)
+	}
+}
+
+func TestUseFairyDustAtCap(t *testing.T) {
+	const dust = 5001
+	addr, stop := startServerClockVol(t, fairyDustDB(int(level.MaxLevel), world.Item{Index: dust}), map[int]int{dust: volFairyDust})
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+
+	sawSendItem, sawEtc := false, false
+	for range 4 {
+		ty, payload, ok := readMaybe(t, c)
+		if !ok {
+			break
+		}
+		switch ty {
+		case protocol.MsgSendItem:
+			sawSendItem = true
+			if le16(payload[4:6]) != 0 {
+				t.Errorf("carry slot 0 item = %d, want empty after use", le16(payload[4:6]))
+			}
+		case protocol.MsgUpdateEtc:
+			sawEtc = true
+			if got := int64(binary.LittleEndian.Uint64(payload[4:12])); got != level.MaxExp {
+				t.Errorf("UpdateEtc.Exp = %d, want %d", got, level.MaxExp)
+			}
+		case protocol.MsgMotion:
+			t.Fatalf("got level-up motion at cap")
+		}
+	}
+	if !sawSendItem {
+		t.Error("missing MsgSendItem after using fairy dust at cap")
+	}
+	if !sawEtc {
+		t.Error("missing MsgUpdateEtc after using fairy dust at cap")
 	}
 }

--- a/tmserver/internal/handler/mobkilled.go
+++ b/tmserver/internal/handler/mobkilled.go
@@ -91,42 +91,50 @@ func (d *Dispatcher) grantExp(w *world.World, ks *world.Session, killer, mob *wo
 		killer.Exp = level.MaxExp
 	}
 
+	d.applyMortalLevelUps(w, ks, killer)
+}
+
+// applyMortalLevelUps ports the MORTAL path of CMob::CheckGetLevel after Exp has
+// already been raised to the desired total. It is shared by kill EXP and Poeira
+// de Fada, whose legacy handler sets Exp directly to the next threshold.
+func (d *Dispatcher) applyMortalLevelUps(w *world.World, s *world.Session, e *world.Entity) bool {
 	leveled := false
-	for killer.Level < level.MaxLevel && killer.Exp >= level.NextLevelExp(killer.Level) {
-		killer.Level++
+	for e.Level < level.MaxLevel && e.Exp >= level.NextLevelExp(e.Level) {
+		e.Level++
 		// The HP/MP increments belong to the BaseScore (CMob.cpp:1116) — writing
 		// only the live MaxHP would be undone by the next refreshScore (= base +
 		// equip). SkillBonus +3/level (+4 from 200) and SpecialBonus +2/level are
 		// the MORTAL level-up grants (CMob.cpp:1121-1129; tiers deferred).
-		killer.BaseMaxHP = addClamp(killer.BaseMaxHP, level.IncHP(killer.Class), level.MaxHPCap)
-		killer.BaseMaxMP = addClamp(killer.BaseMaxMP, level.IncMP(killer.Class), level.MaxMPCap)
-		killer.BaseAC++
-		if killer.Level >= 200 {
-			killer.SkillBonus += 4
+		e.BaseMaxHP = addClamp(e.BaseMaxHP, level.IncHP(e.Class), level.MaxHPCap)
+		e.BaseMaxMP = addClamp(e.BaseMaxMP, level.IncMP(e.Class), level.MaxMPCap)
+		e.BaseAC++
+		if e.Level >= 200 {
+			e.SkillBonus += 4
 		} else {
-			killer.SkillBonus += 3
+			e.SkillBonus += 3
 		}
-		killer.SpecialBonus += 2
+		e.SpecialBonus += 2
 		leveled = true
 	}
 	if !leveled {
-		return
+		return false
 	}
-	killer.ScoreBonus = uint16(level.ScoreBonus(killer.Class, killer.Level, killer.Str, killer.Int, killer.Dex, killer.Con))
-	d.refreshScore(killer)                            // fold the base HP/MP gains into the live score
-	killer.HP, killer.MP = killer.MaxHP, killer.MaxMP // full heal on level-up
+	e.ScoreBonus = uint16(level.ScoreBonus(e.Class, e.Level, e.Str, e.Int, e.Dex, e.Con))
+	d.refreshScore(e)             // fold the base HP/MP gains into the live score
+	e.HP, e.MP = e.MaxHP, e.MaxMP // full heal on level-up
 
 	// Visible level-up: a fresh score window (own attributes) + the etc packet that
 	// carries the new ScoreBonus (free attribute points) — UpdateScore does NOT carry
 	// it, so without SendEtc the client never shows the points gained. Plus the
 	// level-up sparkle to the killer and everyone who can see it.
 	motion := protocol.EncodeMotion(motionLevelUp, motionLevelUpParm)
-	if ks != nil {
-		d.sendScore(w, ks, killer)
-		d.sendEtc(w, ks, killer)
-		w.Send(ks, protocol.MsgMotion, motion)
+	if s != nil {
+		d.sendScore(w, s, e)
+		d.sendEtc(w, s, e)
+		w.Send(s, protocol.MsgMotion, motion)
 	}
-	w.BroadcastInView(killer.ID, protocol.MsgMotion, motion)
+	w.BroadcastInView(e.ID, protocol.MsgMotion, motion)
+	return true
 }
 
 // addClamp returns v+inc clamped to [0, limit], avoiding int32 overflow.


### PR DESCRIPTION
## Summary
- handle EF_VOLATILE 7 as Poeira de Fada in _MSG_UseItem
- reuse the Mortal level-up flow after setting EXP to the next threshold
- consume one item unit while preserving EF_AMOUNT stacks

Fixes #66

## Tests
- go test ./tmserver/internal/handler ./tmserver/internal/level