### PR TITLE
Fix Huntress illusion action parity

### DIFF
--- a/tmserver/internal/handler/movement.go
+++ b/tmserver/internal/handler/movement.go
@@ -49,6 +49,9 @@ func (d *Dispatcher) action(w *world.World, s *world.Session, h protocol.Header,
 	if h.Type == protocol.MsgAction3 && !d.consumeIllusion(w, s, e, h.ClientTick) {
 		return
 	}
+	if h.Type == protocol.MsgAction && !d.consumeActionAfterIllusion(w, s, h.ClientTick) {
+		return
+	}
 	if !s.LoggedFirstAction {
 		s.LoggedFirstAction = true
 		d.log.Info("movement: first action after login",
@@ -111,6 +114,10 @@ func (d *Dispatcher) action(w *world.World, s *world.Session, h protocol.Header,
 	// GridMulticast: view create/remove deltas + raw frame (original Type) to
 	// everyone in the old or new view window.
 	d.moveMulticast(w, s.Conn, oldX, oldY, h.Type, payload)
+	if h.Type == protocol.MsgAction3 {
+		w.SendTo(s, protocol.Header{Type: protocol.MsgAction3, ID: uint16(s.Conn)}, payload)
+		d.sendSetHpMp(w, s, e)
+	}
 }
 
 func outOfBounds(v, dim int16) bool { return v < 0 || v >= dim }
@@ -138,6 +145,14 @@ func (d *Dispatcher) consumeIllusion(w *world.World, s *world.Session, e *world.
 		return false
 	}
 	s.LastIllusionTick = tick
+	return true
+}
+
+func (d *Dispatcher) consumeActionAfterIllusion(w *world.World, s *world.Session, tick uint32) bool {
+	if tick != protocol.SkipCheckTick && s.LastIllusionTick != 0 && s.LastIllusionTick != protocol.SkipCheckTick && tick < s.LastIllusionTick+900 {
+		w.AddCrackError(s, 1, 103)
+		return false
+	}
 	return true
 }
 

--- a/tmserver/internal/handler/movement_test.go
+++ b/tmserver/internal/handler/movement_test.go
@@ -169,6 +169,16 @@ func movementDB() *fakeDB {
 	return db
 }
 
+func illusionDB() *fakeDB {
+	db := newDB()
+	db.loadResult = world.CharacterState{
+		Slot: 0, Name: "Hero", Class: 3, X: 5, Y: 5,
+		HP: 1000, MaxHP: 1000, MP: 100, MaxMP: 100,
+		LearnedSkill: 2,
+	}
+	return db
+}
+
 func TestMoveBroadcastToInView(t *testing.T) {
 	addr, stop, _ := startServerClock(t, movementDB())
 	defer stop()
@@ -253,6 +263,86 @@ func TestMoveOutOfBoundsDropped(t *testing.T) {
 	actionFrame(t, mover, serverTime, 99)
 	if ty, _, ok := readMaybe(t, watcher); ok {
 		t.Errorf("watcher received %#x; out-of-bounds action should be dropped", ty)
+	}
+}
+
+func TestIllusionActionEchoesAndSyncsMP(t *testing.T) {
+	addr, stop, _ := startServerClock(t, illusionDB())
+	defer stop()
+
+	mover := enterWorld(t, addr)
+	defer mover.Close()
+	watcher := enterWorld(t, addr)
+	defer watcher.Close()
+
+	body := protocol.MsgActionBody{PosX: 5, PosY: 5, Effect: 0, Speed: 6, TargetX: 6, TargetY: 6}
+	actionFrameBody(t, mover, serverTime, protocol.MsgAction3, body)
+
+	ty, payload, ok := readMaybe(t, watcher)
+	if !ok || ty != protocol.MsgAction3 {
+		t.Fatalf("watcher got %#x ok=%v, want broadcast MsgAction3", ty, ok)
+	}
+	var seen protocol.MsgActionBody
+	if err := seen.Decode(payload); err != nil {
+		t.Fatal(err)
+	}
+	if seen.TargetX != 6 || seen.TargetY != 6 {
+		t.Fatalf("watcher action = %+v, want target 6,6", seen)
+	}
+
+	ty, payload, ok = readMaybe(t, mover)
+	if !ok || ty != protocol.MsgAction3 {
+		t.Fatalf("mover got %#x ok=%v, want self MsgAction3 echo", ty, ok)
+	}
+	var echoed protocol.MsgActionBody
+	if err := echoed.Decode(payload); err != nil {
+		t.Fatal(err)
+	}
+	if echoed.TargetX != 6 || echoed.TargetY != 6 {
+		t.Fatalf("echo action = %+v, want target 6,6", echoed)
+	}
+
+	ty, payload, ok = readMaybe(t, mover)
+	if !ok || ty != protocol.MsgSetHpMp {
+		t.Fatalf("mover got %#x ok=%v, want SetHpMp after illusion", ty, ok)
+	}
+	_, mp, _, reqMP := setHpMpFields(t, payload)
+	if mp != 55 || reqMP != 55 {
+		t.Fatalf("MP/ReqMP after illusion = %d/%d, want 55/55", mp, reqMP)
+	}
+}
+
+func TestIllusionBlocksImmediateNormalAction(t *testing.T) {
+	addr, stop, _ := startServerClock(t, illusionDB())
+	defer stop()
+
+	mover := enterWorld(t, addr)
+	defer mover.Close()
+	watcher := enterWorld(t, addr)
+	defer watcher.Close()
+
+	illusion := protocol.MsgActionBody{PosX: 5, PosY: 5, Effect: 0, Speed: 6, TargetX: 6, TargetY: 6}
+	actionFrameBody(t, mover, serverTime, protocol.MsgAction3, illusion)
+	if ty, _, ok := readMaybe(t, watcher); !ok || ty != protocol.MsgAction3 {
+		t.Fatalf("watcher got %#x ok=%v, want initial MsgAction3", ty, ok)
+	}
+	if ty, _, ok := readMaybe(t, mover); !ok || ty != protocol.MsgAction3 {
+		t.Fatalf("mover got %#x ok=%v, want self MsgAction3 echo", ty, ok)
+	}
+	if ty, _, ok := readMaybe(t, mover); !ok || ty != protocol.MsgSetHpMp {
+		t.Fatalf("mover got %#x ok=%v, want SetHpMp after illusion", ty, ok)
+	}
+
+	tooSoon := protocol.MsgActionBody{PosX: 6, PosY: 6, Effect: 0, Speed: 6, TargetX: 7, TargetY: 7}
+	actionFrameBody(t, mover, serverTime+100, protocol.MsgAction, tooSoon)
+	if ty, _, ok := readMaybe(t, watcher); ok {
+		t.Fatalf("watcher got %#x, want no broadcast before 900ms illusion cadence", ty)
+	}
+
+	allowed := protocol.MsgActionBody{PosX: 6, PosY: 6, Effect: 0, Speed: 6, TargetX: 7, TargetY: 7}
+	actionFrameBody(t, mover, serverTime+900, protocol.MsgAction, allowed)
+	if ty, _, ok := readMaybe(t, watcher); !ok || ty != protocol.MsgAction {
+		t.Fatalf("watcher got %#x ok=%v, want normal MsgAction after 900ms", ty, ok)
 	}
 }
 


### PR DESCRIPTION
## Summary
- restore Huntress Ilusao MSG_Action3 self echo and MP sync
- enforce the legacy 900ms cadence before normal movement after illusion
- add socket-level regression coverage for Action3 broadcast, self echo, MP sync, and cadence

## Tests
- go test ./tmserver/internal/handler -run 'Test.*Illusion|TestAction|TestMove|TestMotion|TestBootAutoWalk'\n- go test ./tmserver/internal/handler