### PR TITLE
fix: sync victim HP after PvP damage

### DIFF
--- a/tmserver/internal/handler/combat.go
+++ b/tmserver/internal/handler/combat.go
@@ -134,6 +134,7 @@ func (d *Dispatcher) attack(w *world.World, s *world.Session, h protocol.Header,
 	doubleCritical := uint8(0)
 	doubleCriticalReady := false
 	var healExp int64
+	var hpSyncTargets []int
 	for i := range body.Dam {
 		tid := int(body.Dam[i].TargetID)
 		target := w.Entity(tid)
@@ -221,9 +222,24 @@ func (d *Dispatcher) attack(w *world.World, s *world.Session, h protocol.Header,
 		if dmg > 0 {
 			dmg = applyHuntressForceDamage(e, target, tid, dmg)
 			dmg = d.applyManaControl(w, e, target, tid, dmg)
+			hpBefore := target.HP
 			target.HP -= int32(dmg)
 			if target.HP < 0 {
 				target.HP = 0
+			}
+			if ts := w.Session(tid); ts != nil && target.HP != hpBefore {
+				ts.ReqHp = target.HP
+				setReqHp(ts, target)
+				seen := false
+				for _, syncID := range hpSyncTargets {
+					if syncID == tid {
+						seen = true
+						break
+					}
+				}
+				if !seen {
+					hpSyncTargets = append(hpSyncTargets, tid)
+				}
 			}
 			d.applyOnHitAffects(w, e, target, tid)
 			d.applyHpAbs(w, s, e, dmg)
@@ -299,6 +315,13 @@ func (d *Dispatcher) attack(w *world.World, s *world.Session, h protocol.Header,
 	w.ForEachInView(s.Conn, func(vs *world.Session, _ *world.Entity) {
 		w.SendTo(vs, hdr, payload)
 	})
+	for _, tid := range hpSyncTargets {
+		ts := w.Session(tid)
+		target := w.Entity(tid)
+		if ts != nil && target != nil {
+			d.sendSetHpMp(w, ts, target)
+		}
+	}
 }
 
 // castInfo is the resolved skill context for one attack packet.

--- a/tmserver/internal/handler/combat_test.go
+++ b/tmserver/internal/handler/combat_test.go
@@ -67,6 +67,62 @@ func TestAttackHitExact(t *testing.T) {
 	}
 }
 
+func TestAttackSyncsVictimHpMp(t *testing.T) {
+	addr, stop, _ := startServerClock(t, combatDB())
+	defer stop()
+
+	attacker := enterWorld(t, addr) // conn 1 (attacker)
+	defer attacker.Close()
+	target := enterWorld(t, addr) // conn 2 (target), in view
+	defer target.Close()
+
+	send(t, attacker, protocol.MsgPKMode, protocol.EncodeStandardParm(1)) // PvP requires PK mode
+	attackFrame(t, attacker, serverTime, 2, 0)
+
+	var damage, hp, reqHp int32
+	sawAttack, sawHpSync := false, false
+	for i := 0; i < 6 && (!sawAttack || !sawHpSync); i++ {
+		ty, payload, ok := readMaybe(t, target)
+		if !ok {
+			break
+		}
+		switch ty {
+		case protocol.MsgAttack:
+			var got protocol.MsgAttackBody
+			if err := got.Decode(payload); err != nil {
+				t.Fatal(err)
+			}
+			if len(got.Dam) != 1 || got.Dam[0].TargetID != 2 {
+				t.Fatalf("Dam = %+v", got.Dam)
+			}
+			damage = got.Dam[0].Damage
+			sawAttack = true
+		case protocol.MsgSetHpMp:
+			if len(payload) < 16 {
+				t.Fatalf("SetHpMp body = %d bytes, want at least 16", len(payload))
+			}
+			hp = int32(binary.LittleEndian.Uint32(payload[0:4]))
+			reqHp = int32(binary.LittleEndian.Uint32(payload[8:12]))
+			sawHpSync = true
+		default:
+			t.Fatalf("target got %#x, want MsgAttack/MsgSetHpMp", ty)
+		}
+	}
+	if !sawAttack {
+		t.Fatal("target did not receive MsgAttack")
+	}
+	if !sawHpSync {
+		t.Fatal("target did not receive MsgSetHpMp after taking PvP damage")
+	}
+	if damage <= 0 {
+		t.Fatalf("damage = %d, want > 0", damage)
+	}
+	wantHP := int32(1000) - damage
+	if hp != wantHP || reqHp != wantHP {
+		t.Errorf("SetHpMp Hp/ReqHp = %d/%d, want %d/%d", hp, reqHp, wantHP, wantHP)
+	}
+}
+
 // TestAttackPlayerWithoutPKModeBlocked: PvP damage never lands without the
 // attacker having opted into PK mode first (K key, _MSG_PKMode) — issue #59
 // follow-up (pressing K alone must not blink the nickname; only a landed PvP


### PR DESCRIPTION
## Summary
- sync the victim's HP/ReqHp with MSG_SetHpMp after direct PvP damage
- keep MSG_Attack broadcast ordering for attack animation and viewers
- add regression coverage for issue #100

Fixes #100

## Tests
- go test ./tmserver/internal/handler