### PR TITLE
Fix character login spawn snapshot

### DIFF
--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/binary"
 	"time"
 
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
@@ -226,6 +227,8 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 	if spawnX == 0 && spawnY == 0 {
 		spawnX, spawnY = world.CitySpawn(int(st.LastCity))
 	}
+	s.LoginSpawnX, s.LoginSpawnY = spawnX, spawnY
+	s.LoggedFirstAction = false
 	// Inject the player entity into the world (the slot was docked at connect).
 	if e := w.Entity(s.Conn); e != nil {
 		e.Mode = world.MobUser
@@ -319,8 +322,7 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 			carry[i] = itemToSel(st.Carry[i])
 		}
 		body := protocol.EncodeCNFCharacterLoginRaw(tmpl, st.Name, st.Coin, st.Exp, equip, carry, spawnX, spawnY, s.Slot, s.Conn, 0, shortSkill, skill)
-		d.log.Info("char login: sending CNFCharacterLogin (template)",
-			"conn", s.Conn, "class", st.Class, "name", st.Name, "x", spawnX, "y", spawnY, "body", len(body))
+		d.logCNFCharacterLogin("template", s, st, spawnX, spawnY, body)
 		w.SendTo(s, protocol.Header{Type: protocol.MsgCNFCharacterLogin, ID: protocol.IDScene}, body)
 		d.enterWorldView(w, s)
 		d.sendLoginAffects(w, s)
@@ -337,7 +339,7 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 		Class: uint8(st.Class),
 		Coin:  st.Coin,
 		Exp:   st.Exp,
-		SPX:   st.X, SPY: st.Y,
+		SPX:   spawnX, SPY: spawnY,
 		Level: int32(st.Level), Ac: st.AC, Damage: st.Damage,
 		MaxHp: st.MaxHP, MaxMp: st.MaxMP, Hp: st.HP, Mp: st.MP,
 		Str: st.Str, Int: st.Int, Dex: st.Dex, Con: st.Con,
@@ -360,9 +362,35 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 		}
 	}
 	body := protocol.EncodeCNFCharacterLoginBody(s.Slot, s.Conn, 0, m, shortSkill)
+	d.logCNFCharacterLogin("fallback", s, st, spawnX, spawnY, body)
 	w.SendTo(s, protocol.Header{Type: protocol.MsgCNFCharacterLogin, ID: protocol.IDScene}, body)
 	d.enterWorldView(w, s)
 	d.sendLoginAffects(w, s)
+}
+
+func (d *Dispatcher) logCNFCharacterLogin(path string, s *world.Session, st world.CharacterState, spawnX, spawnY int16, body []byte) {
+	var msgX, msgY, mobSPX, mobSPY uint16
+	if len(body) >= 4+44 {
+		msgX = binary.LittleEndian.Uint16(body[0:])
+		msgY = binary.LittleEndian.Uint16(body[2:])
+		mobSPX = binary.LittleEndian.Uint16(body[4+40:])
+		mobSPY = binary.LittleEndian.Uint16(body[4+42:])
+	}
+	d.log.Info("char login: sending CNFCharacterLogin",
+		"path", path,
+		"conn", s.Conn,
+		"slot", s.Slot,
+		"client_id", s.Conn,
+		"class", st.Class,
+		"name", st.Name,
+		"last_city", st.LastCity,
+		"spawn_x", spawnX,
+		"spawn_y", spawnY,
+		"cnf_pos_x", int16(msgX),
+		"cnf_pos_y", int16(msgY),
+		"mob_spx", int16(mobSPX),
+		"mob_spy", int16(mobSPY),
+		"body", len(body))
 }
 
 // sendLoginAffects pushes the rehydrated buff snapshot right after the world

--- a/tmserver/internal/handler/handler_test.go
+++ b/tmserver/internal/handler/handler_test.go
@@ -480,6 +480,45 @@ func TestCharacterLoginAndLogout(t *testing.T) {
 	}
 }
 
