### PR TITLE
fix: apply boot movement speed bonus

### DIFF
--- a/tmserver/internal/content/catalog.go
+++ b/tmserver/internal/content/catalog.go
@@ -68,7 +68,7 @@ var efName = map[string]uint8{
 	"EF_SPECIAL1": 11, "EF_SPECIAL2": 12, "EF_SPECIAL3": 13, "EF_SPECIAL4": 14,
 	"EF_POS": 17, "EF_SANC": 43, "EF_HPADD": 45, "EF_MPADD": 46, "EF_ACADD": 53,
 	"EF_DAMAGEADD": 67, "EF_HPADD2": 69, "EF_MPADD2": 70,
-	"EF_ITEMLEVEL": 87, "EF_MOBTYPE": 112,
+	"EF_ITEMLEVEL": 87, "EF_MOBTYPE": 112, "EF_RUNSPEED": 29,
 }
 
 // BaseEffects returns item index → its score-relevant static effects, parsed from

--- a/tmserver/internal/content/content_test.go
+++ b/tmserver/internal/content/content_test.go
@@ -92,9 +92,10 @@ func TestBaseEffects(t *testing.T) {
 	for _, e := range eff {
 		got[e.Eff] = e.Val
 	}
-	// Score-relevant effects plus EF_ITEMLEVEL (used by combine matching).
-	if len(got) != 3 || got[3] != 96 || got[2] != 24 || got[87] != 5 {
-		t.Errorf("BaseEffects = %v, want AC(3):96, DAMAGE(2):24, ITEMLEVEL(87):5", got)
+	// Score-relevant effects plus EF_ITEMLEVEL (used by combine matching) and
+	// EF_RUNSPEED (issue #64: boots' move-speed bonus).
+	if len(got) != 4 || got[3] != 96 || got[2] != 24 || got[87] != 5 || got[29] != 2 {
+		t.Errorf("BaseEffects = %v, want AC(3):96, DAMAGE(2):24, ITEMLEVEL(87):5, RUNSPEED(29):2", got)
 	}
 }
 

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -444,6 +444,7 @@ const (
 	efDamageAdd = 67 // EF_DAMAGEADD: extra flat damage — only counts for jewels (nUnique 41-50)
 	efHpAdd2    = 69 // EF_HPADD2/EF_MPADD2: also fold into the HPADD%/MPADD% multiplier
 	efMpAdd2    = 70
+	efRunSpeed  = 29 // EF_RUNSPEED: boots' bonus to the move-speed (low) nibble of AttackRun
 
 	// baseAttackRun is the class templates' base speed byte (run<<4 | move) = 82
 	// (run 5, move 2). UNVERIFIED: per-state speed curves are not reproduced.
@@ -537,6 +538,7 @@ type equipBonus struct {
 	ac, damage           int32
 	maxHP, maxMP         int32
 	hpAddPct, mpAddPct   int32
+	runSpeed             int32
 }
 
 func (d *Dispatcher) equipBonus(e *world.Entity) equipBonus {
@@ -579,6 +581,8 @@ func (d *Dispatcher) equipBonus(e *world.Entity) equipBonus {
 			b.hpAddPct += val
 		case efMpAdd, efMpAdd2:
 			b.mpAddPct += val
+		case efRunSpeed:
+			b.runSpeed += val
 		}
 	}
 	for slot := range e.Equip {
@@ -647,6 +651,7 @@ func (d *Dispatcher) refreshScore(e *world.Entity) {
 	e.MaxMP = e.BaseMaxMP + b.maxMP
 	e.HpAddPct = b.hpAddPct
 	e.MpAddPct = b.mpAddPct
+	e.RunSpeedBonus = b.runSpeed
 	applyAffectScore(e)
 
 	e.EquipExpBonus = d.equipExpBonus(e)
@@ -747,7 +752,16 @@ func attackRunOf(e *world.Entity) uint8 {
 	if !e.Equip[mountEquipSlot].Empty() {
 		return (baseAttackRun & 0xF0) | mountedMoveSpeed
 	}
-	return baseAttackRun
+	// Boots' EF_RUNSPEED adds to the base move-speed nibble, clamped [1,6] like
+	// the legacy BASE_GetSpeed (Basedef.cpp:1250-1262).
+	move := int32(baseAttackRun&0x0F) + e.RunSpeedBonus
+	if move < 1 {
+		move = 1
+	}
+	if move > 6 {
+		move = 6
+	}
+	return (baseAttackRun & 0xF0) | uint8(move)
 }
 
 // sendScore pushes the recomputed CurrentScore to the player (_MSG_UpdateScore), so

--- a/tmserver/internal/handler/item_test.go
+++ b/tmserver/internal/handler/item_test.go
@@ -409,6 +409,34 @@ func TestWeaponDamageRefine(t *testing.T) {
 	}
 }
 
+// TestAttackRunOfBoots verifies EF_RUNSPEED (boots) raises the move-speed (low)
+// nibble of AttackRun (issue #64: base speed 2 stayed 2 with boots equipped).
+func TestAttackRunOfBoots(t *testing.T) {
+	d := New(Config{
+		ItemEffects: map[int][]content.BaseEffect{321: {{Eff: efRunSpeed, Val: 1}}}, // boots, +1 speed
+	})
+
+	bare := &world.Entity{}
+	d.refreshScore(bare)
+	if got := attackRunOf(bare); got != baseAttackRun {
+		t.Errorf("no boots: attackRunOf = %#x, want base %#x", got, baseAttackRun)
+	}
+
+	booted := &world.Entity{}
+	booted.Equip[5] = world.Item{Index: 321} // boots occupy equip slot 5 (nPos 32)
+	d.refreshScore(booted)
+	if got := attackRunOf(booted); got != baseAttackRun+1 {
+		t.Errorf("boots +1: attackRunOf = %#x, want %#x", got, baseAttackRun+1)
+	}
+
+	// Clamp parity with legacy BASE_GetSpeed: an oversized bonus still clamps
+	// the nibble to 6, never wrapping past it.
+	overboosted := &world.Entity{RunSpeedBonus: 99}
+	if got := attackRunOf(overboosted); got != (baseAttackRun&0xF0)|6 {
+		t.Errorf("clamped: attackRunOf = %#x, want %#x", got, (baseAttackRun&0xF0)|6)
+	}
+}
+
 // TestRefreshScoreSpecial confirms refreshScore folds a divine special into the live
 // entity (and so into the score sent to the client), and that a clean
 // deriveBaseScore→refreshScore round-trip reproduces the loaded score (no double count).

--- a/tmserver/internal/world/session.go
+++ b/tmserver/internal/world/session.go
@@ -164,6 +164,11 @@ type Entity struct {
 	// derivation by subtraction holds (captura-wyd-affect-divina.md §E).
 	HpAddPct, MpAddPct int32
 
+	// RunSpeedBonus is the summed EF_RUNSPEED from equipped gear (boots), cached by
+	// refreshScore and applied at read time by handler.attackRunOf to the move-speed
+	// (low) nibble of AttackRun.
+	RunSpeedBonus int32
+
 	// Affect holds the active buffs/debuffs (STRUCT_AFFECT[32]). DivineEnd is the
 	// wall-clock (Unix seconds) deadline of the Divine buff — the source of truth for
 	// its expiry; the slot's Affect.Time is only the client icon timer.


### PR DESCRIPTION
## Summary
- parse EF_RUNSPEED from item effects so boots expose their movement bonus
- cache equipped run speed bonuses during score refresh
- apply the bonus to the AttackRun move-speed nibble with legacy clamp behavior

## Tests
- go test ./tmserver/internal/content ./tmserver/internal/handler ./tmserver/internal/world
- make test