### PR TITLE
fix: stop XP chest buff leaking across characters on the same account

### DIFF
--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -229,6 +229,10 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 	// Inject the player entity into the world (the slot was docked at connect).
 	if e := w.Entity(s.Conn); e != nil {
 		e.Mode = world.MobUser
+		// The entity is per-connection: wipe any affect left by a previously
+		// played character before rehydrating this one's persisted slots (the
+		// rehydrate below only ADDS slots — issue #47's cross-character leak).
+		e.ResetAffects()
 		e.Name = st.Name
 		e.Class = uint8(st.Class)
 		e.LastCity = st.LastCity
@@ -464,6 +468,10 @@ func (d *Dispatcher) characterLogout(w *world.World, s *world.Session, _ protoco
 		w.SaveCargoThen(s, func(w *world.World, s *world.Session) {
 			if e := w.Entity(s.Conn); e != nil {
 				e.Mode = world.MobUserDock
+				// The save above already captured this character's buffs; drop
+				// them from the per-connection entity so they can't bleed into
+				// the next character selected on this session (issue #47).
+				e.ResetAffects()
 			}
 			s.Mode = world.UserSelChar
 			w.Send(s, protocol.MsgCNFCharacterLogout, nil)

--- a/tmserver/internal/handler/character_relogin_test.go
+++ b/tmserver/internal/handler/character_relogin_test.go
@@ -1,0 +1,90 @@
+package handler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// slotDB is a fakeDB whose LoadCharacter is slot-aware, so one account can host
+// two different characters (the relogin-leak scenario needs a chest-buffed
+// character and a clean one).
+type slotDB struct {
+	*fakeDB
+	bySlot map[int]world.CharacterState
+}
+
+func (f *slotDB) LoadCharacter(_ context.Context, _ int64, slot int) (world.CharacterState, error) {
+	return f.bySlot[slot], nil
+}
+
+// TestAffectsDoNotLeakAcrossCharacters is the issue #47 regression: the Baú de
+// Experiência buff on the character being left must NOT survive the return to
+// the selection screen — the entity is per-connection, and before the fix the
+// next character picked on the same session showed (and re-persisted!) the
+// previous character's chest buff.
+func TestAffectsDoNotLeakAcrossCharacters(t *testing.T) {
+	db := &slotDB{
+		fakeDB: &fakeDB{accounts: map[string]*fakeAccount{
+			"tester": {id: 7, pass: "secret", chars: []world.CharSummary{
+				{Slot: 0, Name: "Chested", Class: 1, Level: 50},
+				{Slot: 1, Name: "Clean", Class: 0, Level: 2},
+			}},
+		}},
+		bySlot: map[int]world.CharacterState{
+			0: {
+				Slot: 0, Name: "Chested", Class: 1, X: 2100, Y: 2100,
+				HP: 500, MaxHP: 500, Level: 50,
+				Affects: []world.Affect{{Type: world.AffectExpChest, Time: 140}},
+			},
+			1: {
+				Slot: 1, Name: "Clean", Class: 0, X: 2100, Y: 2100,
+				HP: 105, MaxHP: 105, Level: 2,
+			},
+		},
+	}
+	addr, stop := startServer(t, db)
+	defer stop()
+	c := loginAndSelect(t, addr)
+	defer c.Close()
+
+	playAndLogout := func(slot uint8) {
+		t.Helper()
+		var body protocol.MsgCharacterLoginBody
+		body.Slot = int32(slot)
+		send(t, c, protocol.MsgCharacterLogin, body.Encode())
+		if ty, _ := read(t, c); ty != protocol.MsgCNFCharacterLogin {
+			t.Fatalf("slot %d: got %#x, want CNFCharacterLogin", slot, ty)
+		}
+		drainLoginScore(t, c)
+		send(t, c, protocol.MsgCharacterLogout, nil)
+		for {
+			ty, _ := read(t, c)
+			if ty == protocol.MsgCNFCharacterLogout {
+				return
+			}
+		}
+	}
+
+	playAndLogout(0) // the chest: buff rehydrated, then saved on logout
+	chestedSave, n := db.lastSavedChar()
+	if n != 1 || chestedSave.Slot != 0 {
+		t.Fatalf("first logout: saves = %d (slot %d), want 1 save of slot 0", n, chestedSave.Slot)
+	}
+	// The reset must not eat the leaving character's own buff: its save still
+	// carries the XP chest affect.
+	if len(chestedSave.Affects) != 1 || chestedSave.Affects[0].Type != world.AffectExpChest {
+		t.Fatalf("chested save affects = %+v, want the persisted XP chest (Type %d)", chestedSave.Affects, world.AffectExpChest)
+	}
+
+	playAndLogout(1) // the clean character on the SAME connection
+	cleanSave, n := db.lastSavedChar()
+	if n != 2 || cleanSave.Slot != 1 {
+		t.Fatalf("second logout: saves = %d (slot %d), want 2nd save of slot 1", n, cleanSave.Slot)
+	}
+	if len(cleanSave.Affects) != 0 {
+		t.Errorf("clean save affects = %+v, want none (XP chest leaked across characters)", cleanSave.Affects)
+	}
+}

--- a/tmserver/internal/world/affect.go
+++ b/tmserver/internal/world/affect.go
@@ -37,6 +37,23 @@ func (e *Entity) EmptyAffect(t uint8) int {
 	return -1
 }
 
+// ResetAffects wipes every buff/debuff slot and the derived affect state
+// (caches + Rsv + DivineEnd). The player Entity lives as long as the
+// CONNECTION, not the character (allocated once per TCP connection, reused
+// across character-select swaps), so both character-login (before rehydrating
+// the persisted slots) and the return to the selection screen must call this —
+// otherwise a buff cast on one character (e.g. the Baú de Experiência, issue
+// #47) survives the swap, applies to a different character and even gets
+// persisted onto it by the next characterLogout save.
+func (e *Entity) ResetAffects() {
+	e.Affect = [MaxAffect]Affect{}
+	e.DivineEnd = 0
+	e.Rsv = 0
+	e.AffDamage, e.AffAC, e.AffMaxHP, e.AffMaxMP, e.AffCon, e.AffExpBonus = 0, 0, 0, 0, 0, 0
+	e.AffSpecial = [4]int16{}
+	e.AffResist = [4]int16{}
+}
+
 // HasAnyAffect reports whether any slot holds a buff/debuff (Type != 0).
 func (e *Entity) HasAnyAffect() bool {
 	for i := range e.Affect {


### PR DESCRIPTION
## Summary
- The player `Entity` lives per connection, not per character; `completeCharacterLogin` only added persisted affect slots without clearing whatever the previously played character left behind.
- A buff like the Baú de Experiência (XP chest, affect type 39) activated on one character therefore leaked onto the next character selected in the same session, and was even re-persisted onto it on logout.
- Adds `Entity.ResetAffects()` and calls it on character login (before rehydrating the new character's affects) and on character logout (after the outgoing character is saved).

Fixes #47

## Test plan
- [x] `go test -race ./tmserver/...` — full suite green
- [x] New regression test `TestAffectsDoNotLeakAcrossCharacters` (`tmserver/internal/handler/character_relogin_test.go`) — verified it fails without the fix and passes with it
- [x] `go vet ./tmserver/...` and `golangci-lint run` clean on touched packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)