### PR TITLE
fix: handle Mestre Grifo warp opcode

### DIFF
--- a/docs/migration/handlers/npc-map.md
+++ b/docs/migration/handlers/npc-map.md
@@ -33,7 +33,7 @@ O **`Merchant`** do NPC decide o que o clique manda:
 | 16 | 81 | BarebackHorse, WildBoar, Sem_Sela | REQShopList? | ❌ **montarias** (captura/loja de mount) |
 | 19 | 5 | Foema_Ancian, Mestre_Archi | REQShopList | ✅ loja especial (shopType 3) |
 | 20 | 1 | BlackOracle | _MSG_Quest | ❌ |
-| 23 | 2 | Griphon_Master, Mestre_Grifo | _MSG_Quest | ❌ montaria grifo |
+| 23 | 2 | Griphon_Master, Mestre_Grifo | _MSG_MasterGriff / _MSG_Quest | ✅ Mestre Grifo → rotas de campo; restante montaria grifo pendente |
 | 24 | 1 | Alquimista_Odin | CombineItem (Odin) | ✅ combine |
 | 26 | 2 | (Kingdom) | _MSG_Quest (KINGDOM) | ❌ |
 | 30 | 2 | Leaky_Zakum | _MSG_Quest (ZAKUM info) | ❌ |
@@ -85,9 +85,12 @@ quests grade 11–16/24–30) **não**.
 - **Cargo/banco** (Merchant 2): `reqShopList` → `openCargo`, deposit/withdraw.
 - **Combine/refino**: família `combineItem` (Odin/Lindy/Shany/… via opcodes dedicados).
 - **Perzen** (Merchant 100 grade 7/8/9): troca esfera→montaria.
+- **Mestre Grifo** (`_MSG_MasterGriff` 0x0AD9): teleporta, após a animação de viagem do cliente, para
+  Defensor de Almas `(2372,2099)`, Jardim dos Deuses `(2220,1714)`, Calabouco `(2365,2279)` ou
+  Submundo `(1826,1771)`.
 
 ## Gaps prioritários (sugestão)
-1. **Montarias** (Merchant 16 captura, 58 Mount Master cura/ressuscita, 23 grifo, 101/110 unicórnio)
+1. **Montarias** (Merchant 16 captura, 58 Mount Master cura/ressuscita, restante do 23 grifo, 101/110 unicórnio)
    — alinha com o sistema de montaria (Shire/esfera) que estamos implementando.
 2. **Mestres de skill/classe** (Merchant 3, 31) — progressão.
 3. **Teleportes/guardas** (Merchant 36, 128) — locomoção.

