### PR TITLE
fix: PvP physical damage blocked near cities/spawn points

### DIFF
--- a/docs/migration/handlers/_MSG_Attack.md
+++ b/docs/migration/handlers/_MSG_Attack.md
@@ -40,3 +40,13 @@
   validar por **distribuição** com golden cases (Fase 8). Resta tabelar coef. Dex/Str por classe×arma.
 - `SkillIndex == 99` como "ressurreição" é constante mágica — preservar.
 - A janela de tick depende de `CurrentTime` (clock do servidor) — reproduzir a unidade (ms).
+- **UNVERIFIED — gate de "safe zone"/PK ainda não portado.** O legado zera o dano quando o
+  ATACANTE está num tile com o bit de attribute-map (`GetAttribute(...) & 64`) **e** o alvo não
+  está `PKMode`/`Guilty` (`_MSG_Attack.cpp:405-419`), com bypass total durante
+  RvR/Castle/GTorre/newbie event. Nenhum desses campos (`PKMode`, `GetGuilty`, bit de attribute-map
+  por tile, estado de guerra) existe no servidor Go hoje. Uma tentativa anterior de aproximar isso
+  com os retângulos de `world.Village()` (issue #67) bloqueava dano PvP incondicionalmente perto de
+  toda cidade/spawn, já que nenhum bypass do legado era alcançável — foi removida (ver B12: não
+  travar gameplay em campo não-implementado/não-verificado). Até que attribute-map + PKMode + Guilty
+  + estado de guerra sejam implementados, dano PvP não tem proteção de safe-zone (funciona em
+  qualquer lugar).

--- a/tmserver/internal/handler/combat.go
+++ b/tmserver/internal/handler/combat.go
@@ -150,15 +150,17 @@ func (d *Dispatcher) attack(w *world.World, s *world.Session, h protocol.Header,
 		// skillHit: this entry resolves through the skill pipeline; anything
 		// else (sentinel -2, 0, or an unknown claim) is melee.
 		skillHit := cast.isSkill && claim == damSkill
-		// Town safe zone: players in a city cannot be hit by melee or aggressive
-		// skills (the legacy gates on the attribute map's PK bit + PKMode; we use
-		// the city rectangles until the attribute map semantics are verified).
-		if world.IsPlayer(tid) && tid != s.Conn && world.Village(target.X, target.Y) >= 0 {
-			if !skillHit || cast.spell.Aggressive != 0 {
-				writeDamage(payload, i, 0)
-				continue
-			}
-		}
+		// No town safe-zone gate here (deliberately): the legacy rule
+		// (_MSG_Attack.cpp:405-419) only blocks a hit when the ATTACKER stands on
+		// a PK-attribute tile AND the target isn't already PKMode/Guilty-flagged,
+		// with an RvR/Castle/GTorre-war-state bypass on top. None of PKMode,
+		// Guilty, the real per-tile attribute-map bit, or war state exist yet, so
+		// a prior port of this check (keyed off the coarse city rectangles and
+		// the wrong entity's position) could never satisfy its own bypass and
+		// permanently zeroed PvP damage near every city/spawn point (issue #67).
+		// Per the B12 precedent (combat_regression_test.go), don't hard-block
+		// gameplay on an unimplemented/unverified system — tolerate until a
+		// follow-up implements attribute-map + PKMode + Guilty + war-state.
 
 		var dmg int
 		if skillHit {

--- a/tmserver/internal/handler/combat_regression_test.go
+++ b/tmserver/internal/handler/combat_regression_test.go
@@ -106,3 +106,44 @@ func TestMeleeAlwaysDamagesMob(t *testing.T) {
 		})
 	}
 }
+
+// TestMeleePvPDamageAppliesInCity is the issue #67 regression: a hardcoded,
+// unconditional "town safe zone" gate used to zero all melee/aggressive-skill
+// damage against a player standing inside one of the 5 city rectangles
+// (world.Village) — which includes every character's default spawn point
+// (world.CitySpawn). None of the legacy bypass conditions (PKMode, Guilty,
+// attribute-map bit, RvR/Castle/GTorre war state) are implemented, so that
+// gate could never correctly unblock itself and PvP damage silently never
+// landed wherever players actually gather to fight. Melee must land here
+// exactly like it does in the open field.
+func TestMeleePvPDamageAppliesInCity(t *testing.T) {
+	db := newDB()
+	db.loadResult = world.CharacterState{
+		Slot: 0, Name: "Hero", X: 2086, Y: 2093, // inside Armia (city.go's cities[0])
+		HP: 1000, MaxHP: 1000, Damage: 200, AC: 40,
+	}
+	addr, stop, _ := startServerClock(t, db)
+	defer stop()
+
+	attacker := enterWorld(t, addr) // conn 1 (attacker)
+	defer attacker.Close()
+	target := enterWorld(t, addr) // conn 2 (target), in view
+	defer target.Close()
+
+	attackFrame(t, attacker, serverTime, 2, 0)
+
+	ty, payload, ok := readMaybe(t, target)
+	if !ok || ty != protocol.MsgAttack {
+		t.Fatalf("target got %#x ok=%v, want MsgAttack broadcast", ty, ok)
+	}
+	var got protocol.MsgAttackBody
+	if err := got.Decode(payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Dam) != 1 || got.Dam[0].TargetID != 2 {
+		t.Fatalf("Dam = %+v", got.Dam)
+	}
+	if got.Dam[0].Damage <= 0 {
+		t.Errorf("server damage in city = %d, want > 0 (PvP must not be blocked near spawn/city)", got.Dam[0].Damage)
+	}
+}


### PR DESCRIPTION
## Summary
- Removes the town safe-zone gate in `tmserver/internal/handler/combat.go` that unconditionally zeroed melee/aggressive-skill damage against players inside any of the 5 city rectangles (which include every character's default spawn point) — the gate approximated a legacy PK/attribute-map check but checked the wrong entity's position and could never reach any of the legacy bypass conditions (`PKMode`, `Guilty`, RvR/Castle/GTorre war state), none of which are implemented yet
- Adds `TestMeleePvPDamageAppliesInCity` regression test guarding this exact bug
- Documents the deferred PK/safe-zone system as UNVERIFIED in `docs/migration/handlers/_MSG_Attack.md`

Fixes #67

## Test plan
- [x] `go test -race ./tmserver/...` passes
- [x] `go vet ./tmserver/...` clean
- [x] `golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)