### PR TITLE
fix: halve overly-long skill buff durations (issue #92)

### DIFF
--- a/docs/migration/skills/README.md
+++ b/docs/migration/skills/README.md
@@ -7,7 +7,7 @@ precisa de implementacao, captura Windows ou golden cases no cliente real.
 ## Metodologia
 
 - Fonte de catalogo: `Release/Common/SkillData.csv`, arquivo ISO-8859, lido com nomes decodificados em Latin-1.
-- Loader auditado: `tmserver/internal/content/skilldata.go:79-132`, que usa o indice da coluna 0, ignora linhas fora de `[0,248)`, consome 20 inteiros e divide `AffectTime` por 4.
+- Loader auditado: `tmserver/internal/content/skilldata.go:79-132`, que usa o indice da coluna 0, ignora linhas fora de `[0,248)`, consome 20 inteiros e divide `AffectTime` por 8 (`affectTimeDivisor`). O legado (`Basedef.cpp:6708`) divide por 4; a issue #92 dobrou o divisor para reduzir pela metade as duracoes de buff, que estavam longas demais (ate ~100 min com mastery maxima).
 - Divisao por classe: TK `0..23`, FM `24..47`, BM `48..71`, HT `72..95`, Sephira/shared `96+`.
 - Arvore: `(index % 24) / 8 + 1`.
 - Status e evidencias foram cruzados com `tmserver/internal/combat`, `tmserver/internal/handler`, `tmserver/internal/world`, `tmserver/internal/protocol`, `Source/Code`, `Source/Buff Loop.txt` e os testes existentes.

--- a/tmserver/internal/content/content_test.go
+++ b/tmserver/internal/content/content_test.go
@@ -150,7 +150,7 @@ func TestLoadSkillData(t *testing.T) {
 	if err != nil {
 		t.Skipf("SkillData.csv unavailable: %v", err)
 	}
-	// Golden rows straight from the CSV (sscanf order, AffectTime already ÷4).
+	// Golden rows straight from the CSV (sscanf order, AffectTime already ÷8).
 	tests := []struct {
 		index int
 		want  Spell
@@ -159,7 +159,7 @@ func TestLoadSkillData(t *testing.T) {
 			Range: 5, InstanceType: 4, InstanceValue: 5, InstanceAttribute: 4,
 			Aggressive: 1, MaxTarget: 13, AffectResist: 3, Name: "Giro_da_F\xfaria"}},
 		{5, Spell{Index: 5, SkillPoint: 81, ManaSpent: 53, TickType: 17, TickValue: 75,
-			AffectTime: 150, MaxTarget: 1, Name: "Aura_da_Vida"}},
+			AffectTime: 75, MaxTarget: 1, Name: "Aura_da_Vida"}},
 	}
 	for _, tt := range tests {
 		got, ok := s.Get(tt.index)
@@ -181,7 +181,7 @@ func TestLoadSkillData(t *testing.T) {
 	}
 }
 
