### PR TITLE
feat: crit items (amuletos/set) add to Critical — issue #102

### DIFF
--- a/tmserver/internal/content/catalog.go
+++ b/tmserver/internal/content/catalog.go
@@ -60,15 +60,21 @@ type BaseEffect struct {
 // (the same ids the instance refines use). Only effects the score model can represent
 // are mapped. EF_WTYPE is included because some Huntress affects key off the
 // equipped weapon type, but it still does not fold into CurrentScore. The purely
-// visual/requirement ones (EF_CLASS/EF_GRID/EF_RANGE/EF_REGEN*/EF_CRITICAL/…)
-// are ignored. The ids match ItemEffect.h. EF_SANC carries an item's refine
-// level (the joias), consumed as a multiplier by the handler rather than a flat stat.
+// visual/requirement ones (EF_CLASS/EF_GRID/EF_RANGE/EF_REGEN*/…) are ignored. The ids
+// match ItemEffect.h. EF_SANC carries an item's refine level (the joias), consumed as a
+// multiplier by the handler rather than a flat stat.
+//
+// EF_CRITICAL/EF_CRITICAL2 ARE score stats (Basedef.cpp:3209 derives MOB.Critical from
+// them) — they were misfiled as visual here, which is why crit gear granted nothing
+// (issue #102). Most crit lives in the catalog: the class body items and the armor sets
+// carry EF_CRITICAL directly.
 var efName = map[string]uint8{
 	"EF_DAMAGE": 2, "EF_AC": 3, "EF_HP": 4, "EF_MP": 5,
 	"EF_STR": 7, "EF_INT": 8, "EF_DEX": 9, "EF_CON": 10,
 	"EF_SPECIAL1": 11, "EF_SPECIAL2": 12, "EF_SPECIAL3": 13, "EF_SPECIAL4": 14,
-	"EF_POS": 17, "EF_WTYPE": 21, "EF_SANC": 43, "EF_HPADD": 45, "EF_MPADD": 46, "EF_ACADD": 53,
-	"EF_DAMAGEADD": 67, "EF_HPADD2": 69, "EF_MPADD2": 70,
+	"EF_POS": 17, "EF_WTYPE": 21, "EF_CRITICAL": 42, "EF_SANC": 43,
+	"EF_HPADD": 45, "EF_MPADD": 46, "EF_ACADD": 53,
+	"EF_DAMAGEADD": 67, "EF_HPADD2": 69, "EF_MPADD2": 70, "EF_CRITICAL2": 71,
 	"EF_ITEMLEVEL": 87, "EF_MOBTYPE": 112, "EF_RUNSPEED": 29,
 }
 

--- a/tmserver/internal/content/content_test.go
+++ b/tmserver/internal/content/content_test.go
@@ -99,6 +99,61 @@ func TestBaseEffects(t *testing.T) {
 	}
 }
 
