### PR TITLE
Fix character login spawn movement

### DIFF
--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -220,14 +220,20 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 			st.HP = 1 // guard a broken/zero MaxHP so the player can still act
 		}
 	}
-	// Spawn at the default area of the last city the character was in (business
-	// rule: position itself is not persisted, only the city — see world.CitySpawn).
-	// An explicit loaded position (tests) is honored when present.
-	spawnX, spawnY := st.X, st.Y
-	if spawnX == 0 && spawnY == 0 {
-		spawnX, spawnY = world.CitySpawn(int(st.LastCity))
+	// Login position follows the legacy split: STRUCT_MOB.SPX/SPY is the saved
+	// point, while MSG_CNFCharacterLogin.PosX/PosY is the actual world-entry tile.
+	// An explicit loaded position (tests/captures) is honored when present; live
+	// DB loads currently fall back to the last-city spawn rule.
+	saveX, saveY := st.X, st.Y
+	loginX, loginY := saveX, saveY
+	if loginX == 0 && loginY == 0 {
+		loginX, loginY = world.CitySpawn(int(st.LastCity))
+		if x, y, ok := w.EmptyCellNear(loginX, loginY); ok {
+			loginX, loginY = x, y
+		}
 	}
-	s.LoginSpawnX, s.LoginSpawnY = spawnX, spawnY
+	s.LoginSpawnX, s.LoginSpawnY = loginX, loginY
+	s.LoginTick = w.Now()
 	s.LoggedFirstAction = false
 	// Inject the player entity into the world (the slot was docked at connect).
 	if e := w.Entity(s.Conn); e != nil {
@@ -243,7 +249,7 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 		// Register the player in the spatial grid, not just the entity fields —
 		// mob aggro (FindEnemyFromView) and the view reconciliation scan the
 		// grid, so a player standing still since login must be there.
-		w.SetEntityPos(s.Conn, spawnX, spawnY)
+		w.SetEntityPos(s.Conn, loginX, loginY)
 		e.HP, e.MaxHP = st.HP, st.MaxHP
 		e.MP, e.MaxMP = st.MP, st.MaxMP
 		e.Damage, e.AC, e.Master = st.Damage, st.AC, st.Master
@@ -327,8 +333,8 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 			}
 			carry[i] = itemToSel(st.Carry[i])
 		}
-		body := protocol.EncodeCNFCharacterLoginRaw(tmpl, st.Name, st.Coin, st.Exp, equip, carry, spawnX, spawnY, s.Slot, s.Conn, 0, shortSkill, skill)
-		d.logCNFCharacterLogin("template", s, st, spawnX, spawnY, body)
+		body := protocol.EncodeCNFCharacterLoginRaw(tmpl, st.Name, st.Coin, st.Exp, equip, carry, loginX, loginY, saveX, saveY, s.Slot, s.Conn, 0, shortSkill, skill)
+		d.logCNFCharacterLogin("template", s, st, loginX, loginY, body)
 		w.SendTo(s, protocol.Header{Type: protocol.MsgCNFCharacterLogin, ID: protocol.IDScene}, body)
 		d.enterWorldView(w, s)
 		d.sendLoginAffects(w, s)
@@ -338,6 +344,9 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 		"conn", s.Conn, "class", st.Class)
 	// Fallback: build the snapshot from the stored relational state (no equipment).
 	// Byte-exact MSG_CNFCharacterLogin (STRUCT_MOB + pos + skillbar), ID=30000.
+	if saveX == 0 && saveY == 0 {
+		saveX, saveY = loginX, loginY
+	}
 	m := protocol.MobSnapshot{
 		Name:  st.Name,
 		Clan:  st.Clan,
@@ -345,7 +354,7 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 		Class: uint8(st.Class),
 		Coin:  st.Coin,
 		Exp:   st.Exp,
-		SPX:   spawnX, SPY: spawnY,
+		SPX:   saveX, SPY: saveY,
 		Level: int32(st.Level), Ac: st.AC, Damage: st.Damage,
 		MaxHp: st.MaxHP, MaxMp: st.MaxMP, Hp: st.HP, Mp: st.MP,
 		Str: st.Str, Int: st.Int, Dex: st.Dex, Con: st.Con,
@@ -367,8 +376,8 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 			},
 		}
 	}
