### PR TITLE
fix: make pot heals visible to nearby players (#99)

### DIFF
--- a/tmserver/internal/handler/affect_tick.go
+++ b/tmserver/internal/handler/affect_tick.go
@@ -29,8 +29,7 @@ const affectInfiniteTime = 32400000
 // pass). The Type-16 expiry reverts the transform mesh via refreshEquip (the
 // legacy FaceChange).
 func (d *Dispatcher) sweepAffects(w *world.World) {
-	d.tickCount++
-	phase := d.tickCount % affectTickPeriod
+	phase := d.tickCount % affectTickPeriod // incremented once per tick by Tick
 	w.ForEachPlayer(func(s *world.Session, e *world.Entity) {
 		if s.Conn%affectTickPeriod != phase {
 			return

--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -433,8 +433,13 @@ func (d *Dispatcher) enterWorldView(w *world.World, s *world.Session) {
 	if self == nil {
 		return
 	}
-	w.ClearSeen(s)          // fresh view set on (re)entering the world
-	d.sendScore(w, s, self) // CurrentScore (attributes after equipment + active buffs)
+	w.ClearSeen(s) // fresh view set on (re)entering the world
+	// Unicast, NOT the usual multicast sendScore: this runs before the newcomer's
+	// CreateMob is broadcast below, so in-view clients would get an UpdateScore for
+	// an entity they have not created yet (the B1 confusion). The legacy has no
+	// SendScore in this path at all (ProcessDBMessage.cpp:1017-1037) — observers
+	// learn the newcomer's HP from CreateMob.
+	d.sendScoreSelf(w, s, self) // CurrentScore (attributes after equipment + active buffs)
 	if self.HasAnyAffect() {
 		d.sendAffect(w, s, self) // buff icons/timers (e.g. a re-applied Divine)
 	}

--- a/tmserver/internal/handler/combat.go
+++ b/tmserver/internal/handler/combat.go
@@ -225,6 +225,9 @@ func (d *Dispatcher) attack(w *world.World, s *world.Session, h protocol.Header,
 			if target.HP < 0 {
 				target.HP = 0
 			}
+			// Drop the victim's heal target by the damage, or the regen tick heals
+			// it straight back (_MSG_Attack.cpp:1638-1642).
+			damageReqHp(w.Session(tid), target, int32(dmg))
 			d.applyOnHitAffects(w, e, target, tid)
 			d.applyHpAbs(w, s, e, dmg)
 			if pvpHit && combatHit {

--- a/tmserver/internal/handler/hpmp.go
+++ b/tmserver/internal/handler/hpmp.go
@@ -31,6 +31,76 @@ func setReqMp(s *world.Session, e *world.Entity) {
 	}
 }
 
+// applyCasting is the per-call ceiling ApplyHp/ApplyMp move the live bar by
+// (Server.cpp:9543, :9576). The bar closes on its request target in steps of at
+// most this much per tick, which is what makes a potion visibly ramp instead of
+// snapping — an attacker can out-damage the heal.
+const applyCasting = 2000
+
+// applyHp drains the ReqHp request target into live HP, at most applyCasting per
+// call, and reports whether HP actually moved (ApplyHp, Server.cpp:9530-9562).
+// ReqHp is a TARGET, not a pool: it is never decremented here, and setReqHp keeps
+// it at or above HP. The max clamp is the live effective max (gear/buff %HP), not
+// the flat stored MaxHP, consistent with the rest of this file.
+func applyHp(s *world.Session, e *world.Entity) bool {
+	maxHP := effectiveMaxHP(e)
+	if s.ReqHp > maxHP {
+		s.ReqHp = maxHP
+	}
+	if s.ReqHp <= e.HP {
+		return false
+	}
+	diff := s.ReqHp - e.HP
+	if diff > applyCasting {
+		diff = applyCasting
+	}
+	e.HP += diff
+	if e.HP > s.ReqHp {
+		e.HP = s.ReqHp
+	}
+	return true
+}
+
+// damageReqHp lowers the HP request target by a landed hit. Without it the tick's
+// applyHp would simply heal the damage straight back on the very next pass, because
+// ReqHp would still hold the pre-damage target — a player would be near-immune.
+//
+// The debt is REDUCED by the damage, not discarded (_MSG_Attack.cpp:1638-1642 for a
+// player attacker, ProcessSecMinTimer.cpp:2389-2397 for the mob AI): a potion already
+// in flight keeps healing whatever is left of it after the hit. setReqHp then floors
+// the target back at the live HP. No-op for mobs, which have no session.
+func damageReqHp(s *world.Session, e *world.Entity, dmg int32) {
+	if s == nil {
+		return
+	}
+	if s.ReqHp < dmg {
+		s.ReqHp = 0
+	} else {
+		s.ReqHp -= dmg
+	}
+	setReqHp(s, e)
+}
+
+// applyMp is applyHp for the mana bar (ApplyMp, Server.cpp:9564-9596).
+func applyMp(s *world.Session, e *world.Entity) bool {
+	maxMP := effectiveMaxMP(e)
+	if s.ReqMp > maxMP {
+		s.ReqMp = maxMP
+	}
+	if s.ReqMp <= e.MP {
+		return false
+	}
+	diff := s.ReqMp - e.MP
+	if diff > applyCasting {
+		diff = applyCasting
+	}
+	e.MP += diff
+	if e.MP > s.ReqMp {
+		e.MP = s.ReqMp
+	}
+	return true
+}
+
 func (d *Dispatcher) sendSetHpMp(w *world.World, s *world.Session, e *world.Entity) {
 	setReqHp(s, e)
 	setReqMp(s, e)

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -143,6 +143,11 @@ const (
 	divineAffectTime = 2000000000
 )
 
+// potionDelay is the minimum ms between potion uses (_MSG_UseItem.cpp:105-115).
+// The original defaults to 100 and exposes it to the runtime config (Server.cpp:647,
+// :1463); we take the default — a config knob can follow if it's ever tuned.
+const potionDelay = 100
+
 // useItem handles _MSG_UseItem (0x0373), handlers/_MSG_UseItem.md. The action is
 // classified by the source item's EF_VOLATILE value (BASE_GetItemAbility, captura §B):
 // 0 = equip (CARRY → EQUIP); 64-66 = Poção Divina; other consumables are UNVERIFIED and
@@ -301,28 +306,48 @@ func (d *Dispatcher) useFairyDust(w *world.World, s *world.Session, e *world.Ent
 	d.log.Info("fairy dust used", "conn", s.Conn, "classmaster", e.ClassMaster, "level", e.Level)
 }
 
-// useHealPotion consumes an HP/MP potion (EF_VOLATILE 1): restores HP/MP by the
-// item's catalog EF_HP/EF_MP value, clamped to the live effective max, then eats
-// one unit of the stack (docs/migration/handlers/_MSG_UseItem.md, catalog.go:102).
+// useHealPotion consumes an HP/MP potion (EF_VOLATILE 1), porting
+// _MSG_UseItem.cpp:101-148 (docs/migration/handlers/_MSG_UseItem.md, catalog.go:102).
+//
+// The potion does NOT heal: it raises the ReqHp/ReqMp request targets by the item's
+// catalog EF_HP/EF_MP (clamped to the live effective max) and the 1s tick's
+// applyHp/applyMp closes the bars on them (regenPlayers, mobai.go). That ramp is the
+// original's behavior — a potion is out-damageable, not an instant top-off.
+//
+// The reply is SetHpMp and is deliberately self-only (SendSetHpMp, SendFunc.cpp:1722):
+// it carries ReqHp/ReqMp so the drinker's own client can animate the fill. Nearby
+// players are informed by the tick's multicast sendScore once HP actually moves —
+// that path, not this one, is what fixes the stale HP bar in issue #99.
 func (d *Dispatcher) useHealPotion(w *world.World, s *world.Session, e *world.Entity, src int) {
-	idx := int(e.Carry[src].Index)
-	for _, be := range d.itemEffects[idx] {
+	// PotionDelay anti-spam (_MSG_UseItem.cpp:105-115): a use inside the window is
+	// dropped and the slot re-synced, so the stack is not consumed. Gate on the
+	// SERVER clock — the original reads GetTickCount(), and a client-supplied tick
+	// would be spoofable. int64 math avoids uint32 underflow at tick 0.
+	now := w.Now()
+	if s.PotionTick != 0 && int64(now)-int64(s.PotionTick) < potionDelay {
+		w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
+		return
+	}
+	s.PotionTick = now
+
+	maxHP, maxMP := effectiveMaxHP(e), effectiveMaxMP(e)
+	for _, be := range d.itemEffects[int(e.Carry[src].Index)] {
 		switch be.Eff {
 		case efHp:
-			e.HP += int32(be.Val)
+			s.ReqHp += int32(be.Val)
+			if s.ReqHp > maxHP {
+				s.ReqHp = maxHP
+			}
 		case efMp:
-			e.MP += int32(be.Val)
+			s.ReqMp += int32(be.Val)
+			if s.ReqMp > maxMP {
+				s.ReqMp = maxMP
+			}
 		}
-	}
-	if m := effectiveMaxHP(e); e.HP > m {
-		e.HP = m
-	}
-	if m := effectiveMaxMP(e); e.MP > m {
-		e.MP = m
 	}
 	consumeOneItem(&e.Carry[src])
 	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
-	d.sendScore(w, s, e) // MsgUpdateScore carries Hp/Mp (item.go:776) — no separate SetHpMp packet needed
+	d.sendSetHpMp(w, s, e)
 }
 
 // useDivine consumes a Poção Divina: it sets the Divine buff (Affect 34) for 8/16/31
@@ -969,9 +994,31 @@ func attackRunOf(e *world.Entity) uint8 {
 	return uint8(attack<<4) | uint8(move)
 }
 
-// sendScore pushes the recomputed CurrentScore to the player (_MSG_UpdateScore), so
-// the status window reflects equipment.
+// sendScore publishes the recomputed CurrentScore (_MSG_UpdateScore) to the player
+// AND to everyone in view, mirroring the legacy SendScore — whose single exit is
+// GridMulticast(TargetX, TargetY, ..., skip=0), i.e. self plus the whole view
+// window (SendFunc.cpp:1298; all 113 SendScore call sites funnel through it).
+//
+// The multicast is what resynchronizes an out-of-band HP change (potion, regen,
+// heal, revive) on OTHER clients: MSG_Attack carries only STRUCT_DAM deltas that
+// the client SUBTRACTS from its own copy of the target's HP, so without an
+// explicit push an attacker renders a stale HP bar for a drinker (issue #99).
+//
+// HEADER.ID is the SUBJECT's conn for every recipient — that is how a client knows
+// which entity the score describes. Nothing here is private: gold/exp/free points
+// live in MSG_UpdateEtc (sendEtc), which stays unicast like the legacy SendEtc.
 func (d *Dispatcher) sendScore(w *world.World, s *world.Session, e *world.Entity) {
+	body := protocol.EncodeUpdateScore(d.computeScore(e))
+	w.SendTo(s, protocol.Header{Type: protocol.MsgUpdateScore, ID: uint16(s.Conn)}, body)
+	w.BroadcastInView(s.Conn, protocol.MsgUpdateScore, body) // excludes the source
+}
+
+// sendScoreSelf is the unicast score push, for the one path where the subject is not
+// yet visible to the players around it — enterWorldView pushes the score BEFORE
+// broadcasting the newcomer's CreateMob, and the legacy has no SendScore there at
+// all (ProcessDBMessage.cpp:1017-1037 unicasts the login blob, then GridMulticasts
+// CreateMob, which already carries Hp/MaxHp to observers).
+func (d *Dispatcher) sendScoreSelf(w *world.World, s *world.Session, e *world.Entity) {
 	w.SendTo(s, protocol.Header{Type: protocol.MsgUpdateScore, ID: uint16(s.Conn)}, protocol.EncodeUpdateScore(d.computeScore(e)))
 }
 

--- a/tmserver/internal/handler/item_test.go
+++ b/tmserver/internal/handler/item_test.go
@@ -624,6 +624,33 @@ func startServerClockItems(t *testing.T, persist world.Persistence, vols map[int
 	}
 }
 
+// startServerTickItems is startServerClockItems with the simulation tick running, so
+// regenPlayers/applyHp actually close the bars on their ReqHp target. Tests that
+// assert an exact mid-flight HP should NOT use this: the passive trickle
+// (naturalRegenTicks) also runs and drifts HP upward on its own.
+func startServerTickItems(t *testing.T, persist world.Persistence, vols map[int]int, effects map[int][]content.BaseEffect) (string, func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := New(Config{Log: log, ItemVolatiles: vols, ItemEffects: effects, ExpEvents: level.ExpEvents{KefraLive: true}})
+	w := world.New(world.Config{GridDim: 16}, log, persist, d.Handle)
+	w.SetTickHandler(10*time.Millisecond, d.Tick)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = w.Serve(ctx, ln); close(done) }()
+	return ln.Addr().String(), func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("server did not stop")
+		}
+	}
+}
+
 func healPotionDB(item world.Item, hp, maxHP, mp, maxMP int32) *fakeDB {
 	db := newDB()
 	st := world.CharacterState{Slot: 0, Name: "Hero", X: 5, Y: 5, HP: hp, MaxHP: maxHP, MP: mp, MaxMP: maxMP}
@@ -699,6 +726,23 @@ func TestUseExpChestStack(t *testing.T) {
 	}
 }
 
+// setHpMpFields decodes MSG_SetHpMp (protocol/score.go:110): Hp, Mp, ReqHp, ReqMp.
+func setHpMpFields(t *testing.T, p []byte) (hp, mp, reqHp, reqMp int32) {
+	t.Helper()
+	if len(p) < 16 {
+		t.Fatalf("SetHpMp payload too short: %d", len(p))
+	}
+	return int32(binary.LittleEndian.Uint32(p[0:])), int32(binary.LittleEndian.Uint32(p[4:])),
+		int32(binary.LittleEndian.Uint32(p[8:])), int32(binary.LittleEndian.Uint32(p[12:]))
+}
+
+// The potion tests below run WITHOUT a tick handler on purpose: the potion only
+// raises the ReqHp/ReqMp request target, which is fully deterministic, while the
+// live bar is closed on it later by the tick (applyHp). The ramp itself is covered
+// by TestUseHealPotionRampsOverTicks, where a tick runs.
+
+// TestUseHealPotion: the potion stages the heal as a ReqHp target and leaves HP
+// untouched — the original never writes CurrentScore.Hp (_MSG_UseItem.cpp:117-126).
 func TestUseHealPotion(t *testing.T) {
 	const potion = 400
 	db := healPotionDB(world.Item{Index: potion}, 500, 1000, 0, 0)
@@ -715,9 +759,12 @@ func TestUseHealPotion(t *testing.T) {
 	if got := le16(itemPayload[4:6]); got != 0 {
 		t.Errorf("carry slot 0 item = %d, want empty after use", got)
 	}
-	scorePayload := expect(t, c, protocol.MsgUpdateScore)
-	if got := int32(binary.LittleEndian.Uint32(scorePayload[24:28])); got != 550 {
-		t.Errorf("Hp = %d, want 550 (500 + 50)", got)
+	hp, _, reqHp, _ := setHpMpFields(t, expect(t, c, protocol.MsgSetHpMp))
+	if reqHp != 550 {
+		t.Errorf("ReqHp = %d, want 550 (500 + 50)", reqHp)
+	}
+	if hp != 500 {
+		t.Errorf("Hp = %d, want 500 — the potion stages a target, the tick heals", hp)
 	}
 }
 
@@ -734,9 +781,67 @@ func TestUseHealPotionClampsToMax(t *testing.T) {
 	send(t, c, protocol.MsgUseItem, body.Encode())
 
 	expect(t, c, protocol.MsgSendItem)
-	scorePayload := expect(t, c, protocol.MsgUpdateScore)
-	if got := int32(binary.LittleEndian.Uint32(scorePayload[24:28])); got != 1000 {
-		t.Errorf("Hp = %d, want clamped to 1000", got)
+	if _, _, reqHp, _ := setHpMpFields(t, expect(t, c, protocol.MsgSetHpMp)); reqHp != 1000 {
+		t.Errorf("ReqHp = %d, want clamped to 1000", reqHp)
+	}
+}
+
+// TestUseHealPotionRampsOverTicks is the gradual-heal behavior end to end: the bar
+// closes on the potion's target across ticks (applyHp, <=2000/call) rather than
+// snapping at use time.
+func TestUseHealPotionRampsOverTicks(t *testing.T) {
+	const potion = 406
+	db := healPotionDB(world.Item{Index: potion}, 500, 100000, 0, 0)
+	effects := map[int][]content.BaseEffect{potion: {{Eff: efHp, Val: 1000}}}
+	addr, stop := startServerTickItems(t, db, map[int]int{potion: volHpMpPotion}, effects)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+	expect(t, c, protocol.MsgSendItem)
+
+	// The tick's sendScore reports the healed bar. MaxHP is huge so the passive
+	// trickle (Level+30 per 10 ticks) can't reach 1500 within the window on its own.
+	p := expect(t, c, protocol.MsgUpdateScore)
+	if got := int32(binary.LittleEndian.Uint32(p[24:28])); got < 1500 {
+		t.Errorf("Hp = %d, want >= 1500 (500 + the 1000 potion) once the tick applies it", got)
+	}
+}
+
+// TestUseHealPotionCooldown pins the PotionDelay anti-spam gate
+// (_MSG_UseItem.cpp:105-115): a second use inside the window is refused, the slot is
+// re-synced, and — crucially — the stack is NOT consumed twice.
+func TestUseHealPotionCooldown(t *testing.T) {
+	const potion = 407
+	item := world.Item{Index: potion, Effects: [3]world.Effect{{Effect: efAmount, Value: 5}}}
+	db := healPotionDB(item, 500, 100000, 0, 0)
+	effects := map[int][]content.BaseEffect{potion: {{Eff: efHp, Val: 50}}}
+	addr, stop := startServerClockItems(t, db, map[int]int{potion: volHpMpPotion}, effects)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+	if p := expect(t, c, protocol.MsgSendItem); p[7] != 4 {
+		t.Fatalf("first use: stack = %d, want 4 (one consumed)", p[7])
+	}
+	_, _, reqHp, _ := setHpMpFields(t, expect(t, c, protocol.MsgSetHpMp))
+
+	// Immediately again — the injected clock does not advance, so this is inside the
+	// 100ms window and must be refused.
+	send(t, c, protocol.MsgUseItem, body.Encode())
+	p := expect(t, c, protocol.MsgSendItem)
+	if p[7] != 4 {
+		t.Errorf("second use: stack = %d, want 4 — a refused potion must not be consumed", p[7])
+	}
+	if ty, _, ok := readMaybe(t, c); ok && ty == protocol.MsgSetHpMp {
+		t.Error("refused potion still sent SetHpMp, want the use dropped")
+	}
+	if reqHp != 550 {
+		t.Errorf("ReqHp = %d, want 550 — only the first potion should count", reqHp)
 	}
 }
 
@@ -753,9 +858,8 @@ func TestUseManaPotion(t *testing.T) {
 	send(t, c, protocol.MsgUseItem, body.Encode())
 
 	expect(t, c, protocol.MsgSendItem)
-	scorePayload := expect(t, c, protocol.MsgUpdateScore)
-	if got := int32(binary.LittleEndian.Uint32(scorePayload[28:32])); got != 100 {
-		t.Errorf("Mp = %d, want 100 (50 + 50)", got)
+	if _, _, _, reqMp := setHpMpFields(t, expect(t, c, protocol.MsgSetHpMp)); reqMp != 100 {
+		t.Errorf("ReqMp = %d, want 100 (50 + 50)", reqMp)
 	}
 }
 
@@ -779,9 +883,110 @@ func TestUseHealPotionStack(t *testing.T) {
 	if itemPayload[6] != efAmount || itemPayload[7] != 4 {
 		t.Errorf("effect0 = %d.%d, want %d.4", itemPayload[6], itemPayload[7], efAmount)
 	}
-	scorePayload := expect(t, c, protocol.MsgUpdateScore)
-	if got := int32(binary.LittleEndian.Uint32(scorePayload[24:28])); got != 700 {
-		t.Errorf("Hp = %d, want 700 (500 + 200)", got)
+	if _, _, reqHp, _ := setHpMpFields(t, expect(t, c, protocol.MsgSetHpMp)); reqHp != 700 {
+		t.Errorf("ReqHp = %d, want 700 (500 + 200)", reqHp)
+	}
+}
+
+// TestUseHealPotionBroadcastsToViewers is the issue-#99 regression: when a player
+// pots, everyone in view must learn the new HP. The client tracks another entity's
+// HP by SUBTRACTING the STRUCT_DAM deltas in MSG_Attack from its own local copy, so
+// an out-of-band heal is invisible to an attacker unless the server pushes an
+// explicit score — which the legacy does by GridMulticasting SendScore
+// (SendFunc.cpp:1298). The bug was that our sendScore only replied to the drinker.
+func TestUseHealPotionBroadcastsToViewers(t *testing.T) {
+	const potion = 408
+	// loadResult is the fallback for ANY account (handler_test.go:172), so both
+	// clients spawn at (5,5) — Chebyshev 0, well inside ViewRange 16.
+	db := healPotionDB(world.Item{Index: potion}, 500, 100000, 0, 0)
+	effects := map[int][]content.BaseEffect{potion: {{Eff: efHp, Val: 1000}}}
+	addr, stop := startServerTickItems(t, db, map[int]int{potion: volHpMpPotion}, effects)
+	defer stop()
+
+	drinker := enterWorld(t, addr) // conn 1
+	defer drinker.Close()
+	observer := enterWorldAs(t, addr, "tradeb") // conn 2, in view of conn 1
+	defer observer.Close()
+
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+	send(t, drinker, protocol.MsgUseItem, body.Encode())
+
+	// The observer must receive the DRINKER's score: HEADER.ID identifies the subject,
+	// so it must be conn 1, not the observer's own conn.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		h, p := readFrameHeader(t, observer)
+		if h.Type != protocol.MsgUpdateScore || h.ID != 1 {
+			continue
+		}
+		hp := int32(binary.LittleEndian.Uint32(p[24:28]))
+		if hp < 1500 {
+			continue // the passive trickle can emit a score before the potion lands
+		}
+		if curr := int32(binary.LittleEndian.Uint32(p[124:128])); curr != hp {
+			t.Errorf("CurrHp = %d, want %d (must agree with Score.Hp)", curr, hp)
+		}
+		return
+	}
+	t.Fatal("observer never saw the drinker's healed score — the pot heal is invisible to the attacker (#99)")
+}
+
+// TestUseHealPotionNoBroadcastOutOfView pins BroadcastInView's distance filter: a
+// player beyond ViewRange must not receive the drinker's score.
+func TestUseHealPotionNoBroadcastOutOfView(t *testing.T) {
+	const potion = 409
+	db := healPotionDB(world.Item{Index: potion}, 500, 100000, 0, 0)
+	// Account 11 spawns far away; account 7 keeps the (5,5) loadResult.
+	far := db.loadResult
+	far.X, far.Y = 500, 500
+	db.loads = map[int64]world.CharacterState{11: far}
+	effects := map[int][]content.BaseEffect{potion: {{Eff: efHp, Val: 1000}}}
+	addr, stop := startServerTickItems(t, db, map[int]int{potion: volHpMpPotion}, effects)
+	defer stop()
+
+	drinker := enterWorld(t, addr)
+	defer drinker.Close()
+	observer := enterWorldAs(t, addr, "tradeb")
+	defer observer.Close()
+
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+	send(t, drinker, protocol.MsgUseItem, body.Encode())
+
+	for i := 0; i < 8; i++ {
+		h, _, ok := readMaybeHeader(t, observer)
+		if !ok {
+			return // stream went quiet — nothing leaked
+		}
+		if h.Type == protocol.MsgUpdateScore && h.ID == 1 {
+			t.Fatal("out-of-view player received the drinker's score, want it filtered by ViewRange")
+		}
+	}
+}
+
+// TestEnterWorldViewScoreStaysUnicast locks the sendScoreSelf carve-out: a newcomer's
+// score must NOT be multicast, because enterWorldView pushes it BEFORE broadcasting
+// the newcomer's CreateMob — in-view clients would get a score for an entity they
+// have not created yet. The legacy has no SendScore in this path at all
+// (ProcessDBMessage.cpp:1017-1037); observers learn the newcomer's HP from CreateMob.
+func TestEnterWorldViewScoreStaysUnicast(t *testing.T) {
+	db := healPotionDB(world.Item{}, 500, 1000, 0, 0)
+	addr, stop := startServerClockItems(t, db, nil, nil)
+	defer stop()
+
+	first := enterWorld(t, addr) // conn 1, already in world
+	defer first.Close()
+	second := enterWorldAs(t, addr, "tradeb") // conn 2 logs in at the same cell
+	defer second.Close()
+
+	// conn 1 may see conn 2's CreateMob/PKInfo, but never conn 2's UpdateScore.
+	for i := 0; i < 8; i++ {
+		h, _, ok := readMaybeHeader(t, first)
+		if !ok {
+			return
+		}
+		if h.Type == protocol.MsgUpdateScore && h.ID == 2 {
+			t.Fatal("newcomer's score was multicast before its CreateMob — unknown-entity packet (B1)")
+		}
 	}
 }
 

--- a/tmserver/internal/handler/mobai.go
+++ b/tmserver/internal/handler/mobai.go
@@ -37,6 +37,11 @@ const (
 // death/resurrection flow (a player dropped to 0 HP just stops being a valid
 // target).
 func (d *Dispatcher) Tick(w *world.World) {
+	// One bump per tick, up front: both regenPlayers (natural-regen phase) and
+	// sweepAffects (per-player stagger) read this counter, and regenPlayers runs
+	// first, so it cannot live inside either sweep.
+	d.tickCount++
+
 	// Dormancy gate: snapshot the (few) in-play player positions once, so the
 	// ~10k idle mobs far from any player skip the 81-cell aggro scan. The scratch
 	// slices live on the Dispatcher (loop-only) to avoid a per-tick allocation.
@@ -228,13 +233,25 @@ func inSafeCity(w *world.World, conn int) bool {
 	return e != nil && world.Village(e.X, e.Y) >= 0
 }
 
-// regenPlayers restores a slice of HP/MP to every living player each tick, so a
-// character recovers over time (notably after respawning at 2 HP in a safe city).
+// naturalRegenTicks is the passive-regen cadence: the legacy trickle runs on
+// SecCounter%20 of a 500ms timer (ProcessSecMinTimer.cpp:780) = every 10s. Our
+// tick is 1s, so every 10th tick.
+const naturalRegenTicks = 10
+
+// regenPlayers is the HP/MP upkeep pass (ProcessSecMinTimer.cpp:760-799). It runs
+// on the 1s world tick, which matches the legacy drain cadence (SecCounter%2 of a
+// 500ms timer) exactly.
+//
+// The model is request-based, and it is the SAME model potions use: nothing writes
+// the live bar directly. Callers raise the ReqHp/ReqMp target; applyHp/applyMp
+// close the gap by at most applyCasting per tick. A player with no healing debt
+// (ReqHp <= HP) costs nothing — applyHp reports no movement and we send no packet.
+//
 // The dead (HP==0) don't regen — they must _MSG_Restart first.
 //
-// UNVERIFIED: the original RegenMob rate (Server.cpp, tied to RegenHP/RateRegen)
-// is not in the available source; regenStep is a sane stand-in (~5% of max + a
-// small floor). Combat-reduced regen and town-vs-field rates are deferred.
+// Deferred: the Celestial branch (ProcessSecMinTimer.cpp:676-680) adds MOB.RegenHP
+// /RegenMP on top of the trickle for ClassMaster >= CELESTIAL; those fields are not
+// modeled on world.Entity yet (cf. combat.go:475).
 func (d *Dispatcher) regenPlayers(w *world.World) {
 	now := time.Now().Unix()
 	w.ForEachPlayer(func(s *world.Session, e *world.Entity) {
@@ -250,26 +267,24 @@ func (d *Dispatcher) regenPlayers(w *world.World) {
 			d.sendScore(w, s, e)
 			d.sendAffect(w, s, e)
 		}
-		hp := regenStep(e.HP, effectiveMaxHP(e))
-		mp := regenStep(e.MP, effectiveMaxMP(e))
-		if hp == e.HP && mp == e.MP {
-			return // already full — nothing to push
+		if d.tickCount%naturalRegenTicks == 0 {
+			s.ReqHp += e.Level + 30
+			s.ReqMp += e.Level + 30
 		}
-		e.HP, e.MP = hp, mp
-		d.sendScore(w, s, e)
+		// Both bars always drain; only the SEND is either/or. Keep these as separate
+		// statements — folding them into `if applyHp(...) else if applyMp(...)` would
+		// short-circuit and stop MP regenerating whenever HP is.
+		movedHP := applyHp(s, e)
+		movedMP := applyMp(s, e)
+		// SendScore (multicast) when HP moved, else SendSetHpMp (self-only) for a
+		// mana-only change — the original's exact else-if, so an MP tick never costs
+		// a 152B broadcast. UpdateScore already carries Mp, so the HP branch covers both.
+		if movedHP {
+			d.sendScore(w, s, e)
+		} else if movedMP {
+			d.sendSetHpMp(w, s, e)
+		}
 	})
-}
-
-// regenStep moves cur toward full by ~5% of full (min 2 per tick), capped at full.
-func regenStep(cur, full int32) int32 {
-	if cur >= full || full <= 0 {
-		return cur
-	}
-	inc := full/20 + 2
-	if cur+inc > full {
-		return full
-	}
-	return cur + inc
 }
 
 // Battle decision codes — the BattleProcessor return values (CMob.cpp:233-328),
@@ -391,6 +406,9 @@ func (d *Dispatcher) mobAttack(w *world.World, id int, e, target *world.Entity) 
 		if target.HP < 0 {
 			target.HP = 0
 		}
+		// Drop the victim's heal target by the damage, or regenPlayers heals it
+		// straight back next tick (ProcessSecMinTimer.cpp:2389-2397).
+		damageReqHp(w.Session(target.ID), target, int32(dmg))
 	}
 
 	body := protocol.MsgAttackBody{

--- a/tmserver/internal/handler/mobai_test.go
+++ b/tmserver/internal/handler/mobai_test.go
@@ -777,24 +777,120 @@ func TestGenerateMobsTimer(t *testing.T) {
 	}
 }
 
-func TestRegenStep(t *testing.T) {
+// TestApplyHp covers the ApplyHp port (Server.cpp:9530): the live bar closes on the
+// ReqHp target in steps of at most applyCasting, ReqHp is a target (never spent),
+// and an over-max request is clamped to the live effective max.
+func TestApplyHp(t *testing.T) {
 	tests := []struct {
-		name     string
-		cur, max int32
-		want     int32
+		name           string
+		hp, maxHP, req int32
+		wantHP, wantRq int32
+		wantMoved      bool
 	}{
-		{"recovers ~5%+floor", 100, 1000, 152}, // 100 + (1000/20 + 2)
-		{"caps at max", 990, 1000, 1000},       // 990 + 52 > max → clamped
-		{"already full", 1000, 1000, 1000},
-		{"no max (mp unset)", 0, 0, 0},
-		{"revived 2hp climbs", 2, 1000, 54},
+		{"no debt", 1000, 1000, 1000, 1000, 1000, false},
+		{"req below hp is a no-op", 800, 1000, 500, 800, 500, false},
+		{"closes a small gap in one call", 900, 5000, 1000, 1000, 1000, true},
+		{"caps at applyCasting per call", 0, 10000, 5000, 2000, 5000, true},
+		{"req clamped to effective max", 900, 1000, 9999, 1000, 1000, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := regenStep(tt.cur, tt.max); got != tt.want {
-				t.Errorf("regenStep(%d,%d) = %d, want %d", tt.cur, tt.max, got, tt.want)
+			e := &world.Entity{HP: tt.hp, MaxHP: tt.maxHP}
+			s := &world.Session{Conn: 1, ReqHp: tt.req}
+			if got := applyHp(s, e); got != tt.wantMoved {
+				t.Errorf("applyHp moved = %v, want %v", got, tt.wantMoved)
+			}
+			if e.HP != tt.wantHP {
+				t.Errorf("HP = %d, want %d", e.HP, tt.wantHP)
+			}
+			if s.ReqHp != tt.wantRq {
+				t.Errorf("ReqHp = %d, want %d (a target, not a pool)", s.ReqHp, tt.wantRq)
 			}
 		})
+	}
+}
+
+// TestApplyHpRampsOverTicks: a 5000 HP debt lands over successive calls rather than
+// at once — this is what makes a potion visibly ramp instead of snapping.
+func TestApplyHpRampsOverTicks(t *testing.T) {
+	e := &world.Entity{HP: 0, MaxHP: 10000}
+	s := &world.Session{Conn: 1, ReqHp: 5000}
+	for i, want := range []int32{2000, 4000, 5000} {
+		if !applyHp(s, e) {
+			t.Fatalf("call %d: applyHp reported no movement", i+1)
+		}
+		if e.HP != want {
+			t.Fatalf("call %d: HP = %d, want %d", i+1, e.HP, want)
+		}
+	}
+	if applyHp(s, e) {
+		t.Error("applyHp moved after reaching the target, want no movement")
+	}
+}
+
+// TestDamageReqHp: a landed hit must lower the heal target, or the next applyHp
+// would undo the damage and make the victim near-immune. A potion still in flight
+// keeps whatever debt survives the hit (_MSG_Attack.cpp:1638-1642).
+func TestDamageReqHp(t *testing.T) {
+	tests := []struct {
+		name           string
+		hp, maxHP, req int32
+		dmg            int32
+		wantReq        int32
+	}{
+		{"no pending heal: target tracks hp", 800, 1000, 1000, 200, 800},
+		{"pending potion survives, minus the hit", 500, 5000, 1500, 200, 1300},
+		{"damage beyond the target floors at hp", 300, 1000, 400, 9999, 300},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// HP is already decremented by the caller before damageReqHp runs.
+			e := &world.Entity{HP: tt.hp, MaxHP: tt.maxHP}
+			s := &world.Session{Conn: 1, ReqHp: tt.req}
+			damageReqHp(s, e, tt.dmg)
+			if s.ReqHp != tt.wantReq {
+				t.Errorf("ReqHp = %d, want %d", s.ReqHp, tt.wantReq)
+			}
+			// The invariant that matters: the tick must not resurrect the damage.
+			if s.ReqHp < e.HP {
+				t.Errorf("ReqHp %d fell below HP %d — setReqHp must floor it", s.ReqHp, e.HP)
+			}
+		})
+	}
+}
+
+// TestDamageThenTickDoesNotHealBack is the invariant in one place: after a hit, the
+// regen tick must not restore the lost HP.
+func TestDamageThenTickDoesNotHealBack(t *testing.T) {
+	e := &world.Entity{HP: 1000, MaxHP: 1000}
+	s := &world.Session{Conn: 1, ReqHp: 1000}
+	e.HP -= 300 // a hit lands
+	damageReqHp(s, e, 300)
+	if applyHp(s, e) {
+		t.Error("applyHp healed right after a hit — the victim would be near-immune")
+	}
+	if e.HP != 700 {
+		t.Errorf("HP = %d, want the damage to stick at 700", e.HP)
+	}
+}
+
+// TestApplyMpCapsAndClamps mirrors TestApplyHp for the mana bar (Server.cpp:9564).
+func TestApplyMpCapsAndClamps(t *testing.T) {
+	e := &world.Entity{MP: 0, MaxMP: 10000}
+	s := &world.Session{Conn: 1, ReqMp: 9999}
+	if !applyMp(s, e) {
+		t.Fatal("applyMp reported no movement on a full-bar debt")
+	}
+	if e.MP != applyCasting {
+		t.Errorf("MP = %d, want %d (applyCasting cap)", e.MP, applyCasting)
+	}
+	e = &world.Entity{MP: 90, MaxMP: 100}
+	s = &world.Session{Conn: 1, ReqMp: 500}
+	if !applyMp(s, e) {
+		t.Fatal("applyMp reported no movement")
+	}
+	if e.MP != 100 || s.ReqMp != 100 {
+		t.Errorf("MP/ReqMp = %d/%d, want 100/100 (clamped to effective max)", e.MP, s.ReqMp)
 	}
 }
 

--- a/tmserver/internal/world/session.go
+++ b/tmserver/internal/world/session.go
@@ -29,6 +29,7 @@ type Session struct {
 	TradeMode         int        // non-zero while in auto-trade (blocks attacks)
 	Trade             TradeState // P2P direct-trade state (lote2-trade-autotrade.md)
 	LastAttackTick    uint32     // ClientTick of the last accepted attack (cadence gate)
+	PotionTick        uint32     // CUser.PotionTime: server clock of the last accepted potion
 	LastAttack        int        // SkillIndex of the last attack
 	LastIllusionTick  uint32     // ClientTick of the last Huntress Ilusao movement
 	ReqHp             int32      // CUser.ReqHp: server-owned HP target for regen/potions


### PR DESCRIPTION
Closes #99.

## The bug

Pots were healing fine — the reporter's correction was the key: the heal just wasn't shown to whoever was attacking the drinker.

The client tracks another entity's HP by **subtracting** the `STRUCT_DAM` deltas in `MSG_Attack` from its own local copy. So any HP change that happens outside combat has to be pushed explicitly, or observers never find out. The legacy does that push in `SendScore`, whose single exit is `GridMulticast(..., skip=0)` — everyone in view (`SendFunc.cpp:1298`; all **113** legacy call sites funnel through it). Our Go `sendScore` only replied to the drinker. That one divergence was the whole bug, and it silently affected all 27 `sendScore` call sites, not just pots.

## Changes

**`sendScore` now multicasts** via the existing `BroadcastInView`. Nothing private is exposed — coin/exp/free points live in `MSG_UpdateEtc`, which stays unicast like the legacy `SendEtc`.

**One carve-out:** `enterWorldView` keeps a unicast `sendScoreSelf`. It pushes the score *before* the newcomer's `CreateMob` is broadcast, so multicasting would send a score for an entity observers haven't created yet (the B1 confusion). The legacy has no `SendScore` in that path at all (`ProcessDBMessage.cpp:1017-1037`) — observers learn the newcomer's HP from `CreateMob`.

**The legacy HP model the potion path depends on** is now ported, so regen and pots share one coherent model instead of a half-port:

- `useHealPotion` no longer writes HP. It raises the `ReqHp`/`ReqMp` targets and replies `SetHpMp` (self-only, carrying `ReqHp` so the drinker's client animates the fill) — `_MSG_UseItem.cpp:101-148`.
- `regenPlayers` is the real port of `ProcessSecMinTimer.cpp:760-799` + `ApplyHp`/`ApplyMp` (`Server.cpp:9530-9596`): trickle is `Level+30` every 10s, `applyHp` closes the bars at ≤2000/tick.
- Adds the `PotionDelay` anti-spam gate (~100ms), gated on the **server** clock since a client tick is spoofable.

## ⚠️ Gameplay change worth reviewing

This replaces the invented `regenStep` stand-in (explicitly marked UNVERIFIED, ~5%/s) with the legacy trickle, making **passive regen ~10x slower** — a level-50 with 1500 HP goes from ~77 HP/s to ~8 HP/s. That's authentic WYD and it's *why* pots matter, but players will feel it. This was a deliberate call.

Not a traffic regression, despite the multicast: `applyHp` reports no movement when `ReqHp <= HP`, so a player with no healing debt now emits **nothing at all**. Net traffic should drop versus today, where `regenStep` pushed a score every tick until full.

## A bug caught during implementation

Making `ReqHp` load-bearing meant every path that *lowers* HP had to lower the target too — otherwise the next tick healed the damage straight back and players would have been near-immune to mobs. Both damage paths now call `damageReqHp`, mirroring `_MSG_Attack.cpp:1638-1642` and `ProcessSecMinTimer.cpp:2389-2397`. Note the existing combat tests do **not** catch this (their harnesses register no tick handler); the guard is a new unit test.

## Testing

`make test`, `go vet`, `gofmt`, `golangci-lint` all clean; server boots and ticks cleanly.

- **Two-client regression over the real wire**: the observer must receive `MsgUpdateScore` with `HEADER.ID` = the drinker's conn. Confirmed load-bearing — with the broadcast disabled it fails with *"observer never saw the drinker's healed score"*.
- Out-of-view negative (pins the `ViewRange` filter), `enterWorldView` carve-out lock, potion cooldown, and unit coverage for `applyHp`/`applyMp`/`damageReqHp`.
- The existing potion tests now assert the `ReqHp` target the potion stages rather than an instant HP write.

**Still worth doing before this ships:** a real two-client check with an actual client — especially the slower passive regen, which is the part players will notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)