### PR TITLE
fix: nick vermelho piscando (PK) — MobName[12] PKPoint + self-CreateMob

### DIFF
--- a/docs/migration/prompts/agent-prompt-pk-nick.md
+++ b/docs/migration/prompts/agent-prompt-pk-nick.md
@@ -1,0 +1,90 @@
+# Agent prompt — descobrir o que faz o NICK PISCAR VERMELHO (PK) no cliente 12000
+
+Cole isto no Claude Code da máquina Windows (que tem a FONTE COMPLETA do WYD + o dumper
+`_layout_probe/dump_layout.cpp`). Salve o resultado em `captura-wyd-pk-nick.md`.
+
+---
+
+## Contexto
+
+Estou migrando o servidor do WYD para Go (`w2pp-openwyd`), mirando o **cliente `WYD.exe`
+original sem mods, ClientVersion 12000** (protocolo base 7640). Header CPSock = 12 bytes.
+Já funcionam: login, criação/seleção de char, entrar no mundo, andar, ver outros players,
+NPCs, lojas, combate, EXP.
+
+**Problema (issue #59):** o **nick do PRÓPRIO personagem aparece VERMELHO PISCANDO** (o
+indicador de "PK"/chaos) **assim que entra no mundo, mesmo num personagem recém-criado que
+NUNCA apertou a tecla K e nunca atacou ninguém**. E não some sozinho depois de ~1-2 min.
+
+## O que eu JÁ TENTEI no servidor Go e NÃO resolveu (confirmado no cliente real)
+
+1. **Enviei `_MSG_PKInfo` (0x0166, `102|FLAG_GAME2CLIENT`, MSG_STANDARDPARM) com `Parm=0`**
+   para o próprio conn no login e emparelhado com todo CreateMob de player. Confirmei na
+   captura de bytes (cliente sintético) que o pacote sai com `Parm=0`. **O nick continuou
+   piscando.**
+2. **Zerei o byte `STRUCT_SCORE.ChaosRate` (offset 15 dentro de STRUCT_SCORE)** no blob de
+   `MSG_CNFClientCharacterLogin` (nos dois scores: BaseScore e CurrentScore) e no CreateMob.
+   Os templates BaseMob trazem esse byte como `0xCC` (204, lixo de memória não-inicializada).
+   Confirmei na captura que virou `0`. **O nick continuou piscando.**
+   - OBS: no `Source/Code/NPTool/ProcessMessage.cpp:159` esse mesmo byte
+     (`mob->BaseScore.ChaosRate`) é exibido no editor de NPC como campo **`IDC_ERegen`**
+     (Regen!). Isso me faz suspeitar que o byte "ChaosRate" na verdade é REGEN, e NÃO o que
+     controla a cor do nick. **Preciso que você confirme.**
+
+Ou seja: nem `_MSG_PKInfo` nem `ChaosRate` (do jeito que interpretei) controlam o piscar do
+próprio nick no cliente 12000. Estou às cegas quanto ao mecanismo real.
+
+## Pista forte
+
+`_MSG_PKMode = (153 | FLAG_GAME2CLIENT | FLAG_CLIENT2GAME)` (0x0399) é **BIDIRECIONAL** — o
+servidor PODE enviar `_MSG_PKMode` para o cliente. Suspeito que o piscar do PRÓPRIO nick seja
+um estado LOCAL de "modo PK" do cliente (ligado pela tecla K) e que o servidor sincronize/
+force esse estado via `_MSG_PKMode` enviado ao cliente. Mas não sei — **confirme.**
+
+## PERGUNTAS (responda com evidência `arquivo.cpp:linha` da fonte COMPLETA)
+
+1. **Qual pacote/campo S→C faz o cliente 12000 pintar o PRÓPRIO nick de vermelho piscando?**
+   É `_MSG_PKMode` (0x0399) enviado pelo servidor? `_MSG_PKInfo` (0x0166)? um campo de
+   `STRUCT_SCORE`/`STRUCT_MOB` no `MSG_CNFClientCharacterLogin`? um item especial no inventário
+   (ex.: `Carry[KILL_MARK=63]`, sIndex 547)? ou é 100% estado LOCAL do cliente (tecla K) que o
+   servidor não controla?
+
+2. **O servidor envia `_MSG_PKMode` para o cliente em algum momento** (login, entrar no mundo,
+   toggle)? Cole TODA função que faz `AddMessage`/`SendOneMessage` com `Type = _MSG_PKMode`.
+   Se sim, com que `Parm`? Isso liga ou desliga o piscar no cliente?
+
+3. **O byte em `STRUCT_SCORE` offset 15 (chamado `ChaosRate` na nossa cópia) é chaos ou
+   regen?** Cole a definição EXATA de `STRUCT_SCORE` (todos os campos, offsets via o dumper,
+   tamanho total). Onde esse byte é ESCRITO no servidor? Onde o cliente o lê (se souber)?
+
+4. **Fluxo completo do "guilty/chaos/PK" que faz o nick piscar:**
+   - Onde o servidor SETA o estado ao MATAR/ATACAR outro player? Cole a função (procure
+     `SetGuilty`, `SetPKPoint`, `Carry[KILL_MARK]`, `stEffect`, e QUALQUER call-site — na nossa
+     cópia parcial `SetGuilty`/`SetPKPoint` existem em `GetFunc.cpp` mas **não têm nenhum
+     call-site**, então a lógica de "atacou player → vira guilty" está só na fonte completa).
+   - **Quanto tempo** o estado dura e **como decai** (o valor volta a 0)? Existe um timer/
+     decremento por segundo/minuto? Cole a constante e a função de decaimento (`GetGuilty`
+     zera se `>50` — mas o que INCREMENTA e em que ritmo DECREMENTA?).
+   - Qual VALOR/threshold do campo faz o cliente piscar (ex.: `!= 0`? `>= X`?).
+
+5. **Layout byte-exato dos pacotes** que carregam o estado do nick, via o dumper
+   (`sizeof`/`offsetof`), para eu conferir meus offsets:
+   - `MSG_CNFClientCharacterLogin` (o blob de login) — tamanho total e onde ficam o
+     `STRUCT_MOB`/scores dentro dele.
+   - `MSG_CreateMob` (o snapshot de outros players).
+   - `MSG_STANDARDPARM` (usado por PKInfo/PKMode).
+   - `_MSG_PKInfo` e `_MSG_PKMode`: o valor NUMÉRICO do `Type` no build 12000 (com
+     `FLAG_GAME2CLIENT=0x100` / `FLAG_CLIENT2GAME=0x200`) — quero confirmar que 0x0166 e 0x0399
+     batem, ou se o 12000 usa outro número.
+
+6. **No login do original**, liste TODOS os pacotes S→C que o servidor manda relacionados a
+   PK/chaos/nick (ex.: `SendPKInfo(conn, conn)`, algum `_MSG_PKMode`), na ORDEM em que saem,
+   com o `Parm`/valor de cada um. (No `ProcessDBMessage.cpp` perto do envio do
+   `MSG_CNFClientCharacterLogin` — no nosso parcial isso é ~linha 1021 com `SendPKInfo(conn,
+   conn); SendGridMob(conn);`.)
+
+## Formato da resposta
+
+Salve em `captura-wyd-pk-nick.md`: para cada pergunta, a resposta direta + o trecho de código
+(`arquivo.cpp:linha`) que a comprova. Priorize a pergunta 1 (o mecanismo) e a 4 (liga/desliga/
+decai) — é o que destrava o fix.

--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -296,14 +296,14 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 	// the live Special (base + equip) is on the Entity after refreshScore-on-login
 	// hasn't run yet, so send base+equip via the entity when available.
 	var skill protocol.SkillState
-	var loginChaos uint8 // PK/chaos nick blink (0 at login: GuiltyUntil isn't persisted)
+	loginPKPoint := pkPointNeutral // MobName[12] for the own nick: 75 = white (fresh char is never guilty)
 	if e := w.Entity(s.Conn); e != nil {
 		skill = protocol.SkillState{
 			LearnedSkill: e.LearnedSkill,
 			ScoreBonus:   e.ScoreBonus, SpecialBonus: e.SpecialBonus, SkillBonus: e.SkillBonus,
 			Special: e.Special, BaseSpecial: e.BaseSpecial, SkillBar: e.SkillBar,
 		}
-		loginChaos = chaosRate(e)
+		loginPKPoint = pkPoint(e)
 	}
 	shortSkill := s.ShortSkill
 	// Prefer the per-class BaseMob template (real STRUCT_MOB with starter equipment
@@ -320,7 +320,7 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 			}
 			carry[i] = itemToSel(st.Carry[i])
 		}
-		body := protocol.EncodeCNFCharacterLoginRaw(tmpl, st.Name, st.Coin, st.Exp, equip, carry, spawnX, spawnY, s.Slot, s.Conn, 0, shortSkill, skill, loginChaos)
+		body := protocol.EncodeCNFCharacterLoginRaw(tmpl, st.Name, st.Coin, st.Exp, equip, carry, spawnX, spawnY, s.Slot, s.Conn, 0, shortSkill, skill, loginPKPoint)
 		d.log.Info("char login: sending CNFCharacterLogin (template)",
 			"conn", s.Conn, "class", st.Class, "name", st.Name, "x", spawnX, "y", spawnY, "body", len(body))
 		w.SendTo(s, protocol.Header{Type: protocol.MsgCNFCharacterLogin, ID: protocol.IDScene}, body)
@@ -344,6 +344,7 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 		MaxHp: st.MaxHP, MaxMp: st.MaxMP, Hp: st.HP, Mp: st.MP,
 		Str: st.Str, Int: st.Int, Dex: st.Dex, Con: st.Con,
 		AttackRun:  baseAttackRun,
+		PKPoint:    loginPKPoint, // MobName[12]: 75 = white nick (issue #59)
 		ScoreBonus: st.ScoreBonus, GuildLevel: st.GuildLevel,
 		LearnedSkill: skill.LearnedSkill, SpecialBonus: skill.SpecialBonus,
 		SkillBonus: skill.SkillBonus, Special: skill.Special, SkillBar: skill.SkillBar,
