### PR TITLE
Implement dust refinement

### DIFF
--- a/docs/migration/game-rules.md
+++ b/docs/migration/game-rules.md
@@ -270,15 +270,55 @@ Carregadas por `CReadFiles::ReadCompRate()` (`CReadFiles.h:32`). Formato `Famíl
 
 ### 3.3. Tabela de refino por anvil/sanctificação (`Settings/SancRate.txt`)
 
-Carregada por `ReadSancRate()` (`CReadFiles.h:30`). Taxa de sucesso por **nível de refino** (0..N):
+Carregada por `ReadSancRate()` (`CReadFiles.cpp:77`). **PO = Poeira de Ori (412, `EF_VOLATILE 4`)**,
+**PL = Poeira de Lac (413, `EF_VOLATILE 5`)** — o índice da linha é o `OriLacto = Vol-4`.
+
+O arquivo **só sobrescreve os índices que lista**; o resto mantém o default compilado em
+`Basedef.cpp:68`. As linhas do arquivo:
 
 ```text
-PO (pedra ?)   ref 0..2 = 100%, 3=85, 4=70, 5=40
-PL (pedra ?)   ref 0..5 = 100%, 6=80, 7..8=70, 9=10
-Âmago          ref 0=100,1=80,2=60,3=40,4=20,5..7=10,8..11=5
+PO      0..2 = 100%, 3=85, 4=70, 5=40
+PL      0..5 = 100%, 6=80, 7..8=70, 9=10
+Âmago   0=100,1=80,2=60,3=40,4=20,5..7=10,8..11=5
 ```
 
-> Reproduzir as tabelas **exatamente**; são o coração da economia de refino.
+> ⚠️ **`BASE_GetSuccessRate` indexa a tabela em `sanc+1`**, não em `sanc` (`Basedef.cpp:2261`): o
+> slot 0 de cada linha é morto e um refino **a partir de +N** lê o slot **N+1**. Então "PO 3 = 85"
+> é a chance do **+2→+3**, não do +3→+4.
+
+#### Bug do Âmago no legado — divergência intencional (issue #103)
+
+`CReadFiles.cpp:157` grava as linhas `ÂMAGO` em `g_pSancRate[0]` — **a mesma linha do `PO`**
+(`:123`), um copy-paste. Como o Âmago vem por último no arquivo, ele **sobrescrevia todas as taxas
+do Ori**, e as linhas `PO` do arquivo eram letra morta. A taxa efetiva do Ori no servidor legado era
+a do Âmago: `{100,80,60,40,20,10,...}`.
+
+> **Decisão (issue #103): corrigido.** O Âmago vai para a linha 2 e as linhas `PO` do arquivo passam
+> a valer — o `SancRate.txt` vira genuinamente autoritativo. Consequência: o arquivo não lista `PO 6`,
+> então o índice 6 fica com o default do `Basedef.cpp` (**100**) e o **+5→+6 com Ori é garantido**.
+> Para fechar isso basta acrescentar uma linha `PO 6 <taxa>` ao arquivo. A outra leitora da linha do
+> Âmago é `BASE_GetGrowthRate` (`Basedef.cpp:2275`, crescimento de montaria), ainda não portada.
+
+O arquivo é **cp1252**, não UTF-8 (`Âmago` = bytes `C2 6D 61 67 6F`). O legado também não decodifica:
+`_strupr` só mexe em `a-z` no locale C, então o `0xC2` sobrevive e o `strcmp` casa byte a byte — o
+port faz o mesmo (`content/rates.go`).
+
+#### Pity ("success") e a codificação empacotada do sanc
+
+O `cValue` do par `EF_SANC` **não guarda o nível puro** — ele empacota nível + um contador de
+tentativas falhas (`BASE_SetItemSanc`, `Basedef.cpp:2282`):
+
+```text
+níveis 0..9    cValue = nível + 10*pity     (pity 0..20)
+níveis 10..15  cValue = base + gem          (base 230/234/238/242/246/250, gem 0..3)
+```
+
+Cada ponto de pity soma `g_pSuccessRate[nível+1]` = `{5,5,5,5,4,4,3,3,2,1,0}` à taxa da próxima
+tentativa. Uma falha acumula pity com chance 3/4 (`rand()%4 <= 2`): Lac sempre, Ori só até +5. Um
+sucesso zera o pity.
+
+> ⚠️ Ler o `cValue` cru reporta um nível errado para qualquer item que já falhou um refino — um +5
+> com pity 2 guarda `25`. Ver o pacote `tmserver/internal/refine`, que é a única implementação.
 
 ### 3.4. Cooldown anti-spam de refino — **DESATIVADO no código**
 
@@ -292,6 +332,39 @@ refino hoje.
 ### 3.5. Limites de refino
 - Itens "tipo 5" (selados) não refinam além de `sanc >= 9` (`_MSG_UseItem.cpp:227`); outros não
   passam de `sanc >= 6 && Vol == 4` (`:203`). Mensagem `_NN_Cant_Refine_More`.
+
+### 3.6. Refino com poeiras — onde ele realmente mora (issue #103)
+
+**O refino com poeiras NÃO fica no handler de combine.** Ele vive dentro de `_MSG_UseItem` (0x0373):
+o cliente arrasta a poeira sobre o item e o servidor classifica a ação pelo `EF_VOLATILE` da
+poeira-origem, como qualquer outro uso de item. O `MsgUseItem` já carrega `DestType`/`DestPos`.
+
+São **cinco** caminhos distintos no mesmo handler. Só o primeiro está portado:
+
+| caminho | fonte | roll | falha |
+|---|---|---|---|
+| **equipamento padrão** ✅ | `:802-976` | `rand()%100` | só gasta a poeira; item intacto, pity sobe |
+| selados no inventário ⏳ | `:224` | `rand()%115` + fold `-15` | **item destruído** |
+| celestial/HC (+10~+15) ⏳ | `:385` | `rand()%115` + fold | sanc → 0 |
+| pedras arcanas (1752-1759) ⏳ | `:514` | `rand()%115` + fold | sanc → 0 |
+| brincos +10~+14 (Lac, slot 8) ⏳ | `:716` | `rand()%100` | **item destruído** |
+
+> ⚠️ O roll do caminho principal é `rand()%100` puro — **não** é o `rand()%115` com o fold `>= 100 →
+> -15` do combine (§3.1). As duas distribuições são diferentes e não são intercambiáveis.
+
+Itens relevantes: `Lactolerium_100` (**4141**) tem `EF_VOLATILE 5` como uma Lac comum mas força a
+linha do Âmago → 100% garantido. `EF_NOSANC` (126) bloqueia o refino de vez. Ori trava o item em +6,
+Lac em +9; +10 vai a +11 preservando o gem e para.
+
+**Ovo de montaria (2300-2329):** o bloco de incubação está inline no sucesso (`:890`). O gate de
+choco lê `BASE_GetBonusItemAbility(dest, EF_INCUBATE)`, que é **instance-only** (`Basedef.cpp:2048`)
+— e o `EF_INCUBATE` do ovo está no **catálogo**. Ou seja: lê 0 e **o ovo choca no primeiro refino
+bem-sucedido**, independente do tier do catálogo. É o comportamento do legado, não um atalho do port.
+Uma falha carimba `EF_INCUDELAY` (0..3), que só é decrementado pelo `RegenMob` **com o ovo
+equipado** (`Server.cpp:4884`) — é o cooldown entre tentativas.
+
+`MountProcess(conn, 0)` (`:914`) é **no-op**: com `Mount == NULL` o `IsEqual` fica 1 e a função
+retorna de cara (`Server.cpp:4639-4643`). Não há nada para portar ali.
 
 ---
 

--- a/tmserver/cmd/tmserver/main.go
+++ b/tmserver/cmd/tmserver/main.go
@@ -132,18 +132,21 @@ func run(logger *slog.Logger) error {
 	var combineFamilies map[protocol.Type]handler.CombineFamily
 	var spells *content.SkillData
 	var heights *content.Grid
+	var sancRate *content.SancRate
 	if *contentDir != "" {
-		items, comp, skills, hm, err := loadContent(*contentDir, logger)
+		c, err := loadContent(*contentDir, logger)
 		if err != nil {
 			return err
 		}
+		items := c.items
 		itemPrices, itemEffects, itemReqs = items.Prices(), items.BaseEffects(), items.Requirements()
 		itemVolatiles, itemPos, itemUnique = items.Volatiles(), items.Positions(), items.Uniques()
 		itemGrades = items.Grades()
 		itemRanges = items.Ranges()
-		combineFamilies = handler.DefaultCombineFamilies(handler.NewCombineCatalog(items, comp))
-		spells = skills
-		heights = hm
+		combineFamilies = handler.DefaultCombineFamilies(handler.NewCombineCatalog(items, c.comp))
+		spells = c.skills
+		heights = c.heights
+		sancRate = c.sanc
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -226,6 +229,7 @@ func run(logger *slog.Logger) error {
 	dispatch := handler.New(handler.Config{
 		Log: logger, ClientVersion: int32(*clientVersion), BaseMobs: baseMobs, SummonMobs: summonMobs, VineMob: vineMob, ItemPrices: itemPrices, ItemEffects: itemEffects, ItemReqs: itemReqs,
 		ItemVolatiles: itemVolatiles, ItemPos: itemPos, ItemUnique: itemUnique, ItemGrades: itemGrades, Spells: spells, Heights: heights,
+		SancRate:        sancRate,
 		ExpEvents:       level.ExpEvents{DoubleMode: *doubleExp, NewbieEvent: *newbieEvent, KefraLive: *kefraLive},
 		CombineFamilies: combineFamilies,
 		NpcConfig:       npcConfig,
@@ -395,25 +399,29 @@ func serveStatusHTTP(ctx context.Context, addr, statusFile string, logger *slog.
 // The rates and catalogs are required (a broken mount is a hard error); the maps
 // are large and optional (a warning when absent). It logs what was loaded so the
 // operator can confirm the mount is correct.
-func loadContent(dir string, logger *slog.Logger) (*content.ItemList, *content.CompRate, *content.SkillData, *content.Grid, error) {
+func loadContent(dir string, logger *slog.Logger) (*loadedContent, error) {
 	comp, err := content.LoadCompRate(filepath.Join(dir, "Common", "Settings", "CompRate.txt"))
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, err
 	}
 	sanc, err := content.LoadSancRate(filepath.Join(dir, "Common", "Settings", "SancRate.txt"))
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, err
 	}
 	items, err := content.LoadItemList(filepath.Join(dir, "Common", "ItemList.csv"))
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, err
 	}
 	skills, err := content.LoadSkillData(filepath.Join(dir, "Common", "SkillData.csv"))
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, err
 	}
+	// The Ori/Lac rates are worth logging outright: SancRate.txt only overrides the
+	// indices it lists, so a broken mount silently leaves the compiled defaults and
+	// the operator would otherwise not notice.
 	logger.Info("content loaded",
-		"comprate_families", comp.Families(), "sancrate_anvils", sanc.Anvils(),
+		"comprate_families", comp.Families(),
+		"sancrate_ori", sancRow(sanc, 0), "sancrate_lac", sancRow(sanc, 1),
 		"items", items.Len(), "skills", skills.Len())
 
 	// Maps are optional: 17 MiB HeightMap + 1 MiB AttributeMap aren't required to
@@ -436,5 +444,24 @@ func loadContent(dir string, logger *slog.Logger) (*content.ItemList, *content.C
 	} else if hm != nil || attr != nil {
 		logger.Warn("mob pathfinding disabled: need BOTH HeightMap.dat and AttributeMap.dat")
 	}
-	return items, comp, skills, heights, nil
+	return &loadedContent{items: items, comp: comp, sanc: sanc, skills: skills, heights: heights}, nil
+}
+
+// loadedContent is what a mounted Release/ tree yields. It is a struct rather
+// than a return list only because the list had grown past readability.
+type loadedContent struct {
+	items   *content.ItemList
+	comp    *content.CompRate
+	sanc    *content.SancRate
+	skills  *content.SkillData
+	heights *content.Grid
+}
+
+// sancRow renders one anvil's rate row for the boot log.
+func sancRow(s *content.SancRate, anvil int) []int {
+	row := make([]int, 0, 12)
+	for i := 0; i < 12; i++ {
+		row = append(row, s.Rate(anvil, i))
+	}
+	return row
 }

--- a/tmserver/internal/combine/match.go
+++ b/tmserver/internal/combine/match.go
@@ -2,17 +2,21 @@ package combine
 
 import (
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/refine"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
 )
 
 const (
 	efPos       = 17
-	efSanc      = 43
 	efItemLevel = 87
 	efMobType   = 112
 
 	jewelBaseIndex = 2441
 	blockedItem747 = 747
+
+	// anctResultSanc is the refine level BASE_SetItemSanc stamps on an Anct
+	// success (_MSG_CombineItem.cpp:100).
+	anctResultSanc = 7
 )
 
 // Catalog holds the item metadata GetMatchCombine reads from g_pItemList.
@@ -65,7 +69,7 @@ func MatchAnct(cat Catalog, items []world.Item) int {
 		if il1 > il2 {
 			return 0
 		}
-		switch itemSanc(it) {
+		switch refine.Level(it) {
 		case 7:
 			rate += cat.AnctChance[0]
 		case 8:
@@ -94,16 +98,13 @@ func itemAbility(cat Catalog, it world.Item, eff uint8) int32 {
 	return sum
 }
 
-func itemSanc(it world.Item) int {
-	for _, ef := range it.Effects {
-		if ef.Effect == efSanc {
-			return int(ef.Value)
-		}
-	}
-	return 0
-}
-
 // AnctResult builds the Anct success item (game-rules.md §3.1): joia + Extra, sanc 7.
+//
+// The result inherits item[0]'s effects wholesale — the legacy memcpy's the whole
+// STRUCT_ITEM before overwriting sIndex (_MSG_CombineItem.cpp:97) — and then
+// BASE_SetItemSanc writes 7 into whichever slot already carries a sanc pair. When
+// item[0] has none that call returns FALSE and the result keeps no sanc at all,
+// which refine.Set reproduces.
 func AnctResult(cat Catalog, items []world.Item) world.Item {
 	result := items[0]
 	if len(items) < 2 {
@@ -114,6 +115,6 @@ func AnctResult(cat Catalog, items []world.Item) world.Item {
 	if joia >= 0 && joia <= 3 && extra > 0 {
 		result.Index = int16(joia + extra)
 	}
-	result.Effects[2] = world.Effect{Effect: efSanc, Value: 7}
+	refine.Set(&result, anctResultSanc, 0)
 	return result
 }

--- a/tmserver/internal/combine/match_test.go
+++ b/tmserver/internal/combine/match_test.go
@@ -4,8 +4,13 @@ import (
 	"testing"
 
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/refine"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
 )
+
+// efSanc is EF_SANC (ItemEffect.h:100). The package itself reads levels through
+// refine.Level; the tests still need the raw id to plant pairs.
+const efSanc = 43
 
 func TestMatchAnctBaseRecipe(t *testing.T) {
 	cat := Catalog{
@@ -13,8 +18,9 @@ func TestMatchAnctBaseRecipe(t *testing.T) {
 		Extra:      map[int]int{801: 2451},
 		AnctChance: [3]int{2, 4, 10},
 	}
+	// The base carries a sanc pair, so the result's +7 has a slot to land in.
 	items := []world.Item{
-		{Index: 801},
+		{Index: 801, Effects: [3]world.Effect{{Effect: efSanc, Value: 0}}},
 		{Index: 2442},
 	}
 	if got := MatchAnct(cat, items); got != 1 {
@@ -24,8 +30,33 @@ func TestMatchAnctBaseRecipe(t *testing.T) {
 	if got.Index != 2452 {
 		t.Errorf("result index = %d, want 2452 (joia 1 + extra 2451)", got.Index)
 	}
-	if itemSanc(got) != 7 {
-		t.Errorf("result sanc = %d, want 7", itemSanc(got))
+	if refine.Level(got) != 7 {
+		t.Errorf("result sanc = %d, want 7", refine.Level(got))
+	}
+}
+
+// BASE_SetItemSanc allocates nothing: a base item with no sanc pair produces a
+// result with no sanc at all (Basedef.cpp:2312 returns FALSE). The combine path
+// does not bootstrap a slot — only the dust-refine path does.
+func TestAnctResultWithoutSancSlot(t *testing.T) {
+	cat := Catalog{
+		Unique: map[int]int{801: 41},
+		Extra:  map[int]int{801: 2451},
+	}
+	items := []world.Item{
+		{Index: 801, Effects: [3]world.Effect{{Effect: efPos, Value: 4}, {Effect: efItemLevel, Value: 2}, {Effect: efMobType, Value: 1}}},
+		{Index: 2442},
+	}
+	got := AnctResult(cat, items)
+	if got.Index != 2452 {
+		t.Errorf("result index = %d, want 2452", got.Index)
+	}
+	if lvl := refine.Level(got); lvl != 0 {
+		t.Errorf("result sanc = %d, want 0 (no slot to write into)", lvl)
+	}
+	// And the existing effects must survive untouched.
+	if got.Effects[2] != (world.Effect{Effect: efMobType, Value: 1}) {
+		t.Errorf("Effects[2] = %+v, want the original EF_MOBTYPE pair", got.Effects[2])
 	}
 }
 

--- a/tmserver/internal/content/catalog.go
+++ b/tmserver/internal/content/catalog.go
@@ -70,6 +70,9 @@ var efName = map[string]uint8{
 	"EF_POS": 17, "EF_WTYPE": 21, "EF_SANC": 43, "EF_HPADD": 45, "EF_MPADD": 46, "EF_ACADD": 53,
 	"EF_DAMAGEADD": 67, "EF_HPADD2": 69, "EF_MPADD2": 70,
 	"EF_ITEMLEVEL": 87, "EF_MOBTYPE": 112, "EF_RUNSPEED": 29,
+	// Refine gates (_MSG_UseItem.cpp dust path): EF_NOSANC marks an item that can
+	// never be refined; the two incubation effects drive the mount-egg branch.
+	"EF_NOSANC": 126, "EF_INCUBATE": 78, "EF_INCUDELAY": 84,
 }
 
 // BaseEffects returns item index → its score-relevant static effects, parsed from

--- a/tmserver/internal/content/content_test.go
+++ b/tmserver/internal/content/content_test.go
@@ -49,19 +49,73 @@ func TestLoadSancRate(t *testing.T) {
 		t.Skipf("SancRate.txt unavailable: %v", err)
 	}
 	cases := []struct {
-		anvil       string
-		level, want int
+		name      string
+		anvil     int
+		idx, want int
 	}{
-		{"PO", 0, 100},
-		{"PO", 3, 85},
-		{"PO", 5, 40},
-		{"PL", 6, 80},
-		{"PL", 9, 10},
+		{"PO 0 from file", sancAnvilOri, 0, 100},
+		{"PO 3 from file", sancAnvilOri, 3, 85},
+		{"PO 5 from file", sancAnvilOri, 5, 40},
+		{"PL 6 from file", sancAnvilLac, 6, 80},
+		{"PL 9 from file", sancAnvilLac, 9, 10},
+
+		// The file lists only PO 0..5, so the tail keeps the Basedef.cpp defaults.
+		// Index 6 = 100 makes the +5→+6 Ori refine free; an operator who wants it
+		// gated adds a "PO 6 <rate>" line (issue #103).
+		{"PO 6 falls back to the compiled default", sancAnvilOri, 6, 100},
+		{"PO 7 falls back to the compiled default", sancAnvilOri, 7, 0},
+		{"PL 10 falls back to the compiled default", sancAnvilLac, 10, 0},
+
+		// The Âmago lines land on row 2. In the legacy they aliased onto row 0 and
+		// clobbered every PO rate above (CReadFiles.cpp:157); issue #103 fixed that,
+		// so PO 1 must still be the file's 100 and NOT Âmago's 80.
+		{"Amago 1 on its own row", sancAnvilAma, 1, 80},
+		{"Amago 11 on its own row", sancAnvilAma, 11, 5},
+		{"PO 1 not clobbered by Amago", sancAnvilOri, 1, 100},
+		{"PO 4 not clobbered by Amago", sancAnvilOri, 4, 70},
 	}
 	for _, tt := range cases {
-		got, ok := s.Rate(tt.anvil, tt.level)
-		if !ok || got != tt.want {
-			t.Errorf("Rate(%s,%d) = %d,%v, want %d", tt.anvil, tt.level, got, ok, tt.want)
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s.Rate(tt.anvil, tt.idx); got != tt.want {
+				t.Errorf("Rate(%d,%d) = %d, want %d", tt.anvil, tt.idx, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSancRateOutOfRange(t *testing.T) {
+	s := DefaultSancRate()
+	for _, tt := range []struct{ anvil, idx int }{{-1, 0}, {3, 0}, {0, -1}, {0, 12}} {
+		if got := s.Rate(tt.anvil, tt.idx); got != 0 {
+			t.Errorf("Rate(%d,%d) = %d, want 0", tt.anvil, tt.idx, got)
+		}
+	}
+	var nilTable *SancRate
+	if got := nilTable.Rate(0, 1); got != 0 {
+		t.Errorf("nil Rate = %d, want 0", got)
+	}
+}
+
+// The anvil token is matched on raw cp1252 bytes, the way _strupr+strcmp does.
+func TestSancAnvilRow(t *testing.T) {
+	cases := []struct {
+		token string
+		want  int
+		ok    bool
+	}{
+		{"PO", sancAnvilOri, true},
+		{"po", sancAnvilOri, true},
+		{"PL", sancAnvilLac, true},
+		{"\xC2mago", sancAnvilAma, true}, // cp1252, as the real file spells it
+		{"\xC2MAGO", sancAnvilAma, true},
+		{"\xC3\x82mago", sancAnvilAma, true}, // UTF-8, if the file is ever re-saved
+		{"Ori", 0, false},
+		{"", 0, false},
+	}
+	for _, tt := range cases {
+		got, ok := sancAnvilRow(tt.token)
+		if ok != tt.ok || (ok && got != tt.want) {
+			t.Errorf("sancAnvilRow(%q) = %d,%v, want %d,%v", tt.token, got, ok, tt.want, tt.ok)
 		}
 	}
 }

--- a/tmserver/internal/content/rates.go
+++ b/tmserver/internal/content/rates.go
@@ -97,24 +97,50 @@ func parseCompRate(r io.Reader) (*CompRate, error) {
 	return c, sc.Err()
 }
 
-// SancRate holds refine success rates by anvil and refine level
+// SancRate holds the dust-refine success rates by anvil and table index
 // (Common/Settings/SancRate.txt, ReadSancRate, game-rules.md §3.3). Lines are
-// "Anvil Level Rate".
+// "Anvil Index Rate".
+//
+// The table is a fixed [3][12]: row 0 = Ori (PO), 1 = Lac (PL), 2 = Âmago, and
+// BASE_GetSuccessRate indexes it at level+1 (slot 0 is unused). The file only
+// OVERRIDES the indices it lists — ReadSancRate never clears the table — so the
+// compiled-in defaults of Basedef.cpp:68 are the starting point.
 type SancRate struct {
-	rates map[string]map[int]int // anvil → level → rate
+	rates [3][12]int
 }
 
-// Rate returns the success rate for an anvil at a refine level.
-func (s *SancRate) Rate(anvil string, level int) (int, bool) {
-	if m, ok := s.rates[anvil]; ok {
-		r, ok := m[level]
-		return r, ok
+// sancRateDefaults is g_pSancRate (Basedef.cpp:68), the table before
+// SancRate.txt is applied over it.
+var sancRateDefaults = [3][12]int{
+	{100, 100, 100, 100, 100, 100, 100, 0, 0, 0, 0, 0},         // PO  (Ori)
+	{100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 0, 0},   // PL  (Lac)
+	{100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 80, 80}, // Âmago
+}
+
+// Anvil rows, mirroring refine.Ori/Lac/Amago (kept as plain ints to avoid a
+// content→refine import).
+const (
+	sancAnvilOri = 0
+	sancAnvilLac = 1
+	sancAnvilAma = 2
+)
+
+// Rate returns the success rate for an anvil row at a table index. Out-of-range
+// lookups and a nil table return 0 (always fails) rather than panicking in the
+// game loop.
+func (s *SancRate) Rate(anvil, idx int) int {
+	if s == nil {
+		return 0
 	}
-	return 0, false
+	if anvil < 0 || anvil >= len(s.rates) || idx < 0 || idx >= len(s.rates[anvil]) {
+		return 0
+	}
+	return s.rates[anvil][idx]
 }
 
-// Anvils returns the loaded anvil count.
-func (s *SancRate) Anvils() int { return len(s.rates) }
+// DefaultSancRate returns the table with only the Basedef.cpp defaults — what
+// the refine path uses when no -content tree is mounted.
+func DefaultSancRate() *SancRate { return &SancRate{rates: sancRateDefaults} }
 
 // LoadSancRate reads SancRate.txt.
 func LoadSancRate(path string) (*SancRate, error) {
@@ -126,24 +152,62 @@ func LoadSancRate(path string) (*SancRate, error) {
 	return parseSancRate(f)
 }
 
+// sancAnvilRow maps a SancRate.txt anvil token to its table row.
+//
+// The file is cp1252, not UTF-8: "Âmago" is the bytes C2 6D 61 67 6F. The legacy
+// never decodes it either — ReadFiles _strupr's the token (ASCII-only in the C
+// locale, so the 0xC2 survives) and strcmp's it against the cp1252 literal
+// "ÂMAGO". Matching raw bytes the same way is exact and needs no decoder; the
+// UTF-8 spelling is also accepted in case the file is ever re-saved.
+func sancAnvilRow(token string) (int, bool) {
+	switch asciiUpper(token) {
+	case "PO":
+		return sancAnvilOri, true
+	case "PL":
+		return sancAnvilLac, true
+	case "\xC2MAGO", "\xC3\x82MAGO": // cp1252 / UTF-8 "ÂMAGO"
+		// Deliberate divergence from the legacy: CReadFiles.cpp:157 writes the
+		// Âmago lines into g_pSancRate[0] — the PO row (:123) — a copy-paste bug.
+		// Since Âmago is listed last in the file, it silently overwrote every Ori
+		// rate. Issue #103 resolved this as "fix", so the file's PO lines are the
+		// ones that take effect and Âmago lands on its own row.
+		return sancAnvilAma, true
+	}
+	return 0, false
+}
+
+// asciiUpper uppercases a-z byte-wise, leaving every other byte untouched — the
+// C runtime's _strupr in the "C" locale. strings.ToUpper cannot be used: it
+// decodes runes, and the cp1252 0xC2 is invalid UTF-8, so it would be rewritten
+// as the 3-byte U+FFFD.
+func asciiUpper(s string) string {
+	b := []byte(s)
+	for i, c := range b {
+		if c >= 'a' && c <= 'z' {
+			b[i] = c - ('a' - 'A')
+		}
+	}
+	return string(b)
+}
+
 func parseSancRate(r io.Reader) (*SancRate, error) {
-	s := &SancRate{rates: make(map[string]map[int]int)}
+	s := &SancRate{rates: sancRateDefaults}
 	sc := bufio.NewScanner(r)
 	for sc.Scan() {
 		fields := strings.Fields(sc.Text())
 		if len(fields) != 3 {
 			continue
 		}
-		level, err1 := strconv.Atoi(fields[1])
+		idx, err1 := strconv.Atoi(fields[1])
 		rate, err2 := strconv.Atoi(fields[2])
 		if err1 != nil || err2 != nil {
 			continue
 		}
-		anvil := fields[0]
-		if s.rates[anvil] == nil {
-			s.rates[anvil] = make(map[int]int)
+		anvil, ok := sancAnvilRow(fields[0])
+		if !ok || idx < 0 || idx >= len(s.rates[anvil]) {
+			continue
 		}
-		s.rates[anvil][level] = rate
+		s.rates[anvil][idx] = rate
 	}
 	return s, sc.Err()
 }

--- a/tmserver/internal/handler/combat.go
+++ b/tmserver/internal/handler/combat.go
@@ -909,6 +909,25 @@ func manaControlDamage(target *world.Entity, dmg int, enhanced bool) (int, int32
 	return int(reduced), spent, true
 }
 
+// itemRawSanc returns an item's PACKED sanc cValue, not its refine level.
+//
+// The fairy heal-reduction divisor below is the one place that wants the raw
+// number: the legacy reads Equip[13].stEffect[0].cValue straight off the struct
+// (Server.cpp:10068, :10077) rather than going through BASE_GetItemSanc, so the
+// pity counter deliberately feeds into the divisor. Use refine.Level anywhere a
+// real refine level is meant.
+func itemRawSanc(it world.Item) int {
+	for _, ef := range it.Effects {
+		if ef.Effect >= 116 && ef.Effect <= 125 {
+			return int(ef.Value)
+		}
+		if ef.Effect == efSanc {
+			return int(ef.Value)
+		}
+	}
+	return 0
+}
+
 func (d *Dispatcher) foemaHealAmount(target *world.Entity, heal int32) int32 {
 	switch target.Equip[fairyEquipSlot].Index {
 	case 786:

--- a/tmserver/internal/handler/combine.go
+++ b/tmserver/internal/handler/combine.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/combine"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/refine"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
 )
 
@@ -45,6 +46,12 @@ func defaultCombineFamily(name string) CombineFamily {
 }
 
 // anctApply is the base Anct result fallback when no content catalog is mounted.
+//
+// Like combine.AnctResult, the sanc only lands if the base item already carries a
+// sanc pair — BASE_SetItemSanc allocates nothing and returns FALSE otherwise
+// (Basedef.cpp:2312). This resolves the old "which slot does sanc live in?"
+// UNVERIFIED: it is whichever slot already holds EF_SANC or a [116,125] effect,
+// scanning 0→1→2, never a fixed Effects[2].
 func anctApply(items []world.Item) world.Item {
 	result := items[0]
 	if len(items) >= 2 {
@@ -52,18 +59,8 @@ func anctApply(items []world.Item) world.Item {
 			result.Index = int16(joia)
 		}
 	}
-	setSanc(&result, resultSanc)
+	refine.Set(&result, resultSanc, 0)
 	return result
-}
-
-// setSanc records the refine ("anc") level on an item as a real EF_SANC effect pair,
-// so equipBonus/itemSanc can read it back and scale the item's stats (the joias). It
-// is written to the last instance slot (Effects[2]) to leave the first two for divines.
-//
-// UNVERIFIED: the exact STRUCT_ITEM slot the legacy uses for sanc is unconfirmed; the
-// EF_SANC id (43) is from ItemEffect.h.
-func setSanc(it *world.Item, level uint8) {
-	it.Effects[2] = world.Effect{Effect: efSanc, Value: level}
 }
 
 // combineItem is the shared engine handler for the Item[]-based variants. It

--- a/tmserver/internal/handler/dispatch.go
+++ b/tmserver/internal/handler/dispatch.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/level"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/npccfg"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/refine"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
 )
 
@@ -71,6 +72,12 @@ type Config struct {
 	ItemUnique map[int]int
 	ItemGrades map[int]int
 
+	// SancRate is the dust-refine success table (Common/Settings/SancRate.txt over
+	// the Basedef.cpp defaults; *content.SancRate satisfies it). When nil the
+	// compiled defaults are used, so refine still works without a mounted content
+	// tree.
+	SancRate refine.RateTable
+
 	// ExpEvents toggles global EXP modifiers (MobKilled.cpp:537-549, Server.cpp defaults).
 	ExpEvents level.ExpEvents
 
@@ -113,6 +120,7 @@ type Dispatcher struct {
 	itemPos         map[int]int                  // item index → nPos (refine threshold)
 	itemUnique      map[int]int                  // item index → nUnique (EF_DAMAGEADD gate)
 	itemGrades      map[int]int                  // item index → Grade (ExpBonus)
+	sancRate        refine.RateTable             // dust-refine success table (g_pSancRate)
 	expEvents       level.ExpEvents              // global EXP event flags
 	spells          *content.SkillData           // skill catalog (g_pSpell)
 	heights         *content.Grid                // baked walkability grid (mob pathfinding)
@@ -162,6 +170,7 @@ func New(cfg Config) *Dispatcher {
 		itemPos:         cfg.ItemPos,
 		itemUnique:      cfg.ItemUnique,
 		itemGrades:      cfg.ItemGrades,
+		sancRate:        cfg.SancRate,
 		expEvents:       cfg.ExpEvents,
 		spells:          cfg.Spells,
 		heights:         cfg.Heights,
@@ -173,6 +182,11 @@ func New(cfg Config) *Dispatcher {
 	// cleared. When there is no catalog both stay nil (buy/sell simply find no price).
 	d.baseItemPrices = cfg.ItemPrices
 	d.itemPrices = cloneInt32Map(cfg.ItemPrices)
+	if d.sancRate == nil {
+		// No content tree: fall back to the compiled g_pSancRate, like the original
+		// server before it reads SancRate.txt over it.
+		d.sancRate = content.DefaultSancRate()
+	}
 	if d.combineFamilies == nil {
 		d.combineFamilies = make(map[protocol.Type]CombineFamily)
 	}

--- a/tmserver/internal/handler/exp_bonus.go
+++ b/tmserver/internal/handler/exp_bonus.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/refine"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
 )
 
@@ -43,25 +44,5 @@ func fairyExpBonus(idx int16) int32 {
 	}
 }
 
-func itemRawSanc(it world.Item) int {
-	for _, ef := range it.Effects {
-		if ef.Effect >= 116 && ef.Effect <= 125 {
-			return int(ef.Value)
-		}
-		if ef.Effect == efSanc {
-			return int(ef.Value)
-		}
-	}
-	return 0
-}
-
-func itemGem(it world.Item) int {
-	if it.Index >= 2330 && it.Index < 2390 {
-		return -1
-	}
-	sanc := itemRawSanc(it)
-	if sanc < 230 {
-		return -1
-	}
-	return (sanc - 230) % 4
-}
+// itemGem is BASE_GetItemGem: the gem index of a +10..+15 item, -1 below +10.
+func itemGem(it world.Item) int { return refine.Gem(it) }

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/level"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/refine"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
 )
 
@@ -166,6 +167,8 @@ func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header
 	switch vol := d.itemVolatiles[int(e.Carry[src].Index)]; {
 	case vol == 0:
 		d.equipItem(w, s, e, body, payload)
+	case vol == volDustOri || vol == volDustLac:
+		d.refineItem(w, s, e, body, src, vol)
 	case vol == volHpMpPotion:
 		d.useHealPotion(w, s, e, src)
 	case vol >= volSephiraLo && vol <= volSephiraHi:
@@ -626,23 +629,12 @@ const (
 	weaponSlotL = 7
 )
 
-// itemSanc reads an item's refine ("anc") level from its instance effects (the
-// EF_SANC pair written by combine/refine), clamped to [0,15]. 0 = unrefined.
-func itemSanc(it world.Item) int {
-	for _, ef := range it.Effects {
-		if ef.Effect == efSanc {
-			lvl := int(ef.Value)
-			if lvl < 0 {
-				return 0
-			}
-			if lvl > 15 {
-				return 15
-			}
-			return lvl
-		}
-	}
-	return 0
-}
+// itemSanc reads an item's refine ("anc") level from its instance effects, 0..15
+// (BASE_GetItemSanc). 0 = unrefined.
+//
+// The cValue is NOT the level: it packs the level together with the pity counter,
+// so it has to be unpacked. See the refine package doc.
+func itemSanc(it world.Item) int { return refine.Level(it) }
 
 // nPos equip-slot classes that get refine (+9) threshold bonuses (captura §E).
 const (

--- a/tmserver/internal/handler/item_test.go
+++ b/tmserver/internal/handler/item_test.go
@@ -494,6 +494,49 @@ func TestWeaponDamageRefine(t *testing.T) {
 	}
 }
 
+// TestItemSancUnpacksPity is the issue #103 regression: the EF_SANC cValue packs
+// the refine level together with the pity counter (level + 10*pity), so reading
+// it raw reports a wildly wrong level. A +5 item that had failed two refines
+// stores 25; the old raw read clamped that to 15 and handed the item the +9
+// threshold bonus it never earned. Any item touched by the legacy server or
+// restored from a DB dump can carry a packed value.
+func TestItemSancUnpacksPity(t *testing.T) {
+	cases := []struct {
+		name string
+		cVal uint8
+		want int
+	}{
+		{"+5 no pity", 5, 5},
+		{"+5 with pity 2", 25, 5},
+		{"+0 with pity 1", 10, 0},
+		{"+9 with max pity", 209, 9},
+		{"+9 clean still reads +9", 9, 9},
+		{"+11 packs as 234", 234, 11},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			it := world.Item{Index: 555, Effects: [3]world.Effect{{Effect: efSanc, Value: tt.cVal}}}
+			if got := itemSanc(it); got != tt.want {
+				t.Errorf("itemSanc(cValue %d) = %d, want %d", tt.cVal, got, tt.want)
+			}
+		})
+	}
+}
+
+// The threshold bonus must key off the real level, not the packed byte: a +5
+// item with pity must NOT be granted the +9 AC bonus.
+func TestEquipBonusRefineIgnoresPity(t *testing.T) {
+	d := New(Config{
+		ItemEffects: map[int][]content.BaseEffect{555: {{Eff: efAc, Val: 100}}},
+		ItemPos:     map[int]int{555: 4},
+	})
+	e := &world.Entity{}
+	e.Equip[0] = world.Item{Index: 555, Effects: [3]world.Effect{{Effect: efSanc, Value: 25}}} // +5, pity 2
+	if ac := d.equipBonus(e).ac; ac != 100 {
+		t.Errorf("+5 (pity 2) AC = %d, want 100 — pity must not unlock the +9 threshold", ac)
+	}
+}
+
 // TestAttackRunOfBoots verifies EF_RUNSPEED (boots) raises the move-speed (low)
 // nibble of AttackRun to the issue #64 tier: bare=2, boots=4, mount=6.
 func TestAttackRunOfBoots(t *testing.T) {

--- a/tmserver/internal/handler/mobai.go
+++ b/tmserver/internal/handler/mobai.go
@@ -250,6 +250,7 @@ func (d *Dispatcher) regenPlayers(w *world.World) {
 			d.sendScore(w, s, e)
 			d.sendAffect(w, s, e)
 		}
+		d.tickIncubation(w, s, e)
 		hp := regenStep(e.HP, effectiveMaxHP(e))
 		mp := regenStep(e.MP, effectiveMaxMP(e))
 		if hp == e.HP && mp == e.MP {
@@ -258,6 +259,26 @@ func (d *Dispatcher) regenPlayers(w *world.World) {
 		e.HP, e.MP = hp, mp
 		d.sendScore(w, s, e)
 	})
+}
+
+// tickIncubation counts an equipped egg's incubation cooldown down by one
+// (RegenMob, Server.cpp:4884-4894). Only an EQUIPPED egg ticks — that is the
+// mechanic: a failed refine stamps the cooldown and the player has to wear the
+// egg and wait it out before trying again. Without this the refine path's
+// _NN_Incu_Wait_More gate would brick an egg permanently.
+func (d *Dispatcher) tickIncubation(w *world.World, s *world.Session, e *world.Entity) {
+	egg := &e.Equip[mountEquipSlot]
+	if !isEgg(*egg) {
+		return
+	}
+	delay := itemInstanceAbility(*egg, efIncuDelay)
+	if delay <= 0 {
+		return
+	}
+	egg.Effects[2].Value = uint8(delay - 1)
+	d.sendSlot(w, s, world.ItemPlaceEquip, mountEquipSlot, *egg)
+	// SendClientMessage(_NN_Incu_Proceed) — no notice code for it yet; the item
+	// push is what the client renders.
 }
 
 // regenStep moves cur toward full by ~5% of full (min 2 per tick), capped at full.

--- a/tmserver/internal/handler/notice.go
+++ b/tmserver/internal/handler/notice.go
@@ -38,6 +38,14 @@ const (
 	NoticeAlreadyLearned                    // _NN_Already_Learned_It
 	NoticeNotEnoughCoin                     // _DN_D_Cost (8th skill costs 50M gold)
 	NoticeMaxPoint                          // _NN_Maximum_Point_Now / _200_Now (mastery cap)
+
+	// Dust refine (_MSG_UseItem.cpp dust path; Language.h ids in the comments).
+	NoticeOnlyToEquips   // _NN_Only_To_Equips (74): a dust only refines equipment
+	NoticeCantRefineMore // _NN_Cant_Refine_More (75): at the cap, or EF_NOSANC
+	NoticeFailToRefine   // _NN_Fail_To_Refine (76)
+	NoticeRefineSuccess  // _NN_Refine_Success (176)
+	NoticeIncubated      // _NN_INCUBATED (253): the egg hatched into its mount
+	NoticeIncuWaitMore   // _NN_Incu_Wait_More (261): the egg's incubation timer
 )
 
 // notify sends a client notification.

--- a/tmserver/internal/handler/refine.go
+++ b/tmserver/internal/handler/refine.go
@@ -1,0 +1,311 @@
+package handler
+
+import (
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/refine"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// The refine dusts, classified (like every _MSG_UseItem action) by the source
+// item's EF_VOLATILE rather than by its index. OriLacto = Vol-4
+// (_MSG_UseItem.cpp:849).
+const (
+	volDustOri = 4 // Poeira de Oriharucon (412)
+	volDustLac = 5 // Poeira de Lactolerium (413)
+)
+
+const (
+	// itemLacto100 (Lactolerium_100) carries EF_VOLATILE 5 like an ordinary Lac
+	// dust but forces the Âmago row, a flat 100% (_MSG_UseItem.cpp:850).
+	itemLacto100 = 4141
+	// item769 is capped at +9 by name (_MSG_UseItem.cpp:802).
+	item769 = 769
+
+	// Ori stops at +6, Lac at +9; the dust path never goes past +9 except for the
+	// one +10→+11 step.
+	oriMaxSanc  = 6
+	lacMaxSanc  = 9
+	gemSancLvl  = 10 // the +10 special case: goes to +11 and preserves the gem
+	sancHardCap = 11 // at +11 and above the dust path refuses outright
+
+	// refineRollModulo is the dust roll: a plain rand()%100
+	// (_MSG_UseItem.cpp:851). NOT combine.Roll's rand()%115 with the -15 fold —
+	// the two paths use different distributions.
+	refineRollModulo = 100
+	// pityRollModulo: rand()%4 <= 2, a 3-in-4 chance to accrue pity on a failure
+	// (_MSG_UseItem.cpp:943).
+	pityRollModulo = 4
+	pityRollMax    = 2
+)
+
+// Mount eggs (2300..2329) hatch into their mount at sIndex+30 when refined.
+const (
+	eggLo       = 2300
+	eggHi       = 2330
+	eggHatchAdd = 30
+	// eggIncuDelayBase is the cooldown stamped on a successful egg refine:
+	// rand()%4 + 6 (_MSG_UseItem.cpp:899).
+	eggIncuDelayBase = 6
+	// incuLevelExempt: the incubation gate only applies below level 999
+	// (_MSG_UseItem.cpp:842).
+	incuLevelExempt = 999
+
+	// A freshly hatched mount reinterprets its effect slots as mount data
+	// (BASE_GetItemAbility, Basedef.cpp:1758-1770): stEffect[0].sValue = MOUNTHP,
+	// [1].cEffect = MOUNTSANC, [1].cValue = MOUNTLIFE, [2].cEffect = MOUNTFEED,
+	// [2].cValue = MOUNTKILL.
+	hatchMountHP   = 20000
+	hatchMountSanc = 1
+	hatchMountFeed = 30
+	hatchMountKill = 1
+	hatchLifeBase  = 10 // MOUNTLIFE = rand()%20 + 10
+	hatchLifeSpan  = 20
+)
+
+// Effect ids the refine path gates on (ItemEffect.h).
+const (
+	efNoSanc    = 126 // EF_NOSANC: this item can never be refined
+	efIncubate  = 78  // EF_INCUBATE: the refine level an egg hatches at
+	efIncuDelay = 84  // EF_INCUDELAY: an egg's cooldown between refine attempts
+)
+
+func isEgg(it world.Item) bool { return it.Index >= eggLo && it.Index < eggHi }
+
+// itemInstanceAbility sums ONLY an item's instance effects, which is what
+// BASE_GetBonusItemAbility does (Basedef.cpp:2048) — unlike itemAbility (=
+// BASE_GetItemAbility) it never reads the catalog.
+//
+// Only valid for the effects BASE_GetBonusItemAbility excludes from its
+// `value *= sanc+10` refine scaling (Basedef.cpp:2084). EF_INCUBATE and
+// EF_INCUDELAY, the two this path needs, are both on that exclusion list.
+//
+// The catalog blindness is load-bearing, not an oversight: an egg's EF_INCUBATE
+// lives in ItemList.csv, so this returns 0 for a fresh egg and the hatch gate
+// `level >= incubate` passes on the first successful refine.
+func itemInstanceAbility(it world.Item, eff uint8) int {
+	var total int
+	for _, ef := range it.Effects {
+		if ef.Effect == eff {
+			total += int(ef.Value)
+		}
+	}
+	return total
+}
+
+// putShort writes a raw 16-bit value across an effect pair's two bytes, the way
+// the legacy assigns STRUCT_ITEM's `stEffect[i].sValue` union member on
+// little-endian x86.
+func putShort(ef *world.Effect, v uint16) {
+	ef.Effect = uint8(v)
+	ef.Value = uint8(v >> 8)
+}
+
+// refineItem is the dust-refine path of _MSG_UseItem (_MSG_UseItem.cpp:153-208
+// and :802-976): dragging a Poeira de Ori (Vol 4) or de Lac (Vol 5) onto an item
+// raises its refine level. The dust is consumed either way; on failure the item
+// itself is never destroyed nor downgraded, it only accrues "pity" that raises
+// the next attempt's odds.
+//
+// Only the standard-equipment path is ported (issue #103). The legacy's four
+// other dust branches — sealed items (:224), celestial/HC (:385), arch stones
+// (:514) and +10..+14 earrings (:716) — all roll rand()%115 with the -15 fold and
+// destroy or reset the item on failure; they are deferred to their own issues.
+func (d *Dispatcher) refineItem(w *world.World, s *world.Session, e *world.Entity, body protocol.MsgUseItemBody, src, vol int) {
+	dst := d.itemSlot(w, s, e, int(body.DestType), int(body.DestPos))
+	if dst == nil || dst.Empty() {
+		return // no such target slot — the legacy just logs and drops the message
+	}
+
+	// A dust only refines equipment: a target that is itself a consumable (which
+	// includes dragging a dust onto another dust) is refused (:178).
+	//
+	// The legacy reads EF_VOLATILE with BASE_GetItemAbility (catalog + instance);
+	// this reads the catalog map useItem already classifies the source dust with.
+	// EF_VOLATILE is a catalog property — no minted item carries it as an instance
+	// effect — so the two agree in practice.
+	if d.itemVolatiles[int(dst.Index)] != 0 {
+		d.refineReject(w, s, e, src, NoticeOnlyToEquips)
+		return
+	}
+	if d.itemAbility(*dst, efNoSanc) != 0 {
+		d.refineReject(w, s, e, src, NoticeCantRefineMore)
+		return
+	}
+
+	level := refine.Level(*dst)
+	// Ori cannot touch an item already at +6 or above (:203).
+	if vol == volDustOri && level >= oriMaxSanc {
+		d.refineReject(w, s, e, src, NoticeCantRefineMore)
+		return
+	}
+	// +9 is the dust path's wall. +10 is allowed through as the one special case
+	// (it becomes +11); +11 and up are refused (:802, where the legacy compares
+	// against the REF_11 sentinel).
+	if level == lacMaxSanc || level >= sancHardCap || (level >= lacMaxSanc && dst.Index == item769) {
+		d.refineReject(w, s, e, src, NoticeCantRefineMore)
+		return
+	}
+
+	// Read the pity BEFORE the bootstrap: planting the pair zeroes the slot, and
+	// the legacy reads it first too (:809 before :814), so a failed refine keeps
+	// accruing onto the previous count.
+	pity := refine.Pity(*dst)
+
+	// A never-refined item has nowhere to store a level yet. When all three effect
+	// slots hold real effects the legacy refuses to refine the item at all (:814).
+	if level == 0 && !refine.Bootstrap(dst) {
+		d.refineReject(w, s, e, src, NoticeCantRefineMore)
+		return
+	}
+
+	// An egg that failed a previous refine has to sit out its incubation timer,
+	// which RegenMob ticks down while the egg is equipped (:842, regenPlayers).
+	//
+	// UNVERIFIED: the legacy reads BaseScore.Level here; the Entity only carries
+	// CurrentScore.Level. They differ only via EF_LEVEL gear, never near 999.
+	if isEgg(*dst) && e.Level < incuLevelExempt && itemInstanceAbility(*dst, efIncuDelay) > 0 {
+		d.refineReject(w, s, e, src, NoticeIncuWaitMore)
+		return
+	}
+
+	anvil := vol - volDustOri // 0 = Ori, 1 = Lac — also indexes g_pSancGrade
+	// The rate anvil can differ from the grade anvil: Lactolerium_100 forces the
+	// Âmago row for a guaranteed 100%, but still steps the level as a Lac (:850).
+	rateAnvil := anvil
+	if e.Carry[src].Index == itemLacto100 {
+		rateAnvil = refine.Amago
+	}
+
+	// Order is parity-critical: the rate is computed BEFORE the roll, and the
+	// grade read after it (:850-853). One rand() on the hot path.
+	rate := refine.SuccessRate(d.sancRate, *dst, rateAnvil)
+	roll := w.Rand().Intn(refineRollModulo)
+	grade := d.itemAbility(*dst, efItemLevel)
+
+	t := refineTarget{item: dst, place: int(body.DestType), slot: int(body.DestPos)}
+	// `<=` is inclusive, and a 0 rate always fails despite roll 0 passing it (:855).
+	if roll <= rate && rate != 0 {
+		d.refineSucceed(w, s, e, t, src, vol, anvil, level, grade)
+		return
+	}
+	d.refineFail(w, s, e, t, src, anvil, level, pity)
+}
+
+// refineTarget is the item being refined, together with where it lives so the
+// result can be pushed back to the client.
+type refineTarget struct {
+	item        *world.Item
+	place, slot int
+}
+
+// refineSucceed applies a won roll (_MSG_UseItem.cpp:856-927).
+func (d *Dispatcher) refineSucceed(w *world.World, s *world.Session, e *world.Entity, t refineTarget, src, vol, anvil, level, grade int) {
+	dst := t.item
+
+	if level == gemSancLvl {
+		// +10 → +11, carrying the gem index across (:857).
+		refine.Set(dst, gemSancLvl+1, refine.Gem(*dst))
+	} else {
+		if grade >= 1 && grade <= 5 {
+			level += refine.Step(anvil, grade)
+			if level >= oriMaxSanc && vol == volDustOri {
+				level = oriMaxSanc
+			} else if level > lacMaxSanc {
+				level = lacMaxSanc
+			}
+		} else {
+			// No usable grade → a plain +1. Note the legacy skips BOTH caps on this
+			// branch (:874), so it is the one way past them; reproduced.
+			level++
+		}
+		refine.Set(dst, level, 0) // a success clears the pity
+	}
+
+	d.refreshScore(e)
+	d.sendScore(w, s, e)
+	d.notify(w, s, NoticeRefineSuccess)
+
+	if isEgg(*dst) {
+		d.hatchEgg(w, s, t, level)
+	}
+
+	d.sendSlot(w, s, t.place, t.slot, *dst)
+	// SendEmotion(conn, 14, 3) — cosmetic, and no emotion packet exists in this
+	// port yet (_MSG_UseItem.cpp:920).
+	consumeOneItem(&e.Carry[src])
+	// The dust slot is deliberately NOT re-sent: the client already removed the
+	// item it dragged, and the legacy only echoes the source back on the refusal
+	// paths, to undo that removal.
+}
+
+// refineFail applies a lost roll (_MSG_UseItem.cpp:929-974). The item survives
+// untouched — only the dust is spent and the pity counter grows.
+func (d *Dispatcher) refineFail(w *world.World, s *world.Session, e *world.Entity, t refineTarget, src, anvil, level, pity int) {
+	d.notify(w, s, NoticeFailToRefine)
+	consumeOneItem(&e.Carry[src])
+
+	if w.Rand().Intn(pityRollModulo) <= pityRollMax {
+		// Lac always accrues pity; Ori only up to +5 (:943-949).
+		if anvil == refine.Lac || (level <= 5 && anvil == refine.Ori) {
+			pity++
+		}
+	}
+
+	dst := t.item
+	if isEgg(*dst) {
+		// A failed egg refine starts the incubation cooldown (:951).
+		dst.Effects[2] = world.Effect{Effect: efIncuDelay, Value: uint8(w.Rand().Intn(pityRollModulo))}
+	}
+	if level != gemSancLvl {
+		refine.Set(dst, level, pity)
+	}
+	d.sendSlot(w, s, t.place, t.slot, *dst)
+	// SendEmotion(conn, 15|20, 0) — cosmetic, not ported (:967).
+}
+
+// hatchEgg is the mount-egg branch inlined in the refine success
+// (_MSG_UseItem.cpp:890-917). It stamps a fresh incubation cooldown and, once the
+// egg's level reaches its EF_INCUBATE threshold, turns it into the mount at
+// sIndex+30.
+func (d *Dispatcher) hatchEgg(w *world.World, s *world.Session, t refineTarget, level int) {
+	dst := t.item
+	dst.Effects[2] = world.Effect{
+		Effect: efIncuDelay,
+		Value:  uint8(w.Rand().Intn(pityRollModulo) + eggIncuDelayBase),
+	}
+
+	// Reads the INSTANCE EF_INCUBATE, which a fresh egg does not have (its
+	// threshold is a catalog effect) — so this is 0 and the egg hatches on its
+	// first successful refine. That is the legacy's behaviour, not a shortcut:
+	// see itemInstanceAbility.
+	if level < itemInstanceAbility(*dst, efIncubate) {
+		return
+	}
+
+	dst.Index += eggHatchAdd
+	putShort(&dst.Effects[0], hatchMountHP)
+	dst.Effects[1] = world.Effect{
+		Effect: hatchMountSanc,
+		Value:  uint8(w.Rand().Intn(hatchLifeSpan) + hatchLifeBase),
+	}
+	dst.Effects[2] = world.Effect{Effect: hatchMountFeed, Value: hatchMountKill}
+	d.notify(w, s, NoticeIncubated)
+	// MountProcess(conn, 0) is a no-op: with a NULL mount its IsEqual stays 1 and
+	// it returns immediately (Server.cpp:4639-4643). Nothing to port.
+	//
+	// The legacy sends the slot here AND again after the egg block (:916, :919);
+	// the duplicate is harmless and refineSucceed does the second send.
+	d.sendSlot(w, s, t.place, t.slot, *dst)
+}
+
+// refineReject refuses a refine and re-sends the DUST slot, so the client puts
+// the item it dragged back where it was (_MSG_UseItem.cpp:805).
+func (d *Dispatcher) refineReject(w *world.World, s *world.Session, e *world.Entity, src int, n Notice) {
+	d.notify(w, s, n)
+	d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
+}
+
+// sendSlot pushes one item slot to the client (SendItem).
+func (d *Dispatcher) sendSlot(w *world.World, s *world.Session, place, slot int, it world.Item) {
+	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(place, slot, itemToSel(it)))
+}

--- a/tmserver/internal/handler/refine_test.go
+++ b/tmserver/internal/handler/refine_test.go
@@ -1,0 +1,440 @@
+package handler
+
+import (
+	"context"
+	"encoding/binary"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/refine"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// The refine dust items, as ItemList.csv defines them.
+const (
+	itemPoeiraOri = 412
+	itemPoeiraLac = 413
+	itemArmor     = 555 // a plain refinable armor
+)
+
+// rateTable is an injectable SancRate. Index it at level+1, like the real one.
+type rateTable [3][12]int
+
+func (r rateTable) Rate(anvil, idx int) int {
+	if anvil < 0 || anvil >= len(r) || idx < 0 || idx >= len(r[anvil]) {
+		return 0
+	}
+	return r[anvil][idx]
+}
+
+// alwaysRate is a table where every Ori/Lac lookup returns rate.
+func alwaysRate(rate int) rateTable {
+	var t rateTable
+	for a := range t {
+		for i := range t[a] {
+			t[a][i] = rate
+		}
+	}
+	return t
+}
+
+// refineFixture wires a dispatcher whose catalog mirrors production: the two
+// dusts classified by EF_VOLATILE, and a refinable armor. Mirroring the real
+// Config matters — a handler harness with the catalog switched off silently
+// makes every EF_ gate read 0 (see the B12 lesson).
+type refineFixture struct {
+	d *Dispatcher
+	w *world.World
+	s *world.Session
+	e *world.Entity
+}
+
+func newRefineFixture(t *testing.T, tbl refine.RateTable, effects map[int][]content.BaseEffect) *refineFixture {
+	t.Helper()
+	if effects == nil {
+		effects = map[int][]content.BaseEffect{}
+	}
+	d := New(Config{
+		Log:           slog.New(slog.DiscardHandler),
+		SancRate:      tbl,
+		ItemVolatiles: map[int]int{itemPoeiraOri: volDustOri, itemPoeiraLac: volDustLac, itemLacto100: volDustLac},
+		ItemEffects:   effects,
+	})
+	w := world.New(world.Config{GridDim: 16}, slog.New(slog.DiscardHandler), nil, nil)
+	return &refineFixture{
+		d: d,
+		w: w,
+		s: &world.Session{Conn: 1, Mode: world.UserPlay},
+		e: &world.Entity{ID: 1, HP: 100},
+	}
+}
+
+// refine drags the dust in carry slot 0 onto the item in carry slot 1.
+func (f *refineFixture) refine(dust int16) {
+	f.e.Carry[0] = world.Item{Index: dust}
+	body := protocol.MsgUseItemBody{
+		SourType: world.ItemPlaceCarry, SourPos: 0,
+		DestType: world.ItemPlaceCarry, DestPos: 1,
+	}
+	vol := f.d.itemVolatiles[int(dust)]
+	f.d.refineItem(f.w, f.s, f.e, body, 0, vol)
+}
+
+func (f *refineFixture) target() world.Item { return f.e.Carry[1] }
+
+func TestRefineSuccessRaisesLevel(t *testing.T) {
+	f := newRefineFixture(t, alwaysRate(100), nil)
+	f.e.Carry[1] = world.Item{Index: itemArmor}
+
+	f.refine(itemPoeiraLac)
+
+	if got := refine.Level(f.target()); got != 1 {
+		t.Errorf("level = %d, want 1", got)
+	}
+	if !f.e.Carry[0].Empty() {
+		t.Errorf("dust not consumed: %+v", f.e.Carry[0])
+	}
+	// The level must land in a real EF_SANC pair the rest of the server can read.
+	if f.target().Effects[0] != (world.Effect{Effect: efSanc, Value: 1}) {
+		t.Errorf("Effects[0] = %+v, want {EF_SANC 1}", f.target().Effects[0])
+	}
+}
+
+// A failed dust refine never destroys or downgrades the item — that only happens
+// on the sealed/celestial/earring branches, which are out of scope.
+func TestRefineFailKeepsItemAndAccruesPity(t *testing.T) {
+	f := newRefineFixture(t, alwaysRate(0), nil)
+	f.e.Carry[1] = world.Item{Index: itemArmor}
+	before := f.target().Index
+
+	f.refine(itemPoeiraLac)
+
+	if f.target().Index != before {
+		t.Errorf("item index changed on failure: %d → %d", before, f.target().Index)
+	}
+	if got := refine.Level(f.target()); got != 0 {
+		t.Errorf("level = %d, want 0 (a failure must not downgrade)", got)
+	}
+	if !f.e.Carry[0].Empty() {
+		t.Error("dust must be consumed on failure too")
+	}
+	// rand()#2 % 4 = 3 (the seed-1 stream), and 3 > 2, so this particular failure
+	// does NOT accrue pity — the roll is 3-in-4.
+	if got := refine.Pity(f.target()); got != 0 {
+		t.Errorf("pity = %d, want 0 (rand()#2%%4 = 3 misses the <=2 window)", got)
+	}
+}
+
+// Pity accrues over repeated failures and is what eventually carries a refine
+// through (g_pSuccessRate).
+func TestRefinePityAccrues(t *testing.T) {
+	f := newRefineFixture(t, alwaysRate(0), nil)
+	f.e.Carry[1] = world.Item{Index: itemArmor}
+	for i := 0; i < 6; i++ {
+		f.refine(itemPoeiraLac)
+	}
+	if got := refine.Pity(f.target()); got == 0 {
+		t.Errorf("pity = 0 after 6 failures, want > 0")
+	}
+	if got := refine.Level(f.target()); got != 0 {
+		t.Errorf("level = %d, want 0", got)
+	}
+}
+
+func TestRefineGates(t *testing.T) {
+	cases := []struct {
+		name    string
+		dust    int16
+		target  world.Item
+		effects map[int][]content.BaseEffect
+		want    Notice
+	}{
+		{
+			name:   "Ori refuses an item already at +6",
+			dust:   itemPoeiraOri,
+			target: world.Item{Index: itemArmor, Effects: [3]world.Effect{{Effect: efSanc, Value: 6}}},
+			want:   NoticeCantRefineMore,
+		},
+		{
+			name:   "the dust path stops at +9",
+			dust:   itemPoeiraLac,
+			target: world.Item{Index: itemArmor, Effects: [3]world.Effect{{Effect: efSanc, Value: 9}}},
+			want:   NoticeCantRefineMore,
+		},
+		{
+			name:   "+11 and above is refused",
+			dust:   itemPoeiraLac,
+			target: world.Item{Index: itemArmor, Effects: [3]world.Effect{{Effect: efSanc, Value: 234}}}, // +11
+			want:   NoticeCantRefineMore,
+		},
+		{
+			name:   "item 769 is capped at +9",
+			dust:   itemPoeiraLac,
+			target: world.Item{Index: item769, Effects: [3]world.Effect{{Effect: efSanc, Value: 234}}},
+			want:   NoticeCantRefineMore,
+		},
+		{
+			name:   "a dust cannot be refined onto another dust",
+			dust:   itemPoeiraLac,
+			target: world.Item{Index: itemPoeiraOri},
+			want:   NoticeOnlyToEquips,
+		},
+		{
+			name:    "EF_NOSANC items never refine",
+			dust:    itemPoeiraLac,
+			target:  world.Item{Index: itemArmor},
+			effects: map[int][]content.BaseEffect{itemArmor: {{Eff: efNoSanc, Val: 1}}},
+			want:    NoticeCantRefineMore,
+		},
+		{
+			name: "an item with all three effect slots taken has nowhere to store a level",
+			dust: itemPoeiraLac,
+			target: world.Item{Index: itemArmor, Effects: [3]world.Effect{
+				{Effect: efAc, Value: 10}, {Effect: efHp, Value: 20}, {Effect: efMp, Value: 30},
+			}},
+			want: NoticeCantRefineMore,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newRefineFixture(t, alwaysRate(100), tt.effects)
+			f.e.Carry[1] = tt.target
+			before := f.target()
+
+			f.refine(tt.dust)
+
+			if f.target() != before {
+				t.Errorf("a refused refine mutated the item: %+v → %+v", before, f.target())
+			}
+			if f.e.Carry[0].Empty() {
+				t.Error("a refused refine consumed the dust")
+			}
+		})
+	}
+}
+
+// Ori tops out at +6 even when the roll wins.
+func TestRefineOriCapsAtSix(t *testing.T) {
+	f := newRefineFixture(t, alwaysRate(100), nil)
+	f.e.Carry[1] = world.Item{Index: itemArmor}
+	for i := 0; i < 10; i++ {
+		f.refine(itemPoeiraOri)
+	}
+	if got := refine.Level(f.target()); got != oriMaxSanc {
+		t.Errorf("level = %d, want %d (Ori's cap)", got, oriMaxSanc)
+	}
+}
+
+// Lac tops out at +9.
+func TestRefineLacCapsAtNine(t *testing.T) {
+	f := newRefineFixture(t, alwaysRate(100), nil)
+	f.e.Carry[1] = world.Item{Index: itemArmor}
+	for i := 0; i < 20; i++ {
+		f.refine(itemPoeiraLac)
+	}
+	if got := refine.Level(f.target()); got != lacMaxSanc {
+		t.Errorf("level = %d, want %d (Lac's cap)", got, lacMaxSanc)
+	}
+}
+
+// Lactolerium_100 forces the Âmago row, which is a flat 100% regardless of the
+// table — here the table would otherwise always fail.
+func TestRefineLacto100AlwaysSucceeds(t *testing.T) {
+	f := newRefineFixture(t, alwaysRate(0), nil)
+	f.e.Carry[1] = world.Item{Index: itemArmor}
+
+	f.refine(itemLacto100)
+
+	if got := refine.Level(f.target()); got != 1 {
+		t.Errorf("level = %d, want 1 (Lactolerium_100 is a guaranteed refine)", got)
+	}
+}
+
+// TestRefineRNGGolden pins the rand() call order against the MSVC stream from the
+// CRT default seed 1, which is where every world starts:
+//
+//	Rand() #1..#5 = 41, 18467, 6334, 26500, 19169   → %100 = 41, 67, 34, 0, 69
+//
+// The dust path spends exactly ONE rand() when it succeeds and TWO when it fails
+// (the roll, then the 3-in-4 pity roll). Any extra or reordered draw shifts every
+// later result, so this test is what actually locks the parity.
+func TestRefineRNGGolden(t *testing.T) {
+	// Rate 50: rolls of 41 and 34 win; 67 and 69 lose.
+	f := newRefineFixture(t, alwaysRate(50), nil)
+	f.e.Carry[1] = world.Item{Index: itemArmor}
+
+	steps := []struct {
+		roll      int
+		wantLevel int
+		wantPity  int
+		note      string
+	}{
+		// #1 roll 41 <= 50 → success. One draw spent.
+		{41, 1, 0, "roll 41 wins"},
+		// #2 roll 67 > 50 → fail. #3 = 6334%4 = 2 <= 2 → pity++.
+		{67, 1, 1, "roll 67 loses, pity roll 2 hits the <=2 window"},
+		// #4 roll 26500%100 = 0 <= 50 → success. Pity resets.
+		{0, 2, 0, "roll 0 wins and clears the pity"},
+		// #5 roll 19169%100 = 69 > 50 → fail. #6 = 15724%4 = 0 <= 2 → pity++.
+		{69, 2, 1, "roll 69 loses, pity roll 0 hits the window"},
+	}
+	for i, st := range steps {
+		f.refine(itemPoeiraLac)
+		if got := refine.Level(f.target()); got != st.wantLevel {
+			t.Errorf("step %d (%s): level = %d, want %d", i+1, st.note, got, st.wantLevel)
+		}
+		if got := refine.Pity(f.target()); got != st.wantPity {
+			t.Errorf("step %d (%s): pity = %d, want %d", i+1, st.note, got, st.wantPity)
+		}
+	}
+}
+
+// TestRefineOverTheWire drives the real client path end to end: a _MSG_UseItem
+// frame carrying a dust in SourPos and the target in DestPos must reach
+// refineItem through useItem's EF_VOLATILE switch, and the refined item must come
+// back in a _MSG_SendItem.
+//
+// This is the actual issue #103 regression. The unit tests above call refineItem
+// directly and would all still pass with the switch arm removed — which is
+// exactly the bug that shipped: refine fell through to `default:` and no-oped.
+// It also checks the packet, not just server state: the right level in memory
+// still renders wrong if the S→C frame carries the wrong bytes.
+func TestRefineOverTheWire(t *testing.T) {
+	db := newDB()
+	st := world.CharacterState{Slot: 0, Name: "Hero", X: 5, Y: 5, HP: 1000, MaxHP: 1000}
+	st.Carry[0] = world.Item{Index: itemPoeiraLac}
+	st.Carry[1] = world.Item{Index: itemArmor}
+	db.loadResult = st
+
+	addr, stop := startRefineServer(t, db)
+	defer stop()
+	c := enterWorld(t, addr)
+
+	body := protocol.MsgUseItemBody{
+		SourType: world.ItemPlaceCarry, SourPos: 0,
+		DestType: world.ItemPlaceCarry, DestPos: 1,
+	}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+
+	// Read until the item push (the score/notice frames come first).
+	for i := 0; ; i++ {
+		if i > 8 {
+			t.Fatal("no _MSG_SendItem after a refine — the dust fell through useItem's switch")
+		}
+		ty, payload, ok := readMaybe(t, c)
+		if !ok {
+			t.Fatal("connection closed before the refined item arrived")
+		}
+		if ty != protocol.MsgSendItem {
+			continue
+		}
+		place := int(binary.LittleEndian.Uint16(payload[0:]))
+		slot := int(binary.LittleEndian.Uint16(payload[2:]))
+		index := binary.LittleEndian.Uint16(payload[4:])
+		if place != world.ItemPlaceCarry || slot != 1 {
+			continue // not the target slot
+		}
+		if index != itemArmor {
+			t.Fatalf("SendItem index = %d, want %d", index, itemArmor)
+		}
+		// The effect pairs ride at body+6: the EF_SANC pair must carry the new level.
+		eff0 := world.Effect{Effect: payload[6], Value: payload[7]}
+		if eff0 != (world.Effect{Effect: efSanc, Value: 1}) {
+			t.Fatalf("SendItem Effects[0] = %+v, want {EF_SANC 1} — the client renders THIS, not the server's copy", eff0)
+		}
+		return
+	}
+}
+
+// startRefineServer is startServerClock with a catalog that classifies the dusts.
+func startRefineServer(t *testing.T, persist world.Persistence) (string, func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := slog.New(slog.DiscardHandler)
+	d := New(Config{
+		Log:           log,
+		SancRate:      alwaysRate(100),
+		ItemVolatiles: map[int]int{itemPoeiraOri: volDustOri, itemPoeiraLac: volDustLac},
+	})
+	w := world.New(world.Config{GridDim: 16}, log, persist, d.Handle)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = w.Serve(ctx, ln); close(done) }()
+	return ln.Addr().String(), func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("server did not stop")
+		}
+	}
+}
+
+// An egg hatches into its mount on the first successful refine: the hatch gate
+// reads the INSTANCE EF_INCUBATE, which a fresh egg does not carry.
+func TestRefineEggHatches(t *testing.T) {
+	const egg = 2304
+	f := newRefineFixture(t, alwaysRate(100), map[int][]content.BaseEffect{
+		egg: {{Eff: efIncubate, Val: 2}}, // the catalog threshold is deliberately not read
+	})
+	f.e.Carry[1] = world.Item{Index: egg}
+
+	f.refine(itemPoeiraLac)
+
+	if got := f.target().Index; got != egg+eggHatchAdd {
+		t.Fatalf("index = %d, want %d (hatched mount)", got, egg+eggHatchAdd)
+	}
+	// The hatched mount reinterprets its slots as mount data: [0].sValue = HP.
+	if got := uint16(f.target().Effects[0].Effect) | uint16(f.target().Effects[0].Value)<<8; got != hatchMountHP {
+		t.Errorf("mount HP = %d, want %d", got, hatchMountHP)
+	}
+	if got := f.target().Effects[1].Effect; got != hatchMountSanc {
+		t.Errorf("mount sanc = %d, want %d", got, hatchMountSanc)
+	}
+	if got := f.target().Effects[2]; got != (world.Effect{Effect: hatchMountFeed, Value: hatchMountKill}) {
+		t.Errorf("mount feed/kill = %+v", got)
+	}
+}
+
+// A failed egg refine stamps the incubation cooldown, and the regen tick counts
+// it down only while the egg is equipped.
+func TestEggIncubationCooldown(t *testing.T) {
+	const egg = 2304
+	f := newRefineFixture(t, alwaysRate(0), nil)
+	f.e.Carry[1] = world.Item{Index: egg}
+
+	f.refine(itemPoeiraLac)
+
+	// rand()#3 % 4 = 2 → a cooldown of 2.
+	delay := itemInstanceAbility(f.target(), efIncuDelay)
+	if delay != 2 {
+		t.Fatalf("incubation delay = %d, want 2", delay)
+	}
+
+	// While the cooldown stands, another refine is refused.
+	f.refine(itemPoeiraLac)
+	if got := itemInstanceAbility(f.target(), efIncuDelay); got != delay {
+		t.Errorf("a gated refine changed the cooldown: %d → %d", delay, got)
+	}
+	if f.e.Carry[0].Empty() {
+		t.Error("a gated refine consumed the dust")
+	}
+
+	// The tick only counts an EQUIPPED egg down.
+	f.d.tickIncubation(f.w, f.s, f.e)
+	if got := itemInstanceAbility(f.target(), efIncuDelay); got != delay {
+		t.Errorf("the cooldown ticked while the egg was in the inventory: %d", got)
+	}
+	f.e.Equip[mountEquipSlot] = f.target()
+	f.d.tickIncubation(f.w, f.s, f.e)
+	if got := itemInstanceAbility(f.e.Equip[mountEquipSlot], efIncuDelay); got != delay-1 {
+		t.Errorf("equipped cooldown = %d, want %d", got, delay-1)
+	}
+}

--- a/tmserver/internal/refine/rate.go
+++ b/tmserver/internal/refine/rate.go
@@ -1,0 +1,75 @@
+package refine
+
+import "github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+
+// Anvil rows of the SancRate table. "OriLacto" is the legacy's name for the
+// index, derived from the dust's EF_VOLATILE as Vol-4 (_MSG_UseItem.cpp:849).
+const (
+	Ori   = 0 // Poeira de Oriharucon (412), EF_VOLATILE 4 — caps the item at +6
+	Lac   = 1 // Poeira de Lactolerium (413), EF_VOLATILE 5 — caps the item at +9
+	Amago = 2 // forced by Lactolerium_100 (4141); always a flat 100%
+)
+
+// RateTable supplies the SancRate rows indexed by anvil (Ori/Lac/Amago) and by
+// level+1. *content.SancRate satisfies it; the minimal-interface shape mirrors
+// combine.Rand.
+type RateTable interface {
+	Rate(anvil, idx int) int
+}
+
+// sancGrade is g_pSancGrade (Basedef.cpp:77): the refine step granted per
+// EF_ITEMLEVEL grade. Every entry is 1, and SancRate.txt carries no
+// PO_A..PL_E lines to override it, so a successful refine is always exactly +1.
+var sancGrade = [2][5]int{
+	{1, 1, 1, 1, 1},
+	{1, 1, 1, 1, 1},
+}
+
+// pityWeight is g_pSuccessRate (Basedef.cpp:122): how many rate points each
+// accumulated pity point is worth. Indexed like the rate table, at level+1.
+var pityWeight = [11]int{5, 5, 5, 5, 4, 4, 3, 3, 2, 1, 0}
+
+// Step returns the refine increment for an item of the given EF_ITEMLEVEL grade
+// (_MSG_UseItem.cpp:862-874). Grades outside [1,5] fall back to a plain +1 —
+// and note the legacy skips the level caps entirely on that fallback, which the
+// caller reproduces.
+func Step(anvil, grade int) int {
+	if anvil < Ori || anvil > Lac || grade < 1 || grade > len(sancGrade[0]) {
+		return 1
+	}
+	return sancGrade[anvil][grade-1]
+}
+
+// SuccessRate ports BASE_GetSuccessRate (Basedef.cpp:2243): the chance 0..100
+// that refining `it` with the given anvil succeeds. It reads the item's own
+// level and pity, exactly like the legacy signature does.
+//
+// Note the level+1 index: a row's slot 0 is unused, and a refine from +N reads
+// slot N+1.
+func SuccessRate(t RateTable, it world.Item, anvil int) int {
+	if isGrowth(it) {
+		return 0
+	}
+	if anvil < Ori || anvil > Amago {
+		return 0
+	}
+	level := Level(it)
+	// +10 is the one level the tables do not cover; it is hardcoded upstream.
+	if level == minGemLvl {
+		if anvil == Amago {
+			return 100
+		}
+		return 15
+	}
+	if anvil == Amago {
+		return 100 // the Lactolerium_100 guarantee, before any table lookup
+	}
+	// The dust path gates +9 and +11.. off before rolling, so only 0..8 reach a
+	// table lookup. The legacy would fold the REF_* sentinels with `sanc %= 10`
+	// and read a nonsense row here; returning 0 (always fails) keeps an
+	// unreachable input from indexing out of bounds.
+	if level < 0 || level+1 >= len(pityWeight) {
+		return 0
+	}
+	return t.Rate(anvil, level+1) + Pity(it)*pityWeight[level+1]
+}

--- a/tmserver/internal/refine/rate_test.go
+++ b/tmserver/internal/refine/rate_test.go
@@ -1,0 +1,94 @@
+package refine
+
+import (
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// fakeTable is the effective SancRate.txt table after the issue #103 Âmago fix:
+// the file's PO/PL lines applied over the Basedef.cpp defaults.
+type fakeTable [3][12]int
+
+func (f fakeTable) Rate(anvil, idx int) int {
+	if anvil < 0 || anvil >= len(f) || idx < 0 || idx >= len(f[anvil]) {
+		return 0
+	}
+	return f[anvil][idx]
+}
+
+var liveTable = fakeTable{
+	{100, 100, 100, 85, 70, 40, 100, 0, 0, 0, 0, 0},      // PO: 0..5 from the file, the rest compiled defaults
+	{100, 100, 100, 100, 100, 100, 80, 70, 70, 10, 0, 0}, // PL: 0..9 from the file
+	{100, 80, 60, 40, 20, 10, 10, 10, 5, 5, 5, 5},        // Âmago, now on its own row
+}
+
+func TestSuccessRate(t *testing.T) {
+	cases := []struct {
+		name  string
+		it    world.Item
+		anvil int
+		want  int
+	}{
+		// The table is indexed at level+1, so a refine FROM +N reads slot N+1.
+		{"Ori +0→+1", sanc(0), Ori, 100},
+		{"Ori +2→+3", sanc(2), Ori, 85},
+		{"Ori +3→+4", sanc(3), Ori, 70},
+		{"Ori +4→+5", sanc(4), Ori, 40},
+		// The file has no PO 6 line, so this falls back to the compiled 100. Called
+		// out in issue #103: an operator gates it by adding one.
+		{"Ori +5→+6 is free on the current table", sanc(5), Ori, 100},
+
+		{"Lac +0→+1", sanc(0), Lac, 100},
+		{"Lac +5→+6", sanc(5), Lac, 80},
+		{"Lac +6→+7", sanc(6), Lac, 70},
+		{"Lac +8→+9", sanc(8), Lac, 10},
+
+		// Pity adds level+1's weight per accumulated point (g_pSuccessRate).
+		{"Lac +8 with pity 3 adds 3*1", sanc(encode(8, 3)), Lac, 13},
+		{"Ori +4 with pity 2 adds 2*4", sanc(encode(4, 2)), Ori, 48},
+		{"Ori +0 with pity 1 adds 5 over a full rate", sanc(encode(0, 1)), Ori, 105},
+
+		// +10 is hardcoded upstream of the table.
+		{"+10 with Ori", sanc(230), Ori, 15},
+		{"+10 with Lac", sanc(230), Lac, 15},
+		{"+10 with Amago", sanc(230), Amago, 100},
+
+		// Lactolerium_100 forces the Amago row for a flat guarantee.
+		{"Amago is always 100 regardless of level", sanc(4), Amago, 100},
+		{"Amago is always 100 even at +8", sanc(8), Amago, 100},
+
+		// Guards.
+		{"unknown anvil", sanc(0), 3, 0},
+		{"negative anvil", sanc(0), -1, 0},
+		{"growth items never refine", sancGrowth(2350, 0), Ori, 0},
+		// Gated off before the roll; 0 keeps the unreachable input from indexing OOB.
+		{"+11 is out of the table's reach", sanc(234), Ori, 0},
+		{"+15 is out of the table's reach", sanc(250), Lac, 0},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SuccessRate(liveTable, tt.it, tt.anvil); got != tt.want {
+				t.Errorf("SuccessRate = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStep(t *testing.T) {
+	// g_pSancGrade is all 1s and SancRate.txt has no PO_A..PL_E lines to override
+	// it, so every successful refine is exactly +1.
+	for _, anvil := range []int{Ori, Lac} {
+		for grade := 1; grade <= 5; grade++ {
+			if got := Step(anvil, grade); got != 1 {
+				t.Errorf("Step(%d,%d) = %d, want 1", anvil, grade, got)
+			}
+		}
+	}
+	// Out-of-range grades fall back to a plain +1 (_MSG_UseItem.cpp:874).
+	for _, tt := range []struct{ anvil, grade int }{{Ori, 0}, {Ori, 6}, {Ori, -1}, {Amago, 1}, {-1, 1}} {
+		if got := Step(tt.anvil, tt.grade); got != 1 {
+			t.Errorf("Step(%d,%d) = %d, want 1", tt.anvil, tt.grade, got)
+		}
+	}
+}

--- a/tmserver/internal/refine/sanc.go
+++ b/tmserver/internal/refine/sanc.go
@@ -1,0 +1,194 @@
+// Package refine ports the dust-refine core of _MSG_UseItem ("refino com
+// poeiras"): the packed sanc encoding and the success-rate tables. Like
+// internal/combine it is pure — no world state, no I/O — because the encoding
+// and the rates are parity-critical economy constants (parity-tests.md §4.0).
+//
+// The refine level does NOT live in the item's cValue as a plain number. It is
+// packed together with a second counter (Basedef.cpp:2282, BASE_SetItemSanc):
+//
+//	levels 0..9   cValue = level + 10*pity     (pity 0..20, so 0..209)
+//	levels 10..15 cValue = base + gem          (base 230/234/238/242/246/250, gem 0..3)
+//
+// Reading a cValue back as-is therefore reports a wildly wrong level for any
+// item that has ever failed a refine.
+//
+// This package reports the TRUE level (0..15). The legacy BASE_GetItemSanc
+// instead returns the non-contiguous REF_* sentinels (Basedef.h:256): REF_10=10,
+// REF_11=12, REF_12=15, REF_13=18, REF_14=22, REF_15=27. Every comparison the
+// dust path makes (== 9, >= 6, >= REF_11) yields the same answer in either
+// space, with one translation: `sanc >= REF_11` becomes `level >= 11`.
+package refine
+
+import "github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+
+// Effect ids that can carry a refine level. BASE_GetItemSanc prefers the
+// [116,125] range over EF_SANC when an item somehow has both.
+const (
+	efSanc      = 43  // EF_SANC (ItemEffect.h:100)
+	efSancAltLo = 116 // the alternate carriers (ItemEffect.h), used by some minted items
+	efSancAltHi = 125
+)
+
+// Mount-growth items (2330..2389) are rejected outright by every
+// BASE_GetItemSanc-family function (Basedef.cpp:2138) — they reuse the effect
+// slots for growth data, so a sanc read there would be garbage.
+const (
+	growthLo = 2330
+	growthHi = 2390
+)
+
+// gemBase is the first packed cValue of a +10 item; each level spans 4 values,
+// one per gem index (Basedef.cpp:2294-2308).
+const (
+	gemBase    = 230
+	gemPerLvl  = 4
+	minGemLvl  = 10
+	maxSancLvl = 15
+	maxPity    = 20
+)
+
+func isGrowth(it world.Item) bool { return it.Index >= growthLo && it.Index < growthHi }
+
+// readSlot returns the effect slot BASE_GetItemSanc and BASE_GetItemGem read
+// (Basedef.cpp:2141-2160): ALL slots are scanned for the [116,125] range first,
+// and only then for EF_SANC. -1 when the item carries neither.
+func readSlot(it world.Item) int {
+	for i, ef := range it.Effects {
+		if ef.Effect >= efSancAltLo && ef.Effect <= efSancAltHi {
+			return i
+		}
+	}
+	for i, ef := range it.Effects {
+		if ef.Effect == efSanc {
+			return i
+		}
+	}
+	return -1
+}
+
+// writeSlot returns the effect slot BASE_SetItemSanc writes and
+// BASE_GetItemSancSuccess reads (Basedef.cpp:2312, :2225): the first slot that
+// is EF_SANC *or* in [116,125], scanning 0→1→2. -1 when there is none, which is
+// the legacy's FALSE return — the level is silently not stored.
+//
+// Parity quirk: this is deliberately NOT readSlot. On an item carrying both an
+// EF_SANC pair and a [116,125] pair, the legacy reads the level from one slot
+// and the pity from another. The bootstrap in the dust path normalizes items to
+// a single pair, so this is only reachable for items minted elsewhere (a legacy
+// save or a DB import). Reproduced rather than tidied.
+func writeSlot(it world.Item) int {
+	for i, ef := range it.Effects {
+		if ef.Effect == efSanc || (ef.Effect >= efSancAltLo && ef.Effect <= efSancAltHi) {
+			return i
+		}
+	}
+	return -1
+}
+
+// decodeLevel maps a packed cValue to a true refine level 0..15
+// (BASE_GetItemSanc, Basedef.cpp:2162-2180).
+func decodeLevel(v uint8) int {
+	if v >= gemBase && v <= gemBase+(maxSancLvl-minGemLvl+1)*gemPerLvl-1 {
+		return minGemLvl + int(v-gemBase)/gemPerLvl
+	}
+	// Everything else (including the unreachable 210..229 and the 254/255 tail)
+	// folds by %10, which is what strips the pity back off.
+	return int(v) % 10
+}
+
+// encode packs a level and its aux counter into a cValue (BASE_SetItemSanc,
+// Basedef.cpp:2282-2310). aux is the pity counter below +10 and the gem index
+// from +10 up.
+func encode(level, aux int) uint8 {
+	// Legacy quirk: an out-of-range level wipes the item to +0 — it does NOT
+	// clamp to +15 (Basedef.cpp:2285).
+	if level < 0 || level > maxSancLvl {
+		level = 0
+	}
+	if aux < 0 {
+		aux = 0
+	}
+	if aux > maxPity {
+		aux = maxPity
+	}
+	if level >= minGemLvl {
+		// Overflows past +15 with a large aux, exactly as the legacy's assignment
+		// to an unsigned char does.
+		return uint8(gemBase + (level-minGemLvl)*gemPerLvl + aux)
+	}
+	return uint8(level + 10*aux)
+}
+
+// Level returns an item's true refine level, 0..15 (BASE_GetItemSanc). 0 means
+// unrefined.
+func Level(it world.Item) int {
+	if isGrowth(it) {
+		return 0
+	}
+	i := readSlot(it)
+	if i < 0 {
+		return 0
+	}
+	return decodeLevel(it.Effects[i].Value)
+}
+
+// Pity returns the accumulated "success" counter (BASE_GetItemSancSuccess).
+// Failed refines raise it and it feeds back into the next attempt's rate. From
+// +10 up the same field holds the gem index instead, so the two must not be
+// mixed — the dust path only ever reads Pity below +10.
+func Pity(it world.Item) int {
+	if isGrowth(it) {
+		return 0
+	}
+	i := writeSlot(it)
+	if i < 0 {
+		return 0
+	}
+	return int(it.Effects[i].Value) / 10
+}
+
+// Gem returns the gem index of a +10..+15 item, or -1 below +10
+// (BASE_GetItemGem).
+func Gem(it world.Item) int {
+	if isGrowth(it) {
+		// The legacy returns FALSE here, i.e. gem 0 — not the -1 that means "no
+		// gem" (Basedef.cpp:2186). Reproduced.
+		return 0
+	}
+	i := readSlot(it)
+	if i < 0 {
+		return -1
+	}
+	v := it.Effects[i].Value
+	if v < gemBase {
+		return -1
+	}
+	return int(v-gemBase) % gemPerLvl
+}
+
+// Set stores a level and aux counter in the item's sanc slot, reporting whether
+// a slot was available (BASE_SetItemSanc). It never allocates one: the caller
+// plants the EF_SANC pair first (Bootstrap).
+func Set(it *world.Item, level, aux int) bool {
+	i := writeSlot(*it)
+	if i < 0 {
+		return false
+	}
+	it.Effects[i].Value = encode(level, aux)
+	return true
+}
+
+// Bootstrap plants a zeroed EF_SANC pair in the first slot free to hold one, so
+// that a never-refined item has somewhere to store its level
+// (_MSG_UseItem.cpp:814-840). A slot counts as free when it is empty or already
+// carries a sanc pair. It reports false when all three slots hold real effects —
+// the legacy refuses to refine such an item at all.
+func Bootstrap(it *world.Item) bool {
+	for i, ef := range it.Effects {
+		if ef.Effect == 0 || ef.Effect == efSanc || (ef.Effect >= efSancAltLo && ef.Effect <= efSancAltHi) {
+			it.Effects[i] = world.Effect{Effect: efSanc, Value: 0}
+			return true
+		}
+	}
+	return false
+}

--- a/tmserver/internal/refine/sanc_test.go
+++ b/tmserver/internal/refine/sanc_test.go
@@ -1,0 +1,237 @@
+package refine
+
+import (
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// item builds an item with the given effect pairs, padded to 3 slots.
+func item(idx int16, pairs ...world.Effect) world.Item {
+	it := world.Item{Index: idx}
+	copy(it.Effects[:], pairs)
+	return it
+}
+
+func sanc(v uint8) world.Item { return item(1, world.Effect{Effect: efSanc, Value: v}) }
+
+func TestDecodeLevel(t *testing.T) {
+	cases := []struct {
+		name string
+		cVal uint8
+		want int
+	}{
+		{"unrefined", 0, 0},
+		{"plain +5", 5, 5},
+		{"plain +9", 9, 9},
+		// The regression at the heart of issue #103: pity packs into the tens
+		// digit, so a raw read reports a wildly wrong level.
+		{"+5 with pity 2 is still +5", 25, 5},
+		{"+0 with pity 1 is still +0", 10, 0},
+		{"+9 with max pity 20 is still +9", 209, 9},
+		{"+3 with pity 20 is still +3", 203, 3},
+		// The 230..253 band encodes +10..+15, four gem slots each.
+		{"+10 gem 0", 230, 10},
+		{"+10 gem 3", 233, 10},
+		{"+11 gem 0", 234, 11},
+		{"+12 gem 0", 238, 12},
+		{"+13 gem 0", 242, 13},
+		{"+14 gem 0", 246, 14},
+		{"+15 gem 0", 250, 15},
+		{"+15 gem 3", 253, 15},
+		// Outside the band the legacy just folds by %10.
+		{"254 folds", 254, 4},
+		{"255 folds", 255, 5},
+		{"unreachable 210..229 folds", 215, 5},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := decodeLevel(tt.cVal); got != tt.want {
+				t.Errorf("decodeLevel(%d) = %d, want %d", tt.cVal, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEncode(t *testing.T) {
+	cases := []struct {
+		name       string
+		level, aux int
+		want       uint8
+	}{
+		{"unrefined", 0, 0, 0},
+		{"+5 no pity", 5, 0, 5},
+		{"+5 pity 2", 5, 2, 25},
+		{"+9 pity 20", 9, 20, 209},
+		{"+10 gem 0", 10, 0, 230},
+		{"+11 gem 1", 11, 1, 235},
+		{"+15 gem 3", 15, 3, 253},
+		// Legacy quirks (Basedef.cpp:2283-2291).
+		{"level above 15 wipes to +0, it does not clamp", 16, 0, 0},
+		{"level above 15 wipes but keeps the aux", 16, 3, 30},
+		{"negative level wipes to +0", -1, 0, 0},
+		{"negative aux floors at 0", 5, -1, 5},
+		{"aux saturates at 20", 5, 99, 205},
+		// 250 + 20 overflows the unsigned char exactly as the legacy's assignment does.
+		{"+15 with a pity-sized aux overflows like the C uchar", 15, 20, 14},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := encode(tt.level, tt.aux); got != tt.want {
+				t.Errorf("encode(%d,%d) = %d, want %d", tt.level, tt.aux, got, tt.want)
+			}
+		})
+	}
+}
+
+// Every cValue the refine path can mint must survive an encode→decode round trip.
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	for level := 0; level <= 9; level++ {
+		for pity := 0; pity <= maxPity; pity++ {
+			v := encode(level, pity)
+			if got := decodeLevel(v); got != level {
+				t.Errorf("encode(%d,%d)=%d decoded to %d", level, pity, v, got)
+			}
+			if got := int(v) / 10; got != pity {
+				t.Errorf("encode(%d,%d)=%d has pity %d, want %d", level, pity, v, got, pity)
+			}
+		}
+	}
+	for level := minGemLvl; level <= maxSancLvl; level++ {
+		for gem := 0; gem < gemPerLvl; gem++ {
+			v := encode(level, gem)
+			if got := decodeLevel(v); got != level {
+				t.Errorf("encode(%d,gem %d)=%d decoded to %d", level, gem, v, got)
+			}
+			if got := int(v-gemBase) % gemPerLvl; got != gem {
+				t.Errorf("encode(%d,gem %d)=%d has gem %d", level, gem, v, got)
+			}
+		}
+	}
+}
+
+func TestLevel(t *testing.T) {
+	cases := []struct {
+		name string
+		it   world.Item
+		want int
+	}{
+		{"no effects at all", item(1), 0},
+		{"no sanc pair", item(1, world.Effect{Effect: 2, Value: 50}), 0},
+		{"EF_SANC in slot 0", sanc(5), 5},
+		{"EF_SANC in slot 2", item(1, world.Effect{Effect: 2, Value: 50}, world.Effect{Effect: 3, Value: 9}, world.Effect{Effect: efSanc, Value: 7}), 7},
+		{"the [116,125] range also carries a level", item(1, world.Effect{Effect: 120, Value: 4}), 4},
+		{"the [116,125] range wins over EF_SANC", item(1, world.Effect{Effect: efSanc, Value: 3}, world.Effect{Effect: 120, Value: 8}), 8},
+		// Mount-growth items reuse the slots for growth data (Basedef.cpp:2138).
+		{"growth item reads 0", sancGrowth(2350, 5), 0},
+		{"just below the growth range still reads", sancGrowth(2329, 5), 5},
+		{"just above the growth range still reads", sancGrowth(2390, 5), 5},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Level(tt.it); got != tt.want {
+				t.Errorf("Level = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func sancGrowth(idx int16, v uint8) world.Item {
+	return item(idx, world.Effect{Effect: efSanc, Value: v})
+}
+
+func TestPityAndGem(t *testing.T) {
+	if got := Pity(sanc(25)); got != 2 {
+		t.Errorf("Pity(+5 pity 2) = %d, want 2", got)
+	}
+	if got := Pity(sanc(5)); got != 0 {
+		t.Errorf("Pity(+5 no pity) = %d, want 0", got)
+	}
+	if got := Pity(item(1)); got != 0 {
+		t.Errorf("Pity(no pair) = %d, want 0", got)
+	}
+	if got := Gem(sanc(235)); got != 1 {
+		t.Errorf("Gem(+11 gem 1) = %d, want 1", got)
+	}
+	if got := Gem(sanc(5)); got != -1 {
+		t.Errorf("Gem(+5) = %d, want -1 (no gem below +10)", got)
+	}
+	if got := Gem(item(1)); got != -1 {
+		t.Errorf("Gem(no pair) = %d, want -1", got)
+	}
+}
+
+// Level and Pity deliberately resolve different slots — a legacy quirk kept as
+// parity (Basedef.cpp:2141 vs :2225). Only reachable for items minted outside
+// the refine path, since Bootstrap normalizes to a single pair.
+func TestReadWriteSlotDivergence(t *testing.T) {
+	it := item(1, world.Effect{Effect: efSanc, Value: 30}, world.Effect{Effect: 120, Value: 8})
+	if got := Level(it); got != 8 {
+		t.Errorf("Level = %d, want 8 (read prefers the [116,125] slot 1)", got)
+	}
+	if got := Pity(it); got != 3 {
+		t.Errorf("Pity = %d, want 3 (write/pity takes the first matching slot, 0)", got)
+	}
+}
+
+func TestSet(t *testing.T) {
+	it := sanc(0)
+	if !Set(&it, 5, 2) {
+		t.Fatal("Set returned false on an item with an EF_SANC pair")
+	}
+	if it.Effects[0].Value != 25 {
+		t.Errorf("cValue = %d, want 25", it.Effects[0].Value)
+	}
+
+	// Writes go to the existing pair, not a fixed slot.
+	it = item(1, world.Effect{Effect: 2, Value: 50}, world.Effect{Effect: efSanc, Value: 0})
+	if !Set(&it, 3, 0) {
+		t.Fatal("Set returned false")
+	}
+	if it.Effects[0].Value != 50 {
+		t.Errorf("slot 0 was clobbered: %+v", it.Effects[0])
+	}
+	if it.Effects[1].Value != 3 {
+		t.Errorf("slot 1 cValue = %d, want 3", it.Effects[1].Value)
+	}
+
+	// No pair to write into → the legacy's FALSE.
+	it = item(1, world.Effect{Effect: 2, Value: 50})
+	if Set(&it, 5, 0) {
+		t.Error("Set returned true with no sanc pair present")
+	}
+}
+
+func TestBootstrap(t *testing.T) {
+	cases := []struct {
+		name     string
+		it       world.Item
+		wantOK   bool
+		wantSlot int
+	}{
+		{"empty item takes slot 0", item(1), true, 0},
+		{"first free slot after a real effect", item(1, world.Effect{Effect: 2, Value: 50}), true, 1},
+		{"first free slot after two real effects", item(1, world.Effect{Effect: 2, Value: 50}, world.Effect{Effect: 3, Value: 9}), true, 2},
+		{"an existing EF_SANC slot counts as free", item(1, world.Effect{Effect: efSanc, Value: 4}), true, 0},
+		{"a [116,125] slot counts as free", item(1, world.Effect{Effect: 2, Value: 50}, world.Effect{Effect: 120, Value: 4}), true, 1},
+		{"all three slots taken by real effects refuses", item(1,
+			world.Effect{Effect: 2, Value: 50},
+			world.Effect{Effect: 3, Value: 9},
+			world.Effect{Effect: 4, Value: 7}), false, -1},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			it := tt.it
+			if got := Bootstrap(&it); got != tt.wantOK {
+				t.Fatalf("Bootstrap = %v, want %v", got, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			got := it.Effects[tt.wantSlot]
+			if got.Effect != efSanc || got.Value != 0 {
+				t.Errorf("slot %d = %+v, want {EF_SANC 0}", tt.wantSlot, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Ports the standard Poeira de Ori/Lac dust-refine path through _MSG_UseItem, including packed sanc/pity handling, rate tables, caps, Lacto100, and mount egg incubation.
- Switches sanc/gem reads to the shared refine package so packed pity values do not unlock threshold bonuses.
- Documents issue #103 rate-table behavior and adds handler/refine/content/combine coverage.

## Tests
- make test