### PR TITLE
Fix issue 64 movement speed tiers

### DIFF
--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -504,9 +504,9 @@ const (
 	// baseAttackRun is the class templates' base speed byte (run<<4 | move) = 82
 	// (run 5, move 2). UNVERIFIED: per-state speed curves are not reproduced.
 	baseAttackRun = 82
-	// mountedMoveSpeed bumps the move-speed nibble when a mount is equipped.
-	// UNVERIFIED: the exact mounted speed is in BASE_GetCurrentScore (not in source).
-	mountedMoveSpeed = 5
+	// Issue #64 movement policy: bare player = 2, boots = 4, mount = 6.
+	bootMoveSpeed    = 4
+	mountedMoveSpeed = 6
 
 	// Weapon hands in STRUCT_MOB.Equip (right/left). GetCurrentScore (CMob.cpp:756)
 	// derives WeaponDamage from these two slots' EF_DAMAGE.
@@ -799,29 +799,23 @@ func (d *Dispatcher) computeScore(e *world.Entity) protocol.ScoreData {
 }
 
 // attackRunOf is the entity's live speed byte (run<<4 | move). Players get the
-// class base plus the mount bump; mobs carry their template's CurrentScore
-// value (set at spawn). Every S→C score/snapshot (UpdateScore, CreateMob, the
-// login MOB blob) must carry it: the client animates walks — its own and remote
-// entities' — at this speed, and a 0 here renders a crawling, rubber-banding
-// avatar.
+// issue #64 move-speed tiers (bare=2, boots=4, mount=6); mobs carry their
+// template's CurrentScore value (set at spawn). Every S→C score/snapshot
+// (UpdateScore, CreateMob, the login MOB blob) must carry it: the client animates
+// walks — its own and remote entities' — at this speed, and a 0 here renders a
+// crawling, rubber-banding avatar.
 func attackRunOf(e *world.Entity) uint8 {
 	if !world.IsPlayer(e.ID) {
 		return e.AttackRun
 	}
-	// A mount in the mount slot raises the move-speed (low) nibble.
+	// A mount takes precedence over boots and uses the max client movement tier.
 	if !e.Equip[mountEquipSlot].Empty() {
 		return (baseAttackRun & 0xF0) | mountedMoveSpeed
 	}
-	// Boots' EF_RUNSPEED adds to the base move-speed nibble, clamped [1,6] like
-	// the legacy BASE_GetSpeed (Basedef.cpp:1250-1262).
-	move := int32(baseAttackRun&0x0F) + e.RunSpeedBonus
-	if move < 1 {
-		move = 1
+	if e.RunSpeedBonus > 0 {
+		return (baseAttackRun & 0xF0) | bootMoveSpeed
 	}
-	if move > 6 {
-		move = 6
-	}
-	return (baseAttackRun & 0xF0) | uint8(move)
+	return baseAttackRun
 }
 
 // sendScore pushes the recomputed CurrentScore to the player (_MSG_UpdateScore), so

--- a/tmserver/internal/handler/item_test.go
+++ b/tmserver/internal/handler/item_test.go
@@ -495,10 +495,13 @@ func TestWeaponDamageRefine(t *testing.T) {
 }
 
 // TestAttackRunOfBoots verifies EF_RUNSPEED (boots) raises the move-speed (low)
-// nibble of AttackRun (issue #64: base speed 2 stayed 2 with boots equipped).
+// nibble of AttackRun to the issue #64 tier: bare=2, boots=4, mount=6.
 func TestAttackRunOfBoots(t *testing.T) {
 	d := New(Config{
-		ItemEffects: map[int][]content.BaseEffect{321: {{Eff: efRunSpeed, Val: 1}}}, // boots, +1 speed
+		ItemEffects: map[int][]content.BaseEffect{
+			321: {{Eff: efRunSpeed, Val: 1}},  // boots
+			322: {{Eff: efRunSpeed, Val: 99}}, // overboosted boots still use the boots tier
+		},
 	})
 
 	bare := &world.Entity{}
@@ -510,15 +513,23 @@ func TestAttackRunOfBoots(t *testing.T) {
 	booted := &world.Entity{}
 	booted.Equip[5] = world.Item{Index: 321} // boots occupy equip slot 5 (nPos 32)
 	d.refreshScore(booted)
-	if got := attackRunOf(booted); got != baseAttackRun+1 {
-		t.Errorf("boots +1: attackRunOf = %#x, want %#x", got, baseAttackRun+1)
+	if got := attackRunOf(booted); got != (baseAttackRun&0xF0)|bootMoveSpeed {
+		t.Errorf("boots: attackRunOf = %#x, want %#x", got, (baseAttackRun&0xF0)|bootMoveSpeed)
 	}
 
-	// Clamp parity with legacy BASE_GetSpeed: an oversized bonus still clamps
-	// the nibble to 6, never wrapping past it.
-	overboosted := &world.Entity{RunSpeedBonus: 99}
-	if got := attackRunOf(overboosted); got != (baseAttackRun&0xF0)|6 {
-		t.Errorf("clamped: attackRunOf = %#x, want %#x", got, (baseAttackRun&0xF0)|6)
+	overboosted := &world.Entity{}
+	overboosted.Equip[5] = world.Item{Index: 322}
+	d.refreshScore(overboosted)
+	if got := attackRunOf(overboosted); got != (baseAttackRun&0xF0)|bootMoveSpeed {
+		t.Errorf("overboosted boots: attackRunOf = %#x, want %#x", got, (baseAttackRun&0xF0)|bootMoveSpeed)
+	}
+
+	mounted := &world.Entity{}
+	mounted.Equip[5] = world.Item{Index: 321}
+	mounted.Equip[mountEquipSlot] = world.Item{Index: 342}
+	d.refreshScore(mounted)
+	if got := attackRunOf(mounted); got != (baseAttackRun&0xF0)|mountedMoveSpeed {
+		t.Errorf("mounted with boots: attackRunOf = %#x, want %#x", got, (baseAttackRun&0xF0)|mountedMoveSpeed)
 	}
 }
 

--- a/tmserver/internal/handler/starter_equip_test.go
+++ b/tmserver/internal/handler/starter_equip_test.go
@@ -119,7 +119,7 @@ func TestComputeScoreReadsLiveFields(t *testing.T) {
 	if sc.AttackRun != baseAttackRun {
 		t.Errorf("AttackRun = %#x, want base %#x", sc.AttackRun, baseAttackRun)
 	}
-	// Equipping a mount raises the move-speed (low) nibble.
+	// Equipping a mount raises the move-speed (low) nibble to the issue #64 tier.
 	e.Equip[mountEquipSlot] = world.Item{Index: 342} // any mount item, e.g. Shire
 	if sc := d.computeScore(e); sc.AttackRun != (baseAttackRun&0xF0)|mountedMoveSpeed {
 		t.Errorf("mounted AttackRun = %#x, want %#x", sc.AttackRun, (baseAttackRun&0xF0)|mountedMoveSpeed)


### PR DESCRIPTION
## Summary
- set player movement speed tiers to 2 without boots, 4 with boots, and 6 with mount
- keep mount speed taking precedence over boots
- update handler tests for issue 64 expectations

## Tests
- go test ./tmserver/internal/handler