--- a/tmserver/internal/handler/dispatch.go
+++ b/tmserver/internal/handler/dispatch.go
@@ -227,6 +227,7 @@ func New(cfg Config) *Dispatcher {
 	d.routes[protocol.MsgSetShortSkill] = d.setShortSkill
 	d.routes[protocol.MsgAccountSecure] = d.accountSecure
 	d.routes[protocol.MsgQuest] = d.quest
+	d.routes[protocol.MsgMasterGriff] = d.masterGriff
 	d.routes[protocol.MsgReqRanking] = d.reqRanking
 	d.routes[protocol.MsgCapsuleInfo] = d.capsuleInfo
 	d.routes[protocol.MsgPutoutSeal] = d.putoutSeal

--- a/tmserver/internal/handler/misc.go
+++ b/tmserver/internal/handler/misc.go
@@ -133,6 +133,20 @@ var quest256Steps = []quest256Step{
 	{flag: 5, minLevel: 320, maxLevel: 350, x: 1322, y: 4041, area: questArea{x1: 1312, y1: 4027, x2: 1348, y2: 4055}},
 }
 
+const masterGriffTravelDelay = 9500 * time.Millisecond
+
+type masterGriffDestination struct {
+	name string
+	x, y int16
+}
+
+var masterGriffDestinations = []masterGriffDestination{
+	{name: "Defensor de Almas", x: 2372, y: 2099},
+	{name: "Jardim dos Deuses", x: 2220, y: 1714},
+	{name: "Calabouco", x: 2365, y: 2279},
+	{name: "Submundo", x: 1826, y: 1771},
+}
+
 // mestreGrifo handles the Mestre_Grifo NPC (Merchant 23) shipped in NPCGener.txt
 // at Armia. This server-content shortcut sends the player to the Quest 256 arena
 // matching their level and must set CMob.QuestFlag first; otherwise the legacy
@@ -143,9 +157,45 @@ func (d *Dispatcher) mestreGrifo(w *world.World, s *world.Session, e, npc *world
 		d.log.Debug("mestre grifo: level outside quest range", "conn", s.Conn, "npc", npc.ID, "level", e.Level)
 		return
 	}
+	d.teleportQuest256Step(w, s, e, step)
+	d.log.Info("mestre grifo teleport", "conn", s.Conn, "npc", npc.ID, "level", e.Level, "quest_flag", step.flag)
+}
+
+// masterGriff handles _MSG_MasterGriff (0x0AD9), the packet the 7662 client sends
+// for the Mestre_Grifo warp UI. Real client logs show this opcode instead of
+// _MSG_Quest. The client plays a travel animation after sending it, so the final
+// DoTeleport is delayed a little; doing it immediately cuts the animation short.
+func (d *Dispatcher) masterGriff(w *world.World, s *world.Session, _ protocol.Header, payload []byte) {
+	e := w.Entity(s.Conn)
+	if e == nil || e.HP <= 0 || s.Mode != world.UserPlay {
+		return
+	}
+	warpID, ty, ok := protocol.StandardParm2(payload) // MSG_MasterGriff: int WarpID; int Ty
+	if !ok {
+		return
+	}
+	dest, ok := masterGriffDestinationForWarpID(warpID)
+	if !ok {
+		d.log.Debug("master griff: no destination", "conn", s.Conn, "level", e.Level, "warp_id", warpID, "ty", ty)
+		return
+	}
+	d.log.Info("master griff travel started", "conn", s.Conn, "level", e.Level, "warp_id", warpID, "ty", ty, "dest", dest.name, "x", dest.x, "y", dest.y)
+	w.Go(s, func() func(*world.World, *world.Session) {
+		time.Sleep(masterGriffTravelDelay)
+		return func(w *world.World, s *world.Session) {
+			e := w.Entity(s.Conn)
+			if e == nil || e.HP <= 0 || s.Mode != world.UserPlay {
+				return
+			}
+			d.doTeleport(w, s, dest.x, dest.y)
+			d.log.Info("master griff teleport", "conn", s.Conn, "level", e.Level, "warp_id", warpID, "ty", ty, "dest", dest.name, "x", dest.x, "y", dest.y)
+		}
+	})
+}
+
+func (d *Dispatcher) teleportQuest256Step(w *world.World, s *world.Session, e *world.Entity, step quest256Step) {
 	e.QuestFlag = step.flag
 	d.doTeleport(w, s, step.x+int16(w.Rand().Intn(5)-3), step.y+int16(w.Rand().Intn(5)-3))
-	d.log.Info("mestre grifo teleport", "conn", s.Conn, "npc", npc.ID, "level", e.Level, "quest_flag", step.flag)
 }
 
 func quest256StepForLevel(level int32) (quest256Step, bool) {
@@ -155,6 +205,17 @@ func quest256StepForLevel(level int32) (quest256Step, bool) {
 		}
 	}
 	return quest256Step{}, false
+}
+
+func masterGriffDestinationForWarpID(warpID int32) (masterGriffDestination, bool) {
+	switch {
+	case warpID == 0:
+		return masterGriffDestinations[0], true
+	case warpID >= 1 && int(warpID) <= len(masterGriffDestinations):
+		return masterGriffDestinations[warpID-1], true
+	default:
+		return masterGriffDestination{}, false
+	}
 }
 
 // perzenExchange implements the Perzen NPCs (_MSG_Quest.cpp PERZEN): if the player

