### PR TITLE
Fix refined item visual glow

### DIFF
--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -306,7 +306,7 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 		// own client, via UpdateEquip) see what is actually equipped — not the class
 		// starter set. Empty slots → 0 (no item). AFTER the affect rehydrate +
 		// refreshScore, so a persisted transform (affect 16) renders its beast mesh.
-		e.EquipVisual = equipVisual(e)
+		e.EquipVisual, e.EquipAnct = equipVisual(e)
 	}
 	s.Mode = world.UserPlay
 	// The persisted skill block rides the login snapshot (mask/points/bar/Special);
@@ -473,9 +473,10 @@ func (d *Dispatcher) revealMobsInView(w *world.World, s *world.Session) {
 	})
 }
 
-// createMobFrom builds MSG_CreateMob data from a world entity (player or NPC). The
-// visual Equip codes come from the entity's EquipVisual (set at login/spawn from
-// the relevant STRUCT_MOB template). createType: 0 normal, 2 "just entered".
+// createMobFrom builds MSG_CreateMob data from a world entity (player or NPC).
+// The visual equipment codes and glow overlays come from the entity's
+// EquipVisual/EquipAnct, set at login/spawn from the relevant STRUCT_MOB data.
+// createType: 0 normal, 2 "just entered".
 func createMobFrom(e *world.Entity, createType uint16) protocol.CreateMobData {
 	return protocol.CreateMobData{
 		MobID:           e.ID,
@@ -496,6 +497,7 @@ func createMobFrom(e *world.Entity, createType uint16) protocol.CreateMobData {
 		Merchant:   e.Merchant,
 		AttackRun:  attackRunOf(e),
 		Equip:      e.EquipVisual,
+		AnctCode:   e.EquipAnct,
 		CreateType: createType,
 		// Players pack PKPoint into MobName[12] to color the nick (75 neutral/white,
 		// 0 chaos/red); mobs send a raw name with no PK coloring.

--- a/tmserver/internal/handler/chat.go
+++ b/tmserver/internal/handler/chat.go
@@ -129,7 +129,7 @@ func (d *Dispatcher) clearBuffs(w *world.World, s *world.Session) {
 	_, _, wasTransformed := activeTransform(e)
 	e.ResetAffects()
 	if wasTransformed {
-		d.refreshEquip(w, s, e) // recomputes EquipVisual + score, broadcasts both
+		d.refreshEquip(w, s, e) // recomputes visual gear/glow + score, broadcasts both
 	} else {
 		d.refreshScore(e)
 		d.sendScore(w, s, e)

--- a/tmserver/internal/handler/combat.go
+++ b/tmserver/internal/handler/combat.go
@@ -498,7 +498,7 @@ func (d *Dispatcher) applyCastAffect(w *world.World, e, target *world.Entity, ti
 	// A landed transform (skills 64/66/68/70/71) also swaps the body mesh, which
 	// everyone in view must render — the legacy follows the SetAffect with
 	// GetCurrentScore + SendScore + SendEquip(conn,0) (_MSG_Attack.cpp:1242-1248).
-	// refreshEquip recomputes EquipVisual (where the beast override lives),
+	// refreshEquip recomputes visual gear/glow (where the beast override lives),
 	// broadcasts UpdateEquip self+in-view and re-sends the score.
 	if sp.AffectType == affectTransform {
 		if ts := w.Session(tid); ts != nil {

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -548,26 +548,28 @@ func (d *Dispatcher) meetsEquipReq(e *world.Entity, it world.Item) bool {
 		e.Str >= r.Str && e.Int >= r.Int && e.Dex >= r.Dex && e.Con >= r.Con
 }
 
-// equipVisual derives the 16 visible equipment codes from the entity's equipped
-// items. The visual code is the item index (0 = empty slot), matching how the
-// BaseMob template's equipment is read for other previews.
+// equipVisual derives the 16 visible equipment codes and refine/ancient overlay
+// bytes from the entity's equipped items, matching BASE_VisualItemCode and
+// BASE_VisualAnctCode.
 //
 // A live BM transform overrides slot 0 (the body/face mesh) with the beast
 // model — READ-time, unlike the legacy which mutates MOB.Equip[0].sIndex and
 // must reset it on every recompute (Basedef.cpp:4106/3908). Keeping e.Equip
 // untouched means the persisted body item can't be corrupted and the revert on
-// expiry is just this override no longer firing. The EF_SANC glow the legacy
-// stamps on the transformed mesh (Basedef.cpp:4166) is deferred: the visual
-// code here carries no glow bits for regular gear either.
-func equipVisual(e *world.Entity) [16]uint16 {
+// expiry is just this override no longer firing. Regular item glow is carried
+// by EquipAnct; the transform-specific synthetic EF_SANC from Basedef.cpp:4166
+// is deliberately left out until that separate cosmetic rule is captured.
+func equipVisual(e *world.Entity) ([16]uint16, [16]uint8) {
 	var v [16]uint16
+	var a [16]uint8
 	for i := range e.Equip {
-		v[i] = uint16(e.Equip[i].Index)
+		v[i], a[i] = protocol.VisualEquip(itemToSel(e.Equip[i]), i)
 	}
 	if value, _, ok := activeTransform(e); ok {
 		v[0] = transMesh(value)
+		a[0] = 0
 	}
-	return v
+	return v, a
 }
 
 // refreshEquip recomputes the entity's visible gear and pushes _MSG_UpdateEquip to
@@ -576,8 +578,8 @@ func equipVisual(e *world.Entity) [16]uint16 {
 // is the entity id so the client applies it to the right mob. It also re-sends the
 // score, since equipment changes the character's attributes.
 func (d *Dispatcher) refreshEquip(w *world.World, s *world.Session, e *world.Entity) {
-	e.EquipVisual = equipVisual(e)
-	body := protocol.EncodeUpdateEquip(e.EquipVisual)
+	e.EquipVisual, e.EquipAnct = equipVisual(e)
+	body := protocol.EncodeUpdateEquip(e.EquipVisual, e.EquipAnct)
 	h := protocol.Header{Type: protocol.MsgUpdateEquip, ID: uint16(s.Conn)}
 	w.SendTo(s, h, body)
 	w.ForEachInView(s.Conn, func(vs *world.Session, _ *world.Entity) {

--- a/tmserver/internal/handler/item_test.go
+++ b/tmserver/internal/handler/item_test.go
@@ -153,6 +153,14 @@ func equipDB(carry0, equip1 int16) *fakeDB {
 	return db
 }
 
+func equipItemDB(carry0 world.Item) *fakeDB {
+	db := newDB()
+	st := world.CharacterState{Slot: 0, Name: "Hero", X: 5, Y: 5, HP: 1000, MaxHP: 1000}
+	st.Carry[0] = carry0
+	db.loadResult = st
+	return db
+}
+
 // TestTradingItemEquip drags an inventory item onto an equip slot (0x0376) and
 // asserts the rendered gear is refreshed via _MSG_UpdateEquip with the item code.
 func TestTradingItemEquip(t *testing.T) {
@@ -168,6 +176,26 @@ func TestTradingItemEquip(t *testing.T) {
 	ue := expect(t, c, protocol.MsgUpdateEquip)
 	if got := le16(ue[2:4]); got != 1100 { // Equip[1] visual code @body2
 		t.Errorf("equip visual[1] = %d, want 1100", got)
+	}
+}
+
+func TestTradingItemEquipSendsRefineGlow(t *testing.T) {
+	item := world.Item{Index: 1100, Effects: [3]world.Effect{{Effect: efSanc, Value: 9}}}
+	addr, stop, _ := startServerClock(t, equipItemDB(item))
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	tradeItemFrame(t, c, world.ItemPlaceCarry, 0, world.ItemPlaceEquip, 1, 0)
+	expect(t, c, protocol.MsgTradingItem)
+	expect(t, c, protocol.MsgSendItem)
+	expect(t, c, protocol.MsgSendItem)
+	ue := expect(t, c, protocol.MsgUpdateEquip)
+	if want, got := uint16(1100|9*0x1000), le16(ue[2:4]); got != want {
+		t.Errorf("equip visual[1] = %d, want %d (+9 overlay)", got, want)
+	}
+	if got := ue[33]; got != efSanc { // AnctCode[1] @body32+1
+		t.Errorf("equip anct[1] = %#x, want EF_SANC", got)
 	}
 }
 

--- a/tmserver/internal/handler/transform_test.go
+++ b/tmserver/internal/handler/transform_test.go
@@ -85,7 +85,7 @@ func TestApplyTransformScore(t *testing.T) {
 				t.Errorf("AffRun/AffAttack/AffCritical = %d/%d/%d, want %d/%d/%d",
 					e.AffRunSpeed, e.AffAttackSpeed, e.AffCritical, tt.wantRun, tt.wantAtt, tt.wantCri)
 			}
-			if v := equipVisual(e); v[0] != tt.wantVis {
+			if v, _ := equipVisual(e); v[0] != tt.wantVis {
 				t.Errorf("equipVisual[0] = %d, want %d (beast mesh)", v[0], tt.wantVis)
 			}
 		})
@@ -104,7 +104,7 @@ func TestTransformClassGuard(t *testing.T) {
 		t.Errorf("non-BM transform changed the score: pct=%d dam=%d ac=%d hp=%d",
 			e.AffDamageMultiPct, e.AffDamage, e.AffAC, e.AffMaxHP)
 	}
-	if v := equipVisual(e); v[0] != 21 {
+	if v, _ := equipVisual(e); v[0] != 21 {
 		t.Errorf("equipVisual[0] = %d, want the real body item 21 (no beast mesh on a TK)", v[0])
 	}
 }
@@ -119,7 +119,7 @@ func TestTransformOutOfRangeValueInert(t *testing.T) {
 		if e.AffDamageMultiPct != 100 || e.AffAC != 0 || e.AffMaxHP != 0 {
 			t.Errorf("value %d: transform applied, want inert", v)
 		}
-		if vis := equipVisual(e); vis[0] != 21 {
+		if vis, _ := equipVisual(e); vis[0] != 21 {
 			t.Errorf("value %d: equipVisual[0] = %d, want 21", v, vis[0])
 		}
 	}

--- a/tmserver/internal/protocol/createmob.go
+++ b/tmserver/internal/protocol/createmob.go
@@ -13,7 +13,8 @@ const (
 )
 
 // CreateMobData is the subset of MSG_CreateMob needed to render an entity in
-// view. Equip holds VISUAL item codes (u16[16]); 0 = empty slot (naked).
+// view. Equip holds VISUAL item codes (u16[16]); AnctCode holds the matching
+// refine/ancient glow overlay bytes. 0 = empty/no overlay.
 type CreateMobData struct {
 	MobID                int
 	Name                 string
@@ -28,6 +29,7 @@ type CreateMobData struct {
 	Direction            uint8
 	CreateType           uint16 // 0 normal, 2 "just entered"
 	Equip                [16]uint16
+	AnctCode             [16]uint8
 	// IsPlayer selects the MobName encoding: players (id < MAX_USER) pack PK data
 	// into MobName[12..15]; mobs/NPCs send the full 16-byte name raw (their names
 	// can be 16 chars, e.g. "Ciclope_Arqueiro", and carry no PK coloring).
@@ -101,6 +103,7 @@ func EncodeCreateMobBody(d CreateMobData) []byte {
 	b[120] = d.GuildMemberType          // GuildMemberType @abs132 → body120
 	writeCreateMobScore(b[124:], d)     // Score @abs136 → body124
 	le.PutUint16(b[172:], d.CreateType) // CreateType @abs184 → body172
+	copy(b[174:190], d.AnctCode[:])     // AnctCode[16] @abs186 → body174
 	return b
 }
 

--- a/tmserver/internal/protocol/createmob_test.go
+++ b/tmserver/internal/protocol/createmob_test.go
@@ -16,6 +16,7 @@ func TestCreateMobBodyLayout(t *testing.T) {
 		Merchant: 1, AttackRun: 82, CreateType: 2,
 	}
 	d.Equip[0] = 831
+	d.AnctCode[0] = 43
 	b := EncodeCreateMobBody(d)
 
 	if len(b) != createMobSize-HeaderSize { // 232 - 12 = 220
@@ -42,6 +43,27 @@ func TestCreateMobBodyLayout(t *testing.T) {
 	}
 	if got := le.Uint16(b[172:]); got != 2 { // CreateType @abs184 → body172
 		t.Errorf("CreateType = %d, want 2", got)
+	}
+	if got := b[174]; got != 43 { // AnctCode[0] @abs186 → body174
+		t.Errorf("AnctCode[0] = %d, want 43", got)
+	}
+}
+
+func TestUpdateEquipBodyLayout(t *testing.T) {
+	var visual [16]uint16
+	var anct [16]uint8
+	visual[1] = 1100 | 9*0x1000
+	anct[1] = 43
+	b := EncodeUpdateEquip(visual, anct)
+
+	if len(b) != updateEquipSize-HeaderSize { // 60 - 12 = 48
+		t.Fatalf("UpdateEquip body = %d, want %d", len(b), updateEquipSize-HeaderSize)
+	}
+	if got := binary.LittleEndian.Uint16(b[2:]); got != visual[1] { // Equip[1] @body2
+		t.Errorf("Equip[1] = %d, want %d", got, visual[1])
+	}
+	if got := b[33]; got != 43 { // AnctCode[1] @body32+1
+		t.Errorf("AnctCode[1] = %d, want 43", got)
 	}
 }
 

--- a/tmserver/internal/protocol/mob.go
+++ b/tmserver/internal/protocol/mob.go
@@ -236,15 +236,15 @@ const updateEquipSize = 60
 
 // EncodeUpdateEquip builds _MSG_UpdateEquip (0x006B): the 16 visible equipment
 // codes that drive the character's rendered gear (SendFunc.cpp:SendEquip). visual
-// holds the per-slot visual item code (0 = empty slot). The ancient/refine codes
-// (AnctCode[16]) are left zero this pass. Send with HEADER.ID = the entity id so
-// it applies to the right mob (self or an in-view player).
-func EncodeUpdateEquip(visual [16]uint16) []byte {
+// holds the per-slot visual item code (0 = empty slot); anct holds the matching
+// ancient/refine glow overlay bytes. Send with HEADER.ID = the entity id so it
+// applies to the right mob (self or an in-view player).
+func EncodeUpdateEquip(visual [16]uint16, anct [16]uint8) []byte {
 	b := make([]byte, updateEquipSize-HeaderSize) // 48
 	for i := 0; i < 16; i++ {
 		le.PutUint16(b[i*2:], visual[i]) // Equip[16] @body0
 	}
-	// AnctCode[16] @body32 stays zero (no refine/ancient overlay yet).
+	copy(b[32:48], anct[:]) // AnctCode[16] @body32
 	return b
 }
 

--- a/tmserver/internal/protocol/visual.go
+++ b/tmserver/internal/protocol/visual.go
@@ -1,0 +1,168 @@
+package protocol
+
+// Item effect ids used by the legacy visual-overlay helpers. These are wire
+// item-effect bytes from ItemEffect.h, not score model constants.
+const (
+	visualEfSanc      = 43
+	visualAncientLo   = 116
+	visualAncientHi   = 125
+	visualMountSlot   = 14
+	visualMountLo     = 2360
+	visualMountHi     = 2390
+	visualSpecialLo   = 3980
+	visualSpecialHi   = 3995
+	visualAncientGlow = 12
+)
+
+// VisualEquip returns the two legacy visual codes for one equipped STRUCT_ITEM:
+// MSG_CreateMob/MSG_UpdateEquip.Equip[] and AnctCode[].
+func VisualEquip(it SelItem, slot int) (uint16, uint8) {
+	code := VisualItemCode(it, slot)
+	anct := VisualAnctCode(it)
+
+	if slot == visualMountSlot && code >= visualMountLo && code < visualMountHi {
+		if effectSValue(it, 0) <= 0 {
+			return 0, anct
+		}
+		mountLevel := int(it.Eff[1][0]) / 10
+		if mountLevel > 13 {
+			mountLevel = 13
+		}
+		if mountLevel < 0 {
+			mountLevel = 0
+		}
+		code += uint16(mountLevel * 0x1000)
+	}
+
+	return code, anct
+}
+
+// VisualItemCode mirrors BASE_VisualItemCode: the item id plus the high-nibble
+// refine/ancient overlay that selects the rendered model variant.
+func VisualItemCode(it SelItem, slot int) uint16 {
+	if it.Index == 0 {
+		return 0
+	}
+	if slot == visualMountSlot {
+		if it.Index >= visualSpecialLo && it.Index < visualSpecialHi {
+			return it.Index
+		}
+		return it.Index
+	}
+
+	value, ok := visualSancValue(it)
+	if !ok {
+		if hasAncientEffect(it) {
+			return it.Index | uint16(visualAncientGlow*0x1000)
+		}
+		return it.Index
+	}
+
+	if value < 230 {
+		value %= 10
+	} else if value < 234 {
+		value = 10
+	} else if value < 238 {
+		value = 11
+	} else if value < 242 {
+		value = 12
+	} else if value < 246 {
+		value = 13
+	} else if value < 250 {
+		value = 14
+	} else if value < 254 {
+		value = 15
+	} else {
+		value = 16
+	}
+
+	return it.Index | uint16(value*0x1000)
+}
+
+// VisualAnctCode mirrors BASE_VisualAnctCode: the one-byte glow/effect overlay
+// the 7662 client reads beside the visual item id.
+func VisualAnctCode(it SelItem) uint8 {
+	if it.Index == 0 {
+		return 0
+	}
+	if it.Index >= visualMountLo && it.Index <= visualMountHi && effectSValue(it, 0) > 0 {
+		switch it.Eff[2][1] {
+		case 11:
+			return legacyByte(0x10B)
+		case 12:
+			return legacyByte(0x10C)
+		case 13:
+			return legacyByte(0x10D)
+		case 14:
+			return legacyByte(0x10E)
+		case 15:
+			return legacyByte(0x10F)
+		case 16:
+			return legacyByte(0x110)
+		case 17:
+			return legacyByte(0x111)
+		case 18:
+			return legacyByte(0x112)
+		case 19:
+			return legacyByte(0x113)
+		case 20:
+			return legacyByte(0x114)
+		case 35:
+			if it.Index == 2363 || it.Index == 2377 {
+				return legacyByte(0x115)
+			}
+		default:
+			return 0
+		}
+	}
+
+	value, _ := visualSancValue(it)
+	for _, ef := range it.Eff {
+		if ef[0] >= visualAncientLo && ef[0] <= visualAncientHi {
+			return ef[0] - 3
+		}
+	}
+	if value == 0 {
+		return 0
+	}
+	if value < 230 {
+		return visualEfSanc
+	}
+
+	switch value % 4 {
+	case 0:
+		return 0x30
+	case 1:
+		return 0x40
+	case 2:
+		return 0x10
+	default:
+		return 0x20
+	}
+}
+
+func visualSancValue(it SelItem) (int, bool) {
+	for _, ef := range it.Eff {
+		if ef[0] == visualEfSanc {
+			return int(ef[1]), true
+		}
+	}
+	return 0, false
+}
+
+func hasAncientEffect(it SelItem) bool {
+	for _, ef := range it.Eff {
+		if ef[0] >= visualAncientLo && ef[0] <= visualAncientHi {
+			return true
+		}
+	}
+	return false
+}
+
+func effectSValue(it SelItem, slot int) int16 {
+	return int16(uint16(it.Eff[slot][0]) | uint16(it.Eff[slot][1])<<8)
+}
+
+func legacyByte(v int) uint8 {
+	return uint8(v)
+}

--- a/tmserver/internal/protocol/visual_test.go
+++ b/tmserver/internal/protocol/visual_test.go
@@ -1,0 +1,36 @@
+package protocol
+
+import "testing"
+
+func TestVisualEquipSancGlow(t *testing.T) {
+	it := SelItem{Index: 1100, Eff: [3][2]uint8{{visualEfSanc, 9}}}
+	visual, anct := VisualEquip(it, 1)
+	if want := uint16(1100 | 9*0x1000); visual != want {
+		t.Errorf("visual = %d, want %d", visual, want)
+	}
+	if anct != visualEfSanc {
+		t.Errorf("anct = %#x, want EF_SANC", anct)
+	}
+}
+
+func TestVisualEquipSancGemGlow(t *testing.T) {
+	it := SelItem{Index: 1100, Eff: [3][2]uint8{{visualEfSanc, 232}}}
+	visual, anct := VisualEquip(it, 1)
+	if want := uint16(1100 | 10*0x1000); visual != want {
+		t.Errorf("visual = %d, want %d", visual, want)
+	}
+	if anct != 0x30 {
+		t.Errorf("anct = %#x, want 0x30", anct)
+	}
+}
+
+func TestVisualEquipAncientGlow(t *testing.T) {
+	it := SelItem{Index: 1100, Eff: [3][2]uint8{{116, 7}}}
+	visual, anct := VisualEquip(it, 1)
+	if want := uint16(1100 | 12*0x1000); visual != want {
+		t.Errorf("visual = %d, want %d", visual, want)
+	}
+	if anct != 113 {
+		t.Errorf("anct = %#x, want 113", anct)
+	}
+}

--- a/tmserver/internal/world/api.go
+++ b/tmserver/internal/world/api.go
@@ -123,7 +123,7 @@ func (w *World) SpawnMobAt(sp MobSpawn) int {
 	}
 	eq := protocol.MobEquip(template)
 	for i := range eq {
-		e.EquipVisual[i] = eq[i].Index
+		e.EquipVisual[i], e.EquipAnct[i] = protocol.VisualEquip(eq[i], i)
 	}
 	// Attack reach = BASE_GetMobAbility(EF_RANGE) (Basedef.cpp:2415): the MAX over
 	// the equips of each item's EF_RANGE — catalog base effect plus the instance

--- a/tmserver/internal/world/session.go
+++ b/tmserver/internal/world/session.go
@@ -239,7 +239,8 @@ type Entity struct {
 	AffDamageMultiPct int32
 	EquipExpBonus     int32 // from fairy slot + grade/gem gear (CMob.cpp:711-870)
 
-	EquipVisual [16]uint16 // visual item codes for MSG_CreateMob (gear shown to others)
+	EquipVisual [16]uint16 // visual item codes for MSG_CreateMob/UpdateEquip
+	EquipAnct   [16]uint8  // refine/ancient glow overlay bytes paired with EquipVisual
 
 	// Party state (lote2-party-guilda-guerra.md). Leader is the leader's conn
 	// (0 = solo); LastReqParty is who last invited this entity (anti-forge gate).


### PR DESCRIPTION
## Summary
- port legacy visual item/refine overlay helpers for equipped items
- send AnctCode in CreateMob and UpdateEquip packets
- thread equipment glow state through player and mob visual refresh paths

## Tests
- go test ./tmserver/internal/protocol ./tmserver/internal/world ./tmserver/internal/handler
- make test