### PR TITLE
feat: add daily reward system (issue #35)

### DIFF
--- a/api/web/v1/web.pb.go
+++ b/api/web/v1/web.pb.go
@@ -199,6 +199,63 @@ func (BuyResult) EnumDescriptor() ([]byte, []int) {
 	return file_api_web_v1_web_proto_rawDescGZIP(), []int{2}
 }
 
+// ClaimResult carries the claim outcome in the body; only infra failures
+// become gRPC errors.
+type ClaimResult int32
+
+const (
+	ClaimResult_CLAIM_RESULT_UNSPECIFIED     ClaimResult = 0
+	ClaimResult_CLAIM_RESULT_OK              ClaimResult = 1 // claim recorded + item queued for delivery
+	ClaimResult_CLAIM_RESULT_ALREADY_CLAIMED ClaimResult = 2 // account already claimed today (UTC)
+	ClaimResult_CLAIM_RESULT_NOT_FOUND       ClaimResult = 3 // unknown offer or account
+	ClaimResult_CLAIM_RESULT_DISABLED        ClaimResult = 4 // offer exists but is not claimable
+)
+
+// Enum value maps for ClaimResult.
+var (
+	ClaimResult_name = map[int32]string{
+		0: "CLAIM_RESULT_UNSPECIFIED",
+		1: "CLAIM_RESULT_OK",
+		2: "CLAIM_RESULT_ALREADY_CLAIMED",
+		3: "CLAIM_RESULT_NOT_FOUND",
+		4: "CLAIM_RESULT_DISABLED",
+	}
+	ClaimResult_value = map[string]int32{
+		"CLAIM_RESULT_UNSPECIFIED":     0,
+		"CLAIM_RESULT_OK":              1,
+		"CLAIM_RESULT_ALREADY_CLAIMED": 2,
+		"CLAIM_RESULT_NOT_FOUND":       3,
+		"CLAIM_RESULT_DISABLED":        4,
+	}
+)
+
+func (x ClaimResult) Enum() *ClaimResult {
+	p := new(ClaimResult)
+	*p = x
+	return p
+}
+
+func (x ClaimResult) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ClaimResult) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_web_v1_web_proto_enumTypes[3].Descriptor()
+}
+
+func (ClaimResult) Type() protoreflect.EnumType {
+	return &file_api_web_v1_web_proto_enumTypes[3]
+}
+
+func (x ClaimResult) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ClaimResult.Descriptor instead.
+func (ClaimResult) EnumDescriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{3}
+}
+
 type CreateAccountRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`         // canonicalized to lowercase server-side
@@ -3064,6 +3121,734 @@ func (x *BuyResponse) GetNewBalance() int32 {
 	return 0
 }
 
+// DailyRewardItem is one claimable offer: an item (index + up to three
+// effect/value pairs), free, gated only by the once-per-account-per-UTC-day
+// limit. expires_days > 0 makes the delivered item timed.
+type DailyRewardItem struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	ItemIndex     int32                  `protobuf:"varint,2,opt,name=item_index,json=itemIndex,proto3" json:"item_index,omitempty"`
+	Eff1          int32                  `protobuf:"varint,3,opt,name=eff1,proto3" json:"eff1,omitempty"`
+	Effv1         int32                  `protobuf:"varint,4,opt,name=effv1,proto3" json:"effv1,omitempty"`
+	Eff2          int32                  `protobuf:"varint,5,opt,name=eff2,proto3" json:"eff2,omitempty"`
+	Effv2         int32                  `protobuf:"varint,6,opt,name=effv2,proto3" json:"effv2,omitempty"`
+	Eff3          int32                  `protobuf:"varint,7,opt,name=eff3,proto3" json:"eff3,omitempty"`
+	Effv3         int32                  `protobuf:"varint,8,opt,name=effv3,proto3" json:"effv3,omitempty"`
+	Title         string                 `protobuf:"bytes,9,opt,name=title,proto3" json:"title,omitempty"`
+	Description   string                 `protobuf:"bytes,10,opt,name=description,proto3" json:"description,omitempty"`
+	Enabled       bool                   `protobuf:"varint,11,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	ExpiresDays   int32                  `protobuf:"varint,12,opt,name=expires_days,json=expiresDays,proto3" json:"expires_days,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DailyRewardItem) Reset() {
+	*x = DailyRewardItem{}
+	mi := &file_api_web_v1_web_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DailyRewardItem) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DailyRewardItem) ProtoMessage() {}
+
+func (x *DailyRewardItem) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DailyRewardItem.ProtoReflect.Descriptor instead.
+func (*DailyRewardItem) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{47}
+}
+
+func (x *DailyRewardItem) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *DailyRewardItem) GetItemIndex() int32 {
+	if x != nil {
+		return x.ItemIndex
+	}
+	return 0
+}
+
+func (x *DailyRewardItem) GetEff1() int32 {
+	if x != nil {
+		return x.Eff1
+	}
+	return 0
+}
+
+func (x *DailyRewardItem) GetEffv1() int32 {
+	if x != nil {
+		return x.Effv1
+	}
+	return 0
+}
+
+func (x *DailyRewardItem) GetEff2() int32 {
+	if x != nil {
+		return x.Eff2
+	}
+	return 0
+}
+
+func (x *DailyRewardItem) GetEffv2() int32 {
+	if x != nil {
+		return x.Effv2
+	}
+	return 0
+}
+
+func (x *DailyRewardItem) GetEff3() int32 {
+	if x != nil {
+		return x.Eff3
+	}
+	return 0
+}
+
+func (x *DailyRewardItem) GetEffv3() int32 {
+	if x != nil {
+		return x.Effv3
+	}
+	return 0
+}
+
+func (x *DailyRewardItem) GetTitle() string {
+	if x != nil {
+		return x.Title
+	}
+	return ""
+}
+
+func (x *DailyRewardItem) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *DailyRewardItem) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *DailyRewardItem) GetExpiresDays() int32 {
+	if x != nil {
+		return x.ExpiresDays
+	}
+	return 0
+}
+
+type ListRewardItemsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId   int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListRewardItemsRequest) Reset() {
+	*x = ListRewardItemsRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[48]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListRewardItemsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListRewardItemsRequest) ProtoMessage() {}
+
+func (x *ListRewardItemsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[48]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListRewardItemsRequest.ProtoReflect.Descriptor instead.
+func (*ListRewardItemsRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{48}
+}
+
+func (x *ListRewardItemsRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+type ListRewardItemsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Result        AdminResult            `protobuf:"varint,1,opt,name=result,proto3,enum=web.v1.AdminResult" json:"result,omitempty"`
+	Items         []*DailyRewardItem     `protobuf:"bytes,2,rep,name=items,proto3" json:"items,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListRewardItemsResponse) Reset() {
+	*x = ListRewardItemsResponse{}
+	mi := &file_api_web_v1_web_proto_msgTypes[49]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListRewardItemsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListRewardItemsResponse) ProtoMessage() {}
+
+func (x *ListRewardItemsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[49]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListRewardItemsResponse.ProtoReflect.Descriptor instead.
+func (*ListRewardItemsResponse) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{49}
+}
+
+func (x *ListRewardItemsResponse) GetResult() AdminResult {
+	if x != nil {
+		return x.Result
+	}
+	return AdminResult_ADMIN_RESULT_UNSPECIFIED
+}
+
+func (x *ListRewardItemsResponse) GetItems() []*DailyRewardItem {
+	if x != nil {
+		return x.Items
+	}
+	return nil
+}
+
+type UpsertRewardItemRequest struct {
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	// id == 0 creates a new offer; otherwise the offer with that id is updated.
+	Item          *DailyRewardItem `protobuf:"bytes,2,opt,name=item,proto3" json:"item,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpsertRewardItemRequest) Reset() {
+	*x = UpsertRewardItemRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[50]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpsertRewardItemRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpsertRewardItemRequest) ProtoMessage() {}
+
+func (x *UpsertRewardItemRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[50]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpsertRewardItemRequest.ProtoReflect.Descriptor instead.
+func (*UpsertRewardItemRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{50}
+}
+
+func (x *UpsertRewardItemRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+func (x *UpsertRewardItemRequest) GetItem() *DailyRewardItem {
+	if x != nil {
+		return x.Item
+	}
+	return nil
+}
+
+type UpsertRewardItemResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Result        AdminResult            `protobuf:"varint,1,opt,name=result,proto3,enum=web.v1.AdminResult" json:"result,omitempty"`
+	ItemId        int64                  `protobuf:"varint,2,opt,name=item_id,json=itemId,proto3" json:"item_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpsertRewardItemResponse) Reset() {
+	*x = UpsertRewardItemResponse{}
+	mi := &file_api_web_v1_web_proto_msgTypes[51]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpsertRewardItemResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpsertRewardItemResponse) ProtoMessage() {}
+
+func (x *UpsertRewardItemResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[51]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpsertRewardItemResponse.ProtoReflect.Descriptor instead.
+func (*UpsertRewardItemResponse) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{51}
+}
+
+func (x *UpsertRewardItemResponse) GetResult() AdminResult {
+	if x != nil {
+		return x.Result
+	}
+	return AdminResult_ADMIN_RESULT_UNSPECIFIED
+}
+
+func (x *UpsertRewardItemResponse) GetItemId() int64 {
+	if x != nil {
+		return x.ItemId
+	}
+	return 0
+}
+
+type SetRewardItemEnabledRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId   int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	ItemId        int64                  `protobuf:"varint,2,opt,name=item_id,json=itemId,proto3" json:"item_id,omitempty"`
+	Enabled       bool                   `protobuf:"varint,3,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetRewardItemEnabledRequest) Reset() {
+	*x = SetRewardItemEnabledRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[52]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetRewardItemEnabledRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetRewardItemEnabledRequest) ProtoMessage() {}
+
+func (x *SetRewardItemEnabledRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[52]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetRewardItemEnabledRequest.ProtoReflect.Descriptor instead.
+func (*SetRewardItemEnabledRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{52}
+}
+
+func (x *SetRewardItemEnabledRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+func (x *SetRewardItemEnabledRequest) GetItemId() int64 {
+	if x != nil {
+		return x.ItemId
+	}
+	return 0
+}
+
+func (x *SetRewardItemEnabledRequest) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+type DeleteRewardItemRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId   int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	ItemId        int64                  `protobuf:"varint,2,opt,name=item_id,json=itemId,proto3" json:"item_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteRewardItemRequest) Reset() {
+	*x = DeleteRewardItemRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteRewardItemRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteRewardItemRequest) ProtoMessage() {}
+
+func (x *DeleteRewardItemRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteRewardItemRequest.ProtoReflect.Descriptor instead.
+func (*DeleteRewardItemRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{53}
+}
+
+func (x *DeleteRewardItemRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+func (x *DeleteRewardItemRequest) GetItemId() int64 {
+	if x != nil {
+		return x.ItemId
+	}
+	return 0
+}
+
+type ListRewardsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListRewardsRequest) Reset() {
+	*x = ListRewardsRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[54]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListRewardsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListRewardsRequest) ProtoMessage() {}
+
+func (x *ListRewardsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[54]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListRewardsRequest.ProtoReflect.Descriptor instead.
+func (*ListRewardsRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{54}
+}
+
+type ListRewardsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Items         []*DailyRewardItem     `protobuf:"bytes,1,rep,name=items,proto3" json:"items,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListRewardsResponse) Reset() {
+	*x = ListRewardsResponse{}
+	mi := &file_api_web_v1_web_proto_msgTypes[55]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListRewardsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListRewardsResponse) ProtoMessage() {}
+
+func (x *ListRewardsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[55]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListRewardsResponse.ProtoReflect.Descriptor instead.
+func (*ListRewardsResponse) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{55}
+}
+
+func (x *ListRewardsResponse) GetItems() []*DailyRewardItem {
+	if x != nil {
+		return x.Items
+	}
+	return nil
+}
+
+type GetClaimStatusRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	AccountId     int64                  `protobuf:"varint,1,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"` // from the BFF session, never from browser input
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetClaimStatusRequest) Reset() {
+	*x = GetClaimStatusRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[56]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetClaimStatusRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetClaimStatusRequest) ProtoMessage() {}
+
+func (x *GetClaimStatusRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[56]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetClaimStatusRequest.ProtoReflect.Descriptor instead.
+func (*GetClaimStatusRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{56}
+}
+
+func (x *GetClaimStatusRequest) GetAccountId() int64 {
+	if x != nil {
+		return x.AccountId
+	}
+	return 0
+}
+
+type GetClaimStatusResponse struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	ClaimedToday     bool                   `protobuf:"varint,1,opt,name=claimed_today,json=claimedToday,proto3" json:"claimed_today,omitempty"`
+	ClaimedItemId    int64                  `protobuf:"varint,2,opt,name=claimed_item_id,json=claimedItemId,proto3" json:"claimed_item_id,omitempty"`         // set only when claimed_today
+	ClaimedItemTitle string                 `protobuf:"bytes,3,opt,name=claimed_item_title,json=claimedItemTitle,proto3" json:"claimed_item_title,omitempty"` // set only when claimed_today (empty if the offer was since deleted)
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *GetClaimStatusResponse) Reset() {
+	*x = GetClaimStatusResponse{}
+	mi := &file_api_web_v1_web_proto_msgTypes[57]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetClaimStatusResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetClaimStatusResponse) ProtoMessage() {}
+
+func (x *GetClaimStatusResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[57]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetClaimStatusResponse.ProtoReflect.Descriptor instead.
+func (*GetClaimStatusResponse) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{57}
+}
+
+func (x *GetClaimStatusResponse) GetClaimedToday() bool {
+	if x != nil {
+		return x.ClaimedToday
+	}
+	return false
+}
+
+func (x *GetClaimStatusResponse) GetClaimedItemId() int64 {
+	if x != nil {
+		return x.ClaimedItemId
+	}
+	return 0
+}
+
+func (x *GetClaimStatusResponse) GetClaimedItemTitle() string {
+	if x != nil {
+		return x.ClaimedItemTitle
+	}
+	return ""
+}
+
+type ClaimRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	AccountId     int64                  `protobuf:"varint,1,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"` // from the BFF session, never from browser input
+	RewardItemId  int64                  `protobuf:"varint,2,opt,name=reward_item_id,json=rewardItemId,proto3" json:"reward_item_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClaimRequest) Reset() {
+	*x = ClaimRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[58]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClaimRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClaimRequest) ProtoMessage() {}
+
+func (x *ClaimRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[58]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClaimRequest.ProtoReflect.Descriptor instead.
+func (*ClaimRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{58}
+}
+
+func (x *ClaimRequest) GetAccountId() int64 {
+	if x != nil {
+		return x.AccountId
+	}
+	return 0
+}
+
+func (x *ClaimRequest) GetRewardItemId() int64 {
+	if x != nil {
+		return x.RewardItemId
+	}
+	return 0
+}
+
+type ClaimResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Result        ClaimResult            `protobuf:"varint,1,opt,name=result,proto3,enum=web.v1.ClaimResult" json:"result,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClaimResponse) Reset() {
+	*x = ClaimResponse{}
+	mi := &file_api_web_v1_web_proto_msgTypes[59]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClaimResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClaimResponse) ProtoMessage() {}
+
+func (x *ClaimResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[59]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClaimResponse.ProtoReflect.Descriptor instead.
+func (*ClaimResponse) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{59}
+}
+
+func (x *ClaimResponse) GetResult() ClaimResult {
+	if x != nil {
+		return x.Result
+	}
+	return ClaimResult_CLAIM_RESULT_UNSPECIFIED
+}
+
 var File_api_web_v1_web_proto protoreflect.FileDescriptor
 
 const file_api_web_v1_web_proto_rawDesc = "" +
@@ -3282,7 +4067,56 @@ const file_api_web_v1_web_proto_rawDesc = "" +
 	"\vBuyResponse\x12)\n" +
 	"\x06result\x18\x01 \x01(\x0e2\x11.web.v1.BuyResultR\x06result\x12\x1f\n" +
 	"\vnew_balance\x18\x02 \x01(\x05R\n" +
-	"newBalance*|\n" +
+	"newBalance\"\xb3\x02\n" +
+	"\x0fDailyRewardItem\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x1d\n" +
+	"\n" +
+	"item_index\x18\x02 \x01(\x05R\titemIndex\x12\x12\n" +
+	"\x04eff1\x18\x03 \x01(\x05R\x04eff1\x12\x14\n" +
+	"\x05effv1\x18\x04 \x01(\x05R\x05effv1\x12\x12\n" +
+	"\x04eff2\x18\x05 \x01(\x05R\x04eff2\x12\x14\n" +
+	"\x05effv2\x18\x06 \x01(\x05R\x05effv2\x12\x12\n" +
+	"\x04eff3\x18\a \x01(\x05R\x04eff3\x12\x14\n" +
+	"\x05effv3\x18\b \x01(\x05R\x05effv3\x12\x14\n" +
+	"\x05title\x18\t \x01(\tR\x05title\x12 \n" +
+	"\vdescription\x18\n" +
+	" \x01(\tR\vdescription\x12\x18\n" +
+	"\aenabled\x18\v \x01(\bR\aenabled\x12!\n" +
+	"\fexpires_days\x18\f \x01(\x05R\vexpiresDays\";\n" +
+	"\x16ListRewardItemsRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\"u\n" +
+	"\x17ListRewardItemsResponse\x12+\n" +
+	"\x06result\x18\x01 \x01(\x0e2\x13.web.v1.AdminResultR\x06result\x12-\n" +
+	"\x05items\x18\x02 \x03(\v2\x17.web.v1.DailyRewardItemR\x05items\"i\n" +
+	"\x17UpsertRewardItemRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\x12+\n" +
+	"\x04item\x18\x02 \x01(\v2\x17.web.v1.DailyRewardItemR\x04item\"`\n" +
+	"\x18UpsertRewardItemResponse\x12+\n" +
+	"\x06result\x18\x01 \x01(\x0e2\x13.web.v1.AdminResultR\x06result\x12\x17\n" +
+	"\aitem_id\x18\x02 \x01(\x03R\x06itemId\"s\n" +
+	"\x1bSetRewardItemEnabledRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\x12\x17\n" +
+	"\aitem_id\x18\x02 \x01(\x03R\x06itemId\x12\x18\n" +
+	"\aenabled\x18\x03 \x01(\bR\aenabled\"U\n" +
+	"\x17DeleteRewardItemRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\x12\x17\n" +
+	"\aitem_id\x18\x02 \x01(\x03R\x06itemId\"\x14\n" +
+	"\x12ListRewardsRequest\"D\n" +
+	"\x13ListRewardsResponse\x12-\n" +
+	"\x05items\x18\x01 \x03(\v2\x17.web.v1.DailyRewardItemR\x05items\"6\n" +
+	"\x15GetClaimStatusRequest\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x01 \x01(\x03R\taccountId\"\x93\x01\n" +
+	"\x16GetClaimStatusResponse\x12#\n" +
+	"\rclaimed_today\x18\x01 \x01(\bR\fclaimedToday\x12&\n" +
+	"\x0fclaimed_item_id\x18\x02 \x01(\x03R\rclaimedItemId\x12,\n" +
+	"\x12claimed_item_title\x18\x03 \x01(\tR\x10claimedItemTitle\"S\n" +
+	"\fClaimRequest\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x01 \x01(\x03R\taccountId\x12$\n" +
+	"\x0ereward_item_id\x18\x02 \x01(\x03R\frewardItemId\"<\n" +
+	"\rClaimResponse\x12+\n" +
+	"\x06result\x18\x01 \x01(\x0e2\x13.web.v1.ClaimResultR\x06result*|\n" +
 	"\fCreateResult\x12\x1d\n" +
 	"\x19CREATE_RESULT_UNSPECIFIED\x10\x00\x12\x14\n" +
 	"\x10CREATE_RESULT_OK\x10\x01\x12\x1c\n" +
@@ -3299,7 +4133,13 @@ const file_api_web_v1_web_proto_rawDesc = "" +
 	"\rBUY_RESULT_OK\x10\x01\x12!\n" +
 	"\x1dBUY_RESULT_INSUFFICIENT_FUNDS\x10\x02\x12\x18\n" +
 	"\x14BUY_RESULT_NOT_FOUND\x10\x03\x12\x17\n" +
-	"\x13BUY_RESULT_DISABLED\x10\x042\xbb\x01\n" +
+	"\x13BUY_RESULT_DISABLED\x10\x04*\x99\x01\n" +
+	"\vClaimResult\x12\x1c\n" +
+	"\x18CLAIM_RESULT_UNSPECIFIED\x10\x00\x12\x13\n" +
+	"\x0fCLAIM_RESULT_OK\x10\x01\x12 \n" +
+	"\x1cCLAIM_RESULT_ALREADY_CLAIMED\x10\x02\x12\x1a\n" +
+	"\x16CLAIM_RESULT_NOT_FOUND\x10\x03\x12\x19\n" +
+	"\x15CLAIM_RESULT_DISABLED\x10\x042\xbb\x01\n" +
 	"\x11AccountWebService\x12L\n" +
 	"\rCreateAccount\x12\x1c.web.v1.CreateAccountRequest\x1a\x1d.web.v1.CreateAccountResponse\x12X\n" +
 	"\x11VerifyCredentials\x12 .web.v1.VerifyCredentialsRequest\x1a!.web.v1.VerifyCredentialsResponse2d\n" +
@@ -3329,7 +4169,16 @@ const file_api_web_v1_web_proto_rawDesc = "" +
 	"\rListShopItems\x12\x1d.web.v1.ListStoreItemsRequest\x1a\x1e.web.v1.ListStoreItemsResponse\x12C\n" +
 	"\n" +
 	"GetBalance\x12\x19.web.v1.GetBalanceRequest\x1a\x1a.web.v1.GetBalanceResponse\x12.\n" +
-	"\x03Buy\x12\x12.web.v1.BuyRequest\x1a\x13.web.v1.BuyResponseB3Z1github.com/jeanluca/w2pp-openwyd/api/web/v1;webv1b\x06proto3"
+	"\x03Buy\x12\x12.web.v1.BuyRequest\x1a\x13.web.v1.BuyResponse2\xda\x02\n" +
+	"\x17DailyRewardAdminService\x12R\n" +
+	"\x0fListRewardItems\x12\x1e.web.v1.ListRewardItemsRequest\x1a\x1f.web.v1.ListRewardItemsResponse\x12U\n" +
+	"\x10UpsertRewardItem\x12\x1f.web.v1.UpsertRewardItemRequest\x1a .web.v1.UpsertRewardItemResponse\x12M\n" +
+	"\x14SetRewardItemEnabled\x12#.web.v1.SetRewardItemEnabledRequest\x1a\x10.web.v1.AdminAck\x12E\n" +
+	"\x10DeleteRewardItem\x12\x1f.web.v1.DeleteRewardItemRequest\x1a\x10.web.v1.AdminAck2\xe3\x01\n" +
+	"\x12DailyRewardService\x12F\n" +
+	"\vListRewards\x12\x1a.web.v1.ListRewardsRequest\x1a\x1b.web.v1.ListRewardsResponse\x12O\n" +
+	"\x0eGetClaimStatus\x12\x1d.web.v1.GetClaimStatusRequest\x1a\x1e.web.v1.GetClaimStatusResponse\x124\n" +
+	"\x05Claim\x12\x14.web.v1.ClaimRequest\x1a\x15.web.v1.ClaimResponseB3Z1github.com/jeanluca/w2pp-openwyd/api/web/v1;webv1b\x06proto3"
 
 var (
 	file_api_web_v1_web_proto_rawDescOnce sync.Once
@@ -3343,134 +4192,168 @@ func file_api_web_v1_web_proto_rawDescGZIP() []byte {
 	return file_api_web_v1_web_proto_rawDescData
 }
 
-var file_api_web_v1_web_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_api_web_v1_web_proto_msgTypes = make([]protoimpl.MessageInfo, 47)
+var file_api_web_v1_web_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_api_web_v1_web_proto_msgTypes = make([]protoimpl.MessageInfo, 60)
 var file_api_web_v1_web_proto_goTypes = []any{
 	(CreateResult)(0),                     // 0: web.v1.CreateResult
 	(AdminResult)(0),                      // 1: web.v1.AdminResult
 	(BuyResult)(0),                        // 2: web.v1.BuyResult
-	(*CreateAccountRequest)(nil),          // 3: web.v1.CreateAccountRequest
-	(*CreateAccountResponse)(nil),         // 4: web.v1.CreateAccountResponse
-	(*VerifyCredentialsRequest)(nil),      // 5: web.v1.VerifyCredentialsRequest
-	(*VerifyCredentialsResponse)(nil),     // 6: web.v1.VerifyCredentialsResponse
-	(*ListExpRankingRequest)(nil),         // 7: web.v1.ListExpRankingRequest
-	(*RankingEntry)(nil),                  // 8: web.v1.RankingEntry
-	(*ListExpRankingResponse)(nil),        // 9: web.v1.ListExpRankingResponse
-	(*ListMyCharactersRequest)(nil),       // 10: web.v1.ListMyCharactersRequest
-	(*WebCharacterSummary)(nil),           // 11: web.v1.WebCharacterSummary
-	(*ListMyCharactersResponse)(nil),      // 12: web.v1.ListMyCharactersResponse
-	(*AdminAck)(nil),                      // 13: web.v1.AdminAck
-	(*AdminNpcShopItem)(nil),              // 14: web.v1.AdminNpcShopItem
-	(*AdminNpc)(nil),                      // 15: web.v1.AdminNpc
-	(*ListNpcsRequest)(nil),               // 16: web.v1.ListNpcsRequest
-	(*ListNpcsResponse)(nil),              // 17: web.v1.ListNpcsResponse
-	(*GetNpcRequest)(nil),                 // 18: web.v1.GetNpcRequest
-	(*GetNpcResponse)(nil),                // 19: web.v1.GetNpcResponse
-	(*UpsertNpcRequest)(nil),              // 20: web.v1.UpsertNpcRequest
-	(*UpsertNpcResponse)(nil),             // 21: web.v1.UpsertNpcResponse
-	(*SetNpcVisibilityRequest)(nil),       // 22: web.v1.SetNpcVisibilityRequest
-	(*SetNpcShopRequest)(nil),             // 23: web.v1.SetNpcShopRequest
-	(*SetItemPriceRequest)(nil),           // 24: web.v1.SetItemPriceRequest
-	(*DeleteNpcRequest)(nil),              // 25: web.v1.DeleteNpcRequest
-	(*MerchantTemplate)(nil),              // 26: web.v1.MerchantTemplate
-	(*ListMerchantTemplatesRequest)(nil),  // 27: web.v1.ListMerchantTemplatesRequest
-	(*ListMerchantTemplatesResponse)(nil), // 28: web.v1.ListMerchantTemplatesResponse
-	(*ItemCatalogEntry)(nil),              // 29: web.v1.ItemCatalogEntry
-	(*ListItemCatalogRequest)(nil),        // 30: web.v1.ListItemCatalogRequest
-	(*ListItemCatalogResponse)(nil),       // 31: web.v1.ListItemCatalogResponse
-	(*MapZone)(nil),                       // 32: web.v1.MapZone
-	(*ListMapZonesRequest)(nil),           // 33: web.v1.ListMapZonesRequest
-	(*ListMapZonesResponse)(nil),          // 34: web.v1.ListMapZonesResponse
-	(*DonateShopItem)(nil),                // 35: web.v1.DonateShopItem
-	(*ListShopItemsRequest)(nil),          // 36: web.v1.ListShopItemsRequest
-	(*ListShopItemsResponse)(nil),         // 37: web.v1.ListShopItemsResponse
-	(*UpsertShopItemRequest)(nil),         // 38: web.v1.UpsertShopItemRequest
-	(*UpsertShopItemResponse)(nil),        // 39: web.v1.UpsertShopItemResponse
-	(*SetShopItemEnabledRequest)(nil),     // 40: web.v1.SetShopItemEnabledRequest
-	(*DeleteShopItemRequest)(nil),         // 41: web.v1.DeleteShopItemRequest
-	(*CreditDonateBalanceRequest)(nil),    // 42: web.v1.CreditDonateBalanceRequest
-	(*CreditDonateBalanceResponse)(nil),   // 43: web.v1.CreditDonateBalanceResponse
-	(*ListStoreItemsRequest)(nil),         // 44: web.v1.ListStoreItemsRequest
-	(*ListStoreItemsResponse)(nil),        // 45: web.v1.ListStoreItemsResponse
-	(*GetBalanceRequest)(nil),             // 46: web.v1.GetBalanceRequest
-	(*GetBalanceResponse)(nil),            // 47: web.v1.GetBalanceResponse
-	(*BuyRequest)(nil),                    // 48: web.v1.BuyRequest
-	(*BuyResponse)(nil),                   // 49: web.v1.BuyResponse
+	(ClaimResult)(0),                      // 3: web.v1.ClaimResult
+	(*CreateAccountRequest)(nil),          // 4: web.v1.CreateAccountRequest
+	(*CreateAccountResponse)(nil),         // 5: web.v1.CreateAccountResponse
+	(*VerifyCredentialsRequest)(nil),      // 6: web.v1.VerifyCredentialsRequest
+	(*VerifyCredentialsResponse)(nil),     // 7: web.v1.VerifyCredentialsResponse
+	(*ListExpRankingRequest)(nil),         // 8: web.v1.ListExpRankingRequest
+	(*RankingEntry)(nil),                  // 9: web.v1.RankingEntry
+	(*ListExpRankingResponse)(nil),        // 10: web.v1.ListExpRankingResponse
+	(*ListMyCharactersRequest)(nil),       // 11: web.v1.ListMyCharactersRequest
+	(*WebCharacterSummary)(nil),           // 12: web.v1.WebCharacterSummary
+	(*ListMyCharactersResponse)(nil),      // 13: web.v1.ListMyCharactersResponse
+	(*AdminAck)(nil),                      // 14: web.v1.AdminAck
+	(*AdminNpcShopItem)(nil),              // 15: web.v1.AdminNpcShopItem
+	(*AdminNpc)(nil),                      // 16: web.v1.AdminNpc
+	(*ListNpcsRequest)(nil),               // 17: web.v1.ListNpcsRequest
+	(*ListNpcsResponse)(nil),              // 18: web.v1.ListNpcsResponse
+	(*GetNpcRequest)(nil),                 // 19: web.v1.GetNpcRequest
+	(*GetNpcResponse)(nil),                // 20: web.v1.GetNpcResponse
+	(*UpsertNpcRequest)(nil),              // 21: web.v1.UpsertNpcRequest
+	(*UpsertNpcResponse)(nil),             // 22: web.v1.UpsertNpcResponse
+	(*SetNpcVisibilityRequest)(nil),       // 23: web.v1.SetNpcVisibilityRequest
+	(*SetNpcShopRequest)(nil),             // 24: web.v1.SetNpcShopRequest
+	(*SetItemPriceRequest)(nil),           // 25: web.v1.SetItemPriceRequest
+	(*DeleteNpcRequest)(nil),              // 26: web.v1.DeleteNpcRequest
+	(*MerchantTemplate)(nil),              // 27: web.v1.MerchantTemplate
+	(*ListMerchantTemplatesRequest)(nil),  // 28: web.v1.ListMerchantTemplatesRequest
+	(*ListMerchantTemplatesResponse)(nil), // 29: web.v1.ListMerchantTemplatesResponse
+	(*ItemCatalogEntry)(nil),              // 30: web.v1.ItemCatalogEntry
+	(*ListItemCatalogRequest)(nil),        // 31: web.v1.ListItemCatalogRequest
+	(*ListItemCatalogResponse)(nil),       // 32: web.v1.ListItemCatalogResponse
+	(*MapZone)(nil),                       // 33: web.v1.MapZone
+	(*ListMapZonesRequest)(nil),           // 34: web.v1.ListMapZonesRequest
+	(*ListMapZonesResponse)(nil),          // 35: web.v1.ListMapZonesResponse
+	(*DonateShopItem)(nil),                // 36: web.v1.DonateShopItem
+	(*ListShopItemsRequest)(nil),          // 37: web.v1.ListShopItemsRequest
+	(*ListShopItemsResponse)(nil),         // 38: web.v1.ListShopItemsResponse
+	(*UpsertShopItemRequest)(nil),         // 39: web.v1.UpsertShopItemRequest
+	(*UpsertShopItemResponse)(nil),        // 40: web.v1.UpsertShopItemResponse
+	(*SetShopItemEnabledRequest)(nil),     // 41: web.v1.SetShopItemEnabledRequest
+	(*DeleteShopItemRequest)(nil),         // 42: web.v1.DeleteShopItemRequest
+	(*CreditDonateBalanceRequest)(nil),    // 43: web.v1.CreditDonateBalanceRequest
+	(*CreditDonateBalanceResponse)(nil),   // 44: web.v1.CreditDonateBalanceResponse
+	(*ListStoreItemsRequest)(nil),         // 45: web.v1.ListStoreItemsRequest
+	(*ListStoreItemsResponse)(nil),        // 46: web.v1.ListStoreItemsResponse
+	(*GetBalanceRequest)(nil),             // 47: web.v1.GetBalanceRequest
+	(*GetBalanceResponse)(nil),            // 48: web.v1.GetBalanceResponse
+	(*BuyRequest)(nil),                    // 49: web.v1.BuyRequest
+	(*BuyResponse)(nil),                   // 50: web.v1.BuyResponse
+	(*DailyRewardItem)(nil),               // 51: web.v1.DailyRewardItem
+	(*ListRewardItemsRequest)(nil),        // 52: web.v1.ListRewardItemsRequest
+	(*ListRewardItemsResponse)(nil),       // 53: web.v1.ListRewardItemsResponse
+	(*UpsertRewardItemRequest)(nil),       // 54: web.v1.UpsertRewardItemRequest
+	(*UpsertRewardItemResponse)(nil),      // 55: web.v1.UpsertRewardItemResponse
+	(*SetRewardItemEnabledRequest)(nil),   // 56: web.v1.SetRewardItemEnabledRequest
+	(*DeleteRewardItemRequest)(nil),       // 57: web.v1.DeleteRewardItemRequest
+	(*ListRewardsRequest)(nil),            // 58: web.v1.ListRewardsRequest
+	(*ListRewardsResponse)(nil),           // 59: web.v1.ListRewardsResponse
+	(*GetClaimStatusRequest)(nil),         // 60: web.v1.GetClaimStatusRequest
+	(*GetClaimStatusResponse)(nil),        // 61: web.v1.GetClaimStatusResponse
+	(*ClaimRequest)(nil),                  // 62: web.v1.ClaimRequest
+	(*ClaimResponse)(nil),                 // 63: web.v1.ClaimResponse
 }
 var file_api_web_v1_web_proto_depIdxs = []int32{
 	0,  // 0: web.v1.CreateAccountResponse.result:type_name -> web.v1.CreateResult
-	8,  // 1: web.v1.ListExpRankingResponse.entries:type_name -> web.v1.RankingEntry
-	11, // 2: web.v1.ListMyCharactersResponse.characters:type_name -> web.v1.WebCharacterSummary
+	9,  // 1: web.v1.ListExpRankingResponse.entries:type_name -> web.v1.RankingEntry
+	12, // 2: web.v1.ListMyCharactersResponse.characters:type_name -> web.v1.WebCharacterSummary
 	1,  // 3: web.v1.AdminAck.result:type_name -> web.v1.AdminResult
-	14, // 4: web.v1.AdminNpc.shop:type_name -> web.v1.AdminNpcShopItem
+	15, // 4: web.v1.AdminNpc.shop:type_name -> web.v1.AdminNpcShopItem
 	1,  // 5: web.v1.ListNpcsResponse.result:type_name -> web.v1.AdminResult
-	15, // 6: web.v1.ListNpcsResponse.npcs:type_name -> web.v1.AdminNpc
+	16, // 6: web.v1.ListNpcsResponse.npcs:type_name -> web.v1.AdminNpc
 	1,  // 7: web.v1.GetNpcResponse.result:type_name -> web.v1.AdminResult
-	15, // 8: web.v1.GetNpcResponse.npc:type_name -> web.v1.AdminNpc
+	16, // 8: web.v1.GetNpcResponse.npc:type_name -> web.v1.AdminNpc
 	1,  // 9: web.v1.UpsertNpcResponse.result:type_name -> web.v1.AdminResult
-	14, // 10: web.v1.SetNpcShopRequest.items:type_name -> web.v1.AdminNpcShopItem
+	15, // 10: web.v1.SetNpcShopRequest.items:type_name -> web.v1.AdminNpcShopItem
 	1,  // 11: web.v1.ListMerchantTemplatesResponse.result:type_name -> web.v1.AdminResult
-	26, // 12: web.v1.ListMerchantTemplatesResponse.templates:type_name -> web.v1.MerchantTemplate
+	27, // 12: web.v1.ListMerchantTemplatesResponse.templates:type_name -> web.v1.MerchantTemplate
 	1,  // 13: web.v1.ListItemCatalogResponse.result:type_name -> web.v1.AdminResult
-	29, // 14: web.v1.ListItemCatalogResponse.items:type_name -> web.v1.ItemCatalogEntry
+	30, // 14: web.v1.ListItemCatalogResponse.items:type_name -> web.v1.ItemCatalogEntry
 	1,  // 15: web.v1.ListMapZonesResponse.result:type_name -> web.v1.AdminResult
-	32, // 16: web.v1.ListMapZonesResponse.zones:type_name -> web.v1.MapZone
+	33, // 16: web.v1.ListMapZonesResponse.zones:type_name -> web.v1.MapZone
 	1,  // 17: web.v1.ListShopItemsResponse.result:type_name -> web.v1.AdminResult
-	35, // 18: web.v1.ListShopItemsResponse.items:type_name -> web.v1.DonateShopItem
-	35, // 19: web.v1.UpsertShopItemRequest.item:type_name -> web.v1.DonateShopItem
+	36, // 18: web.v1.ListShopItemsResponse.items:type_name -> web.v1.DonateShopItem
+	36, // 19: web.v1.UpsertShopItemRequest.item:type_name -> web.v1.DonateShopItem
 	1,  // 20: web.v1.UpsertShopItemResponse.result:type_name -> web.v1.AdminResult
 	1,  // 21: web.v1.CreditDonateBalanceResponse.result:type_name -> web.v1.AdminResult
-	35, // 22: web.v1.ListStoreItemsResponse.items:type_name -> web.v1.DonateShopItem
+	36, // 22: web.v1.ListStoreItemsResponse.items:type_name -> web.v1.DonateShopItem
 	2,  // 23: web.v1.BuyResponse.result:type_name -> web.v1.BuyResult
-	3,  // 24: web.v1.AccountWebService.CreateAccount:input_type -> web.v1.CreateAccountRequest
-	5,  // 25: web.v1.AccountWebService.VerifyCredentials:input_type -> web.v1.VerifyCredentialsRequest
-	7,  // 26: web.v1.RankingWebService.ListExpRanking:input_type -> web.v1.ListExpRankingRequest
-	10, // 27: web.v1.CharacterWebService.ListMyCharacters:input_type -> web.v1.ListMyCharactersRequest
-	16, // 28: web.v1.NpcAdminService.ListNpcs:input_type -> web.v1.ListNpcsRequest
-	18, // 29: web.v1.NpcAdminService.GetNpc:input_type -> web.v1.GetNpcRequest
-	20, // 30: web.v1.NpcAdminService.UpsertNpc:input_type -> web.v1.UpsertNpcRequest
-	22, // 31: web.v1.NpcAdminService.SetNpcVisibility:input_type -> web.v1.SetNpcVisibilityRequest
-	23, // 32: web.v1.NpcAdminService.SetNpcShop:input_type -> web.v1.SetNpcShopRequest
-	24, // 33: web.v1.NpcAdminService.SetItemPrice:input_type -> web.v1.SetItemPriceRequest
-	25, // 34: web.v1.NpcAdminService.DeleteNpc:input_type -> web.v1.DeleteNpcRequest
-	27, // 35: web.v1.NpcAdminService.ListMerchantTemplates:input_type -> web.v1.ListMerchantTemplatesRequest
-	30, // 36: web.v1.NpcAdminService.ListItemCatalog:input_type -> web.v1.ListItemCatalogRequest
-	33, // 37: web.v1.NpcAdminService.ListMapZones:input_type -> web.v1.ListMapZonesRequest
-	36, // 38: web.v1.DonateAdminService.ListShopItems:input_type -> web.v1.ListShopItemsRequest
-	38, // 39: web.v1.DonateAdminService.UpsertShopItem:input_type -> web.v1.UpsertShopItemRequest
-	40, // 40: web.v1.DonateAdminService.SetShopItemEnabled:input_type -> web.v1.SetShopItemEnabledRequest
-	41, // 41: web.v1.DonateAdminService.DeleteShopItem:input_type -> web.v1.DeleteShopItemRequest
-	42, // 42: web.v1.DonateAdminService.CreditDonateBalance:input_type -> web.v1.CreditDonateBalanceRequest
-	44, // 43: web.v1.DonateShopService.ListShopItems:input_type -> web.v1.ListStoreItemsRequest
-	46, // 44: web.v1.DonateShopService.GetBalance:input_type -> web.v1.GetBalanceRequest
-	48, // 45: web.v1.DonateShopService.Buy:input_type -> web.v1.BuyRequest
-	4,  // 46: web.v1.AccountWebService.CreateAccount:output_type -> web.v1.CreateAccountResponse
-	6,  // 47: web.v1.AccountWebService.VerifyCredentials:output_type -> web.v1.VerifyCredentialsResponse
-	9,  // 48: web.v1.RankingWebService.ListExpRanking:output_type -> web.v1.ListExpRankingResponse
-	12, // 49: web.v1.CharacterWebService.ListMyCharacters:output_type -> web.v1.ListMyCharactersResponse
-	17, // 50: web.v1.NpcAdminService.ListNpcs:output_type -> web.v1.ListNpcsResponse
-	19, // 51: web.v1.NpcAdminService.GetNpc:output_type -> web.v1.GetNpcResponse
-	21, // 52: web.v1.NpcAdminService.UpsertNpc:output_type -> web.v1.UpsertNpcResponse
-	13, // 53: web.v1.NpcAdminService.SetNpcVisibility:output_type -> web.v1.AdminAck
-	13, // 54: web.v1.NpcAdminService.SetNpcShop:output_type -> web.v1.AdminAck
-	13, // 55: web.v1.NpcAdminService.SetItemPrice:output_type -> web.v1.AdminAck
-	13, // 56: web.v1.NpcAdminService.DeleteNpc:output_type -> web.v1.AdminAck
-	28, // 57: web.v1.NpcAdminService.ListMerchantTemplates:output_type -> web.v1.ListMerchantTemplatesResponse
-	31, // 58: web.v1.NpcAdminService.ListItemCatalog:output_type -> web.v1.ListItemCatalogResponse
-	34, // 59: web.v1.NpcAdminService.ListMapZones:output_type -> web.v1.ListMapZonesResponse
-	37, // 60: web.v1.DonateAdminService.ListShopItems:output_type -> web.v1.ListShopItemsResponse
-	39, // 61: web.v1.DonateAdminService.UpsertShopItem:output_type -> web.v1.UpsertShopItemResponse
-	13, // 62: web.v1.DonateAdminService.SetShopItemEnabled:output_type -> web.v1.AdminAck
-	13, // 63: web.v1.DonateAdminService.DeleteShopItem:output_type -> web.v1.AdminAck
-	43, // 64: web.v1.DonateAdminService.CreditDonateBalance:output_type -> web.v1.CreditDonateBalanceResponse
-	45, // 65: web.v1.DonateShopService.ListShopItems:output_type -> web.v1.ListStoreItemsResponse
-	47, // 66: web.v1.DonateShopService.GetBalance:output_type -> web.v1.GetBalanceResponse
-	49, // 67: web.v1.DonateShopService.Buy:output_type -> web.v1.BuyResponse
-	46, // [46:68] is the sub-list for method output_type
-	24, // [24:46] is the sub-list for method input_type
-	24, // [24:24] is the sub-list for extension type_name
-	24, // [24:24] is the sub-list for extension extendee
-	0,  // [0:24] is the sub-list for field type_name
+	1,  // 24: web.v1.ListRewardItemsResponse.result:type_name -> web.v1.AdminResult
+	51, // 25: web.v1.ListRewardItemsResponse.items:type_name -> web.v1.DailyRewardItem
+	51, // 26: web.v1.UpsertRewardItemRequest.item:type_name -> web.v1.DailyRewardItem
+	1,  // 27: web.v1.UpsertRewardItemResponse.result:type_name -> web.v1.AdminResult
+	51, // 28: web.v1.ListRewardsResponse.items:type_name -> web.v1.DailyRewardItem
+	3,  // 29: web.v1.ClaimResponse.result:type_name -> web.v1.ClaimResult
+	4,  // 30: web.v1.AccountWebService.CreateAccount:input_type -> web.v1.CreateAccountRequest
+	6,  // 31: web.v1.AccountWebService.VerifyCredentials:input_type -> web.v1.VerifyCredentialsRequest
+	8,  // 32: web.v1.RankingWebService.ListExpRanking:input_type -> web.v1.ListExpRankingRequest
+	11, // 33: web.v1.CharacterWebService.ListMyCharacters:input_type -> web.v1.ListMyCharactersRequest
+	17, // 34: web.v1.NpcAdminService.ListNpcs:input_type -> web.v1.ListNpcsRequest
+	19, // 35: web.v1.NpcAdminService.GetNpc:input_type -> web.v1.GetNpcRequest
+	21, // 36: web.v1.NpcAdminService.UpsertNpc:input_type -> web.v1.UpsertNpcRequest
+	23, // 37: web.v1.NpcAdminService.SetNpcVisibility:input_type -> web.v1.SetNpcVisibilityRequest
+	24, // 38: web.v1.NpcAdminService.SetNpcShop:input_type -> web.v1.SetNpcShopRequest
+	25, // 39: web.v1.NpcAdminService.SetItemPrice:input_type -> web.v1.SetItemPriceRequest
+	26, // 40: web.v1.NpcAdminService.DeleteNpc:input_type -> web.v1.DeleteNpcRequest
+	28, // 41: web.v1.NpcAdminService.ListMerchantTemplates:input_type -> web.v1.ListMerchantTemplatesRequest
+	31, // 42: web.v1.NpcAdminService.ListItemCatalog:input_type -> web.v1.ListItemCatalogRequest
+	34, // 43: web.v1.NpcAdminService.ListMapZones:input_type -> web.v1.ListMapZonesRequest
+	37, // 44: web.v1.DonateAdminService.ListShopItems:input_type -> web.v1.ListShopItemsRequest
+	39, // 45: web.v1.DonateAdminService.UpsertShopItem:input_type -> web.v1.UpsertShopItemRequest
+	41, // 46: web.v1.DonateAdminService.SetShopItemEnabled:input_type -> web.v1.SetShopItemEnabledRequest
+	42, // 47: web.v1.DonateAdminService.DeleteShopItem:input_type -> web.v1.DeleteShopItemRequest
+	43, // 48: web.v1.DonateAdminService.CreditDonateBalance:input_type -> web.v1.CreditDonateBalanceRequest
+	45, // 49: web.v1.DonateShopService.ListShopItems:input_type -> web.v1.ListStoreItemsRequest
+	47, // 50: web.v1.DonateShopService.GetBalance:input_type -> web.v1.GetBalanceRequest
+	49, // 51: web.v1.DonateShopService.Buy:input_type -> web.v1.BuyRequest
+	52, // 52: web.v1.DailyRewardAdminService.ListRewardItems:input_type -> web.v1.ListRewardItemsRequest
+	54, // 53: web.v1.DailyRewardAdminService.UpsertRewardItem:input_type -> web.v1.UpsertRewardItemRequest
+	56, // 54: web.v1.DailyRewardAdminService.SetRewardItemEnabled:input_type -> web.v1.SetRewardItemEnabledRequest
+	57, // 55: web.v1.DailyRewardAdminService.DeleteRewardItem:input_type -> web.v1.DeleteRewardItemRequest
+	58, // 56: web.v1.DailyRewardService.ListRewards:input_type -> web.v1.ListRewardsRequest
+	60, // 57: web.v1.DailyRewardService.GetClaimStatus:input_type -> web.v1.GetClaimStatusRequest
+	62, // 58: web.v1.DailyRewardService.Claim:input_type -> web.v1.ClaimRequest
+	5,  // 59: web.v1.AccountWebService.CreateAccount:output_type -> web.v1.CreateAccountResponse
+	7,  // 60: web.v1.AccountWebService.VerifyCredentials:output_type -> web.v1.VerifyCredentialsResponse
+	10, // 61: web.v1.RankingWebService.ListExpRanking:output_type -> web.v1.ListExpRankingResponse
+	13, // 62: web.v1.CharacterWebService.ListMyCharacters:output_type -> web.v1.ListMyCharactersResponse
+	18, // 63: web.v1.NpcAdminService.ListNpcs:output_type -> web.v1.ListNpcsResponse
+	20, // 64: web.v1.NpcAdminService.GetNpc:output_type -> web.v1.GetNpcResponse
+	22, // 65: web.v1.NpcAdminService.UpsertNpc:output_type -> web.v1.UpsertNpcResponse
+	14, // 66: web.v1.NpcAdminService.SetNpcVisibility:output_type -> web.v1.AdminAck
+	14, // 67: web.v1.NpcAdminService.SetNpcShop:output_type -> web.v1.AdminAck
+	14, // 68: web.v1.NpcAdminService.SetItemPrice:output_type -> web.v1.AdminAck
+	14, // 69: web.v1.NpcAdminService.DeleteNpc:output_type -> web.v1.AdminAck
+	29, // 70: web.v1.NpcAdminService.ListMerchantTemplates:output_type -> web.v1.ListMerchantTemplatesResponse
+	32, // 71: web.v1.NpcAdminService.ListItemCatalog:output_type -> web.v1.ListItemCatalogResponse
+	35, // 72: web.v1.NpcAdminService.ListMapZones:output_type -> web.v1.ListMapZonesResponse
+	38, // 73: web.v1.DonateAdminService.ListShopItems:output_type -> web.v1.ListShopItemsResponse
+	40, // 74: web.v1.DonateAdminService.UpsertShopItem:output_type -> web.v1.UpsertShopItemResponse
+	14, // 75: web.v1.DonateAdminService.SetShopItemEnabled:output_type -> web.v1.AdminAck
+	14, // 76: web.v1.DonateAdminService.DeleteShopItem:output_type -> web.v1.AdminAck
+	44, // 77: web.v1.DonateAdminService.CreditDonateBalance:output_type -> web.v1.CreditDonateBalanceResponse
+	46, // 78: web.v1.DonateShopService.ListShopItems:output_type -> web.v1.ListStoreItemsResponse
+	48, // 79: web.v1.DonateShopService.GetBalance:output_type -> web.v1.GetBalanceResponse
+	50, // 80: web.v1.DonateShopService.Buy:output_type -> web.v1.BuyResponse
+	53, // 81: web.v1.DailyRewardAdminService.ListRewardItems:output_type -> web.v1.ListRewardItemsResponse
+	55, // 82: web.v1.DailyRewardAdminService.UpsertRewardItem:output_type -> web.v1.UpsertRewardItemResponse
+	14, // 83: web.v1.DailyRewardAdminService.SetRewardItemEnabled:output_type -> web.v1.AdminAck
+	14, // 84: web.v1.DailyRewardAdminService.DeleteRewardItem:output_type -> web.v1.AdminAck
+	59, // 85: web.v1.DailyRewardService.ListRewards:output_type -> web.v1.ListRewardsResponse
+	61, // 86: web.v1.DailyRewardService.GetClaimStatus:output_type -> web.v1.GetClaimStatusResponse
+	63, // 87: web.v1.DailyRewardService.Claim:output_type -> web.v1.ClaimResponse
+	59, // [59:88] is the sub-list for method output_type
+	30, // [30:59] is the sub-list for method input_type
+	30, // [30:30] is the sub-list for extension type_name
+	30, // [30:30] is the sub-list for extension extendee
+	0,  // [0:30] is the sub-list for field type_name
 }
 
 func init() { file_api_web_v1_web_proto_init() }
@@ -3483,10 +4366,10 @@ func file_api_web_v1_web_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_web_v1_web_proto_rawDesc), len(file_api_web_v1_web_proto_rawDesc)),
-			NumEnums:      3,
-			NumMessages:   47,
+			NumEnums:      4,
+			NumMessages:   60,
 			NumExtensions: 0,