+// TestBaseEffectsCritical: EF_CRITICAL/EF_CRITICAL2 are score stats (Basedef.cpp:3209
+// derives MOB.Critical from them), not the visual effects they were once filed as —
+// dropping them here is what left crit gear worth nothing (issue #102). Most crit in the
+// catalog rides on set pieces and the class body items.
+func TestBaseEffectsCritical(t *testing.T) {
+	// Real rows: an armor set piece (ItemList.csv:225) and a class body item (:1).
+	const rows = "165,Armadura_de_Guarda(Az),17.0,0.0.0.0.0,0,0,4,0,0," +
+		"EF_CLASS,1,EF_GRID,0,EF_AC,138,EF_CRITICAL,50,EF_HPADD,9,EF_ITEMLEVEL,5\n" +
+		"1,TransKnight,0.0,0.0.0.0.0,0,0,1,0,0," +
+		"EF_CLASS,1,EF_RANGE,1,EF_REGENHP,2,EF_REGENMP,2,EF_CRITICAL,10\n"
+	l, err := parseItemList(strings.NewReader(rows))
+	if err != nil {
+		t.Fatal(err)
+	}
+	eff := l.BaseEffects()
+	for _, tc := range []struct {
+		idx  int
+		want int16
+	}{{165, 50}, {1, 10}} {
+		var got int16
+		for _, e := range eff[tc.idx] {
+			if e.Eff == 42 { // EF_CRITICAL
+				got = e.Val
+			}
+		}
+		if got != tc.want {
+			t.Errorf("BaseEffects()[%d] EF_CRITICAL = %d, want %d", tc.idx, got, tc.want)
+		}
+	}
+
+	// The real catalog must actually carry crit — the parser silently dropping it is
+	// what issue #102 was. Guards against the effect disappearing from efName again.
+	full, err := LoadItemList(release(t, "Common", "ItemList.csv"))
+	if err != nil {
+		t.Skipf("ItemList.csv unavailable: %v", err)
+	}
+	var withCrit int
+	for _, effs := range full.BaseEffects() {
+		for _, e := range effs {
+			if e.Eff == 42 || e.Eff == 71 {
+				withCrit++
+				break
+			}
+		}
+	}
+	if withCrit < 100 {
+		t.Errorf("real catalog items carrying EF_CRITICAL = %d, want >= 100", withCrit)
+	}
+	// Pedra_Amunra (the issue's amulet) equips into the four accessory slots: its nPos
+	// 0xF00 is what triggers the +9 x2 refine promotion in handler.itemCritical.
+	if pos := full.Positions()[3464]; pos&0xF00 == 0 {
+		t.Errorf("Pedra_Amunra nPos = %d, want the accessory mask 0xF00 set", pos)
+	}
+}
+
 func TestRanges(t *testing.T) {
 	// Mob-model rows (real format): the archer's body item carries EF_RANGE,4 —
 	// the source of a mob's ranged reach (BASE_GetMobAbility). A row without

--- a/tmserver/internal/handler/affect_score.go
+++ b/tmserver/internal/handler/affect_score.go
@@ -304,7 +304,7 @@ func effectiveDex(e *world.Entity) int16 { return e.Dex + e.AffDex }
 func effectiveMagic(e *world.Entity) int32 { return int32(e.Magic) + e.AffMagic }
 
 func effectiveCritical(e *world.Entity) uint8 {
-	v := int(e.Critical) + int(e.AffCritical) + int(huntressCriticalBonus(e))
+	v := int(e.Critical) + int(e.AffCritical) + int(skillCriticalBonus(e))
 	if v < 0 {
 		return 0
 	}
@@ -314,8 +314,14 @@ func effectiveCritical(e *world.Entity) uint8 {
 	return uint8(v)
 }
 
-func huntressCriticalBonus(e *world.Entity) int16 {
-	if e.Class != 3 || e.LearnedSkill&(1<<18) == 0 {
+// skillCriticalBonus is the class-skill crit bonus. The legacy grants the SAME formula to
+// two classes from two different skill bits — TK "Confiança" (Basedef.cpp:3252, bonus at
+// :3366-3371) and Huntress "Visão do Caçador" (:3856, bonus at :3858-3863) — so the gate
+// is the only thing that differs between them.
+func skillCriticalBonus(e *world.Entity) int16 {
+	tk := e.Class == 0 && e.LearnedSkill&(1<<7) != 0
+	ht := e.Class == 3 && e.LearnedSkill&(1<<18) != 0
+	if !tk && !ht {
 		return 0
 	}
 	add := (int(e.Special[3])+1)/10 + int(effectiveDex(e))/75

--- a/tmserver/internal/handler/affect_score_test.go
+++ b/tmserver/internal/handler/affect_score_test.go
@@ -163,12 +163,37 @@ func TestAffect36SetsDrainFlag(t *testing.T) {
 	}
 }
 
-func TestHuntressVisionCriticalBonus(t *testing.T) {
-	e := &world.Entity{Class: 3, LearnedSkill: 1 << 18, Critical: 10, Dex: 150}
-	e.Special[3] = 99
+// TestSkillCriticalBonus covers the class-skill crit bonus, which the legacy grants with
+// the SAME formula to two classes from two different bits: TK "Confiança" (Class 0, bit 7,
+// Basedef.cpp:3252/3366-3371) and Huntress "Visão do Caçador" (Class 3, bit 18,
+// :3856/3858-3863). Special[3]=99, Dex=150 → (99+1)/10 + 150/75 = 12, on top of
+// Critical 10 → 22.
+func TestSkillCriticalBonus(t *testing.T) {
+	tests := []struct {
+		name         string
+		class        uint8
+		learnedSkill int32
+		want         uint8
+	}{
+		{name: "TK with Confiança", class: 0, learnedSkill: 1 << 7, want: 22},
+		{name: "Huntress with Visão do Caçador", class: 3, learnedSkill: 1 << 18, want: 22},
+		{name: "TK without Confiança", class: 0, learnedSkill: 0, want: 10},
+		{name: "Huntress without Visão do Caçador", class: 3, learnedSkill: 0, want: 10},
+		// The bits are class-scoped: the other class's bit must not grant it.
+		{name: "TK with the Huntress bit", class: 0, learnedSkill: 1 << 18, want: 10},
+		{name: "Huntress with the TK bit", class: 3, learnedSkill: 1 << 7, want: 10},
+		{name: "Foema has no crit skill", class: 1, learnedSkill: 1<<7 | 1<<18, want: 10},
+	}
 
-	if got := effectiveCritical(e); got != 22 {
-		t.Fatalf("effectiveCritical = %d, want 22", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &world.Entity{Class: tt.class, LearnedSkill: tt.learnedSkill, Critical: 10, Dex: 150}
+			e.Special[3] = 99
+
+			if got := effectiveCritical(e); got != tt.want {
+				t.Fatalf("effectiveCritical = %d, want %d", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -252,6 +252,8 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 		w.SetEntityPos(s.Conn, loginX, loginY)
 		e.HP, e.MaxHP = st.HP, st.MaxHP
 		e.MP, e.MaxMP = st.MP, st.MaxMP
+		// Critical is a save-side cache only: refreshScore below re-derives it from the
+		// equipment (Basedef.cpp:3209), so the stored value never survives login.
 		e.Damage, e.AC, e.Master, e.Critical = st.Damage, st.AC, st.Master, st.Critical
 		e.Level, e.Coin, e.Exp = int32(st.Level), st.Coin, st.Exp
 		e.Clan, e.Guild, e.GuildLevel, e.ClassMaster, e.Soul = st.Clan, st.GuildID, st.GuildLevel, st.ClassMaster, st.Soul

--- a/tmserver/internal/handler/critical_test.go
+++ b/tmserver/internal/handler/critical_test.go
@@ -1,0 +1,183 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// Item indices used by the critical tests. amunra mirrors Pedra_Amunra (3464), whose
+// nPos 3840 = 0xF00 is the four accessory slots; armor mirrors a crit set piece carrying
+// static EF_CRITICAL (e.g. ItemList.csv:225 Armadura_de_Guarda).
+const (
+	critAmunra   = 3464
+	critArmor    = 165
+	critRing     = 700
+	critOverflow = 701
+)
+
+// criticalConfig is the catalog the crit tests read: static effects and the nPos each
+// item equips into (the refine promotion keys off nPos & 0xF00).
+func criticalConfig() Config {
+	return Config{
+		ItemEffects: map[int][]content.BaseEffect{
+			critArmor:    {{Eff: efCritical, Val: 50}},
+			critOverflow: {{Eff: efCritical, Val: 2000}},
+		},
+		ItemPos: map[int]int{
+			critAmunra:   3840, // accessory slots 8-11
+			critRing:     3840,
+			critArmor:    nPosDef1,
+			critOverflow: nPosDef1,
+		},
+	}
+}
+
+// TestCriticalFromEquipment covers BASE_GetMobAbility(EF_CRITICAL)/4 (Basedef.cpp:3209)
+// as refreshScore derives it: the EF_CRITICAL2 substitution, the refine multiplier and
+// the /4 on the SUM.
+func TestCriticalFromEquipment(t *testing.T) {
+	sanc9 := world.Effect{Effect: efSanc, Value: 9}
+
+	tests := []struct {
+		name  string
+		equip map[int]world.Item
+		want  uint8
+	}{
+		{
+			// Issue #102: four +9 Pedra_Amunra, EF_CRITICAL2 10 each. The accessory
+			// promotion (sanc 9 → 10) doubles each to 20 → raw 80 → /4 → 20.
+			name: "issue #102: four +9 Pedra_Amunra",
+			equip: map[int]world.Item{
+				8:  {Index: critAmunra, Effects: [3]world.Effect{sanc9, {Effect: efCritical2, Value: 10}}},
+				9:  {Index: critAmunra, Effects: [3]world.Effect{sanc9, {Effect: efCritical2, Value: 10}}},
+				10: {Index: critAmunra, Effects: [3]world.Effect{sanc9, {Effect: efCritical2, Value: 10}}},
+				11: {Index: critAmunra, Effects: [3]world.Effect{sanc9, {Effect: efCritical2, Value: 10}}},
+			},
+			want: 20,
+		},
+		{
+			name: "unrefined EF_CRITICAL is divided by 4",
+			equip: map[int]world.Item{
+				8: {Index: critRing, Effects: [3]world.Effect{{Effect: efCritical, Value: 40}}},
+			},
+			want: 10,
+		},
+		{
+			// The substitution is either/or: 50+10 must NOT be summed (Basedef.cpp:1705).
+			name: "EF_CRITICAL2 in slot 1 supersedes EF_CRITICAL",
+			equip: map[int]world.Item{
+				8: {Index: critRing, Effects: [3]world.Effect{
+					{Effect: efCritical, Value: 50},
+					{Effect: efCritical2, Value: 10},
+				}},
+			},
+			want: 2,
+		},
+		{
+			// Only stEffect[1]/[2] arm the substitution — slot 0 does not.
+			name: "EF_CRITICAL2 in slot 0 does not substitute",
+			equip: map[int]world.Item{
+				8: {Index: critRing, Effects: [3]world.Effect{
+					{Effect: efCritical2, Value: 10},
+					{Effect: efCritical, Value: 40},
+				}},
+			},
+			want: 10,
+		},
+		{
+			// Accessory at +9 → sanc promoted to 10 → x2.0: 10*20/10 = 20 → /4 = 5.
+			name: "accessory +9 doubles crit",
+			equip: map[int]world.Item{
+				8: {Index: critRing, Effects: [3]world.Effect{sanc9, {Effect: efCritical, Value: 10}}},
+			},
+			want: 5,
+		},
+		{
+			// Non-accessory at +9 → no promotion → x1.9: 50*19/10 = 95 → /4 = 23.
+			name: "non-accessory +9 scales x1.9, not x2",
+			equip: map[int]world.Item{
+				2: {Index: critArmor, Effects: [3]world.Effect{sanc9}},
+			},
+			want: 23,
+		},
+		{
+			// The "set" half of the issue: crit straight from the catalog row.
+			name: "catalog EF_CRITICAL on a set piece",
+			equip: map[int]world.Item{
+				2: {Index: critArmor},
+			},
+			want: 12,
+		},
+		{
+			name: "clamped at 255",
+			equip: map[int]world.Item{
+				2: {Index: critOverflow},
+			},
+			want: 255,
+		},
+		{
+			// Mounts return no crit in legacy (BASE_GetItemAbility early-returns for
+			// idx 2330-2390 / 3980-3994 on any non-mount effect).
+			name: "mount slot grants no crit",
+			equip: map[int]world.Item{
+				mountEquipSlot: {Index: 3987, Effects: [3]world.Effect{
+					{}, {Effect: efCritical2, Value: 100},
+				}},
+			},
+			want: 0,
+		},
+		{
+			name:  "no crit gear",
+			equip: map[int]world.Item{},
+			want:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := New(criticalConfig())
+			e := &world.Entity{ID: 1, Level: 50}
+			for slot, it := range tt.equip {
+				e.Equip[slot] = it
+			}
+			d.refreshScore(e)
+			if e.Critical != tt.want {
+				t.Errorf("e.Critical = %d, want %d", e.Critical, tt.want)
+			}
+		})
+	}
+}
+
+// TestCriticalIsDerivedNotAccumulated proves Critical has no base term: it is recomputed
+// from the equipment on every refresh, so unequipping drops it back and a stale persisted
+// value never survives (Basedef.cpp:3209 has no BaseScore.Critical).
+func TestCriticalIsDerivedNotAccumulated(t *testing.T) {
+	d := New(criticalConfig())
+	// Critical 99 stands in for the stale value loaded from the DB at character.go:255.
+	e := &world.Entity{ID: 1, Level: 50, Critical: 99}
+	d.deriveBaseScore(e)
+	d.refreshScore(e)
+	if e.Critical != 0 {
+		t.Fatalf("bare character Critical = %d, want 0 (stale DB value must not survive)", e.Critical)
+	}
+
+	e.Equip[8] = world.Item{Index: critRing, Effects: [3]world.Effect{{Effect: efCritical, Value: 40}}}
+	d.refreshScore(e)
+	if e.Critical != 10 {
+		t.Fatalf("equipped Critical = %d, want 10", e.Critical)
+	}
+
+	// Refreshing twice must not double-count.
+	d.refreshScore(e)
+	if e.Critical != 10 {
+		t.Errorf("Critical after second refresh = %d, want 10 (must not accumulate)", e.Critical)
+	}
+
+	e.Equip[8] = world.Item{}
+	d.refreshScore(e)
+	if e.Critical != 0 {
+		t.Errorf("unequipped Critical = %d, want 0", e.Critical)
+	}
+}

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -602,6 +602,7 @@ const (
 	efSpecial3  = 13
 	efSpecial4  = 14
 	efWType     = 21 // EF_WTYPE: weapon animation/type, used by Huntress RSV gates
+	efCritical  = 42 // EF_CRITICAL: crit source; summed over equip then /4 (Basedef.cpp:3209)
 	efSanc      = 43 // EF_SANC: item refine ("anc"/joias) level — gates the +9 threshold, not a flat stat
 	efHpAdd     = 45 // EF_HPADD: % bonus to MaxHp (MaxHp*(HPADD+HPADD2+100)/100), captura §E
 	efMpAdd     = 46 // EF_MPADD: % bonus to MaxMp
@@ -609,6 +610,7 @@ const (
 	efDamageAdd = 67 // EF_DAMAGEADD: extra flat damage — only counts for jewels (nUnique 41-50)
 	efHpAdd2    = 69 // EF_HPADD2/EF_MPADD2: also fold into the HPADD%/MPADD% multiplier
 	efMpAdd2    = 70
+	efCritical2 = 71 // EF_CRITICAL2: enchanted crit — SUPERSEDES EF_CRITICAL on the same item
 	efItemLevel = 87
 	efMobType   = 112
 	efRunSpeed  = 29 // EF_RUNSPEED: boots' bonus to the move-speed (low) nibble of AttackRun
@@ -687,6 +689,46 @@ func (d *Dispatcher) itemAbility(it world.Item, effect uint8) int {
 	return total
 }
 
+// accessoryPosMask marks the four accessory slots (Equip[8..11]) in an item's catalog
+// nPos bitmask — the slots Pedra_Amunra equips into, which is why a player wears four.
+// BASE_GetItemAbility keys the +9 refine promotion off it (Basedef.cpp:1850).
+const accessoryPosMask = 0xF00
+
+// itemCritical is BASE_GetItemAbility(item, EF_CRITICAL) (Basedef.cpp:1687-1856) for the
+// one effect the score needs: EF_CRITICAL, with two legacy rules the generic itemAbility
+// cannot express because they are properties of the whole item rather than of one effect.
+//
+// First, the EF_CRITICAL2 substitution (Basedef.cpp:1705-1709): 42 is the query id and 71
+// the storage id for enchanted crit, so an item carrying EF_CRITICAL2 in stEffect[1] or
+// [2] reports that value INSTEAD of its EF_CRITICAL — either/or, never summed. Only slots
+// 1 and 2 arm it; slot 0 does not.
+//
+// Second, the refine multiplier (Basedef.cpp:1848-1856): EF_CRITICAL is absent from the
+// exemption list, so crit scales by (sanc+10)/10, and accessories reaching +9 are promoted
+// to sanc 10 for a clean x2.
+//
+// TODO(parity): the legacy applies that multiplier to EVERY non-exempt effect; this port
+// does it for EF_CRITICAL only. AC/damage still use the flat +25/+40 threshold model
+// (equipBonus/weaponDamage), so refined gear diverges there — a deliberate scope call,
+// since converting them is a balance change across every refined item.
+func (d *Dispatcher) itemCritical(it world.Item) int32 {
+	want := uint8(efCritical)
+	if it.Effects[1].Effect == efCritical2 || it.Effects[2].Effect == efCritical2 {
+		want = efCritical2
+	}
+	v := int32(d.itemAbility(it, want))
+	if v == 0 {
+		return 0
+	}
+	// Inherits itemSanc's decoding of the EF_SANC byte (issue #103 is correcting that
+	// decode); crit scales with whatever level it reports, so it improves in step.
+	sanc := itemSanc(it)
+	if sanc == refineThreshold && d.itemPos[int(it.Index)]&accessoryPosMask != 0 {
+		sanc = 10
+	}
+	return v * int32(sanc+10) / 10
+}
+
 // weaponDamage is GetCurrentScore's WeaponDamage (CMob.cpp:756-789): the stronger
 // weapon hand at full damage plus the weaker at half (dual-wield), plus a +40 refine
 // threshold per weapon hand at sanc>=9 (captura §E). It is a SEPARATE field from
@@ -728,6 +770,9 @@ type equipBonus struct {
 	maxHP, maxMP         int32
 	hpAddPct, mpAddPct   int32
 	runSpeed             int32
+	// criticalRaw is the pre-/4 EF_CRITICAL sum over the equipment
+	// (BASE_GetMobAbility(EF_CRITICAL), Basedef.cpp:3209) — see itemCritical.
+	criticalRaw int32
 	// Mount (Equip[14]) contributions, from the g_pMountBonus tables rather than item
 	// effects. magicRaw is the pre-scaling EF_MAGIC sum (see mountMagicScore); resist
 	// applies to all four resistances. damage already folds into the field above.
@@ -795,6 +840,10 @@ func (d *Dispatcher) equipBonus(e *world.Entity) equipBonus {
 			}
 			continue
 		}
+		// Critical is read per item, not per effect (the EF_CRITICAL2 substitution and
+		// the refine multiplier are item-wide) — after the mount slot's early return,
+		// which matches BASE_GetItemAbility returning no crit for mounts.
+		b.criticalRaw += d.itemCritical(it)
 		weaponSlot := slot == weaponSlotR || slot == weaponSlotL
 		nUnique := d.itemUnique[int(it.Index)]
 		dmgJewel := nUnique >= 41 && nUnique <= 50
@@ -865,6 +914,15 @@ func (d *Dispatcher) refreshScore(e *world.Entity) {
 	e.HpAddPct = b.hpAddPct
 	e.MpAddPct = b.mpAddPct
 	e.RunSpeedBonus = b.runSpeed
+	// Critical is derived ENTIRELY from equipment on every refresh — there is no
+	// BaseCritical to add, and no subtraction in deriveBaseScore, because the legacy has
+	// no base term either (Basedef.cpp:3209). The /4 divides the SUM, not each item. Mobs
+	// derive it from their gear too (BASE_GetCurrentScore runs for them, CMob.cpp:709) and
+	// carry no template Critical, so unlike the mount block below this needs no IsPlayer
+	// guard. The clamp is re-applied in effectiveCritical after the skill/affect terms.
+	// (The low clamp is belt-and-braces: no catalog row carries negative crit, but a
+	// bare uint8 conversion would wrap one into a near-guaranteed crit.)
+	e.Critical = uint8(min(max(b.criticalRaw/4, 0), 255))
 	// Mount bonuses: Magic gets the (sum+1)/4 scaling, Parry (evasion) and each Resist
 	// are flat, with Resist capped at the legacy ceiling (CMob.cpp:640-643,692). Mounts
 	// live only in a player's Equip[14]; mobs carry their Magic/Parry/Resist straight


### PR DESCRIPTION
Fixes #102.

## The bug

Items carrying critical — Amunra stones, armor set pieces — contributed **nothing** to a character's Critical. Not a display bug: the server never computed the value.

The legacy derives Critical **entirely from equipment** on every score recompute:

```c
// Basedef.cpp:3209 (in BASE_GetCurrentScore)
int Critical = (BASE_GetMobAbility(&MOB, EF_CRITICAL) / 4);
// ... skill/transform bonuses ...
if (Critical >= 255) Critical = 255;   // :4731
MOB.Critical = Critical;
```

The Go port dropped that term in **two independent layers**:

1. **Catalog parse** — `content/catalog.go` filed `EF_CRITICAL` among the *"purely visual/requirement"* effects it discards. That classification is simply wrong.
2. **Score recompute** — `equipBonus` had no crit case and `refreshScore` never assigned `e.Critical`.

So `e.Critical` only ever held the value loaded from the DB (`character.go:255`) — it starts at 0 and never moves. Everything downstream was already correct and lights up once the source term exists: `effectiveCritical`, the wire byte (`protocol/score.go`), and the `rand()%255 < Critical` partial-crit roll (`combat/critical.go`).

**359 rows of `ItemList.csv` carry `EF_CRITICAL`** — the class body items and the armor sets. That's the **"set" half** of the issue: there is no set-bonus system in the legacy at all (grep for `SetType`/`g_pSetItem`/`CheckSet` returns nothing), so set crit is just per-piece catalog `EF_CRITICAL`.

## Two rules ported with it

Both are properties of the *whole item* rather than of one effect, so they can't ride the per-effect `add()` closure — hence `itemCritical`, which reuses the existing `itemAbility` for the catalog+instance sum:

- **The `EF_CRITICAL2` substitution** (`Basedef.cpp:1705`) — 42 is the query id, 71 the storage id for enchanted crit. An item carrying `EF_CRITICAL2` in `stEffect[1]`/`[2]` reports it **instead of** its `EF_CRITICAL` — either/or, never summed. Slot 0 does not arm it. Summing both would double-count.
- **The refine multiplier** (`Basedef.cpp:1848`) — `EF_CRITICAL` is not in the exemption list, so crit scales by `(sanc+10)/10`, with accessories (`nPos & 0xF00`) at +9 promoted to sanc 10 for a clean ×2.

## Scope calls (agreed before implementing)

- **Refine multiplier scoped to crit only.** The legacy applies it to *every* non-exempt effect; this port implements it for no stat at all, using flat +25 AC / +40 damage thresholds instead. Converting AC/damage is a balance change across every refined item — left as a `TODO(parity)` for its own issue.
- **`itemSanc` inherited as-is.** It doesn't yet implement `BASE_GetItemSanc`'s decode (ids 116-125, `% 10` pity); `Jean1dev/issue-103-refina-o-com-poeiras` is correcting exactly that, so no competing decoder is added here and crit improves in step. Doesn't affect this issue — +9 decodes to 9 either way.
- **TK branch included.** The legacy grants the same crit formula to TK "Confiança" (Class 0, bit 7, `:3366`) and Huntress "Visão do Caçador" (Class 3, bit 18, `:3858`); only the Huntress half was ported. `huntressCriticalBonus` → `skillCriticalBonus`, gate widened.

## ⚠️ Mobs now land partial crits

`refreshScore` takes **no `IsPlayer` guard** here, unlike the mount block above it. `BASE_GetCurrentScore` runs for mobs too (`CMob.cpp:709`) and derives their crit from their gear identically, and `CMob.cpp` never writes `Critical`, so there is no template value to protect. This is correct parity but a **live gameplay change** worth watching.

## Verification

Verified against the **real `Release/` catalog**, not just synthetic fixtures:

| Equipment | Critical |
|---|---|
| bare TransKnight (body item has `EF_CRITICAL,10`) | **2** (was 0) |
| + `Armadura_de_Guarda` (165, `EF_CRITICAL,50`) | **15** |
| + 4× +9 Pedra_Amunra (`EF_CRITICAL2` 10 each) | **35** (raw sum 140) |

The four Amunra stones contribute exactly **80 raw → 20 displayed**, matching the number in the issue.

`go build ./...`, `go test -race ./tmserver/... ./internal/...` and `golangci-lint run` are clean for the changed packages. New tests were mutation-checked — neutering each rule (the `refreshScore` assignment, the substitution, the accessory promotion) fails exactly the intended subtests, so none pass vacuously.

**Not covered:** the client-side render (steps needing the real Windows client). Worth confirming the status window shows 20 with the reporter's four amulets, and sanity-checking incoming mob damage given the crit change above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)