### PR TITLE
feat(tmserver): consumo de Barra de Prata credita ouro

### DIFF
--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -125,10 +125,11 @@ func (d *Dispatcher) getItem(w *world.World, s *world.Session, _ protocol.Header
 // Divine consumable classes (EF_VOLATILE value): the Poção Divina of 7/15/30 days.
 // The buff (Affect 34) lasts these many days; the real deadline is Entity.DivineEnd.
 const (
-	volExpChest = 198
-	volDivine7  = 64
-	volDivine30 = 66
-	volVigor    = 58
+	volExpChest  = 198
+	volDivine7   = 64
+	volDivine30  = 66
+	volVigor     = 58
+	volSilverBar = 185
 	// affect tick units (Basedef.h): one tick = 8s of real time.
 	affect1H          = 450
 	affect1D          = 10800
@@ -170,6 +171,8 @@ func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header
 		d.useDivine(w, s, e, src, vol)
 	case vol == volVigor:
 		d.useVigor(w, s, e, src, int(e.Carry[src].Index))
+	case vol == volSilverBar:
+		d.useSilverBar(w, s, e, src)
 	default:
 		// UNVERIFIED consumable (Vigor/HP-MP potions/scrolls/teleport) — not handled yet.
 	}
@@ -295,6 +298,47 @@ func (d *Dispatcher) useVigor(w *world.World, s *world.Session, e *world.Entity,
 	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
 	d.sendScore(w, s, e)
 	d.sendAffect(w, s, e)
+}
+
+// silverBarGold returns the gold credited by Vol 185 "Barra de Prata" items
+// (_MSG_UseItem.cpp, "Barra de Prata"). The 4011 path is issue #56's 1Bi bar.
+func silverBarGold(itemIdx int16) (int32, bool) {
+	switch itemIdx {
+	case 4026:
+		return 1_000_000, true
+	case 4027:
+		return 5_000_000, true
+	case 4028:
+		return 10_000_000, true
+	case 4029:
+		return 50_000_000, true
+	case 4010:
+		return 100_000_000, true
+	case 4011:
+		return 1_000_000_000, true
+	default:
+		return 0, false
+	}
+}
+
+// useSilverBar consumes a silver-bar item and credits its fixed gold value,
+// preserving the legacy 2G character-gold ceiling.
+func (d *Dispatcher) useSilverBar(w *world.World, s *world.Session, e *world.Entity, src int) {
+	itemIdx := e.Carry[src].Index
+	gold, ok := silverBarGold(itemIdx)
+	if !ok {
+		return
+	}
+	if int64(e.Coin)+int64(gold) > maxCoin {
+		d.notify(w, s, NoticeCargoFull)
+		w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
+		return
+	}
+	e.Coin += gold
+	e.Carry[src] = world.Item{}
+	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
+	d.sendEtc(w, s, e)
+	d.log.Info("silver bar used", "conn", s.Conn, "item", itemIdx, "gold", gold, "coin", e.Coin)
 }
 
 // sendAffect pushes MSG_SendAffect (0x03B9): the full 32-slot buff snapshot, so the

--- a/tmserver/internal/handler/item_test.go
+++ b/tmserver/internal/handler/item_test.go
@@ -454,6 +454,14 @@ func expChestDB() *fakeDB {
 	return db
 }
 
+func silverBarDB(itemIdx int16, coin int32) *fakeDB {
+	db := newDB()
+	st := world.CharacterState{Slot: 0, Name: "Hero", X: 5, Y: 5, HP: 1000, MaxHP: 1000, Coin: coin}
+	st.Carry[0] = world.Item{Index: itemIdx}
+	db.loadResult = st
+	return db
+}
+
 func startServerClockVol(t *testing.T, persist world.Persistence, vols map[int]int) (string, func()) {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -517,5 +525,62 @@ func TestUseExpChest(t *testing.T) {
 	}
 	if !sawScore {
 		t.Error("missing MsgUpdateScore after using exp chest")
+	}
+}
+
+func TestUseSilverBar1Bi(t *testing.T) {
+	addr, stop := startServerClockVol(t, silverBarDB(4011, 0), map[int]int{4011: volSilverBar})
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+
+	sawSendItem, sawEtc := false, false
+	for range 4 {
+		ty, payload, ok := readMaybe(t, c)
+		if !ok {
+			break
+		}
+		switch ty {
+		case protocol.MsgSendItem:
+			sawSendItem = true
+			if le16(payload[2:4]) != 0 || le16(payload[4:6]) != 0 {
+				t.Errorf("slot/item = %d/%d, want slot 0 empty", le16(payload[2:4]), le16(payload[4:6]))
+			}
+		case protocol.MsgUpdateEtc:
+			sawEtc = true
+			if got := int32(le(payload[28:32])); got != 1_000_000_000 {
+				t.Errorf("coin = %d, want 1000000000", got)
+			}
+		}
+	}
+	if !sawSendItem {
+		t.Error("missing MsgSendItem after using silver bar")
+	}
+	if !sawEtc {
+		t.Error("missing MsgUpdateEtc after using silver bar")
+	}
+}
+
+func TestUseSilverBarOver2G(t *testing.T) {
+	addr, stop := startServerClockVol(t, silverBarDB(4011, 1_500_000_000), map[int]int{4011: volSilverBar})
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+
+	if ty, p, ok := readMaybe(t, c); !ok || ty != protocol.MsgMessageBoxOk || noticeCode(t, p) != NoticeCargoFull {
+		t.Fatalf("overflow notice = %#x/%v ok=%v, want NoticeCargoFull", ty, noticeCode(t, p), ok)
+	}
+	item := expect(t, c, protocol.MsgSendItem)
+	if le16(item[2:4]) != 0 || le16(item[4:6]) != 4011 {
+		t.Errorf("slot/item = %d/%d, want slot 0 item 4011 preserved", le16(item[2:4]), le16(item[4:6]))
+	}
+	if ty, _, ok := readMaybe(t, c); ok && ty == protocol.MsgUpdateEtc {
+		t.Error("overflow use sent MsgUpdateEtc; coin should be unchanged")
 	}
 }


### PR DESCRIPTION
## Summary
- Implementa `useSilverBar` para os itens Vol 185 "Barra de Prata" (índices 4026-4029, 4010, 4011), creditando o valor fixo de ouro correspondente (issue #56).
- Respeita o teto de 2G de ouro do personagem: se estourar, notifica `NoticeCargoFull` e preserva o item no slot.
- Cobertura de teste para o caso feliz (barra de 1Bi) e para o overflow acima do teto.

## Test plan
- [x] `go test ./tmserver/internal/handler/...` cobrindo `TestUseSilverBar1Bi` e `TestUseSilverBarOver2G`

🤖 Generated with [Claude Code](https://claude.com/claude-code)