-			NumServices:   6,
+			NumServices:   8,
 		},
 		GoTypes:           file_api_web_v1_web_proto_goTypes,
 		DependencyIndexes: file_api_web_v1_web_proto_depIdxs,

--- a/api/web/v1/web.proto
+++ b/api/web/v1/web.proto
@@ -417,3 +417,109 @@ message BuyResponse {
   BuyResult result = 1;
   int32 new_balance = 2; // set only when result is OK
 }
+
+// DailyRewardAdminService is the moderator-facing daily-reward catalog surface
+// (issue #35): CRUD over the daily_reward_item catalog. Like DonateAdminService
+// every request carries the moderator's account_id, re-authorized server-side
+// against account.role; all writes are cold config in Postgres, never live
+// state. Unlike DonateAdminService there is no balance-credit RPC — daily
+// rewards are free.
+service DailyRewardAdminService {
+  // ListRewardItems returns every offer (enabled or not) — the moderation table.
+  rpc ListRewardItems(ListRewardItemsRequest) returns (ListRewardItemsResponse);
+  // UpsertRewardItem creates (id==0) or updates an offer.
+  rpc UpsertRewardItem(UpsertRewardItemRequest) returns (UpsertRewardItemResponse);
+  // SetRewardItemEnabled toggles whether an offer is claimable.
+  rpc SetRewardItemEnabled(SetRewardItemEnabledRequest) returns (AdminAck);
+  // DeleteRewardItem removes an offer.
+  rpc DeleteRewardItem(DeleteRewardItemRequest) returns (AdminAck);
+}
+
+// DailyRewardItem is one claimable offer: an item (index + up to three
+// effect/value pairs), free, gated only by the once-per-account-per-UTC-day
+// limit. expires_days > 0 makes the delivered item timed.
+message DailyRewardItem {
+  int64 id = 1;
+  int32 item_index = 2;
+  int32 eff1 = 3;  int32 effv1 = 4;
+  int32 eff2 = 5;  int32 effv2 = 6;
+  int32 eff3 = 7;  int32 effv3 = 8;
+  string title = 9;
+  string description = 10;
+  bool enabled = 11;
+  int32 expires_days = 12;
+}
+
+message ListRewardItemsRequest { int64 moderator_id = 1; }
+message ListRewardItemsResponse {
+  AdminResult result = 1;
+  repeated DailyRewardItem items = 2;
+}
+
+message UpsertRewardItemRequest {
+  int64 moderator_id = 1;
+  // id == 0 creates a new offer; otherwise the offer with that id is updated.
+  DailyRewardItem item = 2;
+}
+message UpsertRewardItemResponse {
+  AdminResult result = 1;
+  int64 item_id = 2;
+}
+
+message SetRewardItemEnabledRequest {
+  int64 moderator_id = 1;
+  int64 item_id = 2;
+  bool enabled = 3;
+}
+
+message DeleteRewardItemRequest {
+  int64 moderator_id = 1;
+  int64 item_id = 2;
+}
+
+// DailyRewardService is the player-facing daily reward surface the Next.js BFF
+// calls with the logged account_id from its httpOnly session (never
+// browser-supplied). A claim inserts a daily_reward_claim row for today's UTC
+// calendar day and enqueues the item into delivery_queue, which the tmServer
+// drains into the account cargo on the next login (web-platform-plan.md), the
+// same pipe DonateShopService purchases use.
+service DailyRewardService {
+  // ListRewards returns the enabled offers (the vitrine).
+  rpc ListRewards(ListRewardsRequest) returns (ListRewardsResponse);
+  // GetClaimStatus reports whether the account already claimed today.
+  rpc GetClaimStatus(GetClaimStatusRequest) returns (GetClaimStatusResponse);
+  // Claim redeems one reward offer for the account for today.
+  rpc Claim(ClaimRequest) returns (ClaimResponse);
+}
+
+// ClaimResult carries the claim outcome in the body; only infra failures
+// become gRPC errors.
+enum ClaimResult {
+  CLAIM_RESULT_UNSPECIFIED = 0;
+  CLAIM_RESULT_OK = 1;               // claim recorded + item queued for delivery
+  CLAIM_RESULT_ALREADY_CLAIMED = 2;  // account already claimed today (UTC)
+  CLAIM_RESULT_NOT_FOUND = 3;        // unknown offer or account
+  CLAIM_RESULT_DISABLED = 4;         // offer exists but is not claimable
+}
+
+message ListRewardsRequest {}
+message ListRewardsResponse {
+  repeated DailyRewardItem items = 1;
+}
+
+message GetClaimStatusRequest {
+  int64 account_id = 1; // from the BFF session, never from browser input
+}
+message GetClaimStatusResponse {
+  bool claimed_today = 1;
+  int64 claimed_item_id = 2;     // set only when claimed_today
+  string claimed_item_title = 3; // set only when claimed_today (empty if the offer was since deleted)
+}
+
+message ClaimRequest {
+  int64 account_id = 1;    // from the BFF session, never from browser input
+  int64 reward_item_id = 2;
+}
+message ClaimResponse {
+  ClaimResult result = 1;
+}

