### PR TITLE
fix: include account cargo in CNFAccountLogin

### DIFF
--- a/tmserver/internal/handler/handler_test.go
+++ b/tmserver/internal/handler/handler_test.go
@@ -346,6 +346,35 @@ func TestLoginOK(t *testing.T) {
 	}
 }
 
+func TestLoginSendsCargo(t *testing.T) {
+	db := newDB()
+	cargo := world.CargoState{Coin: 777}
+	cargo.Items[0] = world.Item{Index: 4140}
+	cargo.Items[33] = world.Item{Index: 5134}
+	db.accounts["tester"].cargo = cargo
+
+	addr, stop := startServer(t, db)
+	defer stop()
+	c := dial(t, addr)
+	defer c.Close()
+
+	send(t, c, protocol.MsgAccountLogin, loginBody("tester", "secret", protocol.AppVersion))
+	ty, payload := read(t, c)
+	if ty != protocol.MsgCNFAccountLogin {
+		t.Fatalf("response = %#x, want CNFAccountLogin", ty)
+	}
+	const cargoOff, coinOff = 860, 1884
+	if got := binary.LittleEndian.Uint16(payload[cargoOff : cargoOff+2]); got != 4140 {
+		t.Errorf("cargo[0] = %d, want 4140", got)
+	}
+	if got := binary.LittleEndian.Uint16(payload[cargoOff+33*8 : cargoOff+33*8+2]); got != 5134 {
+		t.Errorf("cargo[33] = %d, want 5134", got)
+	}
+	if got := binary.LittleEndian.Uint32(payload[coinOff : coinOff+4]); got != 777 {
+		t.Errorf("cargo coin = %d, want 777", got)
+	}
+}
+
 func TestSelCharWireLevel(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/tmserver/internal/handler/login.go
+++ b/tmserver/internal/handler/login.go
@@ -86,10 +86,12 @@ func (d *Dispatcher) completeAccountLogin(w *world.World, s *world.Session, out 
 		w.SetCargo(out.AccountID, &cargo)
 		// Drain any pending donate web-shop grants (fetched in the same login
 		// round-trip) into the freshly-loaded cargo (issue #34); items land in the
-		// next free slot, or are lost when full.
+		// next free slot, or are lost when full. Encode AFTER the drain so the
+		// client vault cache includes freshly delivered items.
 		w.ApplyDeliveries(s, out.PendingDeliveries)
 		s.Mode = world.UserSelChar
-		body := protocol.EncodeCNFAccountLoginBody(s.AccountName, d.selCharsFrom(out.Characters))
+		coin, cargoItems := d.cargoWire(w.Cargo(out.AccountID))
+		body := protocol.EncodeCNFAccountLoginBody(s.AccountName, d.selCharsFrom(out.Characters), coin, cargoItems)
 		w.SendTo(s, protocol.Header{Type: protocol.MsgCNFAccountLogin, ID: protocol.IDSelChar}, body)
 	case world.LoginBadPassword:
 		d.fails[s.AccountName]++
@@ -105,6 +107,20 @@ func (d *Dispatcher) completeAccountLogin(w *world.World, s *world.Session, out 
 	case world.LoginAlreadyPlaying:
 		w.Send(s, protocol.MsgAlreadyPlaying, nil)
 	}
+}
+
+func (d *Dispatcher) cargoWire(st *world.CargoState) (int32, [128]protocol.SelItem) {
+	var items [128]protocol.SelItem
+	if st == nil {
+		return 0, items
+	}
+	for i := range st.Items {
+		if i >= len(items) {
+			break
+		}
+		items[i] = itemToSel(st.Items[i])
+	}
+	return st.Coin, items
 }
 
 // selCharsFrom maps the dbServer character summaries to protocol.SelChar rows for

--- a/tmserver/internal/protocol/mob_test.go
+++ b/tmserver/internal/protocol/mob_test.go
@@ -168,18 +168,39 @@ func assertZeroRange(t *testing.T, b []byte, start, end int) {
 
 func TestSelCharSizes(t *testing.T) {
 	chars := []SelChar{{Slot: 0, Name: "Hero", Level: 50}}
-	if got := len(EncodeCNFAccountLoginBody("acc", chars)); got != cnfAccountLoginSize-HeaderSize {
+	var empty [cnfCargoSlots]SelItem
+	if got := len(EncodeCNFAccountLoginBody("acc", chars, 0, empty)); got != cnfAccountLoginSize-HeaderSize {
 		t.Errorf("CNFAccountLogin body = %d, want %d", got, cnfAccountLoginSize-HeaderSize) // 1996
 	}
 	if got := len(EncodeCNFNewCharacterBody(chars)); got != cnfNewCharacterSize-HeaderSize {
 		t.Errorf("CNFNewCharacter body = %d, want %d", got, cnfNewCharacterSize-HeaderSize) // 844
 	}
 	// Slot-0 name at body 36 (sel@20 + Name[][]@16), level at body 100 (sel@20 + Score@80).
-	b := EncodeCNFAccountLoginBody("acc", chars)
+	b := EncodeCNFAccountLoginBody("acc", chars, 0, empty)
 	if cstr16(b[36:52]) != "Hero" {
 		t.Errorf("selchar name = %q, want Hero", cstr16(b[36:52]))
 	}
 	if binary.LittleEndian.Uint32(b[100:104]) != 50 {
 		t.Errorf("selchar level = %d, want 50", binary.LittleEndian.Uint32(b[100:104]))
+	}
+}
+
+func TestCNFAccountLoginCargo(t *testing.T) {
+	chars := []SelChar{{Slot: 0, Name: "Hero", Level: 1}}
+	var cargo [cnfCargoSlots]SelItem
+	cargo[0] = SelItem{Index: 4140}
+	cargo[28] = SelItem{Index: 4199}
+	b := EncodeCNFAccountLoginBody("acc", chars, 12345, cargo)
+	if got := binary.LittleEndian.Uint16(b[cnfCargoBodyOff : cnfCargoBodyOff+2]); got != 4140 {
+		t.Errorf("cargo[0] = %d, want 4140", got)
+	}
+	if got := binary.LittleEndian.Uint16(b[cnfCargoBodyOff+28*8 : cnfCargoBodyOff+28*8+2]); got != 4199 {
+		t.Errorf("cargo[28] = %d, want 4199", got)
+	}
+	if got := binary.LittleEndian.Uint32(b[cnfCoinBodyOff : cnfCoinBodyOff+4]); got != 12345 {
+		t.Errorf("cargo coin = %d, want 12345", got)
+	}
+	if cstr16(b[cnfNameBodyOff:cnfNameBodyOff+16]) != "acc" {
+		t.Errorf("account name = %q, want acc", cstr16(b[cnfNameBodyOff:cnfNameBodyOff+16]))
 	}
 }

--- a/tmserver/internal/protocol/selchar.go
+++ b/tmserver/internal/protocol/selchar.go
@@ -104,13 +104,27 @@ func MobEquip(mob816 []byte) [16]SelItem {
 	return eq
 }
 
-// EncodeCNFAccountLoginBody builds the body of MSG_CNFAccountLogin (0x010A): the
-// character-selection screen. Send with HEADER.ID = IDSelChar (30002).
-func EncodeCNFAccountLoginBody(accountName string, chars []SelChar) []byte {
+const (
+	cnfCargoSlots   = 128
+	cnfCargoBodyOff = 860  // Cargo[128] @ abs872
+	cnfCoinBodyOff  = 1884 // Coin @ abs1896
+	cnfNameBodyOff  = 1888 // AccountName @ abs1900
+)
+
+// EncodeCNFAccountLoginBody builds the body of MSG_CNFAccountLogin (0x010A):
+// SELCHAR + account Cargo[128] + Coin + AccountName (Basedef.h MSG_DBCNFAccountLogin,
+// forwarded to the client as-is). The client caches this cargo for the vault UI;
+// omitting it leaves the warehouse empty even when the server has items. Send with
+// HEADER.ID = IDSelChar (30002).
+func EncodeCNFAccountLoginBody(accountName string, chars []SelChar, coin int32, cargo [cnfCargoSlots]SelItem) []byte {
 	b := make([]byte, cnfAccountLoginSize-HeaderSize) // 1996
 	le.PutUint32(b[16:], 1)                           // Unknow_28=1 (don't recreate starter potions)
 	writeSelChar(b[20:20+structSelCharSize], chars)   // sel @ abs32 → body20
-	copy(b[1888:1888+16], accountName)                // AccountName @ abs1900 → body1888
+	for i := 0; i < cnfCargoSlots; i++ {
+		writeSelItem(b[cnfCargoBodyOff+i*8:], cargo[i])
+	}
+	le.PutUint32(b[cnfCoinBodyOff:], uint32(coin))
+	copy(b[cnfNameBodyOff:cnfNameBodyOff+16], accountName)
 	return b
 }
 


### PR DESCRIPTION
## Summary
- Serialize `Cargo[128]` + `Coin` into `MSG_CNFAccountLogin` (parity with legacy `MSG_DBCNFAccountLogin`), so the client vault cache is not empty after login.
- Encode cargo after `ApplyDeliveries`, so web/daily-reward grants drained at login are visible immediately in the account warehouse.
- Add protocol and handler tests covering cargo item/coin offsets on the wire.

## Test plan
- [ ] `go test -race ./tmserver/internal/protocol/ ./tmserver/internal/handler/ -run 'TestCNFAccountLoginCargo|TestLoginSendsCargo|TestLoginOK|TestDonate'`
- [ ] Deploy tm-server, log in with an account that has cargo items (e.g. daily reward baú XP already `delivered`), open account vault and confirm items appear
- [ ] Claim a new daily reward while offline, log in once, confirm the granted item shows in cargo without needing a second login


Made with [Cursor](https://cursor.com)