### PR TITLE
fix: grant level-up attribute points from BaseScore, not equip-inflated stats

### DIFF
--- a/tmserver/internal/handler/mobkilled.go
+++ b/tmserver/internal/handler/mobkilled.go
@@ -119,7 +119,12 @@ func (d *Dispatcher) applyMortalLevelUps(w *world.World, s *world.Session, e *wo
 	if !leveled {
 		return false
 	}
-	e.ScoreBonus = uint16(level.ScoreBonus(e.Class, e.Level, e.Str, e.Int, e.Dex, e.Con))
+	// BASE_GetBonusScorePoint reads the equipment-free BaseScore attributes: it
+	// derives "points already spent" as (attr − class base). The live e.Str/e.Int/…
+	// are CurrentScore (base + equipment), so feeding them here over-counts the spend
+	// by whatever the gear adds and drives the grant to 0 — the "no points on level-up"
+	// bug for any character wearing attribute gear. Use the allocated BaseScore.
+	e.ScoreBonus = uint16(level.ScoreBonus(e.Class, e.Level, e.BaseStr, e.BaseInt, e.BaseDex, e.BaseCon))
 	d.refreshScore(e)             // fold the base HP/MP gains into the live score
 	e.HP, e.MP = e.MaxHP, e.MaxMP // full heal on level-up
 

--- a/tmserver/internal/handler/mobkilled_test.go
+++ b/tmserver/internal/handler/mobkilled_test.go
@@ -62,7 +62,10 @@ func mobKilledWorld(t *testing.T) (*Dispatcher, *world.World, *world.Entity) {
 		ID: 0, Mode: world.MobUser, Name: "Heroi",
 		Level: 1, ClassMaster: classMasterMortal,
 		BaseMaxHP: 80, BaseMaxMP: 45, HP: 40, MaxHP: 80, MP: 20, MaxMP: 45,
-		Str: 8, Int: 4, Dex: 7, Con: 6, // TK base attributes
+		// TK class-base attributes, no allocated points and no gear, so the live
+		// CurrentScore (Str/…) equals the equipment-free BaseScore (BaseStr/…).
+		Str: 8, Int: 4, Dex: 7, Con: 6,
+		BaseStr: 8, BaseInt: 4, BaseDex: 7, BaseCon: 6,
 	}
 	return d, w, killer
 }
@@ -103,11 +106,56 @@ func TestMobKilledLevelUp(t *testing.T) {
 	if killer.SkillBonus != 3 || killer.SpecialBonus != 2 {
 		t.Errorf("SkillBonus/SpecialBonus = %d/%d, want 3/2", killer.SkillBonus, killer.SpecialBonus)
 	}
+	// A TK at the class base with nothing allocated gets level*5 free attribute
+	// points (B10): 2 levels → 10. Zero here is the "no points on level-up" bug.
+	if killer.ScoreBonus != 10 {
+		t.Errorf("ScoreBonus = %d, want 10 (level 2 × 5, nothing spent)", killer.ScoreBonus)
+	}
 	if killer.BaseMaxHP != 83 { // TK IncHP = 3
 		t.Errorf("BaseMaxHP = %d, want 83", killer.BaseMaxHP)
 	}
 	if killer.HP != killer.MaxHP || killer.MP != killer.MaxMP || killer.MaxHP <= 0 {
 		t.Errorf("HP/MP = %d/%d of %d/%d, want full heal", killer.HP, killer.MP, killer.MaxHP, killer.MaxMP)
+	}
+}
+
+// TestMobKilledLevelUpPointsIgnoreEquipAttributes is the regression guard for the
+// "no attribute points on level-up while wearing gear" bug: BASE_GetBonusScorePoint
+// must read the equipment-free BaseScore. Here the live CurrentScore attributes are
+// inflated far above the class base by equipment (Str 8→108), while the allocated
+// BaseScore is untouched. The free-point grant must stay level*5 (nothing allocated);
+// the pre-fix code fed the inflated e.Str in, counted 100 points as "spent", and
+// handed the player ZERO.
+func TestMobKilledLevelUpPointsIgnoreEquipAttributes(t *testing.T) {
+	d, w, killer := mobKilledWorld(t)
+	// +100 Str from equipment: CurrentScore diverges from the allocated BaseScore.
+	killer.Str = killer.BaseStr + 100
+	killer.Exp = 1100 // crosses exactly one level (nextLevel[2]=1124)
+	mobID := w.SpawnMob(expMobTemplate(1, 1000, 0), 6, 5)
+
+	d.mobKilled(w, killer, w.Entity(mobID))
+	if killer.Level != 2 {
+		t.Fatalf("killer.Level = %d, want 2", killer.Level)
+	}
+	if killer.ScoreBonus != 10 {
+		t.Errorf("ScoreBonus = %d, want 10 — equipment attribute bonus must not consume free points", killer.ScoreBonus)
+	}
+}
+
+// TestMobKilledLevelUpPointsAfterAllocation: points already spent into the
+// BaseScore reduce the grant (the idempotent BASE_GetBonusScorePoint identity),
+// while equipment on top of them still does not. Level 2 grants 10; 4 allocated
+// into Str leaves 6 free even with gear inflating the live Str further.
+func TestMobKilledLevelUpPointsAfterAllocation(t *testing.T) {
+	d, w, killer := mobKilledWorld(t)
+	killer.BaseStr = 8 + 4           // 4 points allocated above the TK base
+	killer.Str = killer.BaseStr + 30 // plus equipment on top
+	killer.Exp = 1100
+	mobID := w.SpawnMob(expMobTemplate(1, 1000, 0), 6, 5)
+
+	d.mobKilled(w, killer, w.Entity(mobID))
+	if killer.ScoreBonus != 6 {
+		t.Errorf("ScoreBonus = %d, want 6 (level 2 × 5 − 4 allocated)", killer.ScoreBonus)
 	}
 }
 


### PR DESCRIPTION
## Problem

Leveling up stopped granting attribute points for any character wearing
attribute gear (regression of the original B10 fix).

## Root cause

`applyMortalLevelUps` (`tmserver/internal/handler/mobkilled.go`) recomputed the
free attribute points via `level.ScoreBonus(...)` (port of
`BASE_GetBonusScorePoint`) using the live `e.Str/e.Int/e.Dex/e.Con`. Those are
**CurrentScore** (`= BaseScore + equipment`, kept live by `refreshScore`), while
`level.ScoreBonus` derives "points already spent" as `(attr − class base)`. For a
geared character `e.Str > e.BaseStr`, so the equipment was counted as spent
points and the grant clamped to **0**. Gearless characters were unaffected
(`Str == BaseStr`), which is why the existing test — a gearless killer that never
even asserted `ScoreBonus` — missed it.

## Fix

Feed the equipment-free base attributes (`e.BaseStr/BaseInt/BaseDex/BaseCon`),
which is where allocation (`applyScoreBonus`) actually writes.

## Regression coverage

- Added the missing `ScoreBonus` assertion to `TestMobKilledLevelUp`.
- `TestMobKilledLevelUpPointsIgnoreEquipAttributes` — `Str = BaseStr + 100` from
  gear; grant must stay `10`, not `0` (the exact bug).
- `TestMobKilledLevelUpPointsAfterAllocation` — allocation counts, equipment on
  top does not.

Verified the new tests fail with `ScoreBonus = 0` when the fix is reverted and
pass with it. `go build ./...`, `go vet`, `gofmt`, and
`go test -race ./tmserver/internal/handler/ ./tmserver/internal/level/` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)