### PR TITLE
Implement Mestre Grifo quest teleport

### DIFF
--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -493,10 +493,14 @@ func (d *Dispatcher) restart(w *world.World, s *world.Session, _ protocol.Header
 	s.CrackError = 0 // NumError = 0
 	d.sendScore(w, s, e)
 
-	// DoRecall: jump to the last-city default spawn (RemoveMob old view + reveal).
+	d.recall(w, s, e)
+	d.sendEtc(w, s, e) // SendEtc (gold + ScoreBonus)
+}
+
+func (d *Dispatcher) recall(w *world.World, s *world.Session, e *world.Entity) {
+	e.QuestFlag = 0
 	rx, ry := world.CitySpawn(int(e.LastCity))
 	d.doTeleport(w, s, rx, ry)
-	d.sendEtc(w, s, e) // SendEtc (gold + ScoreBonus)
 }
 
 // mountEquipSlot is the mount equip slot (Equip[14]). Mounts are acquired in-game

--- a/tmserver/internal/handler/misc.go
+++ b/tmserver/internal/handler/misc.go
@@ -85,11 +85,13 @@ func (d *Dispatcher) accountSecure(w *world.World, s *world.Session, _ protocol.
 // MSG_STANDARDPARM2 (Parm1 = npcIndex, Parm2 = confirm). The NPC sub-type comes
 // from MOB.Merchant (+ EF_GRADE0 for Merchant==100), see _MSG_Quest-npcs.md.
 //
-// This batch implements the PERZEN item-exchange NPCs (Merchant 100, grade 7/8/9):
-// hand over the item the NPC wants for a mount. The remaining 37 quest NPC types
-// (level chains, tutorials, teleports) are UNVERIFIED and not yet routed.
+// This batch implements the PERZEN item-exchange NPCs (Merchant 100, grade 7/8/9)
+// and Mestre Grifo (Merchant 23), a server-content shortcut into the Quest 256
+// arenas. The remaining quest NPC types (level chains, tutorials, teleports) are
+// UNVERIFIED and not yet routed.
 func (d *Dispatcher) quest(w *world.World, s *world.Session, _ protocol.Header, payload []byte) {
-	if e := w.Entity(s.Conn); e == nil || e.HP <= 0 || s.Mode != world.UserPlay {
+	e := w.Entity(s.Conn)
+	if e == nil || e.HP <= 0 || s.Mode != world.UserPlay {
 		return
 	}
 	if s.Trade.Active {
@@ -108,7 +110,51 @@ func (d *Dispatcher) quest(w *world.World, s *world.Session, _ protocol.Header, 
 		d.perzenExchange(w, s, npc)
 		return
 	}
+	if npc.Merchant == 23 {
+		d.mestreGrifo(w, s, e, npc)
+		return
+	}
 	d.log.Debug("quest NPC not implemented", "conn", s.Conn, "npc", npcIndex, "merchant", npc.Merchant, "grade", npc.Grade)
+}
+
+type quest256Step struct {
+	flag     uint8
+	minLevel int32
+	maxLevel int32
+	x, y     int16
+	area     questArea
+}
+
+var quest256Steps = []quest256Step{
+	{flag: 1, minLevel: 39, maxLevel: 115, x: 2398, y: 2105, area: questArea{x1: 2379, y1: 2076, x2: 2426, y2: 2133}},
+	{flag: 2, minLevel: 115, maxLevel: 190, x: 2234, y: 1714, area: questArea{x1: 2228, y1: 1700, x2: 2257, y2: 1728}},
+	{flag: 3, minLevel: 190, maxLevel: 265, x: 464, y: 3902, area: questArea{x1: 459, y1: 3887, x2: 497, y2: 3916}},
+	{flag: 4, minLevel: 265, maxLevel: 320, x: 668, y: 3756, area: questArea{x1: 658, y1: 3728, x2: 703, y2: 3762}},
+	{flag: 5, minLevel: 320, maxLevel: 350, x: 1322, y: 4041, area: questArea{x1: 1312, y1: 4027, x2: 1348, y2: 4055}},
+}
+
+// mestreGrifo handles the Mestre_Grifo NPC (Merchant 23) shipped in NPCGener.txt
+// at Armia. This server-content shortcut sends the player to the Quest 256 arena
+// matching their level and must set CMob.QuestFlag first; otherwise the legacy
+// area guard recalls the player as an intruder.
+func (d *Dispatcher) mestreGrifo(w *world.World, s *world.Session, e, npc *world.Entity) {
+	step, ok := quest256StepForLevel(e.Level)
+	if !ok {
+		d.log.Debug("mestre grifo: level outside quest range", "conn", s.Conn, "npc", npc.ID, "level", e.Level)
+		return
+	}
+	e.QuestFlag = step.flag
+	d.doTeleport(w, s, step.x+int16(w.Rand().Intn(5)-3), step.y+int16(w.Rand().Intn(5)-3))
+	d.log.Info("mestre grifo teleport", "conn", s.Conn, "npc", npc.ID, "level", e.Level, "quest_flag", step.flag)
+}
+
+func quest256StepForLevel(level int32) (quest256Step, bool) {
+	for _, step := range quest256Steps {
+		if level >= step.minLevel && level < step.maxLevel {
+			return step, true
+		}
+	}
+	return quest256Step{}, false
 }
 
 // perzenExchange implements the Perzen NPCs (_MSG_Quest.cpp PERZEN): if the player

--- a/tmserver/internal/handler/mobai.go
+++ b/tmserver/internal/handler/mobai.go
@@ -75,11 +75,38 @@ func (d *Dispatcher) Tick(w *world.World) {
 			d.mobBattle(w, id, e)
 		}
 	})
+	d.guardQuest256Areas(w)
 	d.regenPlayers(w)
 	d.sweepAffects(w)
 	d.respawnMobs(w)
 	d.generateMobs(w)
 	d.pollNPCConfig(w) // hot-reload moderator NPC edits (npc-editing-plan.md)
+}
+
+type questArea struct {
+	x1, y1 int16
+	x2, y2 int16
+}
+
+func (a questArea) contains(x, y int16) bool {
+	return x > a.x1 && y > a.y1 && x < a.x2 && y < a.y2
+}
+
+// guardQuest256Areas ports the ProcessSecMinTimer QuestFlag guard for the five
+// Quest 256 arenas. Entering without the matching volatile flag recalls the
+// player, which is the behavior Mestre Grifo must satisfy before teleporting.
+func (d *Dispatcher) guardQuest256Areas(w *world.World) {
+	w.ForEachPlayer(func(s *world.Session, e *world.Entity) {
+		if e.Level >= 1000 {
+			return
+		}
+		for _, step := range quest256Steps {
+			if step.area.contains(e.X, e.Y) && e.QuestFlag != step.flag {
+				d.recall(w, s, e)
+				return
+			}
+		}
+	})
 }
 
 // battleDragBox is the SetBattle engage box: a group member joins the fight only