+func TestCharacterLoginFallbackCNFUsesComputedCitySpawn(t *testing.T) {
+	db := newDB()
+	db.loadResult = world.CharacterState{Slot: 0, Name: "Hero", LastCity: 2, HP: 1200, MaxHP: 1200}
+	addr, stop := startServer(t, db)
+	defer stop()
+	c := loginAndSelect(t, addr)
+	defer c.Close()
+
+	var body protocol.MsgCharacterLoginBody
+	body.Slot = 0
+	send(t, c, protocol.MsgCharacterLogin, body.Encode())
+	ty, payload := read(t, c)
+	if ty != protocol.MsgCNFCharacterLogin {
+		t.Fatalf("got %#x, want CNFCharacterLogin", ty)
+	}
+	if len(payload) != 1820 {
+		t.Fatalf("CNFCharacterLogin body = %d, want 1820", len(payload))
+	}
+
+	msgX := int16(binary.LittleEndian.Uint16(payload[0:]))
+	msgY := int16(binary.LittleEndian.Uint16(payload[2:]))
+	mobSPX := int16(binary.LittleEndian.Uint16(payload[4+40:]))
+	mobSPY := int16(binary.LittleEndian.Uint16(payload[4+42:]))
+	if msgX != mobSPX || msgY != mobSPY {
+		t.Fatalf("CNF PosX/Y = %d,%d but embedded SPX/SPY = %d,%d", msgX, msgY, mobSPX, mobSPY)
+	}
+	if city := world.Village(msgX, msgY); city != int(db.loadResult.LastCity) {
+		t.Fatalf("CNF spawn = %d,%d in city %d, want city %d", msgX, msgY, city, db.loadResult.LastCity)
+	}
+	if binary.LittleEndian.Uint16(payload[1028:]) != 0 ||
+		binary.LittleEndian.Uint16(payload[1030:]) != 1 ||
+		binary.LittleEndian.Uint16(payload[1032:]) != 0 {
+		t.Fatalf("tail Slot/ClientID/Weather = %d/%d/%d, want 0/1/0",
+			binary.LittleEndian.Uint16(payload[1028:]),
+			binary.LittleEndian.Uint16(payload[1030:]),
+			binary.LittleEndian.Uint16(payload[1032:]))
+	}
+}
+
 func TestCharacterLoginBillingDenied(t *testing.T) {
 	db := newDB()
 	db.loadResult = world.CharacterState{Slot: 0, Name: "Hero"}

--- a/tmserver/internal/handler/movement.go
+++ b/tmserver/internal/handler/movement.go
@@ -48,6 +48,24 @@ func (d *Dispatcher) action(w *world.World, s *world.Session, h protocol.Header,
 	if err := body.Decode(payload); err != nil {
 		return
 	}
+	if !s.LoggedFirstAction {
+		s.LoggedFirstAction = true
+		d.log.Info("movement: first action after login",
+			"conn", s.Conn,
+			"type", h.Type,
+			"client_tick", h.ClientTick,
+			"server_x", e.X,
+			"server_y", e.Y,
+			"login_spawn_x", s.LoginSpawnX,
+			"login_spawn_y", s.LoginSpawnY,
+			"pos_x", body.PosX,
+			"pos_y", body.PosY,
+			"target_x", body.TargetX,
+			"target_y", body.TargetY,
+			"effect", body.Effect,
+			"speed", body.Speed,
+			"route", body.Route)
+	}
 
 	// Anti-speedhack: movetime must be within the window of server time.
 	// Crack codes per legacy: 102 for Action/Action2, 104 for Action3.

--- a/tmserver/internal/protocol/mob_test.go
+++ b/tmserver/internal/protocol/mob_test.go
@@ -109,6 +109,56 @@ func TestCNFCharacterLoginRawLayout(t *testing.T) {
 	if b[1034] != 42 {
 		t.Errorf("ShortSkill tail @1034 = %d, want 42", b[1034])
 	}
+	if le.Uint16(b[1028:]) != 0 || le.Uint16(b[1030:]) != 1 || le.Uint16(b[1032:]) != 0 {
+		t.Errorf("tail Slot/ClientID/Weather = %d/%d/%d, want 0/1/0",
+			le.Uint16(b[1028:]), le.Uint16(b[1030:]), le.Uint16(b[1032:]))
+	}
+	assertZeroRange(t, b, 820, 1028)
+	assertZeroRange(t, b, 1050, len(b))
+}
+
+func TestCNFCharacterLoginBodyLayout(t *testing.T) {
+	var short [16]uint8
+	short[15] = 77
+	b := EncodeCNFCharacterLoginBody(2, 33, 4, MobSnapshot{
+		Name:      "Fallback",
+		SPX:       2494,
+		SPY:       1707,
+		Coin:      123,
+		Exp:       456,
+		AttackRun: 2,
+	}, short)
+
+	if len(b) != cnfCharacterLoginSize-HeaderSize {
+		t.Fatalf("CNFCharacterLogin body = %d, want %d", len(b), cnfCharacterLoginSize-HeaderSize)
+	}
+	le := binary.LittleEndian
+	if le.Uint16(b[0:]) != 2494 || le.Uint16(b[2:]) != 1707 {
+		t.Errorf("msg PosX/PosY = %d,%d want 2494,1707", le.Uint16(b[0:]), le.Uint16(b[2:]))
+	}
+	if le.Uint16(b[4+40:]) != 2494 || le.Uint16(b[4+42:]) != 1707 {
+		t.Errorf("mob SPX/SPY = %d,%d want 2494,1707", le.Uint16(b[4+40:]), le.Uint16(b[4+42:]))
+	}
+	if got := cstr16(b[4:20]); got != "Fallback" {
+		t.Errorf("name = %q, want Fallback", got)
+	}
+	if le.Uint16(b[1028:]) != 2 || le.Uint16(b[1030:]) != 33 || le.Uint16(b[1032:]) != 4 {
+		t.Errorf("tail Slot/ClientID/Weather = %d/%d/%d, want 2/33/4",
+			le.Uint16(b[1028:]), le.Uint16(b[1030:]), le.Uint16(b[1032:]))
+	}
+	if b[1034+15] != 77 {
+		t.Errorf("ShortSkill[15] = %d, want 77", b[1034+15])
+	}
+	assertZeroRange(t, b, 1050, len(b))
+}
+
+func assertZeroRange(t *testing.T, b []byte, start, end int) {
+	t.Helper()
+	for i := start; i < end; i++ {
+		if b[i] != 0 {
+			t.Fatalf("byte[%d] = %#x, want zero", i, b[i])
+		}
+	}
 }
 
 func TestSelCharSizes(t *testing.T) {

--- a/tmserver/internal/world/session.go
+++ b/tmserver/internal/world/session.go
@@ -17,20 +17,23 @@ type outFrame struct {
 // domain-model.md §2.1). It is owned by the loop goroutine; the conn/out/closeCh
 // plumbing is shared with this session's reader and writer goroutines only.
 type Session struct {
-	Conn           int // index into pUser/pMob; also HEADER.ID on the wire
-	AccountName    string
-	AccountID      int64
-	Slot           int
-	Mode           Mode
-	IP             string
-	CrackError     int        // anti-cheat violation count (CUser.NumError)
-	Whisper        bool       // true blocks incoming whispers
-	GuildDisable   bool       // hide guild tag (guildon/guildoff)
-	TradeMode      int        // non-zero while in auto-trade (blocks attacks)
-	Trade          TradeState // P2P direct-trade state (lote2-trade-autotrade.md)
-	LastAttackTick uint32     // ClientTick of the last accepted attack (cadence gate)
-	LastAttack     int        // SkillIndex of the last attack
-	ShortSkill     [16]uint8  // client hotbar layout (CUser.CharShortSkill, _MSG_SetShortSkill)
+	Conn              int // index into pUser/pMob; also HEADER.ID on the wire
+	AccountName       string
+	AccountID         int64
+	Slot              int
+	Mode              Mode
+	IP                string
+	CrackError        int        // anti-cheat violation count (CUser.NumError)
+	Whisper           bool       // true blocks incoming whispers
+	GuildDisable      bool       // hide guild tag (guildon/guildoff)
+	TradeMode         int        // non-zero while in auto-trade (blocks attacks)
+	Trade             TradeState // P2P direct-trade state (lote2-trade-autotrade.md)
+	LastAttackTick    uint32     // ClientTick of the last accepted attack (cadence gate)
+	LastAttack        int        // SkillIndex of the last attack
+	ShortSkill        [16]uint8  // client hotbar layout (CUser.CharShortSkill, _MSG_SetShortSkill)
+	LoginSpawnX       int16      // last server-injected login spawn, for movement diagnostics
+	LoginSpawnY       int16
+	LoggedFirstAction bool // first post-login _MSG_Action diagnostic was emitted
 
 	seen map[int]struct{} // entity ids already create-mob'd to this client (view set)
 


### PR DESCRIPTION
## Summary
- align fallback CNFCharacterLogin snapshot position with the computed city spawn
- add diagnostics for the login snapshot and first post-login movement action
- add regression coverage for CNFCharacterLogin layout and fallback spawn behavior

## Tests
- go test ./tmserver/internal/protocol ./tmserver/internal/handler -run 'Test.*(CNFCharacterLogin|CharacterLogin|Move|Action|View)'\n- go test ./tmserver/internal/protocol ./tmserver/internal/handler ./tmserver/internal/world\n\nCloses #57