-// TestParseSkillDataDividesAffectTime pins the loader's AffectTime ÷4 rule on a
+// TestParseSkillDataDividesAffectTime pins the loader's AffectTime ÷8 rule on a
 // synthetic row (no dependency on the Release CSV): 13 ints, the 2 dotted Act
 // strings, 7 ints, then the name. Column 12 is the raw AffectTime.
 func TestParseSkillDataDividesAffectTime(t *testing.T) {
@@ -194,8 +194,8 @@ func TestParseSkillDataDividesAffectTime(t *testing.T) {
 	if !ok {
 		t.Fatal("skill 2 missing after parse")
 	}
-	if got.AffectTime != 150 {
-		t.Errorf("AffectTime = %d, want 150 (600÷4)", got.AffectTime)
+	if got.AffectTime != 75 {
+		t.Errorf("AffectTime = %d, want 75 (600÷8)", got.AffectTime)
 	}
 	if got.AffectType != 11 || got.AffectValue != 5 {
 		t.Errorf("parsed = %+v, want AffectType 11 / AffectValue 5", got)

--- a/tmserver/internal/content/skilldata.go
+++ b/tmserver/internal/content/skilldata.go
@@ -17,6 +17,13 @@ const (
 	MaxSkillIndex = 248
 )
 
+// affectTimeDivisor scales the raw column-12 AffectTime at load. The legacy
+// loader divides by 4 (Basedef.cpp:6708); this port uses 8 — a deliberate
+// server-tuning divergence from issue #92, where the ÷4 buff durations (up to
+// ~100 min at max mastery) were reported as far too long. ÷8 halves every
+// cast-skill affect duration uniformly.
+const affectTimeDivisor = 8
+
 // Spell is one STRUCT_SPELL row of SkillData.csv (Basedef.h, loaded by
 // BASE_InitializeSkill, Basedef.cpp:6657). Field names match the struct; the
 // Act[] animation bytes are dropped (client-side only). Name is the trailing
@@ -34,7 +41,7 @@ type Spell struct {
 	TickValue         int
 	AffectType        int // affect type applied by SetAffect
 	AffectValue       int
-	AffectTime        int // stored ÷4, as the legacy loader does post-parse
+	AffectTime        int // stored ÷affectTimeDivisor (÷8, issue #92; legacy ÷4)
 	InstanceAttribute int
 	TickAttribute     int
 	Aggressive        int // 1 = hostile (resist roll applies)
@@ -126,7 +133,7 @@ func parseSkillData(r io.Reader) (*SkillData, error) {
 			Index: v[0], SkillPoint: v[1], TargetType: v[2], ManaSpent: v[3],
 			Delay: v[4], Range: v[5], InstanceType: v[6], InstanceValue: v[7],
 			TickType: v[8], TickValue: v[9], AffectType: v[10], AffectValue: v[11],
-			AffectTime:        v[12] / 4,
+			AffectTime:        v[12] / affectTimeDivisor,
 			InstanceAttribute: v[13], TickAttribute: v[14], Aggressive: v[15],
 			MaxTarget: v[16], BParty: v[17], AffectResist: v[18], Passive: v[19],
 			Name: strings.TrimSpace(fields[len(fields)-1]),


### PR DESCRIPTION
## Summary

Fixes #92. In-game buff durations were reported as far too long — the screenshot showed beneficial buffs displaying **59M** (59 min) and item/divine affects showing days.

Investigation confirmed this is **not an arithmetic bug**: it's a faithful port of the legacy formula `t = (AffectTime+1) * (100+Special)/100` ticks × 8s/tick. With skill-mastery `Special` capped at 400, a standard 600-data buff ran ~20 min at 0 mastery up to ~100 min at max (the 59M ≈ Special 193).

Per maintainer decision, the fix **scales the base data** by changing the `AffectTime` load divisor from `/4` (legacy `Basedef.cpp:6708`) to `/8` — a uniform proportional halving of all cast-skill affect durations. Scope is **cast buffs only**; item/mount/divine long durations (`affectTimeCap` = 30 days, divine infinite) are intentionally left untouched.

## Changes

- `tmserver/internal/content/skilldata.go` — named `const affectTimeDivisor = 8` (was inline `/4`), documenting the deliberate divergence from legacy.
- `tmserver/internal/content/content_test.go` — the two `÷4` golden assertions move from `150` to `75`.
- `docs/migration/skills/README.md` — documents the intentional `÷8` tuning divergence and issue #92 rationale.

## Effect

600 raw → 75 (÷8) → `(75+1)*(100+Special)/100` ticks × 8s:
- Special 0 → 76 ticks ≈ **10.1 min** (was ~20)
- Special 193 → 222 ticks ≈ **29.6 min** (was ~59M)
- Special 400 (max) → 380 ticks ≈ **50.7 min** (was ~100)

Nothing becomes instant: the 5 short debuffs at raw 4–5 drop to `AffectTime=0` but still yield ≥1 tick.

## Verification

- `go build ./...` — clean
- `go vet ./tmserver/internal/content/...` — clean
- `go test ./tmserver/internal/content/...` — pass
- `go test -race ./tmserver/internal/handler/ ./tmserver/internal/world/` — pass (unaffected; use explicit values)
- `gofmt -l` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)