--- a/api/web/v1/web_grpc.pb.go
+++ b/api/web/v1/web_grpc.pb.go
@@ -1380,3 +1380,440 @@ var DonateShopService_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "api/web/v1/web.proto",
 }
+
+const (
+	DailyRewardAdminService_ListRewardItems_FullMethodName      = "/web.v1.DailyRewardAdminService/ListRewardItems"
+	DailyRewardAdminService_UpsertRewardItem_FullMethodName     = "/web.v1.DailyRewardAdminService/UpsertRewardItem"
+	DailyRewardAdminService_SetRewardItemEnabled_FullMethodName = "/web.v1.DailyRewardAdminService/SetRewardItemEnabled"
+	DailyRewardAdminService_DeleteRewardItem_FullMethodName     = "/web.v1.DailyRewardAdminService/DeleteRewardItem"
+)
+
+// DailyRewardAdminServiceClient is the client API for DailyRewardAdminService service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// DailyRewardAdminService is the moderator-facing daily-reward catalog surface
+// (issue #35): CRUD over the daily_reward_item catalog. Like DonateAdminService
+// every request carries the moderator's account_id, re-authorized server-side
+// against account.role; all writes are cold config in Postgres, never live
+// state. Unlike DonateAdminService there is no balance-credit RPC — daily
+// rewards are free.
+type DailyRewardAdminServiceClient interface {
+	// ListRewardItems returns every offer (enabled or not) — the moderation table.
+	ListRewardItems(ctx context.Context, in *ListRewardItemsRequest, opts ...grpc.CallOption) (*ListRewardItemsResponse, error)
+	// UpsertRewardItem creates (id==0) or updates an offer.
+	UpsertRewardItem(ctx context.Context, in *UpsertRewardItemRequest, opts ...grpc.CallOption) (*UpsertRewardItemResponse, error)
+	// SetRewardItemEnabled toggles whether an offer is claimable.
+	SetRewardItemEnabled(ctx context.Context, in *SetRewardItemEnabledRequest, opts ...grpc.CallOption) (*AdminAck, error)
+	// DeleteRewardItem removes an offer.
+	DeleteRewardItem(ctx context.Context, in *DeleteRewardItemRequest, opts ...grpc.CallOption) (*AdminAck, error)
+}
+
+type dailyRewardAdminServiceClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewDailyRewardAdminServiceClient(cc grpc.ClientConnInterface) DailyRewardAdminServiceClient {
+	return &dailyRewardAdminServiceClient{cc}
+}
+
+func (c *dailyRewardAdminServiceClient) ListRewardItems(ctx context.Context, in *ListRewardItemsRequest, opts ...grpc.CallOption) (*ListRewardItemsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListRewardItemsResponse)
+	err := c.cc.Invoke(ctx, DailyRewardAdminService_ListRewardItems_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *dailyRewardAdminServiceClient) UpsertRewardItem(ctx context.Context, in *UpsertRewardItemRequest, opts ...grpc.CallOption) (*UpsertRewardItemResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UpsertRewardItemResponse)
+	err := c.cc.Invoke(ctx, DailyRewardAdminService_UpsertRewardItem_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *dailyRewardAdminServiceClient) SetRewardItemEnabled(ctx context.Context, in *SetRewardItemEnabledRequest, opts ...grpc.CallOption) (*AdminAck, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AdminAck)
+	err := c.cc.Invoke(ctx, DailyRewardAdminService_SetRewardItemEnabled_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *dailyRewardAdminServiceClient) DeleteRewardItem(ctx context.Context, in *DeleteRewardItemRequest, opts ...grpc.CallOption) (*AdminAck, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AdminAck)
+	err := c.cc.Invoke(ctx, DailyRewardAdminService_DeleteRewardItem_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// DailyRewardAdminServiceServer is the server API for DailyRewardAdminService service.
+// All implementations must embed UnimplementedDailyRewardAdminServiceServer
+// for forward compatibility.
+//
+// DailyRewardAdminService is the moderator-facing daily-reward catalog surface
+// (issue #35): CRUD over the daily_reward_item catalog. Like DonateAdminService
+// every request carries the moderator's account_id, re-authorized server-side
+// against account.role; all writes are cold config in Postgres, never live
+// state. Unlike DonateAdminService there is no balance-credit RPC — daily
+// rewards are free.
+type DailyRewardAdminServiceServer interface {
+	// ListRewardItems returns every offer (enabled or not) — the moderation table.
+	ListRewardItems(context.Context, *ListRewardItemsRequest) (*ListRewardItemsResponse, error)
+	// UpsertRewardItem creates (id==0) or updates an offer.
+	UpsertRewardItem(context.Context, *UpsertRewardItemRequest) (*UpsertRewardItemResponse, error)
+	// SetRewardItemEnabled toggles whether an offer is claimable.
+	SetRewardItemEnabled(context.Context, *SetRewardItemEnabledRequest) (*AdminAck, error)
+	// DeleteRewardItem removes an offer.
+	DeleteRewardItem(context.Context, *DeleteRewardItemRequest) (*AdminAck, error)
+	mustEmbedUnimplementedDailyRewardAdminServiceServer()
+}
+
+// UnimplementedDailyRewardAdminServiceServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedDailyRewardAdminServiceServer struct{}
+
+func (UnimplementedDailyRewardAdminServiceServer) ListRewardItems(context.Context, *ListRewardItemsRequest) (*ListRewardItemsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListRewardItems not implemented")
+}
+func (UnimplementedDailyRewardAdminServiceServer) UpsertRewardItem(context.Context, *UpsertRewardItemRequest) (*UpsertRewardItemResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method UpsertRewardItem not implemented")
+}
+func (UnimplementedDailyRewardAdminServiceServer) SetRewardItemEnabled(context.Context, *SetRewardItemEnabledRequest) (*AdminAck, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetRewardItemEnabled not implemented")
+}
+func (UnimplementedDailyRewardAdminServiceServer) DeleteRewardItem(context.Context, *DeleteRewardItemRequest) (*AdminAck, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteRewardItem not implemented")
+}
+func (UnimplementedDailyRewardAdminServiceServer) mustEmbedUnimplementedDailyRewardAdminServiceServer() {
+}
+func (UnimplementedDailyRewardAdminServiceServer) testEmbeddedByValue() {}
+
+// UnsafeDailyRewardAdminServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to DailyRewardAdminServiceServer will
+// result in compilation errors.
+type UnsafeDailyRewardAdminServiceServer interface {
+	mustEmbedUnimplementedDailyRewardAdminServiceServer()
+}
+
+func RegisterDailyRewardAdminServiceServer(s grpc.ServiceRegistrar, srv DailyRewardAdminServiceServer) {
+	// If the following call panics, it indicates UnimplementedDailyRewardAdminServiceServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&DailyRewardAdminService_ServiceDesc, srv)
+}
+
+func _DailyRewardAdminService_ListRewardItems_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListRewardItemsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DailyRewardAdminServiceServer).ListRewardItems(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DailyRewardAdminService_ListRewardItems_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DailyRewardAdminServiceServer).ListRewardItems(ctx, req.(*ListRewardItemsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DailyRewardAdminService_UpsertRewardItem_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpsertRewardItemRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DailyRewardAdminServiceServer).UpsertRewardItem(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DailyRewardAdminService_UpsertRewardItem_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DailyRewardAdminServiceServer).UpsertRewardItem(ctx, req.(*UpsertRewardItemRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DailyRewardAdminService_SetRewardItemEnabled_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetRewardItemEnabledRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DailyRewardAdminServiceServer).SetRewardItemEnabled(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DailyRewardAdminService_SetRewardItemEnabled_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DailyRewardAdminServiceServer).SetRewardItemEnabled(ctx, req.(*SetRewardItemEnabledRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DailyRewardAdminService_DeleteRewardItem_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteRewardItemRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DailyRewardAdminServiceServer).DeleteRewardItem(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DailyRewardAdminService_DeleteRewardItem_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DailyRewardAdminServiceServer).DeleteRewardItem(ctx, req.(*DeleteRewardItemRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// DailyRewardAdminService_ServiceDesc is the grpc.ServiceDesc for DailyRewardAdminService service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var DailyRewardAdminService_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "web.v1.DailyRewardAdminService",
+	HandlerType: (*DailyRewardAdminServiceServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "ListRewardItems",
+			Handler:    _DailyRewardAdminService_ListRewardItems_Handler,
+		},
+		{
+			MethodName: "UpsertRewardItem",
+			Handler:    _DailyRewardAdminService_UpsertRewardItem_Handler,
+		},
+		{
+			MethodName: "SetRewardItemEnabled",
+			Handler:    _DailyRewardAdminService_SetRewardItemEnabled_Handler,
+		},
+		{
+			MethodName: "DeleteRewardItem",
+			Handler:    _DailyRewardAdminService_DeleteRewardItem_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "api/web/v1/web.proto",
+}
+
+const (
+	DailyRewardService_ListRewards_FullMethodName    = "/web.v1.DailyRewardService/ListRewards"
+	DailyRewardService_GetClaimStatus_FullMethodName = "/web.v1.DailyRewardService/GetClaimStatus"
+	DailyRewardService_Claim_FullMethodName          = "/web.v1.DailyRewardService/Claim"
+)
+
+// DailyRewardServiceClient is the client API for DailyRewardService service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// DailyRewardService is the player-facing daily reward surface the Next.js BFF
+// calls with the logged account_id from its httpOnly session (never
+// browser-supplied). A claim inserts a daily_reward_claim row for today's UTC
+// calendar day and enqueues the item into delivery_queue, which the tmServer
+// drains into the account cargo on the next login (web-platform-plan.md), the
+// same pipe DonateShopService purchases use.
+type DailyRewardServiceClient interface {
+	// ListRewards returns the enabled offers (the vitrine).
+	ListRewards(ctx context.Context, in *ListRewardsRequest, opts ...grpc.CallOption) (*ListRewardsResponse, error)
+	// GetClaimStatus reports whether the account already claimed today.
+	GetClaimStatus(ctx context.Context, in *GetClaimStatusRequest, opts ...grpc.CallOption) (*GetClaimStatusResponse, error)
+	// Claim redeems one reward offer for the account for today.
+	Claim(ctx context.Context, in *ClaimRequest, opts ...grpc.CallOption) (*ClaimResponse, error)
+}
+
+type dailyRewardServiceClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewDailyRewardServiceClient(cc grpc.ClientConnInterface) DailyRewardServiceClient {
+	return &dailyRewardServiceClient{cc}
+}
+
+func (c *dailyRewardServiceClient) ListRewards(ctx context.Context, in *ListRewardsRequest, opts ...grpc.CallOption) (*ListRewardsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListRewardsResponse)
+	err := c.cc.Invoke(ctx, DailyRewardService_ListRewards_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *dailyRewardServiceClient) GetClaimStatus(ctx context.Context, in *GetClaimStatusRequest, opts ...grpc.CallOption) (*GetClaimStatusResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetClaimStatusResponse)
+	err := c.cc.Invoke(ctx, DailyRewardService_GetClaimStatus_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *dailyRewardServiceClient) Claim(ctx context.Context, in *ClaimRequest, opts ...grpc.CallOption) (*ClaimResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ClaimResponse)
+	err := c.cc.Invoke(ctx, DailyRewardService_Claim_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// DailyRewardServiceServer is the server API for DailyRewardService service.
+// All implementations must embed UnimplementedDailyRewardServiceServer
+// for forward compatibility.
+//
+// DailyRewardService is the player-facing daily reward surface the Next.js BFF
+// calls with the logged account_id from its httpOnly session (never
+// browser-supplied). A claim inserts a daily_reward_claim row for today's UTC
+// calendar day and enqueues the item into delivery_queue, which the tmServer
+// drains into the account cargo on the next login (web-platform-plan.md), the
+// same pipe DonateShopService purchases use.
+type DailyRewardServiceServer interface {
+	// ListRewards returns the enabled offers (the vitrine).
+	ListRewards(context.Context, *ListRewardsRequest) (*ListRewardsResponse, error)
+	// GetClaimStatus reports whether the account already claimed today.
+	GetClaimStatus(context.Context, *GetClaimStatusRequest) (*GetClaimStatusResponse, error)
+	// Claim redeems one reward offer for the account for today.
+	Claim(context.Context, *ClaimRequest) (*ClaimResponse, error)
+	mustEmbedUnimplementedDailyRewardServiceServer()
+}
+
+// UnimplementedDailyRewardServiceServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedDailyRewardServiceServer struct{}
+
+func (UnimplementedDailyRewardServiceServer) ListRewards(context.Context, *ListRewardsRequest) (*ListRewardsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListRewards not implemented")
+}
+func (UnimplementedDailyRewardServiceServer) GetClaimStatus(context.Context, *GetClaimStatusRequest) (*GetClaimStatusResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetClaimStatus not implemented")
+}
+func (UnimplementedDailyRewardServiceServer) Claim(context.Context, *ClaimRequest) (*ClaimResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Claim not implemented")
+}
+func (UnimplementedDailyRewardServiceServer) mustEmbedUnimplementedDailyRewardServiceServer() {}
+func (UnimplementedDailyRewardServiceServer) testEmbeddedByValue()                            {}
+
+// UnsafeDailyRewardServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to DailyRewardServiceServer will
+// result in compilation errors.
+type UnsafeDailyRewardServiceServer interface {
+	mustEmbedUnimplementedDailyRewardServiceServer()
+}
+
+func RegisterDailyRewardServiceServer(s grpc.ServiceRegistrar, srv DailyRewardServiceServer) {
+	// If the following call panics, it indicates UnimplementedDailyRewardServiceServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&DailyRewardService_ServiceDesc, srv)
+}
+
+func _DailyRewardService_ListRewards_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListRewardsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DailyRewardServiceServer).ListRewards(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DailyRewardService_ListRewards_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DailyRewardServiceServer).ListRewards(ctx, req.(*ListRewardsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DailyRewardService_GetClaimStatus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetClaimStatusRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DailyRewardServiceServer).GetClaimStatus(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DailyRewardService_GetClaimStatus_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DailyRewardServiceServer).GetClaimStatus(ctx, req.(*GetClaimStatusRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DailyRewardService_Claim_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ClaimRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DailyRewardServiceServer).Claim(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DailyRewardService_Claim_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DailyRewardServiceServer).Claim(ctx, req.(*ClaimRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// DailyRewardService_ServiceDesc is the grpc.ServiceDesc for DailyRewardService service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var DailyRewardService_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "web.v1.DailyRewardService",
+	HandlerType: (*DailyRewardServiceServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "ListRewards",
+			Handler:    _DailyRewardService_ListRewards_Handler,
+		},
+		{
+			MethodName: "GetClaimStatus",
+			Handler:    _DailyRewardService_GetClaimStatus_Handler,
+		},
+		{
+			MethodName: "Claim",
+			Handler:    _DailyRewardService_Claim_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "api/web/v1/web.proto",
+}

--- a/docs/migration/daily-reward-frontend.md
+++ b/docs/migration/daily-reward-frontend.md
@@ -1,0 +1,201 @@
+# Recompensa Diária — Guia de Integração Front-end (issue #35)
+
+> Público: quem constrói o **BFF Next.js** (Route Handlers / Server Actions) e as telas de
+> **painel admin** (moderador) e **resgate** (jogador). Este doc descreve o contrato gRPC exposto pela
+> `web-api` (serviço Go `webserver`). Fonte da arquitetura: [`web-platform-plan.md`](./web-platform-plan.md).
+> O fluxo é irmão da [loja de donate](./donate-shop-frontend.md) (issue #34) — mesma sessão, mesmo
+> transporte, mesma semântica de entrega — só muda o preço (aqui não existe: é grátis) e o limite
+> (uma vez por dia).
+
+## 1. Como o front fala com o backend
+
+```
+Browser ──HTTPS──> Next.js (Route Handlers / Server Actions = BFF)  ──gRPC + mTLS──> web-api (:7600)
+         cookie de sessão httpOnly            (só server-side)                     └─ Postgres
+```
+
+Regras que **não** mudam (idênticas ao donate):
+
+- **O browser nunca fala gRPC** nem vê o certificado mTLS. Toda chamada sai do lado servidor do
+  Next.js (Route Handler / Server Action), com os stubs gerados de `api/web/v1/web.proto`.
+- O BFF guarda em cookie `httpOnly` de sessão o `account_id` e o `role` do usuário (obtidos no login
+  via `AccountWebService.VerifyCredentials`). **Nunca** aceite `account_id`/`moderator_id` vindos do
+  browser — use sempre o valor da sessão.
+- **Autorização é reconferida no servidor.** O `role` no cookie serve só para mostrar/esconder a UI
+  de moderador. Toda RPC de admin revalida `account.role` no backend; um cookie adulterado recebe
+  `ADMIN_RESULT_FORBIDDEN`.
+
+Endereço do serviço: `web-api` em `:7600` (flag `-addr`, mTLS via `-tls-*`). Pacote proto:
+`web.v1`. Gere os stubs a partir de `api/web/v1/web.proto`.
+
+## 2. Convenção de resultados (importante)
+
+As RPCs **não** usam códigos de erro gRPC para regras de negócio — só para falha de infra
+(indisponibilidade, timeout). O resultado de negócio vem **no corpo**, num enum:
+
+`AdminResult` (operações de moderador — reutilizado do donate, mesmo enum):
+
+| valor | quando | UI sugerida |
+|---|---|---|
+| `ADMIN_RESULT_OK` (1) | sucesso | seguir |
+| `ADMIN_RESULT_FORBIDDEN` (2) | não é moderador/admin | 403 / esconder |
+| `ADMIN_RESULT_INVALID` (3) | validação falhou (item_index ≤ 0, expires_days < 0…) | erro de formulário |
+| `ADMIN_RESULT_NOT_FOUND` (4) | alvo (oferta) não existe | 404 |
+
+`ClaimResult` (resgate do jogador):
+
+| valor | significado | UI sugerida |
+|---|---|---|
+| `CLAIM_RESULT_OK` (1) | resgate registrado + item enfileirado para entrega | sucesso; mostrar confirmação |
+| `CLAIM_RESULT_ALREADY_CLAIMED` (2) | a conta já resgatou uma recompensa hoje (UTC) | "você já resgatou sua recompensa de hoje" |
+| `CLAIM_RESULT_NOT_FOUND` (3) | oferta ou conta inexistente | 404 |
+| `CLAIM_RESULT_DISABLED` (4) | oferta existe mas não está mais disponível | recarregar vitrine |
+
+## 3. Modelo de dados: `DailyRewardItem`
+
+Uma oferta de recompensa = um item entregável, **grátis**, resgatável no máximo uma vez por conta por
+dia. Comparado ao `DonateShopItem`, não existe campo `price`.
+
+| campo | tipo | descrição |
+|---|---|---|
+| `id` | int64 | id da oferta. **0 em `UpsertRewardItem` cria**; ≠0 atualiza a oferta existente |
+| `item_index` | int32 | id do item no jogo (catálogo `ItemList.csv`). Deve ser > 0 |
+| `eff1`,`effv1`,`eff2`,`effv2`,`eff3`,`effv3` | int32 | três pares efeito/valor (encantamento/refino). 0 = sem efeito |
+| `title` | string | nome exibido na tela de resgate |
+| `description` | string | descrição/observação |
+| `enabled` | bool | `true` aparece na vitrine do jogador |
+| `expires_days` | int32 | > 0 entrega item temporário (expira em N dias); 0 = permanente |
+
+> Picker de itens: o catálogo (item_index → nome) é servido pelo `NpcAdminService.ListItemCatalog`
+> (já existente, reutilizado do donate) quando o `web-api` roda com `-content`. Reutilize-o no editor
+> da oferta em vez de pedir `item_index` cru.
+
+## 4. Serviço `DailyRewardAdminService` (painel do moderador)
+
+Todo request tem `moderator_id` como **primeiro campo** — preencha com o `account_id` da sessão do
+moderador; o backend revalida o `role`. Diferente do `DonateAdminService`, **não existe** RPC de
+crédito de saldo aqui — recompensas diárias não têm carteira, só o catálogo.
+
+### `ListRewardItems(moderator_id) → { result, DailyRewardItem[] }`
+Lista **todas** as ofertas (habilitadas ou não) — a tabela de moderação.
+
+### `UpsertRewardItem(moderator_id, DailyRewardItem item) → { result, item_id }`
+Cria (`item.id == 0`) ou atualiza (`item.id != 0`). `item_id` é o id resultante. Validação →
+`ADMIN_RESULT_INVALID`; atualizar id inexistente → `ADMIN_RESULT_NOT_FOUND`.
+
+### `SetRewardItemEnabled(moderator_id, item_id, enabled) → AdminAck`
+Liga/desliga a oferta na vitrine de resgate.
+
+### `DeleteRewardItem(moderator_id, item_id) → AdminAck`
+Remove a oferta.
+
+`AdminAck` = `{ AdminResult result }`.
+
+## 5. Serviço `DailyRewardService` (resgate do jogador)
+
+Passe o `account_id` da sessão httpOnly (nunca do browser).
+
+### `ListRewards() → { DailyRewardItem[] }`
+A **vitrine**: só ofertas `enabled = true`. Sem `moderator_id`, sem `result` (leitura pública).
+
+### `GetClaimStatus(account_id) → { claimed_today, claimed_item_id, claimed_item_title }`
+Consulta se a conta **já resgatou hoje (UTC)**. Use isto para desenhar a tela: se `claimed_today ==
+true`, desabilite o botão de resgate e mostre qual item foi resgatado (`claimed_item_title` — vazio
+se a oferta foi apagada depois do resgate).
+
+### `Claim(account_id, reward_item_id) → { ClaimResult result }`
+Resgata a oferta escolhida: registra o resgate do dia e **enfileira o item para entrega**. O jogador
+escolhe **uma** oferta entre as habilitadas; depois disso `CLAIM_RESULT_ALREADY_CLAIMED` bloqueia
+qualquer outro resgate até o próximo dia UTC, **mesmo que ele tente uma oferta diferente**. Ver
+semântica de entrega abaixo.
+
+## 6. Semântica de entrega (o que dizer ao jogador)
+
+Idêntica ao donate — mesma fila, mesmo dreno:
+
+O resgate **não** coloca o item no jogo na hora — o servidor de jogo é o único que escreve inventário.
+A `web-api` grava o resgate numa fila (`delivery_queue`); o servidor de jogo **drena a fila no próximo
+login do jogador** e coloca o item no **próximo espaço livre do armazém (cargo) da conta**.
+
+Consequências para a UI:
+
+- Após `CLAIM_RESULT_OK`, mostre algo como **"item será entregue no seu armazém no próximo login"**.
+- Se o jogador resgatar enquanto está **online**, o item chega **no próximo login** (não instantâneo —
+  MVP com dreno só no login).
+- **Se o armazém estiver cheio (128 espaços), o item é perdido** — vale avisar o jogador a manter
+  espaço livre antes de resgatar.
+- O limite diário reseta à **meia-noite UTC**, não 24h corridas desde o último resgate — deixe isso
+  claro na UI (ex.: "resgates renovam às 00:00 UTC") em vez de mostrar uma contagem regressiva de 24h.
+
+## 7. Fluxo de sessão (login web)
+
+O login web é separado do login do jogo (CPSock). O BFF autentica via
+`AccountWebService.VerifyCredentials(name, password)`, que retorna `{ ok, account_id, blocked, role }`.
+Grave `account_id` e `role` no cookie de sessão httpOnly e use-os nas chamadas acima. `role ∈
+{player, moderator, admin}` — só `moderator`/`admin` enxergam o painel de admin (e o backend reconfere).
+
+## 8. Exemplo (pseudocódigo BFF, server-side)
+
+```ts
+// Server Action (Next.js) — resgatar a recompensa do dia
+'use server'
+import { getSession } from '@/lib/session'            // lê o cookie httpOnly
+import { dailyRewardClient } from '@/lib/grpc'         // stub gRPC+mTLS, só server-side
+
+export async function claimReward(rewardItemId: string) {
+  const { accountId } = await getSession()             // nunca do browser
+  const res = await dailyRewardClient.claim({
+    accountId: BigInt(accountId),
+    rewardItemId: BigInt(rewardItemId),
+  })
+  switch (res.result) {
+    case ClaimResult.CLAIM_RESULT_OK:
+      return { ok: true, message: 'Item será entregue no seu armazém no próximo login.' }
+    case ClaimResult.CLAIM_RESULT_ALREADY_CLAIMED:
+      return { ok: false, error: 'Você já resgatou sua recompensa de hoje.' }
+    case ClaimResult.CLAIM_RESULT_DISABLED:
+      return { ok: false, error: 'Oferta indisponível.' }
+    default:
+      return { ok: false, error: 'Oferta não encontrada.' }
+  }
+}
+```
+
+```ts
+// Server Component/Action — carregar a tela de resgate
+export async function loadRewardScreen() {
+  const { accountId } = await getSession()
+  const [rewards, status] = await Promise.all([
+    dailyRewardClient.listRewards({}),
+    dailyRewardClient.getClaimStatus({ accountId: BigInt(accountId) }),
+  ])
+  return {
+    offers: rewards.items,
+    alreadyClaimedToday: status.claimedToday,
+    claimedItemTitle: status.claimedItemTitle,
+  }
+}
+```
+
+```ts
+// Server Action — moderador cria/edita uma oferta
+export async function upsertReward(item: DailyRewardItemInput) {
+  const { accountId, role } = await getSession()
+  if (role !== 'moderator' && role !== 'admin') throw new Error('forbidden')  // UI gate; backend reconfere
+  const res = await dailyRewardAdminClient.upsertRewardItem({
+    moderatorId: BigInt(accountId),
+    item: { ...item, id: BigInt(item.id ?? 0) },       // id 0 = criar
+  })
+  if (res.result !== AdminResult.ADMIN_RESULT_OK) throw mapAdminError(res.result)
+  return res.itemId
+}
+```
+
+## 9. Fora de escopo (não existe endpoint ainda)
+
+- **Entrega instantânea para quem já está online** (só há dreno no login, igual ao donate).
+- **Sequência/streak de dias consecutivos** (recompensa maior a cada dia seguido resgatado): o modelo
+  atual é "uma oferta grátis por dia, sem memória de streak" — se isso for pedido no futuro, é uma
+  extensão da tabela `daily_reward_claim`, não deste contrato.
+- **Escolha automática/sorteio da oferta do dia**: hoje o jogador escolhe manualmente entre todas as
+  ofertas habilitadas; não há conceito de "a recompensa de hoje é X para todo mundo".

--- a/docs/migration/web-platform-plan.md
+++ b/docs/migration/web-platform-plan.md
@@ -74,10 +74,18 @@ personagem.
 > **Status (issue #34, implementado):** a tabela `delivery_queue` (migração
 > `0008_donate_shop`), a **loja de donate** administrada por moderador (`donate_shop_item` +
 > `DonateAdminService`/`DonateShopService` em `api/web/v1`, lógica em `webserver/internal/donateshop`),
-> o crédito de saldo (`CreditDonateBalance`) e o **dreno no login** do tmServer (`World.DrainDeliveries`
-> → `AddToCargo` → `SaveCargoWithDeliveries`, RPCs novos em `api/db/v1`) já existem. Só o `kind='item'`
-> é usado; `cash`/`coin`/recompensa-diária continuam reservados. Entrega só no login (sem tick para
-> quem já está online); gateway de pagamento fica para depois (reusa `CreditDonateBalance`).
+> o crédito de saldo (`CreditDonateBalance`) e o **dreno no login** do tmServer (`World.ApplyDeliveries`
+> → `AddToCargo` → `SaveCargoWithDeliveries`, RPCs novos em `api/db/v1`) já existem. Entrega só no login
+> (sem tick para quem já está online); gateway de pagamento fica para depois (reusa
+> `CreditDonateBalance`).
+>
+> **Status (issue #35, implementado):** a **recompensa diária** reusa a mesma `delivery_queue` (só
+> `kind='item'`, `source='daily_reward:<id>'`) e o mesmo dreno acima — nenhuma mudança em tmServer/
+> dbServer. A tabela "resgatou hoje" é `daily_reward_claim` (migração `0009_daily_reward`,
+> `UNIQUE(account_id, claim_date)` em dia-calendário UTC), o catálogo é `daily_reward_item`, e os
+> serviços são `DailyRewardAdminService`/`DailyRewardService` em `api/web/v1`, lógica em
+> `webserver/internal/dailyreward`. Diferente do donate, é grátis (sem `price`/carteira) e limitado a
+> uma oferta por conta por dia. Guia de integração completo: [`daily-reward-frontend.md`](./daily-reward-frontend.md).
 
 ## ⚠️ Loja-web é a feature mais perigosa
 
@@ -112,7 +120,7 @@ reaproveitar o protocolo legado para a web.
 | Ranking | web-api → SELECT read-only no Postgres | dado de char online fica levemente atrasado — aceitável |
 | Ver perfil/personagem | idem, read-only | |
 | Comprar cash | gateway → webhook → web-api credita `donate_balance` + `delivery_queue` | `donate_balance` é coluna por-conta (`account`); ver gotcha abaixo |
-| Recompensa diária | web-api → `delivery_queue` + tabela "resgatou hoje" | |
+| Recompensa diária | web-api → `delivery_queue` + `daily_reward_claim` ("resgatou hoje") | implementado, issue #35 |
 | Loja-web | consignação in-game + entrega via `delivery_queue` | ver seção ⚠️ acima |
 
 ## binServer / billing — papel na nova arquitetura

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -179,3 +179,23 @@ type Delivery struct {
 	ID   int64
 	Item Item
 }
+
+// DailyRewardItem is one moderator-managed offer in the daily reward catalog
+// (issue #35): an item (index + up to three effect/value pairs) claimable once
+// per account per UTC calendar day, free of charge. Cold config owned by
+// Postgres — the tmServer never reads it; only the web-api serves the vitrine
+// and processes claims. ExpiresDays > 0 makes the delivered item timed.
+type DailyRewardItem struct {
+	ID          int64
+	ItemIndex   int32
+	Eff1        uint8
+	EffV1       uint8
+	Eff2        uint8
+	EffV2       uint8
+	Eff3        uint8
+	EffV3       uint8
+	Title       string
+	Description string
+	Enabled     bool
+	ExpiresDays int32
+}

--- a/internal/migrations/0009_daily_reward.down.sql
+++ b/internal/migrations/0009_daily_reward.down.sql
@@ -1,0 +1,4 @@
+-- Reverses 0009_daily_reward. Indexes drop with their tables.
+DROP TABLE IF EXISTS daily_reward_claim;
+DROP TABLE IF EXISTS daily_reward_audit;
+DROP TABLE IF EXISTS daily_reward_item;

--- a/internal/migrations/0009_daily_reward.up.sql
+++ b/internal/migrations/0009_daily_reward.up.sql
@@ -1,0 +1,59 @@
+-- 0009_daily_reward — daily reward system (issue #35).
+--
+-- Mirrors 0008_donate_shop's shape: a moderator-managed catalog
+-- (daily_reward_item) + its audit trail (daily_reward_audit), reusing the
+-- existing delivery_queue mailbox for the actual grant (no schema change
+-- there — see 0008_donate_shop.up.sql). The one genuinely new concept is
+-- daily_reward_claim: the once-per-account-per-UTC-calendar-day gate. The
+-- limit is account-wide (not per item), so the UNIQUE constraint is on
+-- (account_id, claim_date) only; reward_item_id is stored for audit/UI
+-- purposes ("what did they redeem today") but is not part of the key.
+
+-- Moderator-managed reward catalog. One row = one redeemable offer: an item
+-- (item_index + up to three effect/value pairs). Unlike donate_shop_item there
+-- is no price column — daily rewards are free, gated only by the once-a-day
+-- claim. expires_days > 0 makes the delivered item timed.
+CREATE TABLE daily_reward_item (
+    id           BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    item_index   INTEGER NOT NULL,
+    eff1         SMALLINT NOT NULL DEFAULT 0,
+    effv1        SMALLINT NOT NULL DEFAULT 0,
+    eff2         SMALLINT NOT NULL DEFAULT 0,
+    effv2        SMALLINT NOT NULL DEFAULT 0,
+    eff3         SMALLINT NOT NULL DEFAULT 0,
+    effv3        SMALLINT NOT NULL DEFAULT 0,
+    title        TEXT NOT NULL DEFAULT '',
+    description  TEXT NOT NULL DEFAULT '',
+    enabled      BOOLEAN NOT NULL DEFAULT TRUE,        -- shown in the web vitrine
+    expires_days INTEGER NOT NULL DEFAULT 0 CHECK (expires_days >= 0), -- 0 = permanent
+    updated_by   BIGINT REFERENCES account(id) ON DELETE SET NULL,
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Audit trail for reward-item CRUD and claims, mirroring donate_shop_audit.
+CREATE TABLE daily_reward_audit (
+    id             BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    reward_item_id BIGINT,             -- not an FK: survives daily_reward_item deletes
+    account_id     BIGINT NOT NULL,    -- the moderator (CRUD) or claimant (claim)
+    action         TEXT NOT NULL,      -- 'create'|'update'|'delete'|'set_enabled'|'claim'
+    before         JSONB,
+    after          JSONB,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- The once-per-account-per-UTC-day gate. claim_date is the UTC calendar day
+-- (computed server-side as (now() AT TIME ZONE 'UTC')::date), never a rolling
+-- 24h window. reward_item_id records which offer was redeemed (informational;
+-- ON DELETE SET NULL so deleting a catalog item never breaks history) but is
+-- NOT part of the uniqueness key — the limit is one reward total per account
+-- per day, regardless of which item was picked.
+CREATE TABLE daily_reward_claim (
+    id             BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    account_id     BIGINT NOT NULL REFERENCES account(id) ON DELETE CASCADE,
+    reward_item_id BIGINT REFERENCES daily_reward_item(id) ON DELETE SET NULL,
+    claim_date     DATE NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (account_id, claim_date)
+);
+
+CREATE INDEX daily_reward_audit_reward_item_id_idx ON daily_reward_audit(reward_item_id);

--- a/internal/store/dailyreward.go
+++ b/internal/store/dailyreward.go
@@ -1,0 +1,268 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+)
+
+// Daily reward persistence (issue #35). Postgres owns the reward catalog
+// (daily_reward_item) and the once-per-account-per-UTC-day claim gate
+// (daily_reward_claim); claiming enqueues the item into delivery_queue in one
+// transaction, reusing the exact mailbox donate_shop writes into (0008). The
+// tmServer never reads the catalog or the claim table — it only drains
+// delivery_queue, identically for donate and daily-reward grants.
+
+// ErrAlreadyClaimedToday is returned by ClaimDailyReward when the account
+// already has a daily_reward_claim row for today's UTC calendar day.
+var ErrAlreadyClaimedToday = errors.New("store: daily reward already claimed today")
+
+const dailyRewardItemCols = `id, item_index, eff1, effv1, eff2, effv2, eff3, effv3, title, description, enabled, expires_days`
+
+// ListDailyRewardItems returns every reward offer (enabled or not) — the
+// moderation table. ListEnabledDailyRewardItems is the player-facing vitrine.
+func (s *Store) ListDailyRewardItems(ctx context.Context) ([]domain.DailyRewardItem, error) {
+	return s.queryDailyRewardItems(ctx, `SELECT `+dailyRewardItemCols+` FROM daily_reward_item ORDER BY id`)
+}
+
+// ListEnabledDailyRewardItems returns only the offers claimable today (the web vitrine).
+func (s *Store) ListEnabledDailyRewardItems(ctx context.Context) ([]domain.DailyRewardItem, error) {
+	return s.queryDailyRewardItems(ctx, `SELECT `+dailyRewardItemCols+` FROM daily_reward_item WHERE enabled = TRUE ORDER BY id`)
+}
+
+func (s *Store) queryDailyRewardItems(ctx context.Context, sql string) ([]domain.DailyRewardItem, error) {
+	rows, err := s.pool.Query(ctx, sql)
+	if err != nil {
+		return nil, fmt.Errorf("store: list daily reward items: %w", err)
+	}
+	defer rows.Close()
+	var out []domain.DailyRewardItem
+	for rows.Next() {
+		d, err := scanDailyRewardItem(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}
+
+// GetDailyRewardItem loads one offer by id. Returns ErrNotFound when absent.
+func (s *Store) GetDailyRewardItem(ctx context.Context, id int64) (domain.DailyRewardItem, error) {
+	row := s.pool.QueryRow(ctx, `SELECT `+dailyRewardItemCols+` FROM daily_reward_item WHERE id = $1`, id)
+	d, err := scanDailyRewardItem(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return domain.DailyRewardItem{}, ErrNotFound
+	}
+	if err != nil {
+		return domain.DailyRewardItem{}, fmt.Errorf("store: get daily reward item %d: %w", id, err)
+	}
+	return d, nil
+}
+
+func scanDailyRewardItem(row scanRow) (domain.DailyRewardItem, error) {
+	var d domain.DailyRewardItem
+	err := row.Scan(&d.ID, &d.ItemIndex, &d.Eff1, &d.EffV1, &d.Eff2, &d.EffV2, &d.Eff3, &d.EffV3,
+		&d.Title, &d.Description, &d.Enabled, &d.ExpiresDays)
+	return d, err
+}
+
+// UpsertDailyRewardItem inserts a new offer (d.ID == 0) or updates the
+// existing one by id, writing an audit row in the same transaction. Returns
+// the offer id; updating a missing id returns ErrNotFound.
+func (s *Store) UpsertDailyRewardItem(ctx context.Context, d domain.DailyRewardItem, moderatorID int64) (int64, error) {
+	var id int64
+	err := s.inTx(ctx, func(tx pgx.Tx) error {
+		if d.ID == 0 {
+			if err := tx.QueryRow(ctx, `
+				INSERT INTO daily_reward_item
+					(item_index, eff1, effv1, eff2, effv2, eff3, effv3, title, description, enabled, expires_days, updated_by, updated_at)
+				VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12, now())
+				RETURNING id`,
+				d.ItemIndex, d.Eff1, d.EffV1, d.Eff2, d.EffV2, d.Eff3, d.EffV3,
+				d.Title, d.Description, d.Enabled, d.ExpiresDays, nullableID(moderatorID),
+			).Scan(&id); err != nil {
+				return fmt.Errorf("store: insert daily reward item: %w", err)
+			}
+			after, _ := fetchDailyRewardItemJSON(ctx, tx, id)
+			return dailyRewardAudit(ctx, tx, &id, moderatorID, "create", nil, after)
+		}
+
+		before, _ := fetchDailyRewardItemJSON(ctx, tx, d.ID)
+		if before == nil {
+			return ErrNotFound
+		}
+		id = d.ID
+		if _, err := tx.Exec(ctx, `
+			UPDATE daily_reward_item SET
+				item_index=$2, eff1=$3, effv1=$4, eff2=$5, effv2=$6, eff3=$7, effv3=$8,
+				title=$9, description=$10, enabled=$11, expires_days=$12,
+				updated_by=$13, updated_at=now()
+			WHERE id=$1`,
+			id, d.ItemIndex, d.Eff1, d.EffV1, d.Eff2, d.EffV2, d.Eff3, d.EffV3,
+			d.Title, d.Description, d.Enabled, d.ExpiresDays, nullableID(moderatorID),
+		); err != nil {
+			return fmt.Errorf("store: update daily reward item %d: %w", id, err)
+		}
+		after, _ := fetchDailyRewardItemJSON(ctx, tx, id)
+		return dailyRewardAudit(ctx, tx, &id, moderatorID, "update", before, after)
+	})
+	return id, err
+}
+
+// SetDailyRewardItemEnabled toggles whether an offer is claimable. Returns
+// ErrNotFound if the offer does not exist.
+func (s *Store) SetDailyRewardItemEnabled(ctx context.Context, id int64, enabled bool, moderatorID int64) error {
+	return s.inTx(ctx, func(tx pgx.Tx) error {
+		before, _ := fetchDailyRewardItemJSON(ctx, tx, id)
+		if before == nil {
+			return ErrNotFound
+		}
+		if _, err := tx.Exec(ctx,
+			`UPDATE daily_reward_item SET enabled=$2, updated_by=$3, updated_at=now() WHERE id=$1`,
+			id, enabled, nullableID(moderatorID)); err != nil {
+			return fmt.Errorf("store: set daily reward item %d enabled: %w", id, err)
+		}
+		after, _ := fetchDailyRewardItemJSON(ctx, tx, id)
+		return dailyRewardAudit(ctx, tx, &id, moderatorID, "set_enabled", before, after)
+	})
+}
+
+// DeleteDailyRewardItem removes an offer. Returns ErrNotFound if absent.
+func (s *Store) DeleteDailyRewardItem(ctx context.Context, id int64, moderatorID int64) error {
+	return s.inTx(ctx, func(tx pgx.Tx) error {
+		before, _ := fetchDailyRewardItemJSON(ctx, tx, id)
+		if before == nil {
+			return ErrNotFound
+		}
+		if _, err := tx.Exec(ctx, `DELETE FROM daily_reward_item WHERE id = $1`, id); err != nil {
+			return fmt.Errorf("store: delete daily reward item %d: %w", id, err)
+		}
+		return dailyRewardAudit(ctx, tx, &id, moderatorID, "delete", before, nil)
+	})
+}
+
+// DailyRewardClaimedToday reports whether the account has already claimed a
+// daily reward for today's UTC calendar day, and if so which item (and its
+// title, for the UI) they picked. claimed is false with zero/empty
+// itemID/title when there is no claim yet today.
+func (s *Store) DailyRewardClaimedToday(ctx context.Context, accountID int64) (claimed bool, itemID int64, title string, err error) {
+	var rewardItemID *int64
+	err = s.pool.QueryRow(ctx, `
+		SELECT c.reward_item_id, COALESCE(i.title, '')
+		FROM daily_reward_claim c
+		LEFT JOIN daily_reward_item i ON i.id = c.reward_item_id
+		WHERE c.account_id = $1 AND c.claim_date = (now() AT TIME ZONE 'UTC')::date`,
+		accountID).Scan(&rewardItemID, &title)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, 0, "", nil
+	}
+	if err != nil {
+		return false, 0, "", fmt.Errorf("store: daily reward claimed today a=%d: %w", accountID, err)
+	}
+	if rewardItemID != nil {
+		itemID = *rewardItemID
+	}
+	return true, itemID, title, nil
+}
+
+// ClaimDailyReward redeems one reward for the account today: verifies the
+// offer exists and is enabled, inserts the claim row (racing on the
+// (account_id, claim_date) UNIQUE constraint rather than an explicit
+// SELECT ... FOR UPDATE — see the doc comment below), and enqueues the item
+// into delivery_queue, all in one transaction. Returns ErrNotFound (unknown
+// offer or account), ErrShopItemDisabled (offer not enabled), or
+// ErrAlreadyClaimedToday.
+//
+// Design note: donate's BuyDonateItem needs SELECT ... FOR UPDATE because it
+// performs a genuine read-modify-write on a mutable balance (two concurrent
+// buys must not both see the pre-debit balance). A daily claim has no mutable
+// counter to race on — "has this account already claimed today" IS the
+// question the UNIQUE(account_id, claim_date) index answers atomically.
+// Catching the resulting unique_violation is therefore race-safe under
+// concurrent double-submits without taking any row lock.
+func (s *Store) ClaimDailyReward(ctx context.Context, accountID, rewardItemID int64) error {
+	return s.inTx(ctx, func(tx pgx.Tx) error {
+		it, err := scanDailyRewardItem(tx.QueryRow(ctx,
+			`SELECT `+dailyRewardItemCols+` FROM daily_reward_item WHERE id = $1`, rewardItemID))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("store: claim: load offer %d: %w", rewardItemID, err)
+		}
+		if !it.Enabled {
+			return ErrShopItemDisabled
+		}
+
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO daily_reward_claim (account_id, reward_item_id, claim_date)
+			VALUES ($1, $2, (now() AT TIME ZONE 'UTC')::date)`,
+			accountID, it.ID); err != nil {
+			return classifyClaimInsertErr(err)
+		}
+
+		payload, err := json.Marshal(itemPayload{
+			ItemIndex: it.ItemIndex,
+			Eff1:      it.Eff1, EffV1: it.EffV1, Eff2: it.Eff2, EffV2: it.EffV2, Eff3: it.Eff3, EffV3: it.EffV3,
+			ExpiresAt: expiresDaysToUnix(it.ExpiresDays),
+		})
+		if err != nil {
+			return fmt.Errorf("store: claim: marshal payload: %w", err)
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO delivery_queue (account_id, kind, payload, source)
+			VALUES ($1, 'item', $2, $3)`,
+			accountID, payload, fmt.Sprintf("daily_reward:%d", it.ID)); err != nil {
+			return fmt.Errorf("store: claim: enqueue delivery a=%d: %w", accountID, err)
+		}
+		after, _ := json.Marshal(map[string]any{
+			"account_id": accountID, "reward_item_id": it.ID,
+		})
+		return dailyRewardAudit(ctx, tx, &it.ID, accountID, "claim", nil, after)
+	})
+}
+
+// classifyClaimInsertErr maps the daily_reward_claim INSERT's constraint
+// violations to sentinel errors: unique_violation (23505) means the account
+// already claimed today; foreign_key_violation (23503) means the account_id
+// does not exist.
+func classifyClaimInsertErr(err error) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		switch pgErr.Code {
+		case "23505":
+			return ErrAlreadyClaimedToday
+		case "23503":
+			return ErrNotFound
+		}
+	}
+	return fmt.Errorf("store: insert daily reward claim: %w", err)
+}
+
+// --- helpers ---
+
+func dailyRewardAudit(ctx context.Context, tx pgx.Tx, rewardItemID *int64, accountID int64, action string, before, after []byte) error {
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO daily_reward_audit (reward_item_id, account_id, action, before, after)
+		VALUES ($1,$2,$3,$4,$5)`,
+		rewardItemID, accountID, action, nullableJSON(before), nullableJSON(after)); err != nil {
+		return fmt.Errorf("store: write daily reward audit: %w", err)
+	}
+	return nil
+}
+
+func fetchDailyRewardItemJSON(ctx context.Context, tx pgx.Tx, id int64) ([]byte, error) {
+	var js []byte
+	err := tx.QueryRow(ctx, `SELECT to_jsonb(d) FROM daily_reward_item d WHERE id = $1`, id).Scan(&js)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return js, err
+}

--- a/internal/store/dailyreward_integration_test.go
+++ b/internal/store/dailyreward_integration_test.go
@@ -1,0 +1,194 @@
+//go:build integration
+
+// Integration tests for the daily-reward store (issue #35). They require a
+// real database and are excluded from the default build. Run with:
+//
+//	W2PP_TEST_DSN=postgres://postgres:dev@localhost:5432/postgres go test -tags=integration ./internal/store/
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+)
+
+// TestDailyRewardCRUD exercises the moderator catalog write path: create,
+// update, toggle enabled, list, get, delete.
+func TestDailyRewardCRUD(t *testing.T) {
+	ctx := context.Background()
+	pool := testPool(t)
+	if err := Migrate(ctx, pool); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	_, _ = pool.Exec(ctx, `DELETE FROM daily_reward_audit; DELETE FROM daily_reward_claim; DELETE FROM daily_reward_item`)
+	s := New(pool)
+
+	var modID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO account (name, pass_hash, role) VALUES ('mod_dailyreward_test','x','moderator') RETURNING id`).
+		Scan(&modID); err != nil {
+		t.Fatalf("seed moderator: %v", err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM account WHERE id = $1`, modID) })
+
+	id, err := s.UpsertDailyRewardItem(ctx, domain.DailyRewardItem{
+		ItemIndex: 3540, Eff1: 1, EffV1: 9, Title: "Set Celestial",
+		Description: "shiny", Enabled: true, ExpiresDays: 30,
+	}, modID)
+	if err != nil {
+		t.Fatalf("upsert create: %v", err)
+	}
+
+	got, err := s.GetDailyRewardItem(ctx, id)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.ItemIndex != 3540 || !got.Enabled || got.ExpiresDays != 30 || got.Eff1 != 1 || got.EffV1 != 9 {
+		t.Errorf("offer mismatch: %+v", got)
+	}
+
+	// Update in place (same id).
+	got.Title = "Set Celestial +11"
+	if _, err := s.UpsertDailyRewardItem(ctx, got, modID); err != nil {
+		t.Fatalf("upsert update: %v", err)
+	}
+	if updated, _ := s.GetDailyRewardItem(ctx, id); updated.Title != "Set Celestial +11" {
+		t.Errorf("update not applied: %+v", updated)
+	}
+
+	// Updating a missing id is NotFound.
+	if _, err := s.UpsertDailyRewardItem(ctx, domain.DailyRewardItem{ID: 999999, ItemIndex: 1}, modID); !errors.Is(err, ErrNotFound) {
+		t.Errorf("upsert missing id err = %v, want ErrNotFound", err)
+	}
+
+	if err := s.SetDailyRewardItemEnabled(ctx, id, false, modID); err != nil {
+		t.Fatalf("set enabled: %v", err)
+	}
+	all, err := s.ListDailyRewardItems(ctx)
+	if err != nil || len(all) != 1 || all[0].Enabled {
+		t.Fatalf("list = %+v (err %v), want 1 disabled offer", all, err)
+	}
+	if enabled, _ := s.ListEnabledDailyRewardItems(ctx); len(enabled) != 0 {
+		t.Errorf("enabled list = %d, want 0 (offer disabled)", len(enabled))
+	}
+
+	if err := s.DeleteDailyRewardItem(ctx, id, modID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := s.GetDailyRewardItem(ctx, id); !errors.Is(err, ErrNotFound) {
+		t.Errorf("get after delete err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestDailyRewardClaimFlow exercises the once-per-account-per-UTC-day claim
+// gate and the delivery_queue enqueue it drives.
+func TestDailyRewardClaimFlow(t *testing.T) {
+	ctx := context.Background()
+	pool := testPool(t)
+	if err := Migrate(ctx, pool); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	_, _ = pool.Exec(ctx, `DELETE FROM daily_reward_audit; DELETE FROM daily_reward_claim; DELETE FROM daily_reward_item; DELETE FROM delivery_queue`)
+	s := New(pool)
+
+	item1, err := s.UpsertDailyRewardItem(ctx, domain.DailyRewardItem{
+		ItemIndex: 1234, Eff1: 2, EffV1: 5, Title: "Reward One", Enabled: true, ExpiresDays: 7,
+	}, 0)
+	if err != nil {
+		t.Fatalf("upsert item1: %v", err)
+	}
+	item2, err := s.UpsertDailyRewardItem(ctx, domain.DailyRewardItem{
+		ItemIndex: 5678, Title: "Reward Two", Enabled: true,
+	}, 0)
+	if err != nil {
+		t.Fatalf("upsert item2: %v", err)
+	}
+	disabledItem, err := s.UpsertDailyRewardItem(ctx, domain.DailyRewardItem{
+		ItemIndex: 9999, Title: "Disabled Reward", Enabled: false,
+	}, 0)
+	if err != nil {
+		t.Fatalf("upsert disabled item: %v", err)
+	}
+
+	var accID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO account (name, pass_hash) VALUES ('claimer_dailyreward_test','x') RETURNING id`).
+		Scan(&accID); err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM account WHERE id = $1`, accID) })
+
+	// No claim yet today.
+	if claimed, _, _, err := s.DailyRewardClaimedToday(ctx, accID); err != nil || claimed {
+		t.Fatalf("DailyRewardClaimedToday(before) = (%v, err %v), want (false, nil)", claimed, err)
+	}
+
+	// First claim succeeds and enqueues exactly one pending item delivery with
+	// the expected source provenance.
+	if err := s.ClaimDailyReward(ctx, accID, item1); err != nil {
+		t.Fatalf("claim item1: %v", err)
+	}
+	pending, err := s.PendingItemDeliveries(ctx, accID)
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("pending = %+v (err %v), want 1", pending, err)
+	}
+	if pending[0].Item.Index != 1234 || pending[0].Item.Eff1 != 2 || pending[0].Item.EffV1 != 5 || pending[0].Item.ExpiresAt == 0 {
+		t.Errorf("delivery payload mismatch: %+v", pending[0].Item)
+	}
+	var source string
+	if err := pool.QueryRow(ctx, `SELECT source FROM delivery_queue WHERE account_id = $1`, accID).Scan(&source); err != nil {
+		t.Fatalf("read delivery source: %v", err)
+	}
+	if want := fmt.Sprintf("daily_reward:%d", item1); source != want {
+		t.Errorf("delivery source = %q, want %q", source, want)
+	}
+
+	// A second claim the same UTC day, even for a different item, is blocked.
+	if err := s.ClaimDailyReward(ctx, accID, item2); !errors.Is(err, ErrAlreadyClaimedToday) {
+		t.Errorf("claim item2 same day err = %v, want ErrAlreadyClaimedToday", err)
+	}
+
+	// The claim-status read now reflects the redeemed offer.
+	claimed, claimedItemID, title, err := s.DailyRewardClaimedToday(ctx, accID)
+	if err != nil || !claimed || claimedItemID != item1 || title != "Reward One" {
+		t.Fatalf("DailyRewardClaimedToday(after) = (%v, %d, %q, err %v), want (true, %d, \"Reward One\", nil)", claimed, claimedItemID, title, err, item1)
+	}
+
+	// A disabled offer rejects the claim, for a fresh account (no prior claim).
+	var acc2 int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO account (name, pass_hash) VALUES ('claimer2_dailyreward_test','x') RETURNING id`).
+		Scan(&acc2); err != nil {
+		t.Fatalf("seed account 2: %v", err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM account WHERE id = $1`, acc2) })
+	if err := s.ClaimDailyReward(ctx, acc2, disabledItem); !errors.Is(err, ErrShopItemDisabled) {
+		t.Errorf("claim disabled err = %v, want ErrShopItemDisabled", err)
+	}
+
+	// An unknown offer is NotFound.
+	if err := s.ClaimDailyReward(ctx, acc2, 987654); !errors.Is(err, ErrNotFound) {
+		t.Errorf("claim unknown err = %v, want ErrNotFound", err)
+	}
+
+	// A claim recorded for yesterday does not block today's claim (the UNIQUE
+	// constraint is per UTC calendar day, not permanent).
+	var acc3 int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO account (name, pass_hash) VALUES ('claimer3_dailyreward_test','x') RETURNING id`).
+		Scan(&acc3); err != nil {
+		t.Fatalf("seed account 3: %v", err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM account WHERE id = $1`, acc3) })
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO daily_reward_claim (account_id, reward_item_id, claim_date)
+		VALUES ($1, $2, (CURRENT_DATE - INTERVAL '1 day')::date)`, acc3, item1); err != nil {
+		t.Fatalf("seed yesterday claim: %v", err)
+	}
+	if err := s.ClaimDailyReward(ctx, acc3, item1); err != nil {
+		t.Errorf("claim today (after yesterday claim) err = %v, want nil", err)
+	}
+}

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -45,6 +45,12 @@ func resetTestSchema(ctx context.Context, pool *pgxpool.Pool) {
 			item,
 			character,
 			account,
+			donate_shop_audit,
+			donate_shop_item,
+			daily_reward_audit,
+			daily_reward_claim,
+			daily_reward_item,
+			delivery_queue,
 			schema_migrations
 		CASCADE`)
 	_, _ = pool.Exec(ctx, `DROP TYPE IF EXISTS item_owner_kind`)

--- a/webserver/cmd/webserver/main.go
+++ b/webserver/cmd/webserver/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jeanluca/w2pp-openwyd/internal/store"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/account"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/characters"
+	"github.com/jeanluca/w2pp-openwyd/webserver/internal/dailyreward"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/donateshop"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/grpcsrv"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/itemcatalog"
@@ -79,6 +80,7 @@ func run(logger *slog.Logger) error {
 	st := store.New(pool)
 	npcAdmin := npcadmin.New(st)
 	donate := donateshop.New(st)
+	dailyRwd := dailyreward.New(st)
 	if *contentDir != "" {
 		templates, err := npctemplates.Scan(*contentDir, logger)
 		if err != nil {
@@ -102,6 +104,8 @@ func run(logger *slog.Logger) error {
 	webv1.RegisterNpcAdminServiceServer(srv, grpcsrv.NewNpcAdmin(npcAdmin))
 	webv1.RegisterDonateAdminServiceServer(srv, grpcsrv.NewDonateAdmin(donate))
 	webv1.RegisterDonateShopServiceServer(srv, grpcsrv.NewDonateShop(donate))
+	webv1.RegisterDailyRewardAdminServiceServer(srv, grpcsrv.NewDailyRewardAdmin(dailyRwd))
+	webv1.RegisterDailyRewardServiceServer(srv, grpcsrv.NewDailyReward(dailyRwd))
 
 	ln, err := net.Listen("tcp", *addr)
 	if err != nil {

--- a/webserver/internal/dailyreward/service.go
+++ b/webserver/internal/dailyreward/service.go
@@ -1,0 +1,189 @@
+// Package dailyreward holds the web platform's daily-reward logic (issue #35):
+// the moderator CRUD over the cold daily_reward_item catalog, and the
+// player-facing vitrine + claim-status + claim. Admin operations are gated on
+// account.role (mirroring donateshop); the player surface trusts the
+// account_id the BFF supplies from its httpOnly session. It never touches live
+// game state — a claim only enqueues a delivery_queue grant that the tmServer
+// drains inside its single-owner loop.
+package dailyreward
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+	"github.com/jeanluca/w2pp-openwyd/internal/store"
+)
+
+// Store is the persistence surface the service needs (satisfied by *store.Store).
+type Store interface {
+	AccountRole(ctx context.Context, id int64) (string, error)
+	ListDailyRewardItems(ctx context.Context) ([]domain.DailyRewardItem, error)
+	ListEnabledDailyRewardItems(ctx context.Context) ([]domain.DailyRewardItem, error)
+	UpsertDailyRewardItem(ctx context.Context, d domain.DailyRewardItem, moderatorID int64) (int64, error)
+	SetDailyRewardItemEnabled(ctx context.Context, id int64, enabled bool, moderatorID int64) error
+	DeleteDailyRewardItem(ctx context.Context, id int64, moderatorID int64) error
+	DailyRewardClaimedToday(ctx context.Context, accountID int64) (claimed bool, itemID int64, title string, err error)
+	ClaimDailyReward(ctx context.Context, accountID, rewardItemID int64) error
+}
+
+// Result is the business outcome of an admin operation, mirroring
+// donateshop.Result. Only infra failures are returned as errors.
+type Result int
+
+const (
+	// OK means the operation succeeded.
+	OK Result = iota
+	// Forbidden means the caller is not a moderator/admin.
+	Forbidden
+	// Invalid means the request failed validation.
+	Invalid
+	// NotFound means the target offer/account does not exist.
+	NotFound
+)
+
+// ClaimOutcome is the result of a player claim.
+type ClaimOutcome int
+
+const (
+	// ClaimOK means the claim was recorded and the item queued for delivery.
+	ClaimOK ClaimOutcome = iota
+	// ClaimAlreadyClaimed means the account already claimed today (UTC).
+	ClaimAlreadyClaimed
+	// ClaimNotFound means the offer or account does not exist.
+	ClaimNotFound
+	// ClaimDisabled means the offer exists but is not claimable.
+	ClaimDisabled
+)
+
+// Service implements the daily-reward operations.
+type Service struct {
+	store Store
+}
+
+// New builds the service over the given store.
+func New(s Store) *Service { return &Service{store: s} }
+
+// --- moderator surface ---
+
+// List returns every offer (enabled or not), after authorizing the caller.
+func (s *Service) List(ctx context.Context, moderatorID int64) (Result, []domain.DailyRewardItem, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, nil, err
+	}
+	items, err := s.store.ListDailyRewardItems(ctx)
+	if err != nil {
+		return Invalid, nil, fmt.Errorf("dailyreward: list: %w", err)
+	}
+	return OK, items, nil
+}
+
+// Upsert creates (d.ID == 0) or updates an offer after validating it. Unlike
+// donateshop.Upsert there is no price check — daily rewards are free.
+func (s *Service) Upsert(ctx context.Context, moderatorID int64, d domain.DailyRewardItem) (Result, int64, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, 0, err
+	}
+	if d.ItemIndex <= 0 || d.ExpiresDays < 0 {
+		return Invalid, 0, nil
+	}
+	id, err := s.store.UpsertDailyRewardItem(ctx, d, moderatorID)
+	if errors.Is(err, store.ErrNotFound) {
+		return NotFound, 0, nil
+	}
+	if err != nil {
+		return Invalid, 0, fmt.Errorf("dailyreward: upsert %d: %w", d.ID, err)
+	}
+	return OK, id, nil
+}
+
+// SetEnabled toggles whether an offer is claimable.
+func (s *Service) SetEnabled(ctx context.Context, moderatorID, itemID int64, enabled bool) (Result, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, err
+	}
+	return classifyWrite(s.store.SetDailyRewardItemEnabled(ctx, itemID, enabled, moderatorID), "set enabled")
+}
+
+// Delete removes an offer.
+func (s *Service) Delete(ctx context.Context, moderatorID, itemID int64) (Result, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, err
+	}
+	return classifyWrite(s.store.DeleteDailyRewardItem(ctx, itemID, moderatorID), "delete")
+}
+
+// --- player surface ---
+
+// Vitrine returns the enabled offers for the reward front-end.
+func (s *Service) Vitrine(ctx context.Context) ([]domain.DailyRewardItem, error) {
+	items, err := s.store.ListEnabledDailyRewardItems(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("dailyreward: vitrine: %w", err)
+	}
+	return items, nil
+}
+
+// ClaimStatus reports whether the account already claimed today (UTC).
+func (s *Service) ClaimStatus(ctx context.Context, accountID int64) (claimed bool, itemID int64, title string, err error) {
+	claimed, itemID, title, err = s.store.DailyRewardClaimedToday(ctx, accountID)
+	if err != nil {
+		return false, 0, "", fmt.Errorf("dailyreward: claim status a=%d: %w", accountID, err)
+	}
+	return claimed, itemID, title, nil
+}
+
+// Claim redeems a reward offer for the account for today.
+func (s *Service) Claim(ctx context.Context, accountID, rewardItemID int64) (ClaimOutcome, error) {
+	if accountID <= 0 || rewardItemID <= 0 {
+		return ClaimNotFound, nil
+	}
+	err := s.store.ClaimDailyReward(ctx, accountID, rewardItemID)
+	switch {
+	case err == nil:
+		return ClaimOK, nil
+	case errors.Is(err, store.ErrAlreadyClaimedToday):
+		return ClaimAlreadyClaimed, nil
+	case errors.Is(err, store.ErrShopItemDisabled):
+		return ClaimDisabled, nil
+	case errors.Is(err, store.ErrNotFound):
+		return ClaimNotFound, nil
+	default:
+		return ClaimNotFound, fmt.Errorf("dailyreward: claim a=%d item=%d: %w", accountID, rewardItemID, err)
+	}
+}
+
+// --- helpers ---
+
+// authorize checks the caller has a moderator/admin role. A missing account or
+// a plain-player role yields Forbidden (never leaks whether the account exists).
+func (s *Service) authorize(ctx context.Context, moderatorID int64) (Result, error) {
+	if moderatorID <= 0 {
+		return Forbidden, nil
+	}
+	role, err := s.store.AccountRole(ctx, moderatorID)
+	if errors.Is(err, store.ErrNotFound) {
+		return Forbidden, nil
+	}
+	if err != nil {
+		return Invalid, fmt.Errorf("dailyreward: role lookup %d: %w", moderatorID, err)
+	}
+	if role != "moderator" && role != "admin" {
+		return Forbidden, nil
+	}
+	return OK, nil
+}
+
+// classifyWrite maps a store write error to a Result: ErrNotFound → NotFound,
+// nil → OK, anything else → Invalid (wrapped).
+func classifyWrite(err error, op string) (Result, error) {
+	switch {
+	case err == nil:
+		return OK, nil
+	case errors.Is(err, store.ErrNotFound):
+		return NotFound, nil
+	default:
+		return Invalid, fmt.Errorf("dailyreward: %s: %w", op, err)
+	}
+}

--- a/webserver/internal/dailyreward/service_test.go
+++ b/webserver/internal/dailyreward/service_test.go
@@ -1,0 +1,230 @@
+package dailyreward
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+	"github.com/jeanluca/w2pp-openwyd/internal/store"
+)
+
+// fakeStore is an in-memory Store for exercising authorization, validation and
+// the claim outcomes without a database.
+type fakeStore struct {
+	roles  map[int64]string
+	items  map[int64]domain.DailyRewardItem
+	claims map[int64]struct {
+		itemID int64
+		title  string
+	} // accountID -> today's claim
+	claimErr  error // forces ClaimDailyReward to return this
+	upsertErr error
+	lastClaim int64
+}
+
+func (f *fakeStore) AccountRole(_ context.Context, id int64) (string, error) {
+	r, ok := f.roles[id]
+	if !ok {
+		return "", store.ErrNotFound
+	}
+	return r, nil
+}
+func (f *fakeStore) ListDailyRewardItems(context.Context) ([]domain.DailyRewardItem, error) {
+	return f.all(false), nil
+}
+func (f *fakeStore) ListEnabledDailyRewardItems(context.Context) ([]domain.DailyRewardItem, error) {
+	return f.all(true), nil
+}
+func (f *fakeStore) all(enabledOnly bool) []domain.DailyRewardItem {
+	out := make([]domain.DailyRewardItem, 0, len(f.items))
+	for _, it := range f.items {
+		if enabledOnly && !it.Enabled {
+			continue
+		}
+		out = append(out, it)
+	}
+	return out
+}
+func (f *fakeStore) UpsertDailyRewardItem(_ context.Context, d domain.DailyRewardItem, _ int64) (int64, error) {
+	if f.upsertErr != nil {
+		return 0, f.upsertErr
+	}
+	if d.ID != 0 {
+		if _, ok := f.items[d.ID]; !ok {
+			return 0, store.ErrNotFound
+		}
+		return d.ID, nil
+	}
+	return 99, nil
+}
+func (f *fakeStore) SetDailyRewardItemEnabled(_ context.Context, id int64, _ bool, _ int64) error {
+	if _, ok := f.items[id]; !ok {
+		return store.ErrNotFound
+	}
+	return nil
+}
+func (f *fakeStore) DeleteDailyRewardItem(_ context.Context, id int64, _ int64) error {
+	if _, ok := f.items[id]; !ok {
+		return store.ErrNotFound
+	}
+	return nil
+}
+func (f *fakeStore) DailyRewardClaimedToday(_ context.Context, accountID int64) (bool, int64, string, error) {
+	c, ok := f.claims[accountID]
+	if !ok {
+		return false, 0, "", nil
+	}
+	return true, c.itemID, c.title, nil
+}
+func (f *fakeStore) ClaimDailyReward(_ context.Context, accountID, rewardItemID int64) error {
+	if f.claimErr != nil {
+		return f.claimErr
+	}
+	f.lastClaim = rewardItemID
+	if f.claims == nil {
+		f.claims = map[int64]struct {
+			itemID int64
+			title  string
+		}{}
+	}
+	f.claims[accountID] = struct {
+		itemID int64
+		title  string
+	}{itemID: rewardItemID, title: f.items[rewardItemID].Title}
+	return nil
+}
+
+func newFake() *fakeStore {
+	return &fakeStore{
+		roles: map[int64]string{1: "moderator", 2: "admin", 3: "player"},
+		items: map[int64]domain.DailyRewardItem{
+			10: {ID: 10, ItemIndex: 100, Title: "Potion", Enabled: true},
+		},
+	}
+}
+
+// TestAdminAuthorization checks every moderator operation refuses non-moderators.
+func TestAdminAuthorization(t *testing.T) {
+	tests := []struct {
+		name       string
+		moderator  int64
+		wantResult Result
+	}{
+		{"moderator", 1, OK},
+		{"admin", 2, OK},
+		{"player", 3, Forbidden},
+		{"missing account", 999, Forbidden},
+		{"zero id", 0, Forbidden},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := New(newFake())
+			ctx := context.Background()
+
+			if r, _, err := s.List(ctx, tc.moderator); err != nil || r != tc.wantResult {
+				t.Errorf("List = (%v, %v), want %v", r, err, tc.wantResult)
+			}
+			valid := domain.DailyRewardItem{ItemIndex: 100}
+			if r, _, err := s.Upsert(ctx, tc.moderator, valid); err != nil || r != tc.wantResult {
+				t.Errorf("Upsert = (%v, %v), want %v", r, err, tc.wantResult)
+			}
+			if r, err := s.SetEnabled(ctx, tc.moderator, 10, false); err != nil || r != tc.wantResult {
+				t.Errorf("SetEnabled = (%v, %v), want %v", r, err, tc.wantResult)
+			}
+			if r, err := s.Delete(ctx, tc.moderator, 10); err != nil || r != tc.wantResult {
+				t.Errorf("Delete = (%v, %v), want %v", r, err, tc.wantResult)
+			}
+		})
+	}
+}
+
+// TestUpsertValidation rejects offers with a bad item index or negative expiry.
+// Unlike donateshop there is no price check — daily rewards are free.
+func TestUpsertValidation(t *testing.T) {
+	s := New(newFake())
+	ctx := context.Background()
+	bad := []domain.DailyRewardItem{
+		{ItemIndex: 0},                    // no item
+		{ItemIndex: 100, ExpiresDays: -1}, // negative expiry
+	}
+	for _, d := range bad {
+		if r, _, err := s.Upsert(ctx, 1, d); err != nil || r != Invalid {
+			t.Errorf("Upsert(%+v) = (%v, %v), want Invalid", d, r, err)
+		}
+	}
+}
+
+// TestClaimOutcomes maps every store claim result to the right ClaimOutcome.
+func TestClaimOutcomes(t *testing.T) {
+	tests := []struct {
+		name     string
+		claimErr error
+		account  int64
+		item     int64
+		want     ClaimOutcome
+	}{
+		{"ok", nil, 7, 10, ClaimOK},
+		{"already claimed", store.ErrAlreadyClaimedToday, 7, 10, ClaimAlreadyClaimed},
+		{"disabled", store.ErrShopItemDisabled, 7, 10, ClaimDisabled},
+		{"not found", store.ErrNotFound, 7, 10, ClaimNotFound},
+		{"bad account id", nil, 0, 10, ClaimNotFound},
+		{"bad item id", nil, 7, 0, ClaimNotFound},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFake()
+			f.claimErr = tc.claimErr
+			s := New(f)
+			got, err := s.Claim(context.Background(), tc.account, tc.item)
+			if err != nil {
+				t.Fatalf("Claim error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("Claim = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClaimStatus covers the player claim-status read.
+func TestClaimStatus(t *testing.T) {
+	f := newFake()
+	s := New(f)
+	ctx := context.Background()
+
+	claimed, _, _, err := s.ClaimStatus(ctx, 7)
+	if err != nil {
+		t.Fatalf("ClaimStatus: %v", err)
+	}
+	if claimed {
+		t.Errorf("ClaimStatus(unclaimed) claimed = true, want false")
+	}
+
+	if _, err := s.Claim(ctx, 7, 10); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+
+	claimed, itemID, title, err := s.ClaimStatus(ctx, 7)
+	if err != nil {
+		t.Fatalf("ClaimStatus: %v", err)
+	}
+	if !claimed || itemID != 10 || title != "Potion" {
+		t.Errorf("ClaimStatus(claimed) = (%v, %d, %q), want (true, 10, \"Potion\")", claimed, itemID, title)
+	}
+}
+
+// TestVitrine covers the player read surface: only enabled offers are returned.
+func TestVitrine(t *testing.T) {
+	f := newFake()
+	f.items[11] = domain.DailyRewardItem{ID: 11, ItemIndex: 200, Enabled: false}
+	s := New(f)
+	ctx := context.Background()
+
+	vit, err := s.Vitrine(ctx)
+	if err != nil {
+		t.Fatalf("Vitrine: %v", err)
+	}
+	if len(vit) != 1 || vit[0].ID != 10 {
+		t.Errorf("Vitrine returned %d items, want only the enabled offer 10", len(vit))
+	}
+}

--- a/webserver/internal/grpcsrv/dailyreward.go
+++ b/webserver/internal/grpcsrv/dailyreward.go
@@ -1,0 +1,167 @@
+package grpcsrv
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	webv1 "github.com/jeanluca/w2pp-openwyd/api/web/v1"
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+	"github.com/jeanluca/w2pp-openwyd/webserver/internal/dailyreward"
+)
+
+// DailyRewardAdmin is the moderator daily-reward surface (satisfied by
+// *dailyreward.Service). Kept as an interface so the server is unit-testable.
+type DailyRewardAdmin interface {
+	List(ctx context.Context, moderatorID int64) (dailyreward.Result, []domain.DailyRewardItem, error)
+	Upsert(ctx context.Context, moderatorID int64, d domain.DailyRewardItem) (dailyreward.Result, int64, error)
+	SetEnabled(ctx context.Context, moderatorID, itemID int64, enabled bool) (dailyreward.Result, error)
+	Delete(ctx context.Context, moderatorID, itemID int64) (dailyreward.Result, error)
+}
+
+// DailyReward is the player daily-reward surface (satisfied by *dailyreward.Service).
+type DailyReward interface {
+	Vitrine(ctx context.Context) ([]domain.DailyRewardItem, error)
+	ClaimStatus(ctx context.Context, accountID int64) (claimed bool, itemID int64, title string, err error)
+	Claim(ctx context.Context, accountID, rewardItemID int64) (dailyreward.ClaimOutcome, error)
+}
+
+// DailyRewardAdminServer implements webv1.DailyRewardAdminServiceServer.
+type DailyRewardAdminServer struct {
+	webv1.UnimplementedDailyRewardAdminServiceServer
+	admin DailyRewardAdmin
+}
+
+// NewDailyRewardAdmin builds the DailyRewardAdminService over the given admin logic.
+func NewDailyRewardAdmin(a DailyRewardAdmin) *DailyRewardAdminServer {
+	return &DailyRewardAdminServer{admin: a}
+}
+
+// ListRewardItems returns every offer (after authorization).
+func (s *DailyRewardAdminServer) ListRewardItems(ctx context.Context, req *webv1.ListRewardItemsRequest) (*webv1.ListRewardItemsResponse, error) {
+	res, items, err := s.admin.List(ctx, req.GetModeratorId())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list reward items: %v", err)
+	}
+	out := make([]*webv1.DailyRewardItem, 0, len(items))
+	for _, it := range items {
+		out = append(out, dailyRewardItemToProto(it))
+	}
+	return &webv1.ListRewardItemsResponse{Result: dailyRewardAdminResultToProto(res), Items: out}, nil
+}
+
+// UpsertRewardItem creates or updates an offer.
+func (s *DailyRewardAdminServer) UpsertRewardItem(ctx context.Context, req *webv1.UpsertRewardItemRequest) (*webv1.UpsertRewardItemResponse, error) {
+	res, id, err := s.admin.Upsert(ctx, req.GetModeratorId(), protoToDailyRewardItem(req.GetItem()))
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "upsert reward item: %v", err)
+	}
+	return &webv1.UpsertRewardItemResponse{Result: dailyRewardAdminResultToProto(res), ItemId: id}, nil
+}
+
+// SetRewardItemEnabled toggles whether an offer is claimable.
+func (s *DailyRewardAdminServer) SetRewardItemEnabled(ctx context.Context, req *webv1.SetRewardItemEnabledRequest) (*webv1.AdminAck, error) {
+	res, err := s.admin.SetEnabled(ctx, req.GetModeratorId(), req.GetItemId(), req.GetEnabled())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "set reward item enabled: %v", err)
+	}
+	return &webv1.AdminAck{Result: dailyRewardAdminResultToProto(res)}, nil
+}
+
+// DeleteRewardItem removes an offer.
+func (s *DailyRewardAdminServer) DeleteRewardItem(ctx context.Context, req *webv1.DeleteRewardItemRequest) (*webv1.AdminAck, error) {
+	res, err := s.admin.Delete(ctx, req.GetModeratorId(), req.GetItemId())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "delete reward item: %v", err)
+	}
+	return &webv1.AdminAck{Result: dailyRewardAdminResultToProto(res)}, nil
+}
+
+// DailyRewardServer implements webv1.DailyRewardServiceServer.
+type DailyRewardServer struct {
+	webv1.UnimplementedDailyRewardServiceServer
+	reward DailyReward
+}
+
+// NewDailyReward builds the DailyRewardService over the given reward logic.
+func NewDailyReward(r DailyReward) *DailyRewardServer { return &DailyRewardServer{reward: r} }
+
+// ListRewards returns the enabled offers (the vitrine).
+func (s *DailyRewardServer) ListRewards(ctx context.Context, _ *webv1.ListRewardsRequest) (*webv1.ListRewardsResponse, error) {
+	items, err := s.reward.Vitrine(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list rewards: %v", err)
+	}
+	out := make([]*webv1.DailyRewardItem, 0, len(items))
+	for _, it := range items {
+		out = append(out, dailyRewardItemToProto(it))
+	}
+	return &webv1.ListRewardsResponse{Items: out}, nil
+}
+
+// GetClaimStatus reports whether the account already claimed today.
+func (s *DailyRewardServer) GetClaimStatus(ctx context.Context, req *webv1.GetClaimStatusRequest) (*webv1.GetClaimStatusResponse, error) {
+	claimed, itemID, title, err := s.reward.ClaimStatus(ctx, req.GetAccountId())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "get claim status: %v", err)
+	}
+	return &webv1.GetClaimStatusResponse{ClaimedToday: claimed, ClaimedItemId: itemID, ClaimedItemTitle: title}, nil
+}
+
+// Claim redeems a reward offer for the account.
+func (s *DailyRewardServer) Claim(ctx context.Context, req *webv1.ClaimRequest) (*webv1.ClaimResponse, error) {
+	outcome, err := s.reward.Claim(ctx, req.GetAccountId(), req.GetRewardItemId())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "claim: %v", err)
+	}
+	return &webv1.ClaimResponse{Result: claimOutcomeToProto(outcome)}, nil
+}
+
+func dailyRewardItemToProto(d domain.DailyRewardItem) *webv1.DailyRewardItem {
+	return &webv1.DailyRewardItem{
+		Id: d.ID, ItemIndex: d.ItemIndex,
+		Eff1: int32(d.Eff1), Effv1: int32(d.EffV1),
+		Eff2: int32(d.Eff2), Effv2: int32(d.EffV2),
+		Eff3: int32(d.Eff3), Effv3: int32(d.EffV3),
+		Title: d.Title, Description: d.Description,
+		Enabled: d.Enabled, ExpiresDays: d.ExpiresDays,
+	}
+}
+
+func protoToDailyRewardItem(d *webv1.DailyRewardItem) domain.DailyRewardItem {
+	return domain.DailyRewardItem{
+		ID: d.GetId(), ItemIndex: d.GetItemIndex(),
+		Eff1: uint8(d.GetEff1()), EffV1: uint8(d.GetEffv1()),
+		Eff2: uint8(d.GetEff2()), EffV2: uint8(d.GetEffv2()),
+		Eff3: uint8(d.GetEff3()), EffV3: uint8(d.GetEffv3()),
+		Title: d.GetTitle(), Description: d.GetDescription(),
+		Enabled: d.GetEnabled(), ExpiresDays: d.GetExpiresDays(),
+	}
+}
+
+func dailyRewardAdminResultToProto(r dailyreward.Result) webv1.AdminResult {
+	switch r {
+	case dailyreward.OK:
+		return webv1.AdminResult_ADMIN_RESULT_OK
+	case dailyreward.Forbidden:
+		return webv1.AdminResult_ADMIN_RESULT_FORBIDDEN
+	case dailyreward.NotFound:
+		return webv1.AdminResult_ADMIN_RESULT_NOT_FOUND
+	default:
+		return webv1.AdminResult_ADMIN_RESULT_INVALID
+	}
+}
+
+func claimOutcomeToProto(o dailyreward.ClaimOutcome) webv1.ClaimResult {
+	switch o {
+	case dailyreward.ClaimOK:
+		return webv1.ClaimResult_CLAIM_RESULT_OK
+	case dailyreward.ClaimAlreadyClaimed:
+		return webv1.ClaimResult_CLAIM_RESULT_ALREADY_CLAIMED
+	case dailyreward.ClaimDisabled:
+		return webv1.ClaimResult_CLAIM_RESULT_DISABLED
+	default:
+		return webv1.ClaimResult_CLAIM_RESULT_NOT_FOUND
+	}
+}


### PR DESCRIPTION
## Summary
- Moderators manage a free reward catalog (`daily_reward_item`) via a new `DailyRewardAdminService` (list/upsert/enable/delete), mirroring the existing donate-shop admin surface.
- Players claim one offer per account per UTC calendar day via `DailyRewardService` (`ListRewards`/`GetClaimStatus`/`Claim`), gated by a `UNIQUE(account_id, claim_date)` constraint on the new `daily_reward_claim` table — no `SELECT ... FOR UPDATE` needed since the constraint itself is race-safe.
- Claims reuse the existing `delivery_queue` mailbox and tmServer login-time drain (`World.ApplyDeliveries` → `AddToCargo`) completely unchanged — items land in the next free cargo slot or are lost if the warehouse is full, matching the issue's requirement. No tmServer/dbServer code was touched.
- Migration `0009_daily_reward` adds `daily_reward_item`, `daily_reward_audit`, `daily_reward_claim`.
- Fixed a pre-existing gap in `internal/store/store_integration_test.go`'s `resetTestSchema` that never dropped the donate-shop tables (and now the daily-reward tables), which broke full-suite integration runs.
- Added `docs/migration/daily-reward-frontend.md`, a full gRPC integration guide for the Next.js BFF team, and updated `web-platform-plan.md`'s status notes.

Closes #35

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run` clean on all touched packages
- [x] `govulncheck ./...` clean
- [x] `go test ./...` (full suite, including tmserver's existing donate-drain tests, unaffected)
- [x] `go test -tags=integration ./internal/store/...` against a local Postgres container (CRUD + claim flow, including the once-per-UTC-day gate and cross-day unblock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)