### PR TITLE
Mounts grant their attributes (montarias) — issue #93

### DIFF
--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -646,6 +646,10 @@ type equipBonus struct {
 	maxHP, maxMP         int32
 	hpAddPct, mpAddPct   int32
 	runSpeed             int32
+	// Mount (Equip[14]) contributions, from the g_pMountBonus tables rather than item
+	// effects. magicRaw is the pre-scaling EF_MAGIC sum (see mountMagicScore); resist
+	// applies to all four resistances. damage already folds into the field above.
+	magicRaw, parry, resist int32
 }
 
 func (d *Dispatcher) equipBonus(e *world.Entity) equipBonus {
@@ -697,6 +701,18 @@ func (d *Dispatcher) equipBonus(e *world.Entity) equipBonus {
 		if it.Empty() {
 			continue
 		}
+		// The mount slot draws its stats from the g_pMountBonus tables, not from
+		// generic item effects (a mount's Effects hold HP/level/feed, not stats) —
+		// mirror BASE_GetItemAbility's early mount return and skip the effect loop.
+		if slot == mountEquipSlot {
+			if mb, ok := mountBonusFor(it); ok {
+				b.damage += mb.damage
+				b.magicRaw += mb.magicRaw
+				b.parry += mb.parry
+				b.resist += mb.resist
+			}
+			continue
+		}
 		weaponSlot := slot == weaponSlotR || slot == weaponSlotL
 		nUnique := d.itemUnique[int(it.Index)]
 		dmgJewel := nUnique >= 41 && nUnique <= 50
@@ -734,6 +750,14 @@ func (d *Dispatcher) deriveBaseScore(e *world.Entity) {
 	e.BaseDamage = e.Damage - b.damage - d.derivedDamageTotal(e, false)
 	e.BaseMaxHP = e.MaxHP - b.maxHP
 	e.BaseMaxMP = e.MaxMP - b.maxMP
+	// Mount bonuses (Magic/Parry/Resist): same subtraction as the fields above so the
+	// loaded CurrentScore round-trips. Players persist no Parry/Resist (loaded 0), so
+	// their base is 0 until a mount is equipped.
+	e.BaseMagic = e.Magic - int16(mountMagicScore(b.magicRaw))
+	e.BaseParry = e.Parry - int(b.parry)
+	for i := range e.BaseResist {
+		e.BaseResist[i] = e.Resist[i] - int16(b.resist)
+	}
 }
 
 // refreshScore recomputes the live CurrentScore = BaseScore + FLAT equipment, after any
@@ -759,6 +783,18 @@ func (d *Dispatcher) refreshScore(e *world.Entity) {
 	e.HpAddPct = b.hpAddPct
 	e.MpAddPct = b.mpAddPct
 	e.RunSpeedBonus = b.runSpeed
+	// Mount bonuses: Magic gets the (sum+1)/4 scaling, Parry (evasion) and each Resist
+	// are flat, with Resist capped at the legacy ceiling (CMob.cpp:640-643,692). Mounts
+	// live only in a player's Equip[14]; mobs carry their Magic/Parry/Resist straight
+	// from their template (world.SpawnMob) and never derive a BaseScore, so recomputing
+	// them here would zero those template values — guard to players.
+	if world.IsPlayer(e.ID) {
+		e.Magic = e.BaseMagic + int16(mountMagicScore(b.magicRaw))
+		e.Parry = e.BaseParry + int(b.parry)
+		for i := range e.Resist {
+			e.Resist[i] = clampResist(e.BaseResist[i] + int16(b.resist))
+		}
+	}
 	d.applyAffectScore(e)
 
 	e.EquipExpBonus = d.equipExpBonus(e)

--- a/tmserver/internal/handler/mount.go
+++ b/tmserver/internal/handler/mount.go
@@ -1,0 +1,143 @@
+package handler
+
+import "github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+
+// Mount (montaria) attribute bonuses. In legacy WYD a mount's combat stats do NOT
+// come from the item's catalog effects — they are read from the g_pMountBonus /
+// g_pMountTempBonus tables inside BASE_GetItemAbility (Basedef.cpp:1599-1654) and
+// summed into CurrentScore by the normal equip loop. Columns are
+// {Attack, Magic, Evasion, Resist, Speed}; the Speed column is applied separately
+// by attackRunOf (issue #64), so only the first four matter here.
+//
+// Both tables are ported verbatim from the current legacy Source, where every row
+// has been flattened to {750,110,80,32,6} (the per-mount names are kept in comments
+// for a future re-balance; the original values live in Basedef.cpp:242-292).
+
+// mountBonusTable is g_pMountBonus[30][5] — persistent/adult mounts (item indices
+// 2360-2389, indexed by sIndex-2360). Basedef.cpp:238.
+var mountBonusTable = [30][5]int32{
+	{750, 110, 80, 32, 6}, // Porco
+	{750, 110, 80, 32, 6}, // Javali
+	{750, 110, 80, 32, 6}, // Lobo
+	{750, 110, 80, 32, 6}, // Dragao menor
+	{750, 110, 80, 32, 6}, // Urso
+	{750, 110, 80, 32, 6}, // Dente de sabre
+	{750, 110, 80, 32, 6}, // Cavalo s/sela N
+	{750, 110, 80, 32, 6}, // Fantasma N
+	{750, 110, 80, 32, 6}, // Leve N
+	{750, 110, 80, 32, 6}, // Equip N
+	{750, 110, 80, 32, 6}, // Andaluz N
+	{750, 110, 80, 32, 6}, // Cavalo s/sela B
+	{750, 110, 80, 32, 6}, // Fantasma B
+	{750, 110, 80, 32, 6}, // Leve B
+	{750, 110, 80, 32, 6}, // Equip B
+	{750, 110, 80, 32, 6}, // Andaluz B
+	{750, 110, 80, 32, 6}, // Fenrir
+	{750, 110, 80, 32, 6}, // Dragao
+	{750, 110, 80, 32, 6}, // Fenrir das sombras
+	{750, 110, 80, 32, 6}, // Tigre de fogo
+	{750, 110, 80, 32, 6}, // Dragao vermelho
+	{750, 110, 80, 32, 6}, // Unicornio
+	{750, 110, 80, 32, 6}, // Pegasus
+	{750, 110, 80, 32, 6}, // Unisus
+	{750, 110, 80, 32, 6}, // Grifo
+	{750, 110, 80, 32, 6}, // HipoGrifo
+	{750, 110, 80, 32, 6}, // Sangrento
+	{750, 110, 80, 32, 6}, // Svaldfire
+	{750, 110, 80, 32, 6}, // Sleipnir
+	{750, 110, 80, 32, 6}, // Pantera negra
+}
+
+// mountTempBonusTable is g_pMountTempBonus[20][5] — temporary/premium mounts (item
+// indices 3980-3994, indexed by sIndex-3980). Only 15 rows are defined in the legacy
+// Source; the rest stay zero. Basedef.cpp:274.
+var mountTempBonusTable = [20][5]int32{
+	{750, 110, 80, 32, 6}, // Shire 3D
+	{750, 110, 80, 32, 6}, // Thoroughbred 3D
+	{750, 110, 80, 32, 6}, // Klazedale 3D
+	{750, 110, 80, 32, 6}, // Shire 15D
+	{750, 110, 80, 32, 6}, // Thoroughbred 15D
+	{750, 110, 80, 32, 6}, // Klazedale 15D
+	{750, 110, 80, 32, 6}, // Shire 30D
+	{750, 110, 80, 32, 6}, // Thoroughbred 30D
+	{750, 110, 80, 32, 6}, // Klazedale 30D
+	{750, 110, 80, 32, 6}, // Gullfaxi 30D
+	{750, 110, 80, 32, 6}, // Tigre de Fogo
+	{750, 110, 80, 32, 6}, // Dragao Vermelho
+	{750, 110, 80, 32, 6}, // Dragao Menor
+	{750, 110, 80, 32, 6}, // Dragao Akelo
+	{750, 110, 80, 32, 6}, // Dragao Hekalo
+}
+
+// mountAttrBonus is one mount's flat contribution to CurrentScore. resist is applied
+// identically to all four resistances (the legacy uses g_pMountBonus[cd][3] for every
+// EF_RESISTi). magicRaw is the pre-scaling EF_MAGIC value — mountMagicScore turns the
+// accumulated raw sum into the final CurrentScore.Magic addend.
+type mountAttrBonus struct {
+	damage   int32
+	magicRaw int32
+	parry    int32
+	resist   int32
+}
+
+// mountBonusFor returns the mount stat bonus for an item equipped in Equip[14],
+// replicating BASE_GetItemAbility's mount branch (Basedef.cpp:1599-1654). ok is false
+// for any non-mount item, and for an adult mount whose HP has run out (matching the
+// legacy stEffect[0].sValue <= 0 guard). Column order is {Attack, Magic, Evasion,
+// Resist, Speed}; Speed is handled by attackRunOf, so it is ignored here.
+func mountBonusFor(it world.Item) (mountAttrBonus, bool) {
+	idx := int(it.Index)
+
+	switch {
+	// Adult mounts: Attack/Magic scale with the mount level and require live HP.
+	case idx >= 2362 && idx < 2390:
+		// The legacy STRUCT_ITEM aliases stEffect[0] (cEffect,cValue) as a 16-bit
+		// sValue holding the mount's current HP, and stEffect[1].cEffect as its level.
+		hp := int16(uint16(it.Effects[0].Effect) | uint16(it.Effects[0].Value)<<8)
+		if hp <= 0 {
+			return mountAttrBonus{}, false
+		}
+		lv := int32(it.Effects[1].Effect)
+		row := mountBonusTable[idx-2360]
+		return mountAttrBonus{
+			damage:   (lv + 20) * row[0] / 100,
+			magicRaw: (lv + 15) * row[1] / 100,
+			parry:    row[2],
+			resist:   row[3],
+		}, true
+
+	// Temporary/premium mounts: flat table values, no HP gate or level scaling.
+	case idx >= 3980 && idx <= 3994:
+		row := mountTempBonusTable[idx-3980]
+		return mountAttrBonus{
+			damage:   row[0],
+			magicRaw: row[1],
+			parry:    row[2],
+			resist:   row[3],
+		}, true
+	}
+
+	return mountAttrBonus{}, false
+}
+
+// mountMagicScore turns the accumulated raw EF_MAGIC sum into the CurrentScore.Magic
+// addend: magic = (sum + 1) / 4 (Basedef.cpp:3194-3195). Zero when there is no equip
+// magic. Mounts are currently the only equipment feeding this in the Go model.
+func mountMagicScore(raw int32) int32 {
+	if raw <= 0 {
+		return 0
+	}
+	return (raw + 1) / 4
+}
+
+// resistCap is the per-resistance ceiling the legacy applies to a player's
+// equipment-derived resist (CMob.cpp:640-643, min(value, 100)).
+const resistCap = 100
+
+// clampResist caps an equipment-derived resistance at the legacy ceiling.
+func clampResist(v int16) int16 {
+	if v > resistCap {
+		return resistCap
+	}
+	return v
+}

--- a/tmserver/internal/handler/mount_test.go
+++ b/tmserver/internal/handler/mount_test.go
@@ -1,0 +1,134 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// TestMountBonusForTemp covers a temporary/premium mount (idx 3980-3994): flat table
+// values, no HP gate or level scaling. 3987 = Thoroughbred(30dias), the Perzen reward.
+func TestMountBonusForTemp(t *testing.T) {
+	mb, ok := mountBonusFor(world.Item{Index: 3987})
+	if !ok {
+		t.Fatalf("mountBonusFor(3987) ok = false, want true")
+	}
+	if mb.damage != 750 || mb.magicRaw != 110 || mb.parry != 80 || mb.resist != 32 {
+		t.Errorf("temp mount bonus = %+v, want {damage:750 magicRaw:110 parry:80 resist:32}", mb)
+	}
+}
+
+// TestMountBonusForAdult covers an adult mount (idx 2362-2389): Attack/Magic scale with
+// the mount level (stEffect[1].cEffect) and require live HP (stEffect[0].sValue > 0).
+func TestMountBonusForAdult(t *testing.T) {
+	// idx 2362 → cd 2, level 5, HP 20 (Effects[0] low byte). row {750,110,80,32,6}.
+	it := world.Item{Index: 2362}
+	it.Effects[0] = world.Effect{Effect: 20, Value: 0} // sValue = 20 (HP)
+	it.Effects[1] = world.Effect{Effect: 5}            // level = 5
+	mb, ok := mountBonusFor(it)
+	if !ok {
+		t.Fatalf("mountBonusFor(adult, HP>0) ok = false, want true")
+	}
+	// damage = (5+20)*750/100 = 187; magicRaw = (5+15)*110/100 = 22.
+	if mb.damage != 187 || mb.magicRaw != 22 || mb.parry != 80 || mb.resist != 32 {
+		t.Errorf("adult mount bonus = %+v, want {damage:187 magicRaw:22 parry:80 resist:32}", mb)
+	}
+
+	// HP = 0 → dead mount grants nothing (legacy stEffect[0].sValue <= 0 guard).
+	dead := world.Item{Index: 2362}
+	dead.Effects[1] = world.Effect{Effect: 5}
+	if _, ok := mountBonusFor(dead); ok {
+		t.Errorf("mountBonusFor(adult, HP=0) ok = true, want false")
+	}
+}
+
+// TestMountBonusForNonMount: display/permanent mounts (315-346, e.g. Shire 342) and
+// baby mounts get nothing, matching legacy BASE_GetItemAbility coverage.
+func TestMountBonusForNonMount(t *testing.T) {
+	for _, idx := range []int16{0, 342, 2330, 2361, 3995} {
+		if _, ok := mountBonusFor(world.Item{Index: idx}); ok {
+			t.Errorf("mountBonusFor(%d) ok = true, want false", idx)
+		}
+	}
+}
+
+// TestMountEquipScore is the end-to-end score path: equipping a temp mount in Equip[14]
+// raises Attack (Damage), Magic, Evasion (Parry) and Resist; unequipping drops them back.
+func TestMountEquipScore(t *testing.T) {
+	d := New(Config{})
+	e := &world.Entity{ID: 1, Level: 50, Damage: 205}
+	e.Equip[0] = world.Item{Index: 11}
+	// Derive the equipment-free base with no mount, mirroring login.
+	d.deriveBaseScore(e)
+	d.refreshScore(e)
+	baseDamage, baseMagic, baseParry := e.Damage, e.Magic, e.Parry
+	for i := range e.Resist {
+		if e.Resist[i] != 0 {
+			t.Fatalf("unmounted Resist[%d] = %d, want 0", i, e.Resist[i])
+		}
+	}
+
+	// Equip the Thoroughbred and refresh (what refreshEquip does on a drag-equip).
+	e.Equip[mountEquipSlot] = world.Item{Index: 3987}
+	d.refreshScore(e)
+	if e.Damage != baseDamage+750 {
+		t.Errorf("mounted Damage = %d, want %d (+750 attack)", e.Damage, baseDamage+750)
+	}
+	if e.Magic != baseMagic+27 { // (110+1)/4 = 27
+		t.Errorf("mounted Magic = %d, want %d (+27)", e.Magic, baseMagic+27)
+	}
+	if e.Parry != baseParry+80 {
+		t.Errorf("mounted Parry = %d, want %d (+80 evasion)", e.Parry, baseParry+80)
+	}
+	for i := range e.Resist {
+		if e.Resist[i] != 32 {
+			t.Errorf("mounted Resist[%d] = %d, want 32", i, e.Resist[i])
+		}
+	}
+	if sc := d.computeScore(e); sc.Damage != baseDamage+750 || sc.Magic != int32(baseMagic)+27 || sc.Resist[0] != 32 {
+		t.Errorf("computeScore = Damage %d Magic %d Resist0 %d, want %d/%d/32",
+			sc.Damage, sc.Magic, sc.Resist[0], baseDamage+750, int32(baseMagic)+27)
+	}
+
+	// Unequip → everything returns to the unmounted baseline.
+	e.Equip[mountEquipSlot] = world.Item{}
+	d.refreshScore(e)
+	if e.Damage != baseDamage || e.Magic != baseMagic || e.Parry != baseParry || e.Resist[0] != 0 {
+		t.Errorf("unmounted again = Damage %d Magic %d Parry %d Resist0 %d, want %d/%d/%d/0",
+			e.Damage, e.Magic, e.Parry, e.Resist[0], baseDamage, baseMagic, baseParry)
+	}
+}
+
+// TestMountScoreRoundTrip: a mount already equipped at login round-trips — deriveBaseScore
+// then refreshScore reproduces the loaded CurrentScore exactly (no double count).
+func TestMountScoreRoundTrip(t *testing.T) {
+	d := New(Config{})
+	e := &world.Entity{ID: 1, Level: 50, Damage: 955, Magic: 60}
+	e.Resist = [4]int16{32, 32, 32, 32}
+	e.Parry = 80
+	e.Equip[0] = world.Item{Index: 11}
+	e.Equip[mountEquipSlot] = world.Item{Index: 3987}
+	d.deriveBaseScore(e)
+	d.refreshScore(e)
+	if e.Damage != 955 || e.Magic != 60 || e.Parry != 80 {
+		t.Errorf("round-trip = Damage %d Magic %d Parry %d, want 955/60/80", e.Damage, e.Magic, e.Parry)
+	}
+	for i := range e.Resist {
+		if e.Resist[i] != 32 {
+			t.Errorf("round-trip Resist[%d] = %d, want 32", i, e.Resist[i])
+		}
+	}
+}
+
+// TestMountBonusMobResistPreserved: refreshScore runs on mobs too (affect targets). A mob
+// carries its Resist from its template and never derives a BaseScore, so the mount path
+// (player-only) must not zero it.
+func TestMountBonusMobResistPreserved(t *testing.T) {
+	d := New(Config{})
+	m := &world.Entity{ID: world.MaxUser, Level: 100} // first mob id → IsPlayer == false
+	m.Resist = [4]int16{50, 40, 30, 20}
+	d.refreshScore(m)
+	if m.Resist != [4]int16{50, 40, 30, 20} {
+		t.Errorf("mob Resist after refreshScore = %v, want [50 40 30 20] (template preserved)", m.Resist)
+	}
+}

--- a/tmserver/internal/world/session.go
+++ b/tmserver/internal/world/session.go
@@ -179,6 +179,12 @@ type Entity struct {
 	BaseStr, BaseInt, BaseDex, BaseCon int16
 	BaseAC, BaseDamage                 int32
 	BaseMaxHP, BaseMaxMP               int32
+	// BaseMagic/BaseParry/BaseResist: the equipment-free Magic/Parry(evasion)/Resist,
+	// the mount-bonus counterparts of the Base* fields above. Same policy — derived on
+	// login (current − equipment) and re-added by refreshScore, never persisted.
+	BaseMagic  int16
+	BaseParry  int
+	BaseResist [4]int16
 
 	// HpAddPct/MpAddPct: EF_HPADD/EF_MPADD percent bonus from equipment (e.g. +10 =
 	// +10%). Cached by refreshScore and applied at READ time (effective max HP/MP),


### PR DESCRIPTION
## Context

Fixes #93 — "As montarias não estão adicionando os atributos". A player who equipped a mount (`Equip[14]`) got no stat bonus; only the move-speed bump worked.

**Root cause:** In legacy WYD, a mount's combat bonuses do **not** come from the item's catalog/instance effects — they are read from `g_pMountBonus[30][5]` / `g_pMountTempBonus[20][5]` (`Source/Code/Basedef.cpp:238,274`), looked up by item index inside `BASE_GetItemAbility` and summed into `CurrentScore` by the normal equip loop. The Go rewrite had no equivalent, so `equipBonus` iterated slot 14 but mount items carry no scored effects.

## Changes

- **`handler/mount.go`** (new): ports `g_pMountBonus` / `g_pMountTempBonus` (flattened to `{750,110,80,32,6}` to match the current legacy Source), plus `mountBonusFor` and the `mountMagicScore` = `(sum+1)/4` helper.
- **`handler/item.go`**: `equipBonus` folds the mount's Attack→`Damage`, Magic (raw), Evasion→`Parry`, Resist; `refreshScore`/`deriveBaseScore` apply/derive `Magic`/`Parry`/`Resist` (capped at 100) via the existing base+equip pattern.
- **`world/session.go`**: new `BaseMagic`/`BaseParry`/`BaseResist` fields.

### Behavior / parity
- **Coverage exactly as legacy:** adult mounts **2362-2389** (Attack/Magic scale with mount level, gated on HP > 0) and temp mounts **3980-3994** (flat, e.g. Perzen's Thoroughbred 3987). Display mounts 315-346 (incl. Shire 342) and babies grant nothing — matching legacy.
- `ScoreData` already carries `Damage`/`Magic`/`Resist[4]`, so the visible "atributos" refresh automatically; evasion feeds combat dodge.

### Defensive note
`refreshScore` also runs on **mobs** (affect targets), which load `Resist` from their template but never derive a `BaseScore`. The new Magic/Parry/Resist writes are guarded with `world.IsPlayer(e.ID)` so mob template resistances aren't zeroed.

### Migration caveat
A character who had a mount *already equipped* under the old no-bonus code won't see the bonus on the first post-deploy login (base derivation cancels it); self-heals after one logout with the mount unequipped, then re-equip. The normal Perzen/donate flow (mount arrives in inventory → equip after a clean login) is unaffected.

## Testing

- `go build ./...`, `go vet`, `golangci-lint` — clean.
- Full `tmserver` suite passes with `-race`.
- New `mount_test.go`: temp/adult (level-scaled)/HP=0/non-mount cases, full equip→unequip score path through `computeScore`, base-derivation round-trip, and the mob-resist-preserved guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)