@@ -393,10 +394,12 @@ func (d *Dispatcher) enterWorldView(w *world.World, s *world.Session) {
 		d.sendAffect(w, s, self) // buff icons/timers (e.g. a re-applied Divine)
 	}
 	selfMob := protocol.EncodeCreateMobBody(createMobFrom(self, 2))
-	// PKInfo must follow every player CreateMob here, same as movement.go/view.go:
-	// without it the client never learns the entity's PK state and renders its
-	// nickname red/blinking (SendPKInfo/SendGridMob, SendFunc.cpp:1869;
-	// ProcessDBMessage.cpp:1021).
+	// Send the newcomer its OWN CreateMob (the legacy GridMulticast has skip=0, so
+	// the conn — already in the grid — receives its own, ProcessDBMessage.cpp:1029).
+	// This is what colors the player's OWN nick via MobName[12] (PKPoint): without
+	// it the own nick renders forever from the login blob and can't recolor. PKInfo
+	// (attackable flag) rides along for parity (SendPKInfo, SendFunc.cpp:1869).
+	w.SendTo(s, protocol.Header{Type: protocol.MsgCreateMob, ID: protocol.IDScene}, selfMob)
 	w.SendTo(s, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(s.Conn)}, protocol.EncodeStandardParm(pkInfoParm(self)))
 	w.ForEachInView(s.Conn, func(vs *world.Session, ve *world.Entity) {
 		// (A) other players see the newcomer
@@ -444,10 +447,22 @@ func createMobFrom(e *world.Entity, createType uint16) protocol.CreateMobData {
 		Str:             e.Str, Int: e.Int, Dex: e.Dex, Con: e.Con,
 		Merchant:   e.Merchant,
 		AttackRun:  attackRunOf(e),
-		ChaosRate:  chaosRate(e), // PK/chaos nickname blink (0 = clean); mobs are never guilty
 		Equip:      e.EquipVisual,
 		CreateType: createType,
+		// Players pack PKPoint into MobName[12] to color the nick (75 neutral/white,
+		// 0 chaos/red); mobs send a raw name with no PK coloring.
+		IsPlayer: world.IsPlayer(e.ID),
+		PKPoint:  playerPKPoint(e),
 	}
+}
+
+// playerPKPoint is pkPoint(e) for a player, or 0 for a mob (mobs never carry PK
+// coloring and their MobName is sent raw, so the value is ignored anyway).
+func playerPKPoint(e *world.Entity) uint8 {
+	if !world.IsPlayer(e.ID) {
+		return 0
+	}
+	return pkPoint(e)
 }
 
 // characterLogout handles _MSG_CharacterLogout (0x0215): return to the selection

--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -391,14 +391,21 @@ func (d *Dispatcher) enterWorldView(w *world.World, s *world.Session) {
 		d.sendAffect(w, s, self) // buff icons/timers (e.g. a re-applied Divine)
 	}
 	selfMob := protocol.EncodeCreateMobBody(createMobFrom(self, 2))
+	// PKInfo (Parm=0 — PK/war state not modeled yet) must follow every player
+	// CreateMob here, same as movement.go/view.go: without it the client never
+	// learns the entity's clean PK state and renders its nickname red/blinking
+	// (SendPKInfo/SendGridMob, SendFunc.cpp:1869; ProcessDBMessage.cpp:1021).
+	w.SendTo(s, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(s.Conn)}, protocol.EncodeStandardParm(0))
 	w.ForEachInView(s.Conn, func(vs *world.Session, ve *world.Entity) {
 		// (A) other players see the newcomer
 		w.MarkSeen(vs, s.Conn)
 		w.SendTo(vs, protocol.Header{Type: protocol.MsgCreateMob, ID: protocol.IDScene}, selfMob)
+		w.SendTo(vs, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(s.Conn)}, protocol.EncodeStandardParm(0))
 		// (B) the newcomer sees each player already in view
 		w.MarkSeen(s, ve.ID)
 		w.SendTo(s, protocol.Header{Type: protocol.MsgCreateMob, ID: protocol.IDScene},
 			protocol.EncodeCreateMobBody(createMobFrom(ve, 0)))
+		w.SendTo(s, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(ve.ID)}, protocol.EncodeStandardParm(0))
 	})
 	// (C) the newcomer sees the NPCs/monsters in view.
 	d.revealMobsInView(w, s)

--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -296,12 +296,14 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 	// the live Special (base + equip) is on the Entity after refreshScore-on-login
 	// hasn't run yet, so send base+equip via the entity when available.
 	var skill protocol.SkillState
+	var loginChaos uint8 // PK/chaos nick blink (0 at login: GuiltyUntil isn't persisted)
 	if e := w.Entity(s.Conn); e != nil {
 		skill = protocol.SkillState{
 			LearnedSkill: e.LearnedSkill,
 			ScoreBonus:   e.ScoreBonus, SpecialBonus: e.SpecialBonus, SkillBonus: e.SkillBonus,
 			Special: e.Special, BaseSpecial: e.BaseSpecial, SkillBar: e.SkillBar,
 		}
+		loginChaos = chaosRate(e)
 	}
 	shortSkill := s.ShortSkill
 	// Prefer the per-class BaseMob template (real STRUCT_MOB with starter equipment
@@ -318,7 +320,7 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 			}
 			carry[i] = itemToSel(st.Carry[i])
 		}
-		body := protocol.EncodeCNFCharacterLoginRaw(tmpl, st.Name, st.Coin, st.Exp, equip, carry, spawnX, spawnY, s.Slot, s.Conn, 0, shortSkill, skill)
+		body := protocol.EncodeCNFCharacterLoginRaw(tmpl, st.Name, st.Coin, st.Exp, equip, carry, spawnX, spawnY, s.Slot, s.Conn, 0, shortSkill, skill, loginChaos)
 		d.log.Info("char login: sending CNFCharacterLogin (template)",
 			"conn", s.Conn, "class", st.Class, "name", st.Name, "x", spawnX, "y", spawnY, "body", len(body))
 		w.SendTo(s, protocol.Header{Type: protocol.MsgCNFCharacterLogin, ID: protocol.IDScene}, body)
@@ -391,21 +393,21 @@ func (d *Dispatcher) enterWorldView(w *world.World, s *world.Session) {
 		d.sendAffect(w, s, self) // buff icons/timers (e.g. a re-applied Divine)
 	}
 	selfMob := protocol.EncodeCreateMobBody(createMobFrom(self, 2))
-	// PKInfo (Parm=0 — PK/war state not modeled yet) must follow every player
-	// CreateMob here, same as movement.go/view.go: without it the client never
-	// learns the entity's clean PK state and renders its nickname red/blinking
-	// (SendPKInfo/SendGridMob, SendFunc.cpp:1869; ProcessDBMessage.cpp:1021).
-	w.SendTo(s, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(s.Conn)}, protocol.EncodeStandardParm(0))
+	// PKInfo must follow every player CreateMob here, same as movement.go/view.go:
+	// without it the client never learns the entity's PK state and renders its
+	// nickname red/blinking (SendPKInfo/SendGridMob, SendFunc.cpp:1869;
+	// ProcessDBMessage.cpp:1021).
+	w.SendTo(s, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(s.Conn)}, protocol.EncodeStandardParm(pkInfoParm(self)))
 	w.ForEachInView(s.Conn, func(vs *world.Session, ve *world.Entity) {
 		// (A) other players see the newcomer
 		w.MarkSeen(vs, s.Conn)
 		w.SendTo(vs, protocol.Header{Type: protocol.MsgCreateMob, ID: protocol.IDScene}, selfMob)
-		w.SendTo(vs, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(s.Conn)}, protocol.EncodeStandardParm(0))
+		w.SendTo(vs, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(s.Conn)}, protocol.EncodeStandardParm(pkInfoParm(self)))
 		// (B) the newcomer sees each player already in view
 		w.MarkSeen(s, ve.ID)
 		w.SendTo(s, protocol.Header{Type: protocol.MsgCreateMob, ID: protocol.IDScene},
 			protocol.EncodeCreateMobBody(createMobFrom(ve, 0)))
-		w.SendTo(s, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(ve.ID)}, protocol.EncodeStandardParm(0))
+		w.SendTo(s, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(ve.ID)}, protocol.EncodeStandardParm(pkInfoParm(ve)))
 	})
 	// (C) the newcomer sees the NPCs/monsters in view.
 	d.revealMobsInView(w, s)
@@ -442,6 +444,7 @@ func createMobFrom(e *world.Entity, createType uint16) protocol.CreateMobData {
 		Str:             e.Str, Int: e.Int, Dex: e.Dex, Con: e.Con,
 		Merchant:   e.Merchant,
 		AttackRun:  attackRunOf(e),
+		ChaosRate:  chaosRate(e), // PK/chaos nickname blink (0 = clean); mobs are never guilty
 		Equip:      e.EquipVisual,
 		CreateType: createType,
 	}

