### PR TITLE
fix: baú de experiência consuming whole item stack

### DIFF
--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -264,7 +264,7 @@ func (d *Dispatcher) useExpChest(w *world.World, s *world.Session, e *world.Enti
 	if af.Time > affectTimeCap {
 		af.Time = affectTimeCap
 	}
-	e.Carry[src] = world.Item{}
+	consumeOneItem(&e.Carry[src])
 	d.refreshScore(e)
 	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
 	d.sendScore(w, s, e)

--- a/tmserver/internal/handler/item_test.go
+++ b/tmserver/internal/handler/item_test.go
@@ -531,6 +531,29 @@ func TestUseExpChest(t *testing.T) {
 	}
 }
 
+func TestUseExpChestStack(t *testing.T) {
+	db := newDB()
+	st := world.CharacterState{Slot: 0, Name: "Hero", X: 5, Y: 5, HP: 1000, MaxHP: 1000}
+	st.Carry[0] = world.Item{Index: 4140, Effects: [3]world.Effect{{Effect: efAmount, Value: 3}}}
+	db.loadResult = st
+
+	addr, stop := startServerClockVol(t, db, map[int]int{4140: volExpChest})
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+
+	payload := expect(t, c, protocol.MsgSendItem)
+	if got := le16(payload[4:6]); got != 4140 {
+		t.Fatalf("carry slot 0 item = %d, want stacked chest", got)
+	}
+	if payload[6] != efAmount || payload[7] != 2 {
+		t.Errorf("effect0 = %d.%d, want %d.2", payload[6], payload[7], efAmount)
+	}
+}
+
 func TestUseFairyDust(t *testing.T) {
 	const dust = 5001
 	addr, stop := startServerClockVol(t, fairyDustDB(0, world.Item{Index: dust}), map[int]int{dust: volFairyDust})


### PR DESCRIPTION
## Summary
- `useExpChest` unconditionally cleared the whole `Carry` slot on use, so a stacked baú de experiência had every unit in the stack destroyed instead of just one (issue #48).
- Mirrors the fairy-dust stacking fix (`0244a5e`) by delegating to the existing `consumeOneItem` helper, which decrements the stack's `efAmount` effect and only empties the slot when the count reaches 1.

## Test plan
- [x] `go test ./tmserver/internal/handler/... -run TestUseExpChest -race -v` (new `TestUseExpChestStack` + existing `TestUseExpChest` both pass)
- [x] `make test` (full suite, race + cover, clean)
- [x] `make vet` clean

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)