--- a/tmserver/internal/handler/quest_test.go
+++ b/tmserver/internal/handler/quest_test.go
@@ -71,6 +71,63 @@ func questFrame(t *testing.T, c net.Conn, npcID int) {
 	send(t, c, protocol.MsgQuest, protocol.EncodeStandardParm2(int32(npcID), 0))
 }
 
+func mestreGrifoTemplate() []byte {
+	b := make([]byte, 816)
+	copy(b[0:16], "Mestre_Grifo")
+	const cs = 92
+	b[cs+12] = 23                               // Merchant = Mestre Grifo
+	binary.LittleEndian.PutUint32(b[cs+24:], 1) // Hp (alive)
+	return b
+}
+
+func startServerMestreGrifo(t *testing.T, st world.CharacterState, tick bool) (string, func(), int) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := New(Config{Log: log})
+	db := newDB()
+	db.loadResult = st
+	w := world.New(world.Config{GridDim: world.DefaultGridDim}, log, db, d.Handle)
+	if tick {
+		w.SetTickHandler(10*time.Millisecond, d.Tick)
+	}
+	npcID := w.SpawnMob(mestreGrifoTemplate(), 2116, 2080)
+	if npcID < 0 {
+		t.Fatal("failed to spawn Mestre_Grifo")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = w.Serve(ctx, ln); close(done) }()
+	return ln.Addr().String(), func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("server did not stop")
+		}
+	}, npcID
+}
+
+func expectAction(t *testing.T, c net.Conn) protocol.MsgActionBody {
+	t.Helper()
+	ty, payload := read(t, c)
+	if ty != protocol.MsgAction {
+		t.Fatalf("got %#x, want MsgAction", ty)
+	}
+	var body protocol.MsgActionBody
+	if err := body.Decode(payload); err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func inRange(v, center int16) bool {
+	return v >= center-3 && v <= center+1
+}
+
 // TestPerzenExchange: handing the required item to a Perzen NPC swaps it for the
 // reward mount in the same inventory slot.
 func TestPerzenExchange(t *testing.T) {
@@ -101,5 +158,96 @@ func TestPerzenMissingItem(t *testing.T) {
 	questFrame(t, c, npcID)
 	if ty, _, ok := readMaybe(t, c); ok {
 		t.Errorf("exchange without the item produced %#x; should be a no-op", ty)
+	}
+}
+
+func TestMestreGrifoTeleportsByLevel(t *testing.T) {
+	tests := []struct {
+		name  string
+		level int
+		wantX int16
+		wantY int16
+	}{
+		{name: "coveiro", level: 50, wantX: 2398, wantY: 2105},
+		{name: "kaizen", level: 200, wantX: 464, wantY: 3902},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := world.CharacterState{
+				Slot: 0, Name: "Hero", Level: tt.level, X: 2113, Y: 2079,
+				HP: 1000, MaxHP: 1000, ClassMaster: classMasterMortal,
+			}
+			addr, stop, npcID := startServerMestreGrifo(t, st, false)
+			defer stop()
+			c := enterWorld(t, addr)
+			defer c.Close()
+
+			questFrame(t, c, npcID)
+			body := expectAction(t, c)
+			if body.Effect != 1 {
+				t.Errorf("teleport effect = %d, want 1", body.Effect)
+			}
+			if !inRange(body.TargetX, tt.wantX) || !inRange(body.TargetY, tt.wantY) {
+				t.Errorf("target = %d,%d, want around %d,%d", body.TargetX, body.TargetY, tt.wantX, tt.wantY)
+			}
+			if ty, _, ok := readMaybe(t, c); ok && ty == protocol.MsgAction {
+				t.Errorf("unexpected second teleport after Mestre Grifo: %#x", ty)
+			}
+		})
+	}
+}
+
+func TestMestreGrifoOutOfRangeNoop(t *testing.T) {
+	st := world.CharacterState{
+		Slot: 0, Name: "Hero", Level: 350, X: 2113, Y: 2079,
+		HP: 1000, MaxHP: 1000, ClassMaster: classMasterMortal,
+	}
+	addr, stop, npcID := startServerMestreGrifo(t, st, false)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	questFrame(t, c, npcID)
+	if ty, _, ok := readMaybe(t, c); ok {
+		t.Errorf("out-of-range Mestre Grifo produced %#x; want no-op", ty)
+	}
+}
+
+func TestQuest256AreaGuardRecallsWithoutFlag(t *testing.T) {
+	st := world.CharacterState{
+		Slot: 0, Name: "Hero", Level: 50, X: 2398, Y: 2105,
+		HP: 1000, MaxHP: 1000, LastCity: 0, ClassMaster: classMasterMortal,
+	}
+	addr, stop, _ := startServerMestreGrifo(t, st, true)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	body := expectAction(t, c)
+	if body.Effect != 1 {
+		t.Errorf("recall effect = %d, want 1", body.Effect)
+	}
+	if body.TargetX < 2086 || body.TargetX > 2100 || body.TargetY < 2093 || body.TargetY > 2107 {
+		t.Errorf("recall target = %d,%d, want Armia city spawn", body.TargetX, body.TargetY)
+	}
+}
+
+func TestMestreGrifoQuestFlagPreventsImmediateRecall(t *testing.T) {
+	st := world.CharacterState{
+		Slot: 0, Name: "Hero", Level: 50, X: 2113, Y: 2079,
+		HP: 1000, MaxHP: 1000, LastCity: 0, ClassMaster: classMasterMortal,
+	}
+	addr, stop, npcID := startServerMestreGrifo(t, st, true)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	questFrame(t, c, npcID)
+	body := expectAction(t, c)
+	if !inRange(body.TargetX, 2398) || !inRange(body.TargetY, 2105) {
+		t.Fatalf("quest target = %d,%d, want Coveiro", body.TargetX, body.TargetY)
+	}
+	if ty, _, ok := readMaybe(t, c); ok && ty == protocol.MsgAction {
+		t.Errorf("Mestre Grifo target was recalled immediately: %#x", ty)
 	}
 }

--- a/tmserver/internal/world/session.go
+++ b/tmserver/internal/world/session.go
@@ -127,6 +127,7 @@ type Entity struct {
 	Guild       uint16   // guild id (0 = none)
 	GuildLevel  uint8    // 0 = member … 9 = leader
 	ClassMaster uint8    // party tier (MobExtra.ClassMaster)
+	QuestFlag   uint8    // volatile quest-area pass (CMob.QuestFlag; e.g. Quest 256)
 
 	Str        int16 // CurrentScore attributes (base + equipment, kept live by refreshScore)
 	Int        int16


### PR DESCRIPTION
## Summary
- add Mestre Grifo quest NPC handling for Quest 256 level brackets
- add volatile QuestFlag support and recall guard for Quest 256 arenas
- cover Mestre Grifo teleports, out-of-range no-op, and area guard behavior

## Tests
- go test ./tmserver/internal/handler