-	body := protocol.EncodeCNFCharacterLoginBody(s.Slot, s.Conn, 0, m, shortSkill)
-	d.logCNFCharacterLogin("fallback", s, st, spawnX, spawnY, body)
+	body := protocol.EncodeCNFCharacterLoginBody(s.Slot, s.Conn, 0, loginX, loginY, m, shortSkill)
+	d.logCNFCharacterLogin("fallback", s, st, loginX, loginY, body)
 	w.SendTo(s, protocol.Header{Type: protocol.MsgCNFCharacterLogin, ID: protocol.IDScene}, body)
 	d.enterWorldView(w, s)
 	d.sendLoginAffects(w, s)

--- a/tmserver/internal/handler/handler_test.go
+++ b/tmserver/internal/handler/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
 )
@@ -155,6 +156,28 @@ func startServerBilling(t *testing.T, persist world.Persistence, b world.Billing
 	d := New(Config{Log: log})
 	w := world.New(world.Config{GridDim: 16}, log, persist, d.Handle)
 	w.SetBilling(b)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = w.Serve(ctx, ln); close(done) }()
+	return ln.Addr().String(), func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("server did not stop")
+		}
+	}
+}
+
+func startServerBaseMobs(t *testing.T, persist world.Persistence, baseMobs map[int][]byte) (string, func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := New(Config{Log: log, BaseMobs: baseMobs})
+	w := world.New(world.Config{}, log, persist, d.Handle)
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() { _ = w.Serve(ctx, ln); close(done) }()
@@ -482,7 +505,7 @@ func TestCharacterLoginAndLogout(t *testing.T) {
 
 func TestCharacterLoginFallbackCNFUsesComputedCitySpawn(t *testing.T) {
 	db := newDB()
-	db.loadResult = world.CharacterState{Slot: 0, Name: "Hero", LastCity: 2, HP: 1200, MaxHP: 1200}
+	db.loadResult = world.CharacterState{Slot: 0, Name: "Hero", Level: 50, LastCity: 2, HP: 1200, MaxHP: 1200}
 	addr, stop := startServer(t, db)
 	defer stop()
 	c := loginAndSelect(t, addr)
@@ -501,11 +524,6 @@ func TestCharacterLoginFallbackCNFUsesComputedCitySpawn(t *testing.T) {
 
 	msgX := int16(binary.LittleEndian.Uint16(payload[0:]))
 	msgY := int16(binary.LittleEndian.Uint16(payload[2:]))
-	mobSPX := int16(binary.LittleEndian.Uint16(payload[4+40:]))
-	mobSPY := int16(binary.LittleEndian.Uint16(payload[4+42:]))
-	if msgX != mobSPX || msgY != mobSPY {
-		t.Fatalf("CNF PosX/Y = %d,%d but embedded SPX/SPY = %d,%d", msgX, msgY, mobSPX, mobSPY)
-	}
 	if city := world.Village(msgX, msgY); city != int(db.loadResult.LastCity) {
 		t.Fatalf("CNF spawn = %d,%d in city %d, want city %d", msgX, msgY, city, db.loadResult.LastCity)
 	}
@@ -516,6 +534,70 @@ func TestCharacterLoginFallbackCNFUsesComputedCitySpawn(t *testing.T) {
 			binary.LittleEndian.Uint16(payload[1028:]),
 			binary.LittleEndian.Uint16(payload[1030:]),
 			binary.LittleEndian.Uint16(payload[1032:]))
+	}
+}
+
+func TestCharacterLoginTemplateCNFSeparatesLoginPosFromSavePoint(t *testing.T) {
+	db := newDB()
+	db.loadResult = world.CharacterState{Slot: 0, Name: "Hero", Class: 1, Level: 50, LastCity: 2, HP: 1200, MaxHP: 1200}
+	tmpl := make([]byte, content.BaseMobSize)
+	copy(tmpl[0:16], "Template")
+	binary.LittleEndian.PutUint16(tmpl[40:], 2112)
+	binary.LittleEndian.PutUint16(tmpl[42:], 2112)
+	addr, stop := startServerBaseMobs(t, db, map[int][]byte{1: tmpl})
+	defer stop()
+	c := loginAndSelect(t, addr)
+	defer c.Close()
+
+	var body protocol.MsgCharacterLoginBody
+	body.Slot = 0
+	send(t, c, protocol.MsgCharacterLogin, body.Encode())
+	ty, payload := read(t, c)
+	if ty != protocol.MsgCNFCharacterLogin {
+		t.Fatalf("got %#x, want CNFCharacterLogin", ty)
+	}
+
+	msgX := int16(binary.LittleEndian.Uint16(payload[0:]))
+	msgY := int16(binary.LittleEndian.Uint16(payload[2:]))
+	if city := world.Village(msgX, msgY); city != int(db.loadResult.LastCity) {
+		t.Fatalf("CNF login pos = %d,%d in city %d, want city %d", msgX, msgY, city, db.loadResult.LastCity)
+	}
+	mobSPX := int16(binary.LittleEndian.Uint16(payload[4+40:]))
+	mobSPY := int16(binary.LittleEndian.Uint16(payload[4+42:]))
+	if mobSPX != 2112 || mobSPY != 2112 {
+		t.Fatalf("embedded SPX/SPY = %d,%d, want template save point 2112,2112", mobSPX, mobSPY)
+	}
+	if msgX == mobSPX && msgY == mobSPY {
+		t.Fatalf("CNF login pos unexpectedly equals save point: %d,%d", msgX, msgY)
+	}
+}
+
+func TestCharacterLoginLowLevelMortalUsesLastCitySpawn(t *testing.T) {
+	db := newDB()
+	db.loadResult = world.CharacterState{Slot: 0, Name: "Hero", Class: 1, Level: 1, LastCity: 2, HP: 1200, MaxHP: 1200}
+	tmpl := make([]byte, content.BaseMobSize)
+	copy(tmpl[0:16], "Template")
+	binary.LittleEndian.PutUint16(tmpl[40:], 2112)
+	binary.LittleEndian.PutUint16(tmpl[42:], 2112)
+	addr, stop := startServerBaseMobs(t, db, map[int][]byte{1: tmpl})
+	defer stop()
+	c := loginAndSelect(t, addr)
+	defer c.Close()
+
+	var body protocol.MsgCharacterLoginBody
+	body.Slot = 0
+	send(t, c, protocol.MsgCharacterLogin, body.Encode())
+	ty, payload := read(t, c)
+	if ty != protocol.MsgCNFCharacterLogin {
+		t.Fatalf("got %#x, want CNFCharacterLogin", ty)
+	}
+	msgX := int16(binary.LittleEndian.Uint16(payload[0:]))
+	msgY := int16(binary.LittleEndian.Uint16(payload[2:]))
+	if city := world.Village(msgX, msgY); city != int(db.loadResult.LastCity) {
+		t.Fatalf("low-level login pos = %d,%d in city %d, want last city %d", msgX, msgY, city, db.loadResult.LastCity)
+	}
+	if city := world.Village(msgX, msgY); city == 0 {
+		t.Fatalf("low-level login pos = %d,%d spawned in Armia, want last city %d", msgX, msgY, db.loadResult.LastCity)
 	}
 }
 

--- a/tmserver/internal/handler/movement.go
+++ b/tmserver/internal/handler/movement.go
@@ -124,7 +124,7 @@ func (d *Dispatcher) dropBootAutoWalk(w *world.World, s *world.Session, e *world
 	if body.TargetX == e.X && body.TargetY == e.Y {
 		return false
 	}
-	if uint32(w.Now()-s.LoginTick) > 3000 {
+	if w.Now()-s.LoginTick > 3000 {
 		return false
 	}
 	d.log.Warn("movement: dropping boot auto-walk",

--- a/tmserver/internal/handler/movement.go
+++ b/tmserver/internal/handler/movement.go
@@ -65,6 +65,9 @@ func (d *Dispatcher) action(w *world.World, s *world.Session, h protocol.Header,
 			"effect", body.Effect,
 			"speed", body.Speed,
 			"route", body.Route)
+		if d.dropBootAutoWalk(w, s, e, h, body) {
+			return
+		}
 	}
 
 	// Anti-speedhack: movetime must be within the window of server time.
@@ -110,6 +113,30 @@ func (d *Dispatcher) action(w *world.World, s *world.Session, h protocol.Header,
 }
 
 func outOfBounds(v, dim int16) bool { return v < 0 || v >= dim }
+
+func (d *Dispatcher) dropBootAutoWalk(w *world.World, s *world.Session, e *world.Entity, h protocol.Header, body protocol.MsgActionBody) bool {
+	if h.Type != protocol.MsgAction || body.Effect != 0 || body.Speed != int32(attackRunOf(e)&0x0F) {
+		return false
+	}
+	if body.PosX != s.LoginSpawnX || body.PosY != s.LoginSpawnY || e.X != s.LoginSpawnX || e.Y != s.LoginSpawnY {
+		return false
+	}
+	if body.TargetX == e.X && body.TargetY == e.Y {
+		return false
+	}
+	if uint32(w.Now()-s.LoginTick) > 3000 {
+		return false
+	}
+	d.log.Warn("movement: dropping boot auto-walk",
+		"conn", s.Conn,
+		"from_x", body.PosX,
+		"from_y", body.PosY,
+		"target_x", body.TargetX,
+		"target_y", body.TargetY)
+	correction := protocol.MsgActionBody{PosX: e.X, PosY: e.Y, Effect: 1, Speed: 6, TargetX: e.X, TargetY: e.Y}
+	w.SendTo(s, protocol.Header{Type: protocol.MsgAction3, ID: uint16(s.Conn)}, correction.Encode())
+	return true
+}
 
 // motion handles _MSG_Motion (0x036A): emotes/animations, multicast to in-view.
 func (d *Dispatcher) motion(w *world.World, s *world.Session, _ protocol.Header, payload []byte) {

--- a/tmserver/internal/handler/movement_test.go
+++ b/tmserver/internal/handler/movement_test.go
@@ -149,7 +149,12 @@ func actionFrame(t *testing.T, c net.Conn, tick uint32, target int16) {
 	t.Helper()
 	body := protocol.MsgActionBody{PosX: 5, PosY: 5, Effect: 0, Speed: 30, TargetX: target, TargetY: target}
 	copy(body.Route[:], []byte{1, 2, 3})
-	wire, err := protocol.Encode(protocol.Header{Type: protocol.MsgAction, ClientTick: tick}, body.Encode(), 9)
+	actionFrameBody(t, c, tick, protocol.MsgAction, body)
+}
+
+func actionFrameBody(t *testing.T, c net.Conn, tick uint32, ty protocol.Type, body protocol.MsgActionBody) {
+	t.Helper()
+	wire, err := protocol.Encode(protocol.Header{Type: ty, ClientTick: tick}, body.Encode(), 9)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,6 +194,35 @@ func TestMoveBroadcastToInView(t *testing.T) {
 	// The mover does not receive its own movement.
 	if _, _, ok := readMaybe(t, mover); ok {
 		t.Errorf("mover should not receive its own action")
+	}
+}
+
+func TestBootAutoWalkDroppedAndCorrected(t *testing.T) {
+	addr, stop, _ := startServerClock(t, movementDB())
+	defer stop()
+
+	mover := enterWorld(t, addr)
+	defer mover.Close()
+	watcher := enterWorld(t, addr)
+	defer watcher.Close()
+
+	body := protocol.MsgActionBody{PosX: 5, PosY: 5, Effect: 0, Speed: 2, TargetX: 1, TargetY: 1}
+	copy(body.Route[:], []byte{49, 49, 49, 49})
+	actionFrameBody(t, mover, serverTime, protocol.MsgAction, body)
+
+	ty, payload, ok := readMaybe(t, mover)
+	if !ok || ty != protocol.MsgAction3 {
+		t.Fatalf("mover got %#x ok=%v, want correction MsgAction3", ty, ok)
+	}
+	var correction protocol.MsgActionBody
+	if err := correction.Decode(payload); err != nil {
+		t.Fatal(err)
+	}
+	if correction.PosX != 5 || correction.PosY != 5 || correction.TargetX != 5 || correction.TargetY != 5 || correction.Effect != 1 {
+		t.Fatalf("correction = %+v, want self teleport at 5,5", correction)
+	}
+	if ty, _, ok = readMaybe(t, watcher); ok {
+		t.Fatalf("watcher got %#x, want no broadcast for dropped boot auto-walk", ty)
 	}
 }
 

--- a/tmserver/internal/protocol/mob.go
+++ b/tmserver/internal/protocol/mob.go
@@ -167,10 +167,12 @@ type SkillState struct {
 
 // EncodeCNFCharacterLoginRaw builds the snapshot from a RAW 816-byte STRUCT_MOB
 // (a per-class BaseMob template, which already carries valid stats, starter
-// equipment, skills AND a valid spawn position), patching only the name. The
-// position comes from the template itself (the stored relational position is not
-// yet carried over gRPC, and 0,0 would crash the client on an invalid map cell).
-func EncodeCNFCharacterLoginRaw(mob816 []byte, name string, coin int32, exp int64, equip [16]SelItem, carry [64]SelItem, spawnX, spawnY int16, slot, clientID int, weather uint16, shortSkill [16]uint8, skill SkillState) []byte {
+// equipment and skills), patching the character-specific state. loginX/loginY
+// are the actual world-entry position in MSG_CNFCharacterLogin.PosX/PosY; the
+// embedded mob.SPX/SPY remains the save point, matching ProcessDBMessage.cpp's
+// later tx/ty spawn rewrite. When saveX/saveY are zero, the template's SPX/SPY
+// are preserved.
+func EncodeCNFCharacterLoginRaw(mob816 []byte, name string, coin int32, exp int64, equip [16]SelItem, carry [64]SelItem, loginX, loginY, saveX, saveY int16, slot, clientID int, weather uint16, shortSkill [16]uint8, skill SkillState) []byte {
 	b := make([]byte, cnfCharacterLoginSize-HeaderSize) // 1820
 	copy(b[4:4+structMobSize], mob816)                  // mob @ body4 (raw template)
 	for i := 4; i < 4+16; i++ {                         // clear MobName then set it
@@ -197,14 +199,16 @@ func EncodeCNFCharacterLoginRaw(mob816 []byte, name string, coin int32, exp int6
 	// saved total at login (the template ships Exp=0). The client owns the level
 	// curve and renders the bar from this raw value.
 	le.PutUint64(b[4+32:], uint64(exp))
-	// Spawn position: write the caller's actual spawn (city rule) into both the
-	// message PosX/PosY (body0/2) AND the embedded mob's SPX/SPY (mob offset 40/42),
-	// otherwise the client renders the template's position (always Armia) regardless
-	// of where the server placed the entity.
-	le.PutUint16(b[0:], uint16(spawnX)) // PosX @ body0
-	le.PutUint16(b[2:], uint16(spawnY)) // PosY @ body2
-	le.PutUint16(b[4+40:], uint16(spawnX))
-	le.PutUint16(b[4+42:], uint16(spawnY))
+	// The legacy server keeps mob.SPX/SPY as the save point and later overwrites
+	// only MSG_CNFCharacterLogin.PosX/PosY with the actual tx/ty spawn. Keeping
+	// those roles separate prevents the client and server from starting on
+	// different tiles after login.
+	le.PutUint16(b[0:], uint16(loginX)) // PosX @ body0
+	le.PutUint16(b[2:], uint16(loginY)) // PosY @ body2
+	if saveX != 0 || saveY != 0 {
+		le.PutUint16(b[4+40:], uint16(saveX))
+		le.PutUint16(b[4+42:], uint16(saveY))
+	}
 	// Persisted skill state over the template's: learned mask + free points
 	// @780-793, skill bar @796, and the Special mastery in both scores @+40
 	// (BaseScore @44, CurrentScore @92). The template ships all-zero here.
@@ -243,12 +247,12 @@ func EncodeUpdateEquip(visual [16]uint16) []byte {
 }
 
 // EncodeCNFCharacterLoginBody builds the body of MSG_CNFCharacterLogin (0x0114):
-// the in-world snapshot. slot/clientID/weather/shortSkill fill the trailing
-// fields. Send with HEADER.ID = IDScene (30000).
-func EncodeCNFCharacterLoginBody(slot, clientID int, weather uint16, m MobSnapshot, shortSkill [16]uint8) []byte {
+// the in-world snapshot. loginX/loginY are the packet entry position; m.SPX/SPY
+// stays as the embedded save point. Send with HEADER.ID = IDScene (30000).
+func EncodeCNFCharacterLoginBody(slot, clientID int, weather uint16, loginX, loginY int16, m MobSnapshot, shortSkill [16]uint8) []byte {
 	b := make([]byte, cnfCharacterLoginSize-HeaderSize) // 1820
-	le.PutUint16(b[0:], uint16(m.SPX))                  // PosX @ abs12 → body0
-	le.PutUint16(b[2:], uint16(m.SPY))                  // PosY @ abs14 → body2
+	le.PutUint16(b[0:], uint16(loginX))                 // PosX @ abs12 → body0
+	le.PutUint16(b[2:], uint16(loginY))                 // PosY @ abs14 → body2
 	writeStructMob(b[4:4+structMobSize], m)             // mob @ abs16 → body4
 	le.PutUint16(b[1028:], uint16(slot))                // Slot @ abs1040 → body1028
 	le.PutUint16(b[1030:], uint16(clientID))            // ClientID @ abs1042 → body1030

--- a/tmserver/internal/protocol/mob_test.go
+++ b/tmserver/internal/protocol/mob_test.go
@@ -54,7 +54,7 @@ func TestCNFCharacterLoginRawLayout(t *testing.T) {
 		BaseSpecial: [4]int16{1, 2, 3, 4},
 		SkillBar:    [4]uint8{9, 10, 11, 12},
 	}
-	b := EncodeCNFCharacterLoginRaw(tmpl, "Hero", 777777, 123456789, equip, carry, 2453, 2000, 0, 1, 0, sk, skill)
+	b := EncodeCNFCharacterLoginRaw(tmpl, "Hero", 777777, 123456789, equip, carry, 2453, 2000, 0, 0, 0, 1, 0, sk, skill)
 
 	if len(b) != cnfCharacterLoginSize-HeaderSize { // 1832 - 12 = 1820
 		t.Fatalf("CNFCharacterLogin body = %d, want %d", len(b), cnfCharacterLoginSize-HeaderSize)
@@ -63,13 +63,13 @@ func TestCNFCharacterLoginRawLayout(t *testing.T) {
 	if got := cstr16(b[4:20]); got != "Hero" { // MobName patched @ body4
 		t.Errorf("name = %q, want Hero", got)
 	}
-	// Spawn position (the caller's, not the template's) is written to the message
-	// PosX/PosY and the embedded mob's position — else the client renders Armia.
+	// Login position is written to the packet PosX/PosY, while the embedded
+	// STRUCT_MOB keeps its save point (SPX/SPY) from the template.
 	if le.Uint16(b[0:]) != 2453 || le.Uint16(b[2:]) != 2000 {
 		t.Errorf("msg PosX/PosY = %d,%d want 2453,2000", le.Uint16(b[0:]), le.Uint16(b[2:]))
 	}
-	if le.Uint16(b[4+40:]) != 2453 || le.Uint16(b[4+42:]) != 2000 {
-		t.Errorf("mob SPX/SPY = %d,%d want 2453,2000", le.Uint16(b[4+40:]), le.Uint16(b[4+42:]))
+	if le.Uint16(b[4+40:]) != 2096 || le.Uint16(b[4+42:]) != 2096 {
+		t.Errorf("mob SPX/SPY = %d,%d want 2096,2096", le.Uint16(b[4+40:]), le.Uint16(b[4+42:]))
 	}
 	// Gold is written at both candidate offsets (24 = client display, 28 = Coin).
 	if le.Uint32(b[4+24:]) != 777777 || le.Uint32(b[4+28:]) != 777777 {
@@ -120,7 +120,7 @@ func TestCNFCharacterLoginRawLayout(t *testing.T) {
 func TestCNFCharacterLoginBodyLayout(t *testing.T) {
 	var short [16]uint8
 	short[15] = 77
-	b := EncodeCNFCharacterLoginBody(2, 33, 4, MobSnapshot{
+	b := EncodeCNFCharacterLoginBody(2, 33, 4, 2453, 2000, MobSnapshot{
 		Name:      "Fallback",
 		SPX:       2494,
 		SPY:       1707,
@@ -133,8 +133,8 @@ func TestCNFCharacterLoginBodyLayout(t *testing.T) {
 		t.Fatalf("CNFCharacterLogin body = %d, want %d", len(b), cnfCharacterLoginSize-HeaderSize)
 	}
 	le := binary.LittleEndian
-	if le.Uint16(b[0:]) != 2494 || le.Uint16(b[2:]) != 1707 {
-		t.Errorf("msg PosX/PosY = %d,%d want 2494,1707", le.Uint16(b[0:]), le.Uint16(b[2:]))
+	if le.Uint16(b[0:]) != 2453 || le.Uint16(b[2:]) != 2000 {
+		t.Errorf("msg PosX/PosY = %d,%d want 2453,2000", le.Uint16(b[0:]), le.Uint16(b[2:]))
 	}
 	if le.Uint16(b[4+40:]) != 2494 || le.Uint16(b[4+42:]) != 1707 {
 		t.Errorf("mob SPX/SPY = %d,%d want 2494,1707", le.Uint16(b[4+40:]), le.Uint16(b[4+42:]))

--- a/tmserver/internal/world/api.go
+++ b/tmserver/internal/world/api.go
@@ -370,6 +370,12 @@ func (w *World) SetEntityPos(id int, x, y int16) {
 	w.grid.SetMob(int(x), int(y), uint16(id))
 }
 
+// EmptyCellNear returns an unoccupied grid cell at or near (x,y), using the same
+// ring scan as the legacy GetEmptyMobGrid stand-in used for mob spawns. Loop-only.
+func (w *World) EmptyCellNear(x, y int16) (int16, int16, bool) {
+	return w.emptyCellNear(x, y)
+}
+
 // GridDim returns the world's grid side length (valid coordinate bound).
 func (w *World) GridDim() int { return w.grid.dim }
 

--- a/tmserver/internal/world/session.go
+++ b/tmserver/internal/world/session.go
@@ -33,6 +33,7 @@ type Session struct {
 	ShortSkill        [16]uint8  // client hotbar layout (CUser.CharShortSkill, _MSG_SetShortSkill)
 	LoginSpawnX       int16      // last server-injected login spawn, for movement diagnostics
 	LoginSpawnY       int16
+	LoginTick         uint32
 	LoggedFirstAction bool // first post-login _MSG_Action diagnostic was emitted
 
 	seen map[int]struct{} // entity ids already create-mob'd to this client (view set)


### PR DESCRIPTION
## Summary
- split the login packet entry position from embedded STRUCT_MOB save-point coordinates
- drop the first boot auto-walk action when it starts from the login tile and correct the client position
- preserve last visited city spawn for low-level mortal characters, including Erion regression coverage

## Tests
- go test ./tmserver/internal/handler ./tmserver/internal/world ./tmserver/internal/protocol
- go test ./...
- docker compose build tmserver