--- a/tmserver/internal/handler/quest_test.go
+++ b/tmserver/internal/handler/quest_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -72,6 +74,9 @@ func questFrame(t *testing.T, c net.Conn, npcID int) {
 }
 
 func mestreGrifoTemplate() []byte {
+	if b, err := os.ReadFile(filepath.Join("..", "..", "..", "Release", "TMsrv", "run", "npc", "Mestre_Grifo")); err == nil && len(b) == 816 {
+		return b
+	}
 	b := make([]byte, 816)
 	copy(b[0:16], "Mestre_Grifo")
 	const cs = 92
@@ -249,5 +254,113 @@ func TestMestreGrifoQuestFlagPreventsImmediateRecall(t *testing.T) {
 	}
 	if ty, _, ok := readMaybe(t, c); ok && ty == protocol.MsgAction {
 		t.Errorf("Mestre Grifo target was recalled immediately: %#x", ty)
+	}
+}
+
+func TestMestreGrifoRealTemplateTeleportsAndSurvivesGuard(t *testing.T) {
+	tmpl, err := os.ReadFile(filepath.Join("..", "..", "..", "Release", "TMsrv", "run", "npc", "Mestre_Grifo"))
+	if err != nil {
+		t.Fatalf("read real Mestre_Grifo template: %v", err)
+	}
+	if len(tmpl) != 816 {
+		t.Fatalf("real Mestre_Grifo template len = %d, want 816", len(tmpl))
+	}
+	if got := tmpl[92+12]; got != 23 {
+		t.Fatalf("real Mestre_Grifo merchant = %d, want 23", got)
+	}
+
+	st := world.CharacterState{
+		Slot: 0, Name: "Hero", Level: 50, X: 2113, Y: 2079,
+		HP: 1000, MaxHP: 1000, LastCity: 0, ClassMaster: classMasterMortal,
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := New(Config{Log: log})
+	db := newDB()
+	db.loadResult = st
+	w := world.New(world.Config{GridDim: world.DefaultGridDim}, log, db, d.Handle)
+	w.SetTickHandler(10*time.Millisecond, d.Tick)
+	npcID := w.SpawnMob(tmpl, 2116, 2080)
+	if npcID < 0 {
+		t.Fatal("failed to spawn real Mestre_Grifo")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = w.Serve(ctx, ln); close(done) }()
+	defer func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("server did not stop")
+		}
+	}()
+
+	c := enterWorld(t, ln.Addr().String())
+	defer c.Close()
+	questFrame(t, c, npcID)
+	body := expectAction(t, c)
+	if !inRange(body.TargetX, 2398) || !inRange(body.TargetY, 2105) {
+		t.Fatalf("quest target = %d,%d, want Coveiro", body.TargetX, body.TargetY)
+	}
+	if ty, _, ok := readMaybe(t, c); ok && ty == protocol.MsgAction {
+		t.Errorf("real Mestre_Grifo target was recalled immediately: %#x", ty)
+	}
+}
+
+func TestMasterGriffOpcodeUsesWarpDestinations(t *testing.T) {
+	tests := []struct {
+		name   string
+		warpID int32
+		wantX  int16
+		wantY  int16
+	}{
+		{name: "defensor almas", warpID: 1, wantX: 2372, wantY: 2099},
+		{name: "jardim deuses", warpID: 2, wantX: 2220, wantY: 1714},
+		{name: "calabouco", warpID: 3, wantX: 2365, wantY: 2279},
+		{name: "submundo", warpID: 4, wantX: 1826, wantY: 1771},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := world.CharacterState{
+				Slot: 0, Name: "Hero", Level: 1, X: 2113, Y: 2079,
+				HP: 1000, MaxHP: 1000, LastCity: 0, ClassMaster: classMasterMortal,
+			}
+			addr, stop, _ := startServerMestreGrifo(t, st, true)
+			defer stop()
+			c := enterWorld(t, addr)
+			defer c.Close()
+
+			send(t, c, protocol.MsgMasterGriff, protocol.EncodeStandardParm2(tt.warpID, 0))
+			if ty, _, ok := readMaybe(t, c); ok && ty == protocol.MsgAction {
+				t.Fatalf("MasterGriff teleported immediately with %#x; want delayed travel", ty)
+			}
+			time.Sleep(masterGriffTravelDelay + 100*time.Millisecond)
+			body := expectAction(t, c)
+			if body.TargetX != tt.wantX || body.TargetY != tt.wantY {
+				t.Fatalf("master griff target = %d,%d, want %d,%d", body.TargetX, body.TargetY, tt.wantX, tt.wantY)
+			}
+		})
+	}
+}
+
+func TestMasterGriffWarpIDZeroDefaultsToFirstDestination(t *testing.T) {
+	st := world.CharacterState{
+		Slot: 0, Name: "Hero", Level: 200, X: 2113, Y: 2079,
+		HP: 1000, MaxHP: 1000, LastCity: 0, ClassMaster: classMasterMortal,
+	}
+	addr, stop, _ := startServerMestreGrifo(t, st, true)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	send(t, c, protocol.MsgMasterGriff, protocol.EncodeStandardParm2(0, 0))
+	time.Sleep(masterGriffTravelDelay + 100*time.Millisecond)
+	body := expectAction(t, c)
+	if body.TargetX != 2372 || body.TargetY != 2099 {
+		t.Fatalf("master griff target = %d,%d, want first destination", body.TargetX, body.TargetY)
 	}
 }