--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -442,9 +442,12 @@ func createMobFrom(e *world.Entity, createType uint16) protocol.CreateMobData {
 		Level:           e.Level,
 		Ac:              e.AC,
 		Damage:          e.Damage,
-		MaxHp:           e.MaxHP,
-		Hp:              e.HP,
-		Str:             e.Str, Int: e.Int, Dex: e.Dex, Con: e.Con,
+		// HP/MP must match the authoritative score (effective max incl. HP/MP% gear):
+		// the self-CreateMob now drives the player's own bars, so a missing MaxMp/Mp
+		// zeroed the client's MP (regression from adding the login self-CreateMob).
+		MaxHp: effectiveMaxHP(e), Hp: e.HP,
+		MaxMp: effectiveMaxMP(e), Mp: e.MP,
+		Str: e.Str, Int: e.Int, Dex: e.Dex, Con: e.Con,
 		Merchant:   e.Merchant,
 		AttackRun:  attackRunOf(e),
 		Equip:      e.EquipVisual,

--- a/tmserver/internal/handler/combat.go
+++ b/tmserver/internal/handler/combat.go
@@ -181,11 +181,13 @@ func (d *Dispatcher) attack(w *world.World, s *world.Session, h protocol.Header,
 			}
 			if pvpHit && combatHit {
 				// Landing a PvP hit starts (or refreshes) the chaotic red-blink
-				// timer, independent of whether it's already running.
-				wasGuilty := pkInfoParm(e) != 0
+				// timer, independent of whether it's already running. On the 0→1
+				// transition, re-broadcast the PK state so the attacker's nick turns
+				// red (MobName[12]=0) for itself and everyone in view.
+				wasGuilty := pkGuilty(e)
 				e.GuiltyUntil = time.Now().Add(pkGuiltyDuration).Unix()
 				if !wasGuilty {
-					broadcastPKInfo(w, s, e)
+					d.broadcastPKState(w, s, e)
 				}
 			}
 		} else if dmg < 0 && cast.isSkill && cast.spell.InstanceType == 6 {

--- a/tmserver/internal/handler/combat.go
+++ b/tmserver/internal/handler/combat.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/binary"
+	"time"
 
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/combat"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
@@ -139,14 +140,19 @@ func (d *Dispatcher) attack(w *world.World, s *world.Session, h protocol.Header,
 		// skillHit: this entry resolves through the skill pipeline; anything
 		// else (sentinel -2, 0, or an unknown claim) is melee.
 		skillHit := cast.isSkill && claim == damSkill
-		// Town safe zone: players in a city cannot be hit by melee or aggressive
-		// skills (the legacy gates on the attribute map's PK bit + PKMode; we use
-		// the city rectangles until the attribute map semantics are verified).
-		if world.IsPlayer(tid) && tid != s.Conn && world.Village(target.X, target.Y) >= 0 {
-			if !skillHit || cast.spell.Aggressive != 0 {
-				writeDamage(payload, i, 0)
-				continue
-			}
+		// PvP gate: combat damage (melee or an aggressive skill) against another
+		// player requires BOTH that the target isn't standing in a city safe zone
+		// (the legacy gates on the attribute map's PK bit + PKMode; we use the
+		// city rectangles until the attribute map semantics are verified) AND that
+		// the attacker has opted into PK mode (K key, _MSG_PKMode) — outside a
+		// city, PKMode is the consent flag that lets a hit land at all. Landing
+		// one then starts the "chaotic" red-blink timer below, regardless of the
+		// gate (a non-aggressive skill, e.g. a buff, always passes through).
+		pvpHit := world.IsPlayer(tid) && tid != s.Conn
+		combatHit := !skillHit || cast.spell.Aggressive != 0
+		if pvpHit && combatHit && (world.Village(target.X, target.Y) >= 0 || !e.PKMode) {
+			writeDamage(payload, i, 0)
+			continue
 		}
 
 		var dmg int
@@ -172,6 +178,15 @@ func (d *Dispatcher) attack(w *world.World, s *world.Session, h protocol.Header,
 			target.HP -= int32(dmg)
 			if target.HP < 0 {
 				target.HP = 0
+			}
+			if pvpHit && combatHit {
+				// Landing a PvP hit starts (or refreshes) the chaotic red-blink
+				// timer, independent of whether it's already running.
+				wasGuilty := pkInfoParm(e) != 0
+				e.GuiltyUntil = time.Now().Add(pkGuiltyDuration).Unix()
+				if !wasGuilty {
+					broadcastPKInfo(w, s, e)
+				}
 			}
 		} else if dmg < 0 && cast.isSkill && cast.spell.InstanceType == 6 {
 			// Heal: a negative Dam is the healed amount; clamp to the target's max.

--- a/tmserver/internal/handler/combat_test.go
+++ b/tmserver/internal/handler/combat_test.go
@@ -109,38 +109,48 @@ func TestAttackPlayerWithPKModeSetsGuilty(t *testing.T) {
 	drainRaw(t, target)
 
 	send(t, attacker, protocol.MsgPKMode, protocol.EncodeStandardParm(1))
-	// The toggle ack must NOT claim guilty — pressing K alone doesn't blink.
-	ty, payload, ok := readMaybeRaw(t, attacker)
-	if !ok || ty != protocol.MsgPKInfo {
-		t.Fatalf("attacker got %#x ok=%v, want PKInfo ack", ty, ok)
-	}
-	if parm, _ := protocol.StandardParm(payload); parm != 0 {
-		t.Errorf("PKInfo ack parm = %d, want 0 (PK mode alone must not blink)", parm)
+	// Pressing K only sends a PKInfo (attackable flag) — NO CreateMob, so the nick
+	// color (MobName[12]) is untouched. Just drain the ack.
+	if ty, _, ok := readMaybeRaw(t, attacker); !ok || ty != protocol.MsgPKInfo {
+		t.Fatalf("attacker K-ack = %#x ok=%v, want PKInfo", ty, ok)
 	}
 	drainRaw(t, target) // the toggle also reaches the target as a viewer
 
 	attackFrame(t, attacker, serverTime, 2, 0)
 
-	// Landing the hit must broadcast PKInfo(1) about the attacker before the
-	// attack frame itself (combat.go: broadcastPKInfo inside the damage loop,
-	// the MsgAttack forward after it).
-	ty, payload, ok = readMaybeRaw(t, target)
-	if !ok || ty != protocol.MsgPKInfo {
-		t.Fatalf("target got %#x ok=%v, want PKInfo (guilty) before the attack frame", ty, ok)
+	// Landing the hit recolors the attacker's nick red: the target (in view) gets a
+	// fresh CreateMob for the attacker (id 1) whose MobName[12] = 0 (chaos/red),
+	// before the MsgAttack frame. Scan for it, then for the damage.
+	sawRedNick, sawAttack := false, false
+	for i := 0; i < 20 && !sawAttack; i++ {
+		ty, payload, ok := readMaybeRaw(t, target)
+		if !ok {
+			break
+		}
+		switch ty {
+		case protocol.MsgCreateMob:
+			if _, _, id := createMobFields(t, payload); id == 1 {
+				if payload[6+12] != 0 {
+					t.Errorf("attacker self-CreateMob MobName[12] = %d, want 0 (red/chaos after PvP hit)", payload[6+12])
+				}
+				sawRedNick = true
+			}
+		case protocol.MsgAttack:
+			var got protocol.MsgAttackBody
+			if err := got.Decode(payload); err != nil {
+				t.Fatal(err)
+			}
+			if len(got.Dam) != 1 || got.Dam[0].Damage <= 0 {
+				t.Errorf("Dam = %+v, want a landed hit (PK mode on)", got.Dam)
+			}
+			sawAttack = true
+		}
 	}
-	if parm, _ := protocol.StandardParm(payload); parm != 1 {
-		t.Errorf("PKInfo parm = %d, want 1 (attacker now chaotic)", parm)
+	if !sawRedNick {
+		t.Error("attacker's nick was not recolored red (no CreateMob with MobName[12]=0) after landing a PvP hit")
 	}
-	ty, payload, ok = readMaybeRaw(t, target)
-	if !ok || ty != protocol.MsgAttack {
-		t.Fatalf("target got %#x ok=%v, want MsgAttack broadcast", ty, ok)
-	}
-	var got protocol.MsgAttackBody
-	if err := got.Decode(payload); err != nil {
-		t.Fatal(err)
-	}
-	if len(got.Dam) != 1 || got.Dam[0].Damage <= 0 {
-		t.Errorf("Dam = %+v, want a landed hit (PK mode on)", got.Dam)
+	if !sawAttack {
+		t.Error("no MsgAttack broadcast to target")
 	}
 }
 

--- a/tmserver/internal/handler/combat_test.go
+++ b/tmserver/internal/handler/combat_test.go
@@ -85,7 +85,7 @@ func readFrameHeader(t *testing.T, c net.Conn) (protocol.Header, []byte) {
 		if err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		if h.Type == protocol.MsgCreateMob || h.Type == protocol.MsgRemoveMob {
+		if h.Type == protocol.MsgCreateMob || h.Type == protocol.MsgRemoveMob || h.Type == protocol.MsgPKInfo {
 			continue
 		}
 		return h, payload

--- a/tmserver/internal/handler/combat_test.go
+++ b/tmserver/internal/handler/combat_test.go
@@ -48,6 +48,7 @@ func TestAttackHitExact(t *testing.T) {
 	target := enterWorld(t, addr) // conn 2 (target), in view
 	defer target.Close()
 
+	send(t, attacker, protocol.MsgPKMode, protocol.EncodeStandardParm(1)) // PvP requires PK mode
 	attackFrame(t, attacker, serverTime, 2, 0)
 
 	ty, payload, ok := readMaybe(t, target)
@@ -63,6 +64,83 @@ func TestAttackHitExact(t *testing.T) {
 	}
 	if got.Dam[0].Damage != 145 {
 		t.Errorf("server damage = %d, want 145 (exact LCG golden)", got.Dam[0].Damage)
+	}
+}
+
+// TestAttackPlayerWithoutPKModeBlocked: PvP damage never lands without the
+// attacker having opted into PK mode first (K key, _MSG_PKMode) — issue #59
+// follow-up (pressing K alone must not blink the nickname; only a landed PvP
+// hit does, and a hit can't land without PK mode).
+func TestAttackPlayerWithoutPKModeBlocked(t *testing.T) {
+	addr, stop, _ := startServerClock(t, combatDB())
+	defer stop()
+
+	attacker := enterWorld(t, addr) // conn 1, PK mode never toggled
+	defer attacker.Close()
+	target := enterWorld(t, addr) // conn 2, in view
+	defer target.Close()
+
+	attackFrame(t, attacker, serverTime, 2, 0)
+
+	ty, payload, ok := readMaybe(t, target)
+	if !ok || ty != protocol.MsgAttack {
+		t.Fatalf("target got %#x ok=%v, want MsgAttack broadcast", ty, ok)
+	}
+	var got protocol.MsgAttackBody
+	if err := got.Decode(payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Dam) != 1 || got.Dam[0].Damage != 0 {
+		t.Errorf("Dam = %+v, want damage 0 (blocked, no PK mode)", got.Dam)
+	}
+}
+
+// TestAttackPlayerWithPKModeSetsGuilty: toggling PK mode alone must not blink
+// the nickname (no PKInfo(1) on the ack); landing a PvP hit afterward must.
+func TestAttackPlayerWithPKModeSetsGuilty(t *testing.T) {
+	addr, stop, _ := startServerClock(t, combatDB())
+	defer stop()
+
+	attacker := enterWorld(t, addr) // conn 1
+	defer attacker.Close()
+	target := enterWorld(t, addr) // conn 2, in view
+	defer target.Close()
+	drainRaw(t, attacker)
+	drainRaw(t, target)
+
+	send(t, attacker, protocol.MsgPKMode, protocol.EncodeStandardParm(1))
+	// The toggle ack must NOT claim guilty — pressing K alone doesn't blink.
+	ty, payload, ok := readMaybeRaw(t, attacker)
+	if !ok || ty != protocol.MsgPKInfo {
+		t.Fatalf("attacker got %#x ok=%v, want PKInfo ack", ty, ok)
+	}
+	if parm, _ := protocol.StandardParm(payload); parm != 0 {
+		t.Errorf("PKInfo ack parm = %d, want 0 (PK mode alone must not blink)", parm)
+	}
+	drainRaw(t, target) // the toggle also reaches the target as a viewer
+
+	attackFrame(t, attacker, serverTime, 2, 0)
+
+	// Landing the hit must broadcast PKInfo(1) about the attacker before the
+	// attack frame itself (combat.go: broadcastPKInfo inside the damage loop,
+	// the MsgAttack forward after it).
+	ty, payload, ok = readMaybeRaw(t, target)
+	if !ok || ty != protocol.MsgPKInfo {
+		t.Fatalf("target got %#x ok=%v, want PKInfo (guilty) before the attack frame", ty, ok)
+	}
+	if parm, _ := protocol.StandardParm(payload); parm != 1 {
+		t.Errorf("PKInfo parm = %d, want 1 (attacker now chaotic)", parm)
+	}
+	ty, payload, ok = readMaybeRaw(t, target)
+	if !ok || ty != protocol.MsgAttack {
+		t.Fatalf("target got %#x ok=%v, want MsgAttack broadcast", ty, ok)
+	}
+	var got protocol.MsgAttackBody
+	if err := got.Decode(payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Dam) != 1 || got.Dam[0].Damage <= 0 {
+		t.Errorf("Dam = %+v, want a landed hit (PK mode on)", got.Dam)
 	}
 }
 

--- a/tmserver/internal/handler/dispatch.go
+++ b/tmserver/internal/handler/dispatch.go
@@ -180,6 +180,7 @@ func New(cfg Config) *Dispatcher {
 	d.routes[protocol.MsgChangeCity] = d.changeCity
 	d.routes[protocol.MsgReqTeleport] = d.reqTeleport
 	d.routes[protocol.MsgNoViewMob] = d.noViewMob
+	d.routes[protocol.MsgPKMode] = d.pkMode
 	// Batch 3 — combat.
 	d.routes[protocol.MsgAttack] = d.attack
 	d.routes[protocol.MsgAttackOne] = d.attack

--- a/tmserver/internal/handler/handler_test.go
+++ b/tmserver/internal/handler/handler_test.go
@@ -480,6 +480,37 @@ func TestCharacterLoginAndLogout(t *testing.T) {
 	}
 }
 
+// TestCharacterLoginSendsCleanPKInfo is the login-time regression guard for
+// issue #59: a freshly logged-in character (nobody else in view) must receive
+// its own PKInfo(Parm=0) right after the score, so the client never renders the
+// nickname red/blinking before it has ever toggled PK mode or landed a hit.
+func TestCharacterLoginSendsCleanPKInfo(t *testing.T) {
+	db := newDB()
+	db.loadResult = world.CharacterState{Slot: 0, Name: "Hero", X: 2100, Y: 2100, HP: 1200, MaxHP: 1200}
+	addr, stop := startServer(t, db)
+	defer stop()
+	c := loginAndSelect(t, addr)
+	defer c.Close()
+
+	var body protocol.MsgCharacterLoginBody
+	body.Slot = 0
+	send(t, c, protocol.MsgCharacterLogin, body.Encode())
+	if ty, _, ok := readMaybeRaw(t, c); !ok || ty != protocol.MsgCNFCharacterLogin {
+		t.Fatalf("got %#x ok=%v, want CNFCharacterLogin", ty, ok)
+	}
+	if ty, _, ok := readMaybeRaw(t, c); !ok || ty != protocol.MsgUpdateScore {
+		t.Fatalf("got %#x ok=%v, want UpdateScore", ty, ok)
+	}
+	ty, payload, ok := readMaybeRaw(t, c)
+	if !ok || ty != protocol.MsgPKInfo {
+		t.Fatalf("got %#x ok=%v, want PKInfo (self) right after login", ty, ok)
+	}
+	parm, decodeOK := protocol.StandardParm(payload)
+	if !decodeOK || parm != 0 {
+		t.Errorf("login PKInfo parm = %d (ok=%v), want 0 (clean, never toggled/attacked)", parm, decodeOK)
+	}
+}
+
 func TestCharacterLoginBillingDenied(t *testing.T) {
 	db := newDB()
 	db.loadResult = world.CharacterState{Slot: 0, Name: "Hero"}

--- a/tmserver/internal/handler/handler_test.go
+++ b/tmserver/internal/handler/handler_test.go
@@ -480,11 +480,12 @@ func TestCharacterLoginAndLogout(t *testing.T) {
 	}
 }
 
-// TestCharacterLoginSendsCleanPKInfo is the login-time regression guard for
-// issue #59: a freshly logged-in character (nobody else in view) must receive
-// its own PKInfo(Parm=0) right after the score, so the client never renders the
-// nickname red/blinking before it has ever toggled PK mode or landed a hit.
-func TestCharacterLoginSendsCleanPKInfo(t *testing.T) {
+// TestCharacterLoginColorsOwnNickWhite is the login-time regression guard for
+// issue #59: a freshly logged-in character must (a) get its OWN CreateMob (the
+// legacy self-CreateMob that colors the own nick) and (b) that CreateMob's
+// MobName[12] (PKPoint) must be 75 = neutral/white — NOT 0, which renders the
+// nick red/blinking. Both the login blob and the self-CreateMob carry PKPoint 75.
+func TestCharacterLoginColorsOwnNickWhite(t *testing.T) {
 	db := newDB()
 	db.loadResult = world.CharacterState{Slot: 0, Name: "Hero", X: 2100, Y: 2100, HP: 1200, MaxHP: 1200}
 	addr, stop := startServer(t, db)
@@ -495,19 +496,35 @@ func TestCharacterLoginSendsCleanPKInfo(t *testing.T) {
 	var body protocol.MsgCharacterLoginBody
 	body.Slot = 0
 	send(t, c, protocol.MsgCharacterLogin, body.Encode())
-	if ty, _, ok := readMaybeRaw(t, c); !ok || ty != protocol.MsgCNFCharacterLogin {
+	// The login blob's own MobName[12] must be 75 (white). mob @ body4, MobName[0].
+	ty, payload, ok := readMaybeRaw(t, c)
+	if !ok || ty != protocol.MsgCNFCharacterLogin {
 		t.Fatalf("got %#x ok=%v, want CNFCharacterLogin", ty, ok)
 	}
-	if ty, _, ok := readMaybeRaw(t, c); !ok || ty != protocol.MsgUpdateScore {
-		t.Fatalf("got %#x ok=%v, want UpdateScore", ty, ok)
+	if payload[4+12] != 75 {
+		t.Errorf("login blob MobName[12] = %d, want 75 (neutral/white nick)", payload[4+12])
 	}
-	ty, payload, ok := readMaybeRaw(t, c)
-	if !ok || ty != protocol.MsgPKInfo {
-		t.Fatalf("got %#x ok=%v, want PKInfo (self) right after login", ty, ok)
+	// The self-CreateMob (id = own conn) must also carry MobName[12] = 75. Scan the
+	// post-login frames for a CreateMob whose MobID is the player's conn.
+	found := false
+	for i := 0; i < 20 && !found; i++ {
+		ty, payload, ok = readMaybeRaw(t, c)
+		if !ok {
+			break
+		}
+		if ty != protocol.MsgCreateMob {
+			continue
+		}
+		_, _, mobID := createMobFields(t, payload)
+		if mobID == 1 { // first (only) player conn
+			found = true
+			if payload[6+12] != 75 { // MobName @ body6, [12] = PKPoint
+				t.Errorf("self-CreateMob MobName[12] = %d, want 75 (white)", payload[6+12])
+			}
+		}
 	}
-	parm, decodeOK := protocol.StandardParm(payload)
-	if !decodeOK || parm != 0 {
-		t.Errorf("login PKInfo parm = %d (ok=%v), want 0 (clean, never toggled/attacked)", parm, decodeOK)
+	if !found {
+		t.Error("no self-CreateMob received at login — own nick can't be colored/recolored")
 	}
 }
 

--- a/tmserver/internal/handler/handler_test.go
+++ b/tmserver/internal/handler/handler_test.go
@@ -211,7 +211,7 @@ func read(t *testing.T, c net.Conn) (protocol.Type, []byte) {
 			t.Fatalf("decode: %v", err)
 		}
 		// Entity-visibility packets are background noise for gameplay assertions.
-		if h.Type == protocol.MsgCreateMob || h.Type == protocol.MsgRemoveMob {
+		if h.Type == protocol.MsgCreateMob || h.Type == protocol.MsgRemoveMob || h.Type == protocol.MsgPKInfo {
 			continue
 		}
 		return h.Type, payload

--- a/tmserver/internal/handler/mobai.go
+++ b/tmserver/internal/handler/mobai.go
@@ -77,6 +77,7 @@ func (d *Dispatcher) Tick(w *world.World) {
 	})
 	d.regenPlayers(w)
 	d.sweepAffects(w)
+	d.sweepGuilty(w)
 	d.respawnMobs(w)
 	d.generateMobs(w)
 	d.pollNPCConfig(w) // hot-reload moderator NPC edits (npc-editing-plan.md)

--- a/tmserver/internal/handler/movement.go
+++ b/tmserver/internal/handler/movement.go
@@ -201,9 +201,8 @@ func (d *Dispatcher) noViewMob(w *world.World, s *world.Session, _ protocol.Head
 		w.SendTo(s, protocol.Header{Type: protocol.MsgCreateMob, ID: protocol.IDScene},
 			protocol.EncodeCreateMobBody(createMobFrom(target, 1)))
 		if id < world.MaxUser {
-			// PKInfo travels only about players (SendPKInfo, SendFunc.cpp:1869);
-			// Parm=0 — PK/war state not modeled yet.
-			w.SendTo(s, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(id)}, protocol.EncodeStandardParm(0))
+			// PKInfo travels only about players (SendPKInfo, SendFunc.cpp:1869).
+			w.SendTo(s, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(id)}, protocol.EncodeStandardParm(pkInfoParm(target)))
 		}
 	} else {
 		w.SendTo(s, protocol.Header{Type: protocol.MsgRemoveMob, ID: uint16(id)}, protocol.EncodeRemoveMobBody(0))

--- a/tmserver/internal/handler/movement_test.go
+++ b/tmserver/internal/handler/movement_test.go
@@ -90,8 +90,8 @@ func readMaybe(t *testing.T, c net.Conn) (protocol.Type, []byte, bool) {
 		if err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		// Skip entity-visibility noise (CreateMob/RemoveMob) for gameplay asserts.
-		if h.Type == protocol.MsgCreateMob || h.Type == protocol.MsgRemoveMob {
+		// Skip entity-visibility noise (CreateMob/RemoveMob/PKInfo) for gameplay asserts.
+		if h.Type == protocol.MsgCreateMob || h.Type == protocol.MsgRemoveMob || h.Type == protocol.MsgPKInfo {
 			continue
 		}
 		return h.Type, payload, true
@@ -117,7 +117,7 @@ func readMaybeHeader(t *testing.T, c net.Conn) (protocol.Header, []byte, bool) {
 		if err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		if h.Type == protocol.MsgCreateMob || h.Type == protocol.MsgRemoveMob {
+		if h.Type == protocol.MsgCreateMob || h.Type == protocol.MsgRemoveMob || h.Type == protocol.MsgPKInfo {
 			continue
 		}
 		return h, payload, true

--- a/tmserver/internal/handler/party_test.go
+++ b/tmserver/internal/handler/party_test.go
@@ -87,6 +87,8 @@ func TestGuildInvite(t *testing.T) {
 	defer a.Close()
 	b := enterWorldAs(t, addr, "tradeb") // conn 2 (recruit, same clan, no guild)
 	defer b.Close()
+	drainRaw(t, a)
+	drainRaw(t, b)
 
 	send(t, a, protocol.MsgInviteGuild, protocol.EncodeStandardParm2(2, 0)) // target conn 2, type 0
 	// The recruit is welcomed; the leader sees the recruit's refreshed tag.

--- a/tmserver/internal/handler/pkmode.go
+++ b/tmserver/internal/handler/pkmode.go
@@ -1,0 +1,93 @@
+package handler
+
+import (
+	"time"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// pkGuiltyDuration is how long a "chaotic" PvP attacker's nickname stays
+// red/blinking after landing a hit, refreshed on every further hit. The exact
+// legacy value isn't in the available source (SetGuilty/GetGuilty exist in
+// GetFunc.cpp but no PvP-attack call site does — an incomplete leak); ~2 minutes
+// per confirmed live-client behavior (issue #59 follow-up). UNVERIFIED exact figure.
+const pkGuiltyDuration = 2 * time.Minute
+
+// chaosBlink is the STRUCT_SCORE.ChaosRate value written for a "chaotic" player
+// so the client blinks the nickname red. The exact legacy value/threshold isn't
+// in our partial source (the templates ship 0xCC uninitialized garbage here), so
+// any non-zero is treated as "blink"; 1 is the minimal trigger. UNVERIFIED exact
+// mapping — pin with the Windows agent if a specific count is required.
+const chaosBlink uint8 = 1
+
+// pkGuilty reports whether e is currently in the chaotic (red-blinking-nick)
+// state — a PvP hit landed within the last pkGuiltyDuration.
+func pkGuilty(e *world.Entity) bool {
+	return e.GuiltyUntil > time.Now().Unix()
+}
+
+// chaosRate is the STRUCT_SCORE.ChaosRate byte for e's current state: non-zero
+// blinks the nickname red, 0 is clean. This is the field the client actually
+// renders (NOT _MSG_PKInfo) — both the CreateMob snapshot others see and the
+// CNFCharacterLogin blob of the player's own character carry it.
+func chaosRate(e *world.Entity) uint8 {
+	if pkGuilty(e) {
+		return chaosBlink
+	}
+	return 0
+}
+
+// pkInfoParm is the S→C PKInfo Parm for e: 1 makes the client render the
+// nickname red/blinking, 0 clears it. It reflects the "chaotic" (guilty) timer,
+// NOT the raw PKMode consent flag — pressing K alone never blinks the nickname
+// by itself; only actually landing a PvP hit does (see attack() in combat.go).
+func pkInfoParm(e *world.Entity) int32 {
+	if pkGuilty(e) {
+		return 1
+	}
+	return 0
+}
+
+// broadcastPKInfo sends target's current PKInfo state to itself and everyone in
+// view — used whenever the chaotic timer flips (a PvP hit lands, or it decays).
+func broadcastPKInfo(w *world.World, s *world.Session, e *world.Entity) {
+	body := protocol.EncodeStandardParm(pkInfoParm(e))
+	w.SendTo(s, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(s.Conn)}, body)
+	w.ForEachInView(s.Conn, func(vs *world.Session, _ *world.Entity) {
+		w.SendTo(vs, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(s.Conn)}, body)
+	})
+}
+
+// pkMode handles _MSG_PKMode (0x0399): the client's K-key Player-Killer consent
+// toggle (Exec_MSG_PKMode, _MSG_PKMode.cpp). Toggling only flips the consent gate
+// checked by attack() — it cancels any active trade (same anti-dup guard as
+// legacy's OpponentID check) and echoes the current PKInfo state, but does not by
+// itself start the red/blinking timer.
+func (d *Dispatcher) pkMode(w *world.World, s *world.Session, _ protocol.Header, payload []byte) {
+	if s.Mode != world.UserPlay {
+		return
+	}
+	e := w.Entity(s.Conn)
+	if e == nil {
+		return
+	}
+	parm, _ := protocol.StandardParm(payload)
+	e.PKMode = parm != 0
+
+	d.removeTrade(w, s)
+	broadcastPKInfo(w, s, e)
+}
+
+// sweepGuilty expires the chaotic PvP timer once its wall-clock deadline passes
+// (mirrors the DivineEnd expiry check in regenPlayers) and notifies everyone in
+// view so the nickname stops blinking without requiring the player to move.
+func (d *Dispatcher) sweepGuilty(w *world.World) {
+	now := time.Now().Unix()
+	w.ForEachPlayer(func(s *world.Session, e *world.Entity) {
+		if e.GuiltyUntil > 0 && now >= e.GuiltyUntil {
+			e.GuiltyUntil = 0
+			broadcastPKInfo(w, s, e)
+		}
+	})
+}

--- a/tmserver/internal/handler/pkmode.go
+++ b/tmserver/internal/handler/pkmode.go
@@ -8,18 +8,21 @@ import (
 )
 
 // pkGuiltyDuration is how long a "chaotic" PvP attacker's nickname stays
-// red/blinking after landing a hit, refreshed on every further hit. The exact
-// legacy value isn't in the available source (SetGuilty/GetGuilty exist in
-// GetFunc.cpp but no PvP-attack call site does — an incomplete leak); ~2 minutes
-// per confirmed live-client behavior (issue #59 follow-up). UNVERIFIED exact figure.
+// red/blinking after landing a hit, refreshed on every further hit. The legacy
+// model is a PKPoint that decays +1 toward the neutral 75 every 450 ticks plus a
+// per-tick Guilty counter (Server.cpp:4871/4933); we model it as a flat timer
+// until the exact PKPoint math is ported. UNVERIFIED exact figure (~2 min per
+// live-client behavior).
 const pkGuiltyDuration = 2 * time.Minute
 
-// chaosBlink is the STRUCT_SCORE.ChaosRate value written for a "chaotic" player
-// so the client blinks the nickname red. The exact legacy value/threshold isn't
-// in our partial source (the templates ship 0xCC uninitialized garbage here), so
-// any non-zero is treated as "blink"; 1 is the minimal trigger. UNVERIFIED exact
-// mapping — pin with the Windows agent if a specific count is required.
-const chaosBlink uint8 = 1
+// PK nickname coloring: the client reads MobName[12] (PKPoint) from a player's
+// MSG_CreateMob to color the nick — 75 is NEUTRAL (white), 0 is red/blinking
+// (chaos/guilty), <75 is chaos (GetFunc.cpp:1082-1101). This is the real driver,
+// NOT _MSG_PKInfo (which only carries the "attackable/war" state).
+const (
+	pkPointNeutral uint8 = 75 // white nick
+	pkPointChaos   uint8 = 0  // red blinking nick
+)
 
 // pkGuilty reports whether e is currently in the chaotic (red-blinking-nick)
 // state — a PvP hit landed within the last pkGuiltyDuration.
@@ -27,43 +30,46 @@ func pkGuilty(e *world.Entity) bool {
 	return e.GuiltyUntil > time.Now().Unix()
 }
 
-// chaosRate is the STRUCT_SCORE.ChaosRate byte for e's current state: non-zero
-// blinks the nickname red, 0 is clean. This is the field the client actually
-// renders (NOT _MSG_PKInfo) — both the CreateMob snapshot others see and the
-// CNFCharacterLogin blob of the player's own character carry it.
-func chaosRate(e *world.Entity) uint8 {
+// pkPoint is the MobName[12] byte for e's current state: 75 (neutral/white) when
+// clean, 0 (chaos/red) while guilty. Packed into every player MSG_CreateMob and
+// the CNFCharacterLogin blob so the nick renders the right color.
+func pkPoint(e *world.Entity) uint8 {
 	if pkGuilty(e) {
-		return chaosBlink
+		return pkPointChaos
 	}
-	return 0
+	return pkPointNeutral
 }
 
-// pkInfoParm is the S→C PKInfo Parm for e: 1 makes the client render the
-// nickname red/blinking, 0 clears it. It reflects the "chaotic" (guilty) timer,
-// NOT the raw PKMode consent flag — pressing K alone never blinks the nickname
-// by itself; only actually landing a PvP hit does (see attack() in combat.go).
+// pkInfoParm is the S→C PKInfo Parm for e: 1 = PK/attackable state, 0 = clean.
+// This drives the "can be attacked / at war" flag, NOT the nick color (that's
+// MobName[12]); we still send it for parity with the original login/view flow.
 func pkInfoParm(e *world.Entity) int32 {
-	if pkGuilty(e) {
+	if pkGuilty(e) || e.PKMode {
 		return 1
 	}
 	return 0
 }
 
-// broadcastPKInfo sends target's current PKInfo state to itself and everyone in
-// view — used whenever the chaotic timer flips (a PvP hit lands, or it decays).
-func broadcastPKInfo(w *world.World, s *world.Session, e *world.Entity) {
-	body := protocol.EncodeStandardParm(pkInfoParm(e))
-	w.SendTo(s, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(s.Conn)}, body)
-	w.ForEachInView(s.Conn, func(vs *world.Session, _ *world.Entity) {
-		w.SendTo(vs, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(s.Conn)}, body)
-	})
+// broadcastPKState re-sends e's current PK state to itself and everyone in view
+// whenever it changes (a PvP hit lands, or the guilty timer decays): a fresh
+// MSG_CreateMob (whose MobName[12] recolors the nick — Server.cpp:4933-4941 does
+// exactly this when guilty hits 0) plus the MSG_PKInfo attackable flag.
+func (d *Dispatcher) broadcastPKState(w *world.World, s *world.Session, e *world.Entity) {
+	mob := protocol.EncodeCreateMobBody(createMobFrom(e, 0))
+	info := protocol.EncodeStandardParm(pkInfoParm(e))
+	send := func(vs *world.Session) {
+		w.SendTo(vs, protocol.Header{Type: protocol.MsgCreateMob, ID: protocol.IDScene}, mob)
+		w.SendTo(vs, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(s.Conn)}, info)
+	}
+	send(s) // the player's own client (recolors the own nick)
+	w.ForEachInView(s.Conn, func(vs *world.Session, _ *world.Entity) { send(vs) })
 }
 
 // pkMode handles _MSG_PKMode (0x0399): the client's K-key Player-Killer consent
 // toggle (Exec_MSG_PKMode, _MSG_PKMode.cpp). Toggling only flips the consent gate
 // checked by attack() — it cancels any active trade (same anti-dup guard as
-// legacy's OpponentID check) and echoes the current PKInfo state, but does not by
-// itself start the red/blinking timer.
+// legacy's OpponentID check) and echoes the current PKInfo state. Pressing K does
+// NOT by itself blink the nick (that needs a landed PvP hit → guilty).
 func (d *Dispatcher) pkMode(w *world.World, s *world.Session, _ protocol.Header, payload []byte) {
 	if s.Mode != world.UserPlay {
 		return
@@ -76,18 +82,24 @@ func (d *Dispatcher) pkMode(w *world.World, s *world.Session, _ protocol.Header,
 	e.PKMode = parm != 0
 
 	d.removeTrade(w, s)
-	broadcastPKInfo(w, s, e)
+	// Only the attackable flag (PKInfo) changes on a K toggle — the nick color
+	// (MobName[12]) is unaffected, so no CreateMob re-broadcast is needed.
+	info := protocol.EncodeStandardParm(pkInfoParm(e))
+	w.SendTo(s, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(s.Conn)}, info)
+	w.ForEachInView(s.Conn, func(vs *world.Session, _ *world.Entity) {
+		w.SendTo(vs, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(s.Conn)}, info)
+	})
 }
 
 // sweepGuilty expires the chaotic PvP timer once its wall-clock deadline passes
-// (mirrors the DivineEnd expiry check in regenPlayers) and notifies everyone in
-// view so the nickname stops blinking without requiring the player to move.
+// (mirrors the DivineEnd expiry check in regenPlayers) and re-broadcasts the PK
+// state so the nick returns to white without the player having to move.
 func (d *Dispatcher) sweepGuilty(w *world.World) {
 	now := time.Now().Unix()
 	w.ForEachPlayer(func(s *world.Session, e *world.Entity) {
 		if e.GuiltyUntil > 0 && now >= e.GuiltyUntil {
 			e.GuiltyUntil = 0
-			broadcastPKInfo(w, s, e)
+			d.broadcastPKState(w, s, e)
 		}
 	})
 }

--- a/tmserver/internal/handler/skill_test.go
+++ b/tmserver/internal/handler/skill_test.go
@@ -72,6 +72,7 @@ func TestSkillCastSpendsMana(t *testing.T) {
 	target := enterWorld(t, addr) // conn 2, in view
 	defer target.Close()
 
+	send(t, attacker, protocol.MsgPKMode, protocol.EncodeStandardParm(1)) // PvP requires PK mode
 	skillAttackFrame(t, attacker, serverTime, 2, 2, -1)
 	ty, payload, ok := readMaybe(t, target)
 	if !ok || ty != protocol.MsgAttack {
@@ -181,6 +182,7 @@ func TestMeleeWithNegativeSkillIndex(t *testing.T) {
 	target := enterWorld(t, addr)
 	defer target.Close()
 
+	send(t, attacker, protocol.MsgPKMode, protocol.EncodeStandardParm(1)) // PvP requires PK mode
 	skillAttackFrame(t, attacker, serverTime, 2, -1, -2)
 	ty, payload, ok := readMaybe(t, target)
 	if !ok || ty != protocol.MsgAttack {

--- a/tmserver/internal/handler/view.go
+++ b/tmserver/internal/handler/view.go
@@ -19,9 +19,9 @@ import (
 //   - in either window → the raw frame, preserving the caller's Type
 //     (Action/Action2/Action3 travel verbatim in legacy).
 //
-// PKInfo is only sent about players (SendPKInfo bails on mob ids); Parm=0 is a
-// simplification — PK/war state is not modeled yet (legacy sends 1 only during
-// PK/guild-war/RvR, SendFunc.cpp:1884-1896).
+// PKInfo is only sent about players (SendPKInfo bails on mob ids); guild-war/RvR
+// state is not modeled yet, so the PK toggle (pkInfoParm, PKMode) is the only
+// input for now (legacy also ORs those in, SendFunc.cpp:1884-1896).
 //
 // For a player mover it also reconciles NPC/monster visibility: reveals mobs in
 // the new window and removes mobs from the old window now out of range (the
@@ -67,11 +67,11 @@ func (d *Dispatcher) moveMulticast(w *world.World, moverID int, oldX, oldY int16
 			w.MarkSeen(s, moverID)
 			w.SendTo(s, protocol.Header{Type: protocol.MsgCreateMob, ID: protocol.IDScene}, moverBody)
 			if moverSess != nil {
-				w.SendTo(s, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(moverID)}, protocol.EncodeStandardParm(0))
+				w.SendTo(s, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(moverID)}, protocol.EncodeStandardParm(pkInfoParm(mover)))
 				w.MarkSeen(moverSess, e.ID)
 				w.SendTo(moverSess, protocol.Header{Type: protocol.MsgCreateMob, ID: protocol.IDScene},
 					protocol.EncodeCreateMobBody(createMobFrom(e, 0)))
-				w.SendTo(moverSess, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(e.ID)}, protocol.EncodeStandardParm(0))
+				w.SendTo(moverSess, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(e.ID)}, protocol.EncodeStandardParm(pkInfoParm(e)))
 			}
 			if payload != nil {
 				w.SendTo(s, protocol.Header{Type: msgType, ID: uint16(moverID)}, payload)

--- a/tmserver/internal/protocol/createmob.go
+++ b/tmserver/internal/protocol/createmob.go
@@ -26,9 +26,18 @@ type CreateMobData struct {
 	Merchant             uint8 // NPC type (shop/bank/…); makes the name always-visible
 	AttackRun            uint8 // speed byte (run<<4 | move): the client animates this entity's walks with it — 0 = crawling avatar that rubber-bands
 	Direction            uint8
-	ChaosRate            uint8  // STRUCT_SCORE.ChaosRate: non-zero → the client blinks the nickname red (PK/chaos). MUST be 0 for a clean player.
 	CreateType           uint16 // 0 normal, 2 "just entered"
 	Equip                [16]uint16
+	// IsPlayer selects the MobName encoding: players (id < MAX_USER) pack PK data
+	// into MobName[12..15]; mobs/NPCs send the full 16-byte name raw (their names
+	// can be 16 chars, e.g. "Ciclope_Arqueiro", and carry no PK coloring).
+	IsPlayer bool
+	// PKPoint is the chaos/PK level packed into MobName[12] (players only). NEUTRAL
+	// is 75 (white nick); 0 = red blinking (chaos/guilty); <75 = chaos. See
+	// PackMobName (GetFunc.cpp:1082-1101).
+	PKPoint uint8
+	CurKill uint8  // MobName[13]
+	TotKill uint16 // MobName[14..15]
 }
 
 func writeCreateMobScore(b []byte, d CreateMobData) {
@@ -38,7 +47,8 @@ func writeCreateMobScore(b []byte, d CreateMobData) {
 	b[12] = d.Merchant  // STRUCT_SCORE.Merchant — NPC type
 	b[13] = d.AttackRun // STRUCT_SCORE.AttackRun — speed
 	b[14] = d.Direction
-	b[15] = d.ChaosRate // STRUCT_SCORE.ChaosRate — PK/chaos nickname blink (0 = clean)
+	// b[15] STRUCT_SCORE.ChaosRate is unused by the server (NPTool edits it as a
+	// regen field; it does NOT drive the nick color — that's MobName[12]). Leave 0.
 	le.PutUint32(b[16:], uint32(d.MaxHp))
 	le.PutUint32(b[20:], uint32(d.MaxMp))
 	le.PutUint32(b[24:], uint32(d.Hp))
@@ -49,6 +59,27 @@ func writeCreateMobScore(b []byte, d CreateMobData) {
 	le.PutUint16(b[38:], uint16(d.Con))
 }
 
+// PackMobName writes the 16-byte MobName field for a PLAYER: only the first 12
+// bytes hold the name; bytes [12..15] carry the PK/chaos data the client reads to
+// color the nickname (GetFunc.cpp:1082-1101). MobName[12] = PKPoint (75 = neutral/
+// white, 0 = red blinking), [13] = curkill, [14..15] = totkill (little-endian).
+// NPCs/mobs (id ≥ MAX_USER) pass pkPoint=0 curkill=0 totkill=0 — the legacy only
+// packs this for id < MAX_USER, and a mob's name has no PK coloring.
+func PackMobName(dst []byte, name string, pkPoint, curKill uint8, totKill uint16) {
+	for i := 0; i < 16; i++ {
+		dst[i] = 0
+	}
+	nb := []byte(name)
+	if len(nb) > 12 {
+		nb = nb[:12]
+	}
+	copy(dst[0:12], nb)
+	dst[12] = pkPoint
+	dst[13] = curKill
+	dst[14] = byte(totKill)
+	dst[15] = byte(totKill >> 8)
+}
+
 // EncodeCreateMobBody builds the body (after the 12-byte header) of MSG_CreateMob
 // (0x0364). Send with HEADER.ID = IDScene (30000); the entity id is MobID.
 func EncodeCreateMobBody(d CreateMobData) []byte {
@@ -56,8 +87,14 @@ func EncodeCreateMobBody(d CreateMobData) []byte {
 	le.PutUint16(b[0:], uint16(d.PosX))         // PosX @abs12 → body0
 	le.PutUint16(b[2:], uint16(d.PosY))         // PosY @abs14 → body2
 	le.PutUint16(b[4:], uint16(d.MobID))        // MobID @abs16 → body4
-	copy(b[6:6+16], d.Name)                     // MobName @abs18 → body6
-	for i := 0; i < 16; i++ {                   // Equip[16] @abs34 → body22
+	// MobName @abs18 → body6. Players: name in [0..11] + PK data in [12..15] (colors
+	// the nick). Mobs/NPCs: full 16-byte raw name (no PK packing).
+	if d.IsPlayer {
+		PackMobName(b[6:6+16], d.Name, d.PKPoint, d.CurKill, d.TotKill)
+	} else {
+		copy(b[6:6+16], d.Name)
+	}
+	for i := 0; i < 16; i++ { // Equip[16] @abs34 → body22
 		le.PutUint16(b[22+i*2:], d.Equip[i])
 	}
 	le.PutUint16(b[118:], d.Guild)      // Guild @abs130 → body118

--- a/tmserver/internal/protocol/createmob.go
+++ b/tmserver/internal/protocol/createmob.go
@@ -26,6 +26,7 @@ type CreateMobData struct {
 	Merchant             uint8 // NPC type (shop/bank/…); makes the name always-visible
 	AttackRun            uint8 // speed byte (run<<4 | move): the client animates this entity's walks with it — 0 = crawling avatar that rubber-bands
 	Direction            uint8
+	ChaosRate            uint8  // STRUCT_SCORE.ChaosRate: non-zero → the client blinks the nickname red (PK/chaos). MUST be 0 for a clean player.
 	CreateType           uint16 // 0 normal, 2 "just entered"
 	Equip                [16]uint16
 }
@@ -37,6 +38,7 @@ func writeCreateMobScore(b []byte, d CreateMobData) {
 	b[12] = d.Merchant  // STRUCT_SCORE.Merchant — NPC type
 	b[13] = d.AttackRun // STRUCT_SCORE.AttackRun — speed
 	b[14] = d.Direction
+	b[15] = d.ChaosRate // STRUCT_SCORE.ChaosRate — PK/chaos nickname blink (0 = clean)
 	le.PutUint32(b[16:], uint32(d.MaxHp))
 	le.PutUint32(b[20:], uint32(d.MaxMp))
 	le.PutUint32(b[24:], uint32(d.Hp))

--- a/tmserver/internal/protocol/mob.go
+++ b/tmserver/internal/protocol/mob.go
@@ -170,7 +170,7 @@ type SkillState struct {
 // equipment, skills AND a valid spawn position), patching only the name. The
 // position comes from the template itself (the stored relational position is not
 // yet carried over gRPC, and 0,0 would crash the client on an invalid map cell).
-func EncodeCNFCharacterLoginRaw(mob816 []byte, name string, coin int32, exp int64, equip [16]SelItem, carry [64]SelItem, spawnX, spawnY int16, slot, clientID int, weather uint16, shortSkill [16]uint8, skill SkillState) []byte {
+func EncodeCNFCharacterLoginRaw(mob816 []byte, name string, coin int32, exp int64, equip [16]SelItem, carry [64]SelItem, spawnX, spawnY int16, slot, clientID int, weather uint16, shortSkill [16]uint8, skill SkillState, chaosRate uint8) []byte {
 	b := make([]byte, cnfCharacterLoginSize-HeaderSize) // 1820
 	copy(b[4:4+structMobSize], mob816)                  // mob @ body4 (raw template)
 	for i := 4; i < 4+16; i++ {                         // clear MobName then set it
@@ -217,6 +217,14 @@ func EncodeCNFCharacterLoginRaw(mob816 []byte, name string, coin int32, exp int6
 		le.PutUint16(b[4+44+40+i*2:], uint16(skill.BaseSpecial[i]))
 		le.PutUint16(b[4+92+40+i*2:], uint16(skill.Special[i]))
 	}
+	// STRUCT_SCORE.ChaosRate@15 in BOTH scores (BaseScore@44+15=59, CurrentScore@92+15=107).
+	// The BaseMob template ships this byte as uninitialized 0xCC memory (same 0xCC
+	// dump as the gold/Quest padding, B2), which the client reads as a non-zero
+	// chaos level → it blinks the player's OWN nickname red (issue #59). Overwrite
+	// it with the real PK/chaos state (0 = clean) so a fresh, non-guilty character
+	// never blinks.
+	b[4+44+15] = chaosRate
+	b[4+92+15] = chaosRate
 	le.PutUint16(b[1028:], uint16(slot))
 	le.PutUint16(b[1030:], uint16(clientID))
 	le.PutUint16(b[1032:], weather)

--- a/tmserver/internal/protocol/mob.go
+++ b/tmserver/internal/protocol/mob.go
@@ -89,6 +89,7 @@ type MobSnapshot struct {
 	GuildLevel           uint8
 	RegenHP, RegenMP     uint16
 	Resist               [4]uint8
+	PKPoint              uint8 // MobName[12] chaos byte: 75 = neutral/white nick, 0 = red (players only)
 }
 
 // writeMobScore writes a 48-byte STRUCT_SCORE from a MobSnapshot.
@@ -114,19 +115,19 @@ func writeMobScore(b []byte, m MobSnapshot) {
 
 // writeStructMob writes a 816-byte STRUCT_MOB.
 func writeStructMob(b []byte, m MobSnapshot) {
-	copy(b[0:16], m.Name)                // MobName @0
-	b[16] = m.Clan                       // Clan @16
-	b[17] = m.Merchant                   // Merchant @17
-	le.PutUint16(b[18:], m.Guild)        // Guild @18
-	b[20] = m.Class                      // Class @20
-	b[24] = m.Quest                      // Quest @24
-	le.PutUint32(b[28:], uint32(m.Coin)) // Coin @28
-	le.PutUint64(b[32:], uint64(m.Exp))  // Exp @32
-	le.PutUint16(b[40:], uint16(m.SPX))  // SPX @40
-	le.PutUint16(b[42:], uint16(m.SPY))  // SPY @42
-	writeMobScore(b[44:], m)             // BaseScore @44
-	writeMobScore(b[92:], m)             // CurrentScore @92
-	for i := 0; i < 16; i++ {            // Equip[16] @140
+	PackMobName(b[0:16], m.Name, m.PKPoint, 0, 0) // MobName @0: name[0..11] + PK data[12..15]
+	b[16] = m.Clan                                // Clan @16
+	b[17] = m.Merchant                            // Merchant @17
+	le.PutUint16(b[18:], m.Guild)                 // Guild @18
+	b[20] = m.Class                               // Class @20
+	b[24] = m.Quest                               // Quest @24
+	le.PutUint32(b[28:], uint32(m.Coin))          // Coin @28
+	le.PutUint64(b[32:], uint64(m.Exp))           // Exp @32
+	le.PutUint16(b[40:], uint16(m.SPX))           // SPX @40
+	le.PutUint16(b[42:], uint16(m.SPY))           // SPY @42
+	writeMobScore(b[44:], m)                      // BaseScore @44
+	writeMobScore(b[92:], m)                      // CurrentScore @92
+	for i := 0; i < 16; i++ {                     // Equip[16] @140
 		writeSelItem(b[140+i*8:], m.Equip[i])
 	}
 	for i := 0; i < 64; i++ { // Carry[64] @268
@@ -170,13 +171,14 @@ type SkillState struct {
 // equipment, skills AND a valid spawn position), patching only the name. The
 // position comes from the template itself (the stored relational position is not
 // yet carried over gRPC, and 0,0 would crash the client on an invalid map cell).
-func EncodeCNFCharacterLoginRaw(mob816 []byte, name string, coin int32, exp int64, equip [16]SelItem, carry [64]SelItem, spawnX, spawnY int16, slot, clientID int, weather uint16, shortSkill [16]uint8, skill SkillState, chaosRate uint8) []byte {
+func EncodeCNFCharacterLoginRaw(mob816 []byte, name string, coin int32, exp int64, equip [16]SelItem, carry [64]SelItem, spawnX, spawnY int16, slot, clientID int, weather uint16, shortSkill [16]uint8, skill SkillState, pkPoint uint8) []byte {
 	b := make([]byte, cnfCharacterLoginSize-HeaderSize) // 1820
 	copy(b[4:4+structMobSize], mob816)                  // mob @ body4 (raw template)
-	for i := 4; i < 4+16; i++ {                         // clear MobName then set it
-		b[i] = 0
-	}
-	copy(b[4:4+16], name)
+	// MobName @ body4: name in [0..11] + PK data in [12..15]. The client colors the
+	// player's own nick from MobName[12] (PKPoint: 75 = neutral/white, 0 = red
+	// blinking). Packing it here avoids a red flash before the self-CreateMob
+	// arrives (GetFunc.cpp:1082-1101).
+	PackMobName(b[4:4+16], name, pkPoint, 0, 0)
 	// Overlay the persisted equipment onto the template's Equip@140, so the saved
 	// gear (not the class starter set) shows on the model and in the equip window.
 	for i := 0; i < 16; i++ {
@@ -217,14 +219,6 @@ func EncodeCNFCharacterLoginRaw(mob816 []byte, name string, coin int32, exp int6
 		le.PutUint16(b[4+44+40+i*2:], uint16(skill.BaseSpecial[i]))
 		le.PutUint16(b[4+92+40+i*2:], uint16(skill.Special[i]))
 	}
-	// STRUCT_SCORE.ChaosRate@15 in BOTH scores (BaseScore@44+15=59, CurrentScore@92+15=107).
-	// The BaseMob template ships this byte as uninitialized 0xCC memory (same 0xCC
-	// dump as the gold/Quest padding, B2), which the client reads as a non-zero
-	// chaos level → it blinks the player's OWN nickname red (issue #59). Overwrite
-	// it with the real PK/chaos state (0 = clean) so a fresh, non-guilty character
-	// never blinks.
-	b[4+44+15] = chaosRate
-	b[4+92+15] = chaosRate
 	le.PutUint16(b[1028:], uint16(slot))
 	le.PutUint16(b[1030:], uint16(clientID))
 	le.PutUint16(b[1032:], weather)

--- a/tmserver/internal/protocol/mob_test.go
+++ b/tmserver/internal/protocol/mob_test.go
@@ -54,11 +54,7 @@ func TestCNFCharacterLoginRawLayout(t *testing.T) {
 		BaseSpecial: [4]int16{1, 2, 3, 4},
 		SkillBar:    [4]uint8{9, 10, 11, 12},
 	}
-	// ChaosRate 0xCC is the uninitialized-template garbage the real BaseMob ships;
-	// pre-fill both score slots to prove the encoder overwrites them (issue #59).
-	tmpl[44+15] = 0xCC
-	tmpl[92+15] = 0xCC
-	b := EncodeCNFCharacterLoginRaw(tmpl, "Hero", 777777, 123456789, equip, carry, 2453, 2000, 0, 1, 0, sk, skill, 0)
+	b := EncodeCNFCharacterLoginRaw(tmpl, "Hero", 777777, 123456789, equip, carry, 2453, 2000, 0, 1, 0, sk, skill, 75)
 
 	if len(b) != cnfCharacterLoginSize-HeaderSize { // 1832 - 12 = 1820
 		t.Fatalf("CNFCharacterLogin body = %d, want %d", len(b), cnfCharacterLoginSize-HeaderSize)
@@ -84,11 +80,10 @@ func TestCNFCharacterLoginRawLayout(t *testing.T) {
 	if got := le.Uint64(b[4+32:]); got != 123456789 {
 		t.Errorf("exp @mob32 = %d, want 123456789", got)
 	}
-	// ChaosRate (STRUCT_SCORE @15) in BOTH scores must be overwritten with the
-	// passed value (0 = clean), clearing the template's 0xCC garbage — else the
-	// client blinks the player's own nickname red (issue #59).
-	if b[4+44+15] != 0 || b[4+92+15] != 0 {
-		t.Errorf("ChaosRate not cleared: BaseScore=%d CurrentScore=%d, want 0/0", b[4+44+15], b[4+92+15])
+	// MobName[12] (body 4+12) is the PKPoint that colors the own nick: 75 = white
+	// (neutral). Passing 75 must land there — 0 would render the nick red (issue #59).
+	if b[4+12] != 75 {
+		t.Errorf("MobName[12] (PKPoint) = %d, want 75 (neutral/white nick)", b[4+12])
 	}
 	// Persisted equip overlays the template's Equip@140 (mob) → body 4+140 + 1*8.
 	if got := le.Uint16(b[4+structMobEquip+1*8:]); got != 1100 {

--- a/tmserver/internal/protocol/mob_test.go
+++ b/tmserver/internal/protocol/mob_test.go
@@ -54,7 +54,11 @@ func TestCNFCharacterLoginRawLayout(t *testing.T) {
 		BaseSpecial: [4]int16{1, 2, 3, 4},
 		SkillBar:    [4]uint8{9, 10, 11, 12},
 	}
-	b := EncodeCNFCharacterLoginRaw(tmpl, "Hero", 777777, 123456789, equip, carry, 2453, 2000, 0, 1, 0, sk, skill)
+	// ChaosRate 0xCC is the uninitialized-template garbage the real BaseMob ships;
+	// pre-fill both score slots to prove the encoder overwrites them (issue #59).
+	tmpl[44+15] = 0xCC
+	tmpl[92+15] = 0xCC
+	b := EncodeCNFCharacterLoginRaw(tmpl, "Hero", 777777, 123456789, equip, carry, 2453, 2000, 0, 1, 0, sk, skill, 0)
 
 	if len(b) != cnfCharacterLoginSize-HeaderSize { // 1832 - 12 = 1820
 		t.Fatalf("CNFCharacterLogin body = %d, want %d", len(b), cnfCharacterLoginSize-HeaderSize)
@@ -79,6 +83,12 @@ func TestCNFCharacterLoginRawLayout(t *testing.T) {
 	// saved total at login.
 	if got := le.Uint64(b[4+32:]); got != 123456789 {
 		t.Errorf("exp @mob32 = %d, want 123456789", got)
+	}
+	// ChaosRate (STRUCT_SCORE @15) in BOTH scores must be overwritten with the
+	// passed value (0 = clean), clearing the template's 0xCC garbage — else the
+	// client blinks the player's own nickname red (issue #59).
+	if b[4+44+15] != 0 || b[4+92+15] != 0 {
+		t.Errorf("ChaosRate not cleared: BaseScore=%d CurrentScore=%d, want 0/0", b[4+44+15], b[4+92+15])
 	}
 	// Persisted equip overlays the template's Equip@140 (mob) → body 4+140 + 1*8.
 	if got := le.Uint16(b[4+structMobEquip+1*8:]); got != 1100 {

--- a/tmserver/internal/protocol/types.go
+++ b/tmserver/internal/protocol/types.go
@@ -100,6 +100,7 @@ const (
 	MsgCreateMob          Type = 0x0364 // 868  spawn in view
 	MsgRemoveMob          Type = 0x0165 // 357  despawn
 	MsgPKInfo             Type = 0x0166 // 358  S→C PK/war state of a player (MSG_STANDARDPARM, Basedef.h:1954)
+	MsgPKMode             Type = 0x0399 // 921  C→S PlayerKiller toggle (K key; MSG_STANDARDPARM, Basedef.h:2164)
 	MsgSendItem           Type = 0x0182 // 386  update one slot
 	MsgUpdateEquip        Type = 0x006B // 107  S→C refresh visible equipment (_MSG_UpdateEquip)
 	MsgREQShopList        Type = 0x027B // 635  C→S open NPC shop (Target=NPC)

--- a/tmserver/internal/world/session.go
+++ b/tmserver/internal/world/session.go
@@ -127,6 +127,15 @@ type Entity struct {
 	Guild       uint16   // guild id (0 = none)
 	GuildLevel  uint8    // 0 = member … 9 = leader
 	ClassMaster uint8    // party tier (MobExtra.ClassMaster)
+	// PKMode is the player-toggled Player-Killer consent flag (K key, _MSG_PKMode;
+	// legacy pUser[conn].PKMode) — it gates whether the player can land a hit on
+	// another player outside a safe city; it does NOT by itself blink the nickname.
+	// GuiltyUntil is the wall-clock deadline (Unix seconds) of the "chaotic" state
+	// set when a PvP hit actually lands (refreshed on every hit); the nickname
+	// blinks red while now < GuiltyUntil and reverts once it decays with no further
+	// PvP (handler.pkGuiltyDuration). Neither is persisted (session-only).
+	PKMode      bool
+	GuiltyUntil int64
 
 	Str        int16 // CurrentScore attributes (base + equipment, kept live by refreshScore)
 	Int        int16


### PR DESCRIPTION
## Summary
Fixes #59: characters spawned with a **red blinking nickname** even when freshly created and never flagged for PK.

**Root cause (via the Windows agent's full-source capture, `docs/migration/prompts/agent-prompt-pk-nick.md` → `captura-wyd-pk-nick.md`):** the client colors a player's nick from **`MobName[12]`** (the "chaos" byte) packed into `MSG_CreateMob`. A player name is only 12 usable bytes; `[12..15]` carry PK data. **Neutral = 75 (white), 0 = red blinking.** We were sending the raw 16-byte name (leaving `MobName[12]=0` → red) **and** never sending the player its own self-CreateMob, so the own nick rendered forever from the login blob = permanent red.

Two earlier theories were dead ends (both verified "correct" on the wire yet still red): `_MSG_PKInfo` is only the *attackable/war* flag, and `STRUCT_SCORE.ChaosRate` is a dead/regen byte (`IDC_ERegen` in NPTool) — neither colors the nick.

## Changes
- **`PackMobName`**: name in `[0..11]` + `MobName[12]=PKPoint` (75 clean / 0 guilty), `[13..15]` kill counts — **players only**; mob/NPC names stay raw (no truncation of e.g. "Ciclope_Arqueiro").
- Applied in the CreateMob encoder (via `IsPlayer`) and both `CNFCharacterLogin` paths (Raw template + fallback snapshot).
- **Send the self-CreateMob at login** (legacy `GridMulticast skip=0`), so the own nick colors white and can recolor.
- PK model: `K` (`_MSG_PKMode`) consent gate; landing a PvP hit sets `GuiltyUntil` and re-broadcasts the CreateMob (nick→red); the tick sweep decays it (nick→white).
- Reverted the wrong `ChaosRate` byte work.
- **Follow-up regression fixed**: `createMobFrom` never set `MaxMp`/`Mp`; since the self-CreateMob now drives the player's own bars, this zeroed client MP — now set from the authoritative score.

## Verification
- `go build`, `go vet`, `go test -race ./tmserver/...`, `golangci-lint` — all clean.
- Wire-verified against the live stack: fresh char's login blob **and** self-CreateMob carry `MobName[12]=75`; self-CreateMob carries real `MaxMp/Mp`.
- **User-confirmed in the real WYD.exe client**: nick is white, MP bar restored.

## Known simplifications (UNVERIFIED)
The PKPoint decay (75-based, +1/450 ticks) and guilty timer are simplified vs the legacy `Carry[63]` kill-mark model — exact math is in the agent capture for later full parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)