--- a/tmserver/internal/protocol/types.go
+++ b/tmserver/internal/protocol/types.go
@@ -69,6 +69,7 @@ const (
 	MsgApplyBonus          Type = 0x0277 // 631  distribute attribute points
 	MsgSetShortSkill       Type = 0x0378 // 888  set the skill hotbar (Skill1[4]+Skill2[16])
 	MsgQuest               Type = 0x028B // 651  quest NPC (MSG_STANDARDPARM2)
+	MsgMasterGriff         Type = 0x0AD9 // 2777 Mestre Grifo warp request (MSG_MasterGriff)
 	MsgReqRanking          Type = 0x039F // 927  duel / PvP ranking (MSG_STANDARDPARM2)
 	MsgCapsuleInfo         Type = 0x02CD // 717  capsule/cash info (relay to DB)
 	MsgPutoutSeal          Type = 0x03CC // 972  seal

--- a/tmserver/internal/world/generator.go
+++ b/tmserver/internal/world/generator.go
@@ -71,11 +71,18 @@ func (w *World) GenerateMob(idx int) []int {
 		qmob = 1 // "err,zero divide" guard (Server.cpp:3486)
 	}
 	n := g.MinGroup + w.rng.Intn(qmob)
-	if g.CurrentNumMob >= g.MaxNumMob {
+	maxNumMob := g.MaxNumMob
+	if maxNumMob < 0 {
+		// NPCGener uses -1 on at least Mestre_Grifo. The old bootstrap policy
+		// populates static merchant blocks up front, so keep one live instance
+		// instead of treating the negative cap as already saturated.
+		maxNumMob = 1
+	}
+	if g.CurrentNumMob >= maxNumMob {
 		return nil
 	}
-	if g.CurrentNumMob+n > g.MaxNumMob {
-		n = g.MaxNumMob - g.CurrentNumMob
+	if g.CurrentNumMob+n > maxNumMob {
+		n = maxNumMob - g.CurrentNumMob
 	}
 	if w.mobCount >= generateWorldCap {
 		return nil

--- a/tmserver/internal/world/generator_test.go
+++ b/tmserver/internal/world/generator_test.go
@@ -16,6 +16,13 @@ func genMobTemplate(clan uint8) []byte {
 	return b
 }
 
+func genMerchantTemplate(merchant uint8) []byte {
+	b := genMobTemplate(0)
+	const cs = 92
+	b[cs+12] = merchant
+	return b
+}
+
 // TestGenerateMobGroup covers the GenerateMob port (Server.cpp:3442-3810):
 // group size, leader/follower linking, per-block population accounting
 // (including the leader-not-counted-in-the-clamp quirk) and the cap.
@@ -137,5 +144,26 @@ func TestGenerateMobQueueFallback(t *testing.T) {
 	}
 	if g.CurrentNumMob != 1 {
 		t.Fatalf("CurrentNumMob after queue respawn = %d, want 1 (SpawnMobAt re-counts)", g.CurrentNumMob)
+	}
+}
+
+func TestGenerateMobNegativeCapSpawnsStaticMerchant(t *testing.T) {
+	w := New(Config{GridDim: 4096}, slogDiscard(), nil, nil)
+	g := &Generator{
+		MinuteGenerate: 1, MinGroup: 0, MaxGroup: 0, MaxNumMob: -1,
+		SegX: [5]int16{2116}, SegY: [5]int16{2080},
+		LeaderTmpl: genMerchantTemplate(23),
+	}
+	w.RegisterGenerators([]*Generator{g})
+
+	ids := w.GenerateMob(0)
+	if len(ids) != 1 {
+		t.Fatalf("GenerateMob negative cap spawned %d mobs, want 1", len(ids))
+	}
+	if g.CurrentNumMob != 1 {
+		t.Fatalf("CurrentNumMob = %d, want 1", g.CurrentNumMob)
+	}
+	if got := len(w.GenerateMob(0)); got != 0 {
+		t.Fatalf("second GenerateMob spawned %d, want cap reached", got)
 	}
 }


### PR DESCRIPTION
## Summary
- route the real 7662 client _MSG_MasterGriff opcode for Mestre Grifo travel
- delay the final teleport so the client travel animation can complete
- use the verified destination coordinates for Defensor de Almas, Jardim dos Deuses, Calabouco and Submundo
- keep Mestre_Grifo spawned from the real NPCGener negative cap block

## Tests
- go test ./tmserver/internal/handler -run 'MestreGrifo|MasterGriff|Quest256' -count=1 -v
- go test ./tmserver/internal/protocol ./tmserver/internal/world -count=1
- go test ./...

## Runtime validation
- docker compose build tmserver
- docker compose up -d tmserver