### PR TITLE
Paridade de IA de mob da issue 121

### DIFF
--- a/tmserver/cmd/tmserver/main.go
+++ b/tmserver/cmd/tmserver/main.go
@@ -347,6 +347,7 @@ func spawnNPCs(w *world.World, dir string, skipMerchants bool, logger *slog.Logg
 			MaxGroup:       g.MaxGroup,
 			MaxNumMob:      g.MaxNumMob,
 			RouteType:      uint8(g.RouteType),
+			Formation:      g.Formation,
 			SegX:           g.SegX,
 			SegY:           g.SegY,
 			LeaderTmpl:     leader,

--- a/tmserver/cmd/tmserver/main.go
+++ b/tmserver/cmd/tmserver/main.go
@@ -352,6 +352,8 @@ func spawnNPCs(w *world.World, dir string, skipMerchants bool, logger *slog.Logg
 			SegY:           g.SegY,
 			LeaderTmpl:     leader,
 			FollowerTmpl:   load(g.Follower),
+			FightAction:    g.FightAction,
+			DieAction:      g.DieAction,
 		}
 		for s := 0; s < 5; s++ {
 			wg.SegRange[s] = int16(g.SegRange[s])

--- a/tmserver/cmd/tmserver/main.go
+++ b/tmserver/cmd/tmserver/main.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"syscall"
 
@@ -329,10 +330,17 @@ func spawnNPCs(w *world.World, dir string, skipMerchants bool, logger *slog.Logg
 
 	wgens := make([]*world.Generator, len(gens))
 	skipped := 0
+	missingLeaderBlocks, missingFollowerBlocks := 0, 0
+	missingLeaderNames := make(map[string]struct{})
+	missingFollowerNames := make(map[string]struct{})
 	for i, g := range gens {
 		leader := load(g.Leader)
 		if leader == nil {
-			continue // block unusable without its Leader template (~1400 miss files)
+			missingLeaderBlocks++
+			if g.Leader != "" {
+				missingLeaderNames[g.Leader] = struct{}{}
+			}
+			continue // block unusable without its Leader template
 		}
 		// When DB-managed NPC config is active, merchant blocks are owned by
 		// npc_definition (materialized by the dispatcher overlay), so skip them here
@@ -340,6 +348,11 @@ func spawnNPCs(w *world.World, dir string, skipMerchants bool, logger *slog.Logg
 		if skipMerchants && protocol.ParseMobBasics(leader).Merchant != 0 {
 			skipped++
 			continue
+		}
+		follower := load(g.Follower)
+		if g.Follower != "" && follower == nil {
+			missingFollowerBlocks++
+			missingFollowerNames[g.Follower] = struct{}{}
 		}
 		wg := &world.Generator{
 			MinuteGenerate: g.MinuteGenerate,
@@ -351,7 +364,7 @@ func spawnNPCs(w *world.World, dir string, skipMerchants bool, logger *slog.Logg
 			SegX:           g.SegX,
 			SegY:           g.SegY,
 			LeaderTmpl:     leader,
-			FollowerTmpl:   load(g.Follower),
+			FollowerTmpl:   follower,
 			FightAction:    g.FightAction,
 			DieAction:      g.DieAction,
 		}
@@ -369,8 +382,32 @@ func spawnNPCs(w *world.World, dir string, skipMerchants bool, logger *slog.Logg
 			total += len(w.GenerateMob(i))
 		}
 	}
+	if missingLeaderBlocks > 0 || missingFollowerBlocks > 0 {
+		logger.Warn("NPC templates missing",
+			"leader_blocks_skipped", missingLeaderBlocks,
+			"missing_leader_templates", len(missingLeaderNames),
+			"missing_leader_sample", sampleNames(missingLeaderNames, 10),
+			"follower_blocks_degraded", missingFollowerBlocks,
+			"missing_follower_templates", len(missingFollowerNames),
+			"missing_follower_sample", sampleNames(missingFollowerNames, 10))
+	}
 	logger.Info("NPCs spawned", "generators", len(gens), "mobs", total, "templates", len(templates),
 		"merchant_blocks_skipped", skipped)
+}
+
+func sampleNames(names map[string]struct{}, limit int) []string {
+	if len(names) == 0 || limit <= 0 {
+		return nil
+	}
+	out := make([]string, 0, len(names))
+	for name := range names {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	if len(out) > limit {
+		return out[:limit]
+	}
+	return out
 }
 
 // serveStatusHTTP runs the channel-status web server (serv00.htm). It answers any

--- a/tmserver/cmd/tmserver/main_test.go
+++ b/tmserver/cmd/tmserver/main_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+func TestSpawnNPCsWarnsMissingTemplates(t *testing.T) {
+	dir := t.TempDir()
+	runDir := filepath.Join(dir, "TMsrv", "run")
+	npcDir := filepath.Join(runDir, "npc")
+	if err := os.MkdirAll(npcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const npcGener = `# [0]
+	Leader: MissingLeader
+	MinGroup: 0
+	MaxGroup: 0
+	MaxNumMob: 1
+	StartX: 10
+	StartY: 10
+
+# [1]
+	Leader: ExistingLeader
+	Follower: MissingFollower
+	MinGroup: 1
+	MaxGroup: 1
+	MaxNumMob: 2
+	StartX: 20
+	StartY: 20
+`
+	if err := os.WriteFile(filepath.Join(runDir, "NPCGener.txt"), []byte(npcGener), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(npcDir, "ExistingLeader"), testMobTemplate("ExistingLeader"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	w := world.New(world.Config{GridDim: 64}, logger, nil, nil)
+	spawnNPCs(w, dir, false, logger)
+
+	if g := w.GeneratorAt(0); g != nil {
+		t.Fatalf("missing leader generator = %#v, want skipped nil slot", g)
+	}
+	g := w.GeneratorAt(1)
+	if g == nil {
+		t.Fatal("existing leader generator was not registered")
+	}
+	if g.FollowerTmpl != nil {
+		t.Fatal("missing follower template should degrade to leader-only group")
+	}
+	if g.CurrentNumMob != 1 {
+		t.Fatalf("CurrentNumMob = %d, want one spawned leader", g.CurrentNumMob)
+	}
+
+	gotLog := logs.String()
+	for _, want := range []string{
+		"NPC templates missing",
+		"leader_blocks_skipped=1",
+		"missing_leader_templates=1",
+		"MissingLeader",
+		"follower_blocks_degraded=1",
+		"missing_follower_templates=1",
+		"MissingFollower",
+	} {
+		if !strings.Contains(gotLog, want) {
+			t.Fatalf("log missing %q:\n%s", want, gotLog)
+		}
+	}
+}
+
+func testMobTemplate(name string) []byte {
+	b := make([]byte, content.BaseMobSize)
+	copy(b[0:16], name)
+	b[16] = 2
+	const cs = 92
+	binary.LittleEndian.PutUint32(b[cs+0:], 1)
+	binary.LittleEndian.PutUint32(b[cs+16:], 100)
+	binary.LittleEndian.PutUint32(b[cs+24:], 100)
+	return b
+}

--- a/tmserver/internal/content/npc.go
+++ b/tmserver/internal/content/npc.go
@@ -25,7 +25,7 @@ type NPCGenerator struct {
 	MaxGroup       int
 	MaxNumMob      int
 	RouteType      int
-	Formation      int // parsed, not modeled yet (group formation offsets)
+	Formation      int
 	SegX, SegY     [5]int16
 	SegRange       [5]int
 	SegWait        [5]int

--- a/tmserver/internal/content/npc.go
+++ b/tmserver/internal/content/npc.go
@@ -29,6 +29,8 @@ type NPCGenerator struct {
 	SegX, SegY     [5]int16
 	SegRange       [5]int
 	SegWait        [5]int
+	FightAction    [4]string
+	DieAction      [4]string
 }
 
 // LoadNPCGenerators parses NPCGener.txt. Blocks start with '#'; lines are
@@ -87,6 +89,10 @@ func LoadNPCGenerators(path string) ([]NPCGenerator, error) {
 			cur.RouteType = atoi(val)
 		case "Formation":
 			cur.Formation = atoi(val)
+		case "FightAction":
+			setAction(&cur.FightAction, val)
+		case "DieAction":
+			setAction(&cur.DieAction, val)
 		// Waypoints: Start→[0], Segment1..3→[1..3], Dest→[4] (ParseString).
 		case "StartX":
 			cur.SegX[0] = int16(atoi(val))
@@ -105,8 +111,13 @@ func LoadNPCGenerators(path string) ([]NPCGenerator, error) {
 		case "DestWait":
 			cur.SegWait[4] = atoi(val)
 		default:
-			// Segment1..3{X,Y,Range,Wait} → indices 1..3. *Action keys (mob chat
-			// lines) are not modeled.
+			if setIndexedAction(key, "FightAction", &cur.FightAction, val) ||
+				setIndexedAction(key, "DieAction", &cur.DieAction, val) {
+				continue
+			}
+			// Segment1..3{X,Y,Range,Wait} → indices 1..3. Segment*Action keys are
+			// route flavor text and remain unmapped; FightAction/DieAction above are
+			// combat-visible chat lines.
 			if strings.HasPrefix(key, "Segment") && len(key) > 8 {
 				if i := int(key[7] - '0'); i >= 1 && i <= 3 {
 					switch key[8:] {
@@ -147,4 +158,33 @@ func LoadNPCTemplate(dir, name string) ([]byte, error) {
 func atoi(s string) int {
 	n, _ := strconv.Atoi(strings.TrimSpace(s))
 	return n
+}
+
+func setAction(dst *[4]string, val string) {
+	if len(val) >= 79 {
+		return // CNPCGene::SetAct rejects action strings that would overflow [80].
+	}
+	for i := range dst {
+		if dst[i] == "" {
+			dst[i] = val
+			return
+		}
+	}
+}
+
+func setIndexedAction(key, prefix string, dst *[4]string, val string) bool {
+	if !strings.HasPrefix(key, prefix) || key == prefix {
+		return false
+	}
+	n, err := strconv.Atoi(key[len(prefix):])
+	if err != nil {
+		return false
+	}
+	if n < 1 || n > 4 {
+		return false
+	}
+	if len(val) < 79 {
+		dst[n-1] = val
+	}
+	return true
 }

--- a/tmserver/internal/content/npc_test.go
+++ b/tmserver/internal/content/npc_test.go
@@ -21,6 +21,10 @@ func TestLoadNPCGenerators(t *testing.T) {
 	Follower:	Arq_Ciclope
 	RouteType:	2
 	Formation:	0
+	FightAction:	Lute
+	FightAction:	Venha
+	FightAction4:	Ultima
+	DieAction2:	Morri
 	StartX:		2635
 	StartY:		1726
 	StartRange:	5
@@ -58,6 +62,12 @@ func TestLoadNPCGenerators(t *testing.T) {
 	}
 	if g.Follower != "Arq_Ciclope" || g.MinuteGenerate != -1 || g.MaxGroup != 7 || g.RouteType != 2 {
 		t.Errorf("gen[0] extras = %+v", g)
+	}
+	if g.FightAction != [4]string{"Lute", "Venha", "", "Ultima"} {
+		t.Errorf("gen[0] FightAction = %#v", g.FightAction)
+	}
+	if g.DieAction != [4]string{"", "Morri", "", ""} {
+		t.Errorf("gen[0] DieAction = %#v", g.DieAction)
 	}
 	if g.SegX[4] != 2625 || g.SegY[4] != 1726 || g.SegRange[4] != 10 || g.SegWait[4] != 10 || g.SegWait[0] != 10 {
 		t.Errorf("gen[0] Dest→Seg[4] mapping = %+v", g)

--- a/tmserver/internal/handler/combat.go
+++ b/tmserver/internal/handler/combat.go
@@ -269,11 +269,10 @@ func (d *Dispatcher) attack(w *world.World, s *world.Session, h protocol.Header,
 			}
 			healExp += healExpGain(e, target, before)
 		}
-		// A struck mob either dies (rewards) or retaliates: it focuses the attacker
-		// — and drags its spawn group into the fight (SetBattle + the PartyList
-		// propagation, setGroupBattle) — so the AI tick (mobai.go) chases and
-		// fights back. Provocation happens even on a blocked hit, matching the
-		// original AddEnemyList-on-attack.
+		// A struck mob either dies (rewards) or records the attacker in its
+		// EnemyList — and drags its spawn group into the fight (SetBattle +
+		// PartyList propagation, setGroupBattle). Provocation happens even on a
+		// blocked hit, matching the original AddEnemyList-on-attack.
 		if !world.IsPlayer(tid) {
 			if target.HP == 0 {
 				d.mobKilled(w, e, target)
@@ -622,6 +621,7 @@ func (d *Dispatcher) applySkillSpecial(w *world.World, s *world.Session, e, targ
 
 	case cast.spell.InstanceType == 7: // Flash: clear combat state.
 		target.Target = 0
+		clearEnemyList(target)
 		if !world.IsPlayer(tid) && target.Mode == world.MobCombat {
 			target.Mode = world.MobPeace
 		}

--- a/tmserver/internal/handler/mobai.go
+++ b/tmserver/internal/handler/mobai.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/combat"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/level"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/rng"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/route"
@@ -125,17 +126,15 @@ const battleDragBox = 23
 // setGroupBattle puts a mob in combat with target and drags its group into the
 // same fight — SetBattle (Server.cpp:8013-8047) plus the PartyList propagation
 // of the AI tick (ProcessSecMinTimer.cpp:1882-1929): resolve the mob's leader
-// (or itself), then every living, unengaged member within the drag box focuses
-// the target. The leader itself is dragged too (the original block only walks
-// PartyList — leaders join via their own paths; folding it here is a small,
-// coherent divergence). Already-engaged members keep their target (we model a
-// single Target, not the EnemyList[13]).
+// (or itself), then every living member within the drag box records the target
+// in its EnemyList. The leader itself is dragged too (the original block only
+// walks PartyList — leaders join via their own paths; folding it here is a
+// small, coherent divergence).
 func setGroupBattle(w *world.World, id int, e, target *world.Entity) {
 	if target == nil {
 		return
 	}
-	e.Target = target.ID
-	e.Mode = world.MobCombat
+	setBattle(w, id, e, target)
 	lid := e.Leader
 	if lid == 0 {
 		lid = id
@@ -145,12 +144,11 @@ func setGroupBattle(w *world.World, id int, e, target *world.Entity) {
 		return
 	}
 	drag := func(mid int, me *world.Entity) {
-		if mid == id || me == nil || me.HP <= 0 || me.Merchant != 0 || me.Target != 0 {
+		if mid == id || me == nil || me.HP <= 0 || me.Merchant != 0 {
 			return
 		}
 		if abs16(me.X-target.X) <= battleDragBox && abs16(me.Y-target.Y) <= battleDragBox {
-			me.Target = target.ID
-			me.Mode = world.MobCombat
+			setBattle(w, mid, me, target)
 		}
 	}
 	if lid != id {
@@ -162,6 +160,137 @@ func setGroupBattle(w *world.World, id int, e, target *world.Entity) {
 		}
 		drag(m, w.Entity(m))
 	}
+}
+
+func setBattle(w *world.World, id int, e, target *world.Entity) {
+	if e == nil || target == nil || id <= 0 || target.ID <= 0 || id >= world.MaxMob || target.ID >= world.MaxMob || id == target.ID {
+		return
+	}
+	targetInWorld := w.Entity(target.ID) != nil
+	if e.Mode == world.MobEmpty || (targetInWorld && target.Mode == world.MobEmpty) {
+		return
+	}
+	if targetInWorld && world.IsPlayer(target.ID) {
+		if m, ok := w.SessionMode(target.ID); !ok || m != world.UserPlay {
+			return
+		}
+	}
+	if abs16(e.X-target.X) > battleDragBox || abs16(e.Y-target.Y) > battleDragBox {
+		return
+	}
+	e.Mode = world.MobCombat
+	addEnemyList(e, target)
+	if targetInWorld {
+		selectTargetFromEnemyList(w, e)
+	} else if e.Target == 0 {
+		// Several low-level tests pass a synthetic attacker entity rather than a
+		// world-owned player. Production targets are always in World and use the
+		// EnemyList selection above.
+		e.Target = target.ID
+	}
+}
+
+func addEnemyList(e, target *world.Entity) {
+	if e == nil || target == nil || target.ID <= 0 || target.ID >= world.MaxMob {
+		return
+	}
+	if world.IsPlayer(target.ID) {
+		if target.Rsv&world.RsvHide != 0 || target.Merchant&1 != 0 {
+			return
+		}
+	}
+	for _, id := range e.EnemyList {
+		if id == target.ID {
+			return
+		}
+	}
+	for i, id := range e.EnemyList {
+		if id == 0 {
+			e.EnemyList[i] = target.ID
+			return
+		}
+	}
+}
+
+func removeEnemyList(e *world.Entity, targetID int) {
+	if e == nil || targetID <= 0 {
+		return
+	}
+	for i, id := range e.EnemyList {
+		if id == targetID {
+			e.EnemyList[i] = 0
+			return
+		}
+	}
+}
+
+func clearEnemyList(e *world.Entity) {
+	if e != nil {
+		e.EnemyList = [protocol.MaxTarget]int{}
+	}
+}
+
+func selectTargetFromEnemyList(w *world.World, e *world.Entity) {
+	if e == nil {
+		return
+	}
+	e.Target = 0
+	enemyDist := [protocol.MaxTarget]int{}
+	for i := range enemyDist {
+		enemyDist[i] = world.MaxUser
+	}
+	dis := enemySelectRange(e)
+	for i, enemyID := range e.EnemyList {
+		if enemyID <= 0 || enemyID >= world.MaxMob {
+			continue
+		}
+		enemy := w.Entity(enemyID)
+		if enemy == nil || enemy.Mode == world.MobEmpty || enemy.HP <= 0 {
+			e.EnemyList[i] = 0
+			continue
+		}
+		if world.IsPlayer(enemyID) {
+			if enemy.Rsv&world.RsvHide != 0 {
+				e.EnemyList[i] = 0
+				continue
+			}
+			if enemy.Level > level.MaxLevel && enemy.Merchant&1 == 0 {
+				e.EnemyList[i] = 0
+				continue
+			}
+		}
+		if enemy.X < e.X-int16(dis) || enemy.X > e.X+int16(dis) ||
+			enemy.Y < e.Y-int16(dis) || enemy.Y > e.Y+int16(dis) {
+			e.EnemyList[i] = 0
+			continue
+		}
+		enemyDist[i] = mobDistance(e.X, e.Y, enemy.X, enemy.Y)
+		if enemyID > world.MaxUser {
+			enemyDist[i] += 2 // CMob.cpp uses > MAX_USER, so id==MAX_USER is unpenalized.
+		}
+	}
+	bestDist := world.MaxUser
+	best := 0
+	for i, enemyID := range e.EnemyList {
+		if enemyID != 0 && bestDist >= enemyDist[i] {
+			best = enemyID
+			bestDist = enemyDist[i]
+		}
+	}
+	if bestDist != world.MaxUser {
+		e.Target = best
+	}
+}
+
+func enemySelectRange(e *world.Entity) int {
+	dis := 6
+	if e.Clan == summonClan || e.Clan == 7 || e.Clan == 8 {
+		dis = 12
+	}
+	if int(e.X)/128 < 12 && int(e.Y)/128 > 25 {
+		dis = 8
+	}
+	return dis
 }
 
 // generateMobs is the per-generator regeneration timer (the GenerateMobs block
@@ -320,8 +449,10 @@ const (
 // mobBattle advances one engaged monster: validate the target, roll the Int
 // hesitation, then attack / back away / chase per the BattleProcessor decision.
 func (d *Dispatcher) mobBattle(w *world.World, id int, e *world.Entity) {
+	selectTargetFromEnemyList(w, e)
 	target := w.Entity(e.Target)
 	if !validTarget(w, e, target) {
+		removeEnemyList(e, e.Target)
 		e.Target = 0
 		e.Mode = world.MobIdle
 		return
@@ -454,11 +585,10 @@ func (d *Dispatcher) mobAttack(w *world.World, id int, e, target *world.Entity) 
 		w.SendTo(vs, protocol.Header{Type: protocol.MsgAttack, ID: protocol.IDScene}, payload)
 	})
 
-	// Summon fights (mob targets): a pet's kill rewards its OWNER
-	// (MobKilled.cpp:181-190 credits the Summoner); a monster that downs a pet
-	// removes it for good (removeType 1; the Summoner guard in DespawnMob keeps
-	// it out of the respawn queue). A struck-but-alive monster retaliates
-	// against the pet.
+	// Mob targets: a pet's kill rewards its OWNER (MobKilled.cpp:181-190 credits
+	// the Summoner); a monster that downs a pet removes it for good (removeType
+	// 1; the Summoner guard in DespawnMob keeps it out of the respawn queue). Any
+	// struck-but-alive monster records the attacker in its EnemyList.
 	if !world.IsPlayer(target.ID) {
 		if target.HP == 0 {
 			if e.Summoner != 0 {
@@ -470,9 +600,10 @@ func (d *Dispatcher) mobAttack(w *world.World, id int, e, target *world.Entity) 
 			} else {
 				w.DespawnMob(target.ID, 1)
 			}
+			removeEnemyList(e, target.ID)
 			e.Target = 0
 			e.Mode = world.MobIdle
-		} else if e.Summoner != 0 && target.Target == 0 {
+		} else {
 			setGroupBattle(w, target.ID, target, e)
 		}
 		return
@@ -483,6 +614,7 @@ func (d *Dispatcher) mobAttack(w *world.World, id int, e, target *world.Entity) 
 
 	// Player down: stop targeting it (the death/resurrection flow is deferred).
 	if target.HP == 0 {
+		removeEnemyList(e, target.ID)
 		e.Target = 0
 		e.Mode = world.MobIdle
 	}

--- a/tmserver/internal/handler/mobai.go
+++ b/tmserver/internal/handler/mobai.go
@@ -29,13 +29,12 @@ const (
 
 // Tick is the world's per-tick mob-AI hook (registered via World.SetTickHandler).
 // It runs inside the loop goroutine, so it mutates entities directly. Each live
-// monster (Merchant==0) acquires a nearby player as a target, then chases and
-// melees it. NPCs (shops/quest givers) and dead mobs are skipped.
+// monster (Merchant==0) acquires a nearby hostile player or mob as a target, then
+// chases and melees it. NPCs (shops/quest givers) and dead mobs are skipped.
 //
 // UNVERIFIED / deferred (captura): real pathfinding (we step one Chebyshev
-// tile), roaming/segments/summons, mob-vs-mob combat (guards), and the player
-// death/resurrection flow (a player dropped to 0 HP just stops being a valid
-// target).
+// tile), roaming/segments/summons, and the player death/resurrection flow (a
+// player dropped to 0 HP just stops being a valid target).
 func (d *Dispatcher) Tick(w *world.World) {
 	// One bump per tick, up front: both regenPlayers (natural-regen phase) and
 	// sweepAffects (per-player stagger) read this counter, and regenPlayers runs
@@ -369,15 +368,15 @@ func battleCode(r *rng.MSVC, dis, reach, dex int) int {
 	return battleChase
 }
 
-// validTarget reports whether a mob's target is still attackable: an in-play,
-// living player within the mob's leash box — centred on its current waypoint
-// anchor (BattleProcessor leashes on SegmentX±HALFGRIDX, CMob.cpp:292; for a
-// routeless mob the anchor is its spawn point).
+// validTarget reports whether a mob's target is still attackable: an in-play
+// player or a hostile mob within the mob's leash box — centred on its current
+// waypoint anchor (BattleProcessor leashes on SegmentX±HALFGRIDX, CMob.cpp:292;
+// for a routeless mob the anchor is its spawn point).
 //
-// Mob targets exist only in summon fights: a summon attacking a monster, or a
-// monster retaliating against a summon (the legacy's EnemyList held either).
-// The summon side skips the waypoint leash — its leash is the distance to its
-// OWNER, enforced by summonTick before mobBattle runs.
+// Summons keep their separate rules: pets attack monsters but never players or
+// other pets, while regular mobs can still retaliate against pets. The summon
+// side skips the waypoint leash — its leash is the distance to its OWNER,
+// enforced by summonTick before mobBattle runs.
 func validTarget(w *world.World, e, target *world.Entity) bool {
 	if target == nil || target.HP <= 0 {
 		return false
@@ -389,8 +388,13 @@ func validTarget(w *world.World, e, target *world.Entity) bool {
 		if e.Summoner != 0 {
 			return target.Clan != summonClan // pets fight monsters, never other pets
 		}
-		return target.Summoner != 0 && // a monster only ever targets a pet, and
-			chebyshev(e.SegmentX, e.SegmentY, target.X, target.Y) <= leashRadius
+		if chebyshev(e.SegmentX, e.SegmentY, target.X, target.Y) > leashRadius {
+			return false
+		}
+		if target.Summoner != 0 {
+			return true // regular mobs can retaliate against pets
+		}
+		return world.ClanHostile(e.Clan, target.Clan)
 	}
 	if e.Summoner != 0 {
 		return false // pets never attack players (clan 4 is friendly, clan.go)
@@ -405,10 +409,9 @@ func validTarget(w *world.World, e, target *world.Entity) bool {
 }
 
 // mobAttack resolves a strike (melee or in-reach ranged — the original uses the
-// same attack message for both, no projectile) against the target player and
-// broadcasts it so the victim (and onlookers) see the damage. Damage is
-// server-authoritative via the shared combat formula. The player's HP bar
-// updates from the Dam entry.
+// same attack message for both, no projectile) against the target entity and
+// broadcasts it so nearby players see the damage. Damage is server-authoritative
+// via the shared combat formula. Player HP bars update from the Dam entry.
 func (d *Dispatcher) mobAttack(w *world.World, id int, e, target *world.Entity) {
 	now := w.Now()
 	if now < e.AtkTick+mobAttackCadence {

--- a/tmserver/internal/handler/mobai.go
+++ b/tmserver/internal/handler/mobai.go
@@ -16,6 +16,7 @@ import (
 const (
 	leashRadius      = 16   // HALFGRIDX: target outside the mob's home box drops aggro
 	meleeRange       = 1    // reach floor when the template has no EF_RANGE gear
+	kefraBossRange   = 25   // CMob.cpp BattleProcessor: KEFRA_BOSS ignores EF_RANGE
 	mobAttackCadence = 1000 // ms between a mob's attacks (≈ the player 800ms guard)
 	// wakeRadius gates the per-tick aggro scan: an idle mob with no player within
 	// this Chebyshev distance skips FindEnemyFromView entirely. It must cover the
@@ -313,6 +314,9 @@ func enemySelectRange(e *world.Entity) int {
 	if int(e.X)/128 < 12 && int(e.Y)/128 > 25 {
 		dis = 8
 	}
+	if isKefraBoss(e) {
+		dis = leashRadius
+	}
 	return dis
 }
 
@@ -490,19 +494,37 @@ func (d *Dispatcher) mobBattle(w *world.World, id int, e *world.Entity) {
 		return
 	}
 
-	reach := int(e.Range)
-	if reach < meleeRange {
-		reach = meleeRange // no EF_RANGE on the template's gear → melee adjacency
-	}
+	reach := mobReach(e)
 	dis := mobDistance(e.X, e.Y, target.X, target.Y)
 	switch battleCode(w.Rand(), dis, reach, int(e.Dex)) {
 	case battleAttack:
 		d.mobAttack(w, id, e, target)
 	case battleRetreat:
+		if isKefraBoss(e) {
+			return
+		}
 		d.mobRetreat(w, id, e, target)
 	default:
+		if isKefraBoss(e) {
+			return
+		}
 		d.mobStep(w, id, e, target)
 	}
+}
+
+func mobReach(e *world.Entity) int {
+	if isKefraBoss(e) {
+		return kefraBossRange
+	}
+	reach := int(e.Range)
+	if reach < meleeRange {
+		return meleeRange // no EF_RANGE on the template's gear → melee adjacency
+	}
+	return reach
+}
+
+func isKefraBoss(e *world.Entity) bool {
+	return e != nil && int(e.GenIndex) == world.KefraBossGenIndex
 }
 
 // battleCode ports the BattleProcessor reach decision (CMob.cpp:308-327): within
@@ -650,6 +672,9 @@ func (d *Dispatcher) mobAttack(w *world.World, id int, e, target *world.Entity) 
 // MOB_RETURN, BattleProcessor code 16). Summons (RouteType 5) never reach
 // here — the Tick routes them to summonTick (summon.go).
 func (d *Dispatcher) mobRoam(w *world.World, id int, e *world.Entity) {
+	if isKefraBoss(e) {
+		return
+	}
 	if e.RouteType == 0 || e.RouteType == 5 || !hasWaypoints(e) {
 		if e.X != e.SegmentX || e.Y != e.SegmentY {
 			d.stepToward(w, id, e, e.SegmentX, e.SegmentY) // return home

--- a/tmserver/internal/handler/mobai.go
+++ b/tmserver/internal/handler/mobai.go
@@ -19,10 +19,10 @@ const (
 	kefraBossRange   = 25   // CMob.cpp BattleProcessor: KEFRA_BOSS ignores EF_RANGE
 	mobAttackCadence = 1000 // ms between a mob's attacks (≈ the player 800ms guard)
 	// wakeRadius gates the per-tick aggro scan: an idle mob with no player within
-	// this Chebyshev distance skips FindEnemyFromView entirely. It must cover the
-	// widest aggro window (clan 7/8 scan [x-6, x+10) → offset 9); 12 leaves margin.
-	// Pure optimization — the original processed every mob each cycle.
-	wakeRadius = 12
+	// this Chebyshev distance skips FindEnemyFromView entirely. It is ViewRange
+	// rather than the player-aggro window so visible guard-vs-mob encounters still
+	// start when the watcher is near the edge of the scene.
+	wakeRadius = world.ViewRange
 	// roamRadius gates roaming the same way, but must exceed ViewRange (16) so a
 	// player never watches a frozen patrol: mobs start walking just beyond what
 	// the client can see. Same divergence class as wakeRadius.
@@ -60,6 +60,11 @@ func (d *Dispatcher) Tick(w *world.World) {
 			d.summonTick(w, id, e) // summoned pets follow their own AI (summon.go)
 			return
 		}
+		if e.Target == 0 && hasEnemyList(e) {
+			e.Mode = world.MobCombat
+			d.mobBattle(w, id, e)
+			return
+		}
 		if e.Target == 0 {
 			if !d.playerNear(e.X, e.Y, roamRadius) {
 				return // dormant: nobody close enough to see or be aggroed
@@ -72,7 +77,8 @@ func (d *Dispatcher) Tick(w *world.World) {
 			// the group drag (setGroupBattle).
 			if e.Leader == 0 && d.playerNear(e.X, e.Y, wakeRadius) &&
 				chebyshev(e.X, e.Y, e.SegmentX, e.SegmentY) <= leashRadius {
-				if p := w.FindEnemyFromView(e.X, e.Y, e.Clan); p != 0 && !inSafeCity(w, p) {
+				if p := w.FindEnemyFromView(e.X, e.Y, e.Clan); p != 0 &&
+					(!world.IsPlayer(p) || !inSafeCity(w, p)) {
 					setGroupBattle(w, id, e, w.Entity(p))
 				}
 			}
@@ -252,6 +258,18 @@ func clearEnemyList(e *world.Entity) {
 	if e != nil {
 		e.EnemyList = [protocol.MaxTarget]int{}
 	}
+}
+
+func hasEnemyList(e *world.Entity) bool {
+	if e == nil {
+		return false
+	}
+	for _, id := range e.EnemyList {
+		if id != 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func selectTargetFromEnemyList(w *world.World, e *world.Entity) {
@@ -640,14 +658,14 @@ func (d *Dispatcher) mobAttack(w *world.World, id int, e, target *world.Entity) 
 				if owner := w.Entity(e.Summoner); owner != nil {
 					d.mobKilled(w, owner, target)
 				} else {
+					sendDieAction(w, target)
 					w.DespawnMob(target.ID, 1)
 				}
 			} else {
+				sendDieAction(w, target)
 				w.DespawnMob(target.ID, 1)
 			}
-			removeEnemyList(e, target.ID)
-			e.Target = 0
-			e.Mode = world.MobIdle
+			dropCurrentTarget(e, target.ID)
 		} else {
 			setGroupBattle(w, target.ID, target, e)
 		}
@@ -659,8 +677,16 @@ func (d *Dispatcher) mobAttack(w *world.World, id int, e, target *world.Entity) 
 
 	// Player down: stop targeting it (the death/resurrection flow is deferred).
 	if target.HP == 0 {
-		removeEnemyList(e, target.ID)
-		e.Target = 0
+		dropCurrentTarget(e, target.ID)
+	}
+}
+
+func dropCurrentTarget(e *world.Entity, targetID int) {
+	removeEnemyList(e, targetID)
+	e.Target = 0
+	if hasEnemyList(e) {
+		e.Mode = world.MobCombat
+	} else {
 		e.Mode = world.MobIdle
 	}
 }

--- a/tmserver/internal/handler/mobai.go
+++ b/tmserver/internal/handler/mobai.go
@@ -682,6 +682,14 @@ func (d *Dispatcher) mobRoam(w *world.World, id int, e *world.Entity) {
 		return
 	}
 	if e.X == e.SegmentX && e.Y == e.SegmentY { // arrived at the current waypoint
+		if e.RouteType == 3 && e.SegProgress == 4 {
+			if e.WaitTicks > 0 {
+				e.WaitTicks--
+				return
+			}
+			w.DespawnMob(id, 3) // StandingByProcessor 0x10000 → DeleteMob(index, 3)
+			return
+		}
 		if e.RouteType == 6 {
 			return // fixed guard post: SetSegment always resets to 0 (CMob.cpp:167)
 		}
@@ -725,7 +733,8 @@ func hasWaypoints(e *world.Entity) bool {
 //
 // Per-RouteType end behaviour (both ends: past-4 while forward, past-0 while
 // backward): 1 = restart at 0; 2 = ping-pong (also restarts forward at the home
-// end); 3 = ping-pong once, then stop; 4 = circular loop; 6 = always reset to 0.
+// end); 3 would ping-pong here, but StandingByProcessor deletes it at waypoint 4
+// before calling SetSegment again; 4 = circular loop; 6 = always reset to 0.
 // RouteType 0 walks the list once and then becomes a fixed NPC — the original
 // also flips Mode=4 and bit-packs the facing direction into MOB.Merchant
 // (CMob.cpp:558-579); we only stop the walk (our Merchant carries the spawn-city

--- a/tmserver/internal/handler/mobai.go
+++ b/tmserver/internal/handler/mobai.go
@@ -180,6 +180,7 @@ func setBattle(w *world.World, id int, e, target *world.Entity) {
 	}
 	e.Mode = world.MobCombat
 	addEnemyList(e, target)
+	sendFightAction(w, id, e)
 	if targetInWorld {
 		selectTargetFromEnemyList(w, e)
 	} else if e.Target == 0 {
@@ -188,6 +189,28 @@ func setBattle(w *world.World, id int, e, target *world.Entity) {
 		// EnemyList selection above.
 		e.Target = target.ID
 	}
+}
+
+func sendFightAction(w *world.World, id int, e *world.Entity) {
+	if e == nil {
+		return
+	}
+	say := w.Rand().Intn(4) // Server.cpp SetBattle consumes rand()%4 on engage.
+	gen := w.GeneratorAt(int(e.GenIndex))
+	if gen == nil || e.Leader != 0 || gen.FightAction[say] == "" {
+		return
+	}
+	sendMobChat(w, id, gen.FightAction[say])
+}
+
+func sendMobChat(w *world.World, id int, text string) {
+	if text == "" {
+		return
+	}
+	payload := protocol.EncodeMessageChatBody(text)
+	w.ForEachInView(id, func(vs *world.Session, _ *world.Entity) {
+		w.SendTo(vs, protocol.Header{Type: protocol.MsgMessageChat, ID: uint16(id)}, payload)
+	})
 }
 
 func addEnemyList(e, target *world.Entity) {

--- a/tmserver/internal/handler/mobai_test.go
+++ b/tmserver/internal/handler/mobai_test.go
@@ -74,6 +74,11 @@ func startServerMobAIRouted(t *testing.T, persist world.Persistence, gridDim int
 // MobSpawn (route/waypoints included) exactly as PROD's spawnNPCs builds it.
 func startServerMobAISpawn(t *testing.T, persist world.Persistence, gridDim int, sp world.MobSpawn, heights *content.Grid) (string, func()) {
 	t.Helper()
+	return startServerMobAISpawns(t, persist, gridDim, []world.MobSpawn{sp}, heights)
+}
+
+func startServerMobAISpawns(t *testing.T, persist world.Persistence, gridDim int, spawns []world.MobSpawn, heights *content.Grid) (string, func()) {
+	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
@@ -83,7 +88,9 @@ func startServerMobAISpawn(t *testing.T, persist world.Persistence, gridDim int,
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	d := New(Config{Log: log, Heights: heights})
 	w := world.New(world.Config{GridDim: gridDim, Now: clock.Load}, log, persist, d.Handle)
-	w.SpawnMobAt(sp) // init-time spawn (loop-safe)
+	for _, sp := range spawns {
+		w.SpawnMobAt(sp) // init-time spawn (loop-safe)
+	}
 	w.SetTickHandler(10*time.Millisecond, d.Tick)
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -194,6 +201,67 @@ func TestFriendlyClanMobDoesNotAttack(t *testing.T) {
 			t.Fatal("friendly-clan mob attacked a player")
 		}
 	}
+}
+
+func TestGuardAttacksHostileMob(t *testing.T) {
+	guard := aggressiveMob()
+	copy(guard[0:16], "Guard")
+	guard[16] = 7 // clanTable[7][5]==0, but clanTable[7][0]==1 (player-friendly)
+	const cs = 92
+	binary.LittleEndian.PutUint32(guard[cs+8:], 5000) // one clean hit kills the weak mob
+
+	hostile := aggressiveMob()
+	copy(hostile[0:16], "Intruder")
+	hostile[16] = 5
+	binary.LittleEndian.PutUint32(hostile[cs+8:], 1)   // harmless if it ever ticks
+	binary.LittleEndian.PutUint32(hostile[cs+16:], 30) // MaxHp
+	binary.LittleEndian.PutUint32(hostile[cs+24:], 30) // Hp
+
+	spawns := []world.MobSpawn{
+		{Template: guard, X: 6, Y: 5, GenIndex: -1},
+		{Template: hostile, X: 7, Y: 5, GenIndex: -1},
+	}
+	addr, stop := startServerMobAISpawns(t, combatDB(), 16, spawns, nil)
+	defer stop()
+
+	c := enterWorld(t, addr)
+	defer c.Close()
+	actionFrameAt(t, c, serverTime, 5, 5) // observer keeps both mobs awake and in view
+
+	guardID := world.MaxUser
+	hostileID := world.MaxUser + 1
+	sawAttack := false
+	for i := 0; i < 30; i++ {
+		h, payload, ok := readMaybeHeaderRaw(t, c)
+		if !ok {
+			continue
+		}
+		switch h.Type {
+		case protocol.MsgAttack:
+			var body protocol.MsgAttackBody
+			if err := body.Decode(payload); err != nil {
+				t.Fatal(err)
+			}
+			if int(body.AttackerID) != guardID {
+				continue
+			}
+			if len(body.Dam) == 0 || int(body.Dam[0].TargetID) != hostileID {
+				t.Fatalf("guard attack Dam = %+v, want target mob %d", body.Dam, hostileID)
+			}
+			if body.Dam[0].Damage <= 0 {
+				t.Fatalf("guard attack damage = %d, want > 0", body.Dam[0].Damage)
+			}
+			sawAttack = true
+		case protocol.MsgRemoveMob:
+			if int(h.ID) == hostileID && sawAttack {
+				return
+			}
+		}
+	}
+	if !sawAttack {
+		t.Fatal("guard never attacked the hostile mob")
+	}
+	t.Fatal("hostile mob was attacked but not removed")
 }
 
 // TestMobDistance pins BASE_GetDistance (Basedef.cpp:6484): the rounded-Euclidean

--- a/tmserver/internal/handler/mobai_test.go
+++ b/tmserver/internal/handler/mobai_test.go
@@ -683,6 +683,38 @@ func TestMobRoamPatrolAndWait(t *testing.T) {
 	}
 }
 
+// TestRouteType3DespawnsAtFinalWaypoint pins the StandingByProcessor RT3 branch:
+// when a route-3 mob reaches waypoint 4, it returns 0x10000 and the timer calls
+// DeleteMob(index, 3). It does not ping-pong back home and become idle.
+func TestRouteType3DespawnsAtFinalWaypoint(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := New(Config{Log: log})
+	w := world.New(world.Config{GridDim: 32}, log, nil, d.Handle)
+
+	id := w.SpawnMobAt(world.MobSpawn{
+		Template: aggressiveMob(),
+		X:        5, Y: 5,
+		RouteType: 3,
+		SegX:      [5]int16{5, 0, 0, 0, 7},
+		SegY:      [5]int16{5, 0, 0, 0, 5},
+		GenIndex:  -1,
+	})
+	if id < 0 {
+		t.Fatal("SpawnMobAt failed")
+	}
+
+	for i := 0; i < 4; i++ {
+		e := w.Entity(id)
+		if e == nil {
+			break
+		}
+		d.mobRoam(w, id, e)
+	}
+	if e := w.Entity(id); e != nil {
+		t.Fatalf("RT3 mob still alive at (%d,%d), want despawn at waypoint 4", e.X, e.Y)
+	}
+}
+
 // TestMobReturnsHomeAfterCombat: a routeless mob displaced from its anchor (e.g.
 // its target died elsewhere) walks back — the emergent MOB_RETURN (the original
 // BattleProcessor code 16 → GetNextPos(1)).

--- a/tmserver/internal/handler/mobai_test.go
+++ b/tmserver/internal/handler/mobai_test.go
@@ -673,7 +673,7 @@ func groupWorld(t *testing.T) (*Dispatcher, *world.World, []int) {
 // TestSetGroupBattleDragsGroup: striking one follower puts the whole spawn
 // group on the attacker — SetBattle (Server.cpp:8013) plus the PartyList
 // propagation (ProcessSecMinTimer.cpp:1882-1929). A member already fighting
-// someone else keeps its target.
+// someone else keeps its selected target but records the new enemy.
 func TestSetGroupBattleDragsGroup(t *testing.T) {
 	_, w, ids := groupWorld(t)
 	leader, f1, f2 := w.Entity(ids[0]), w.Entity(ids[1]), w.Entity(ids[2])
@@ -691,6 +691,9 @@ func TestSetGroupBattleDragsGroup(t *testing.T) {
 	if f2.Target != 7 {
 		t.Fatalf("engaged follower Target = %d, want 7 (kept)", f2.Target)
 	}
+	if !enemyListContains(f2, 3) {
+		t.Fatalf("engaged follower EnemyList = %v, want attacker 3 recorded", f2.EnemyList)
+	}
 
 	// Out of the ±23 drag box nobody joins.
 	leader.Target = 0
@@ -699,6 +702,65 @@ func TestSetGroupBattleDragsGroup(t *testing.T) {
 	if leader.Target != 0 {
 		t.Fatalf("leader dragged from %d tiles away, want no drag", 40)
 	}
+}
+
+func TestEnemyListSelectsNearestAndDropsInvalid(t *testing.T) {
+	_, w, _ := groupWorld(t)
+	seekerID := w.SpawnMobAt(world.MobSpawn{Template: aggressiveMob(), X: 10, Y: 10, GenIndex: -1})
+	farID := w.SpawnMobAt(world.MobSpawn{Template: aggressiveMob(), X: 14, Y: 10, GenIndex: -1})
+	nearID := w.SpawnMobAt(world.MobSpawn{Template: aggressiveMob(), X: 11, Y: 10, GenIndex: -1})
+	seeker := w.Entity(seekerID)
+	far := w.Entity(farID)
+	near := w.Entity(nearID)
+
+	addEnemyList(seeker, far)
+	addEnemyList(seeker, near)
+	selectTargetFromEnemyList(w, seeker)
+	if seeker.Target != nearID {
+		t.Fatalf("selected target = %d, want nearer mob %d", seeker.Target, nearID)
+	}
+
+	near.HP = 0
+	selectTargetFromEnemyList(w, seeker)
+	if seeker.Target != farID {
+		t.Fatalf("selected after death = %d, want remaining mob %d", seeker.Target, farID)
+	}
+	if enemyListContains(seeker, nearID) {
+		t.Fatalf("dead target %d still in EnemyList %v", nearID, seeker.EnemyList)
+	}
+
+	w.SetEntityPos(farID, 40, 40)
+	selectTargetFromEnemyList(w, seeker)
+	if seeker.Target != 0 {
+		t.Fatalf("selected out-of-range target = %d, want 0", seeker.Target)
+	}
+	if enemyListContains(seeker, farID) {
+		t.Fatalf("out-of-range target %d still in EnemyList %v", farID, seeker.EnemyList)
+	}
+}
+
+func TestEnemyListTieSelectsLaterSlot(t *testing.T) {
+	_, w, _ := groupWorld(t)
+	seekerID := w.SpawnMobAt(world.MobSpawn{Template: aggressiveMob(), X: 10, Y: 10, GenIndex: -1})
+	firstID := w.SpawnMobAt(world.MobSpawn{Template: aggressiveMob(), X: 12, Y: 10, GenIndex: -1})
+	secondID := w.SpawnMobAt(world.MobSpawn{Template: aggressiveMob(), X: 10, Y: 12, GenIndex: -1})
+	seeker := w.Entity(seekerID)
+
+	addEnemyList(seeker, w.Entity(firstID))
+	addEnemyList(seeker, w.Entity(secondID))
+	selectTargetFromEnemyList(w, seeker)
+	if seeker.Target != secondID {
+		t.Fatalf("tie selected target = %d, want later slot %d", seeker.Target, secondID)
+	}
+}
+
+func enemyListContains(e *world.Entity, target int) bool {
+	for _, id := range e.EnemyList {
+		if id == target {
+			return true
+		}
+	}
+	return false
 }
 
 // TestFollowerDoesNotSelfAggro (e2e): a hostile FOLLOWER adjacent to the player

--- a/tmserver/internal/handler/mobai_test.go
+++ b/tmserver/internal/handler/mobai_test.go
@@ -203,6 +203,61 @@ func TestMobDieActionChat(t *testing.T) {
 	waitMobChat(t, c, ids[0], "Adeus!")
 }
 
+func TestMobKillSendsDieActionChat(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock := &atomic.Uint32{}
+	clock.Store(serverTime)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := New(Config{Log: log})
+	w := world.New(world.Config{GridDim: 64, Now: clock.Load}, log, combatDB(), d.Handle)
+
+	target := aggressiveMob()
+	copy(target[0:16], "Target")
+	target[16] = 5
+	binary.LittleEndian.PutUint32(target[92+8:], 1)
+	binary.LittleEndian.PutUint32(target[92+16:], 30)
+	binary.LittleEndian.PutUint32(target[92+24:], 30)
+	gen := &world.Generator{
+		MinuteGenerate: -1, MinGroup: 0, MaxGroup: 0, MaxNumMob: 1,
+		SegX: [5]int16{10}, SegY: [5]int16{10},
+		LeaderTmpl: target,
+		DieAction:  [4]string{"MobDown", "MobDown", "MobDown", "MobDown"},
+	}
+	w.RegisterGenerators([]*world.Generator{gen})
+	ids := w.GenerateMob(0)
+	if len(ids) != 1 {
+		t.Fatalf("generated %d mobs, want 1", len(ids))
+	}
+	targetID := ids[0]
+
+	guard := aggressiveMob()
+	copy(guard[0:16], "Guard")
+	guard[16] = 7
+	binary.LittleEndian.PutUint32(guard[92+8:], 5000)
+	guardID := w.SpawnMobAt(world.MobSpawn{Template: guard, X: 9, Y: 10, GenIndex: -1})
+	if guardID < 0 {
+		t.Fatal("SpawnMobAt guard failed")
+	}
+
+	w.SetTickHandler(10*time.Millisecond, d.Tick)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = w.Serve(ctx, ln); close(done) }()
+	defer func() {
+		cancel()
+		<-done
+	}()
+
+	c := enterWorld(t, ln.Addr().String())
+	defer c.Close()
+	actionFrameAt(t, c, serverTime, 8, 10)
+
+	waitMobChat(t, c, targetID, "MobDown")
+}
+
 // actionFrameAt pins the player at (x,y): _MSG_Action sets the entity position
 // to the body's DESTINATION (TargetX/TargetY, legacy pMob.TargetX semantics).
 func actionFrameAt(t *testing.T, c net.Conn, tick uint32, x, y int16) {
@@ -360,6 +415,49 @@ func TestGuardAttacksHostileMob(t *testing.T) {
 		t.Fatal("guard never attacked the hostile mob")
 	}
 	t.Fatal("hostile mob was attacked but not removed")
+}
+
+func TestGuardAggrosHostileMobInCityAtViewEdge(t *testing.T) {
+	guard := aggressiveMob()
+	copy(guard[0:16], "Guard")
+	guard[16] = 7 // player-friendly guard, hostile to clan 5
+	const cs = 92
+	binary.LittleEndian.PutUint32(guard[cs+8:], 5000)
+
+	hostile := aggressiveMob()
+	copy(hostile[0:16], "Intruder")
+	hostile[16] = 5
+	binary.LittleEndian.PutUint32(hostile[cs+8:], 1)
+	binary.LittleEndian.PutUint32(hostile[cs+16:], 30)
+	binary.LittleEndian.PutUint32(hostile[cs+24:], 30)
+
+	spawns := []world.MobSpawn{
+		{Template: guard, X: 2090, Y: 2095, GenIndex: -1},
+		{Template: hostile, X: 2091, Y: 2095, GenIndex: -1},
+	}
+	addr, stop := startServerMobAISpawns(t, combatDB(), 2200, spawns, nil)
+	defer stop()
+
+	c := enterWorld(t, addr)
+	defer c.Close()
+	actionFrameAt(t, c, serverTime, 2075, 2095) // inside Armia, 15 tiles from guard
+
+	guardID := world.MaxUser
+	hostileID := world.MaxUser + 1
+	for i := 0; i < 30; i++ {
+		h, payload, ok := readMaybeHeaderRaw(t, c)
+		if !ok || h.Type != protocol.MsgAttack {
+			continue
+		}
+		var body protocol.MsgAttackBody
+		if err := body.Decode(payload); err != nil {
+			t.Fatal(err)
+		}
+		if int(body.AttackerID) == guardID && len(body.Dam) > 0 && int(body.Dam[0].TargetID) == hostileID {
+			return
+		}
+	}
+	t.Fatal("guard did not acquire the hostile mob inside the visible city area")
 }
 
 // TestMobDistance pins BASE_GetDistance (Basedef.cpp:6484): the rounded-Euclidean
@@ -881,6 +979,32 @@ func TestEnemyListTieSelectsLaterSlot(t *testing.T) {
 	selectTargetFromEnemyList(w, seeker)
 	if seeker.Target != secondID {
 		t.Fatalf("tie selected target = %d, want later slot %d", seeker.Target, secondID)
+	}
+}
+
+func TestTickPromotesEnemyListWithoutCurrentTarget(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := New(Config{Log: log})
+	w := world.New(world.Config{GridDim: 64}, log, nil, d.Handle)
+
+	guard := aggressiveMob()
+	guard[16] = 7
+	guardID := w.SpawnMobAt(world.MobSpawn{Template: guard, X: 10, Y: 10, GenIndex: -1})
+	target := aggressiveMob()
+	target[16] = 5
+	targetID := w.SpawnMobAt(world.MobSpawn{Template: target, X: 11, Y: 10, GenIndex: -1})
+	guardEntity := w.Entity(guardID)
+	addEnemyList(guardEntity, w.Entity(targetID))
+	guardEntity.Target = 0
+	guardEntity.Mode = world.MobIdle
+
+	d.Tick(w)
+
+	if guardEntity.Target != targetID {
+		t.Fatalf("promoted target = %d, want %d from EnemyList %v", guardEntity.Target, targetID, guardEntity.EnemyList)
+	}
+	if guardEntity.Mode != world.MobCombat {
+		t.Fatalf("guard mode = %v, want MobCombat", guardEntity.Mode)
 	}
 }
 

--- a/tmserver/internal/handler/mobai_test.go
+++ b/tmserver/internal/handler/mobai_test.go
@@ -105,6 +105,104 @@ func startServerMobAISpawns(t *testing.T, persist world.Persistence, gridDim int
 	}
 }
 
+func startServerMobAIGenerator(t *testing.T, persist world.Persistence, gridDim int, gen *world.Generator) (string, func(), []int) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock := &atomic.Uint32{}
+	clock.Store(serverTime)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := New(Config{Log: log})
+	w := world.New(world.Config{GridDim: gridDim, Now: clock.Load}, log, persist, d.Handle)
+	w.RegisterGenerators([]*world.Generator{gen})
+	ids := w.GenerateMob(0)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = w.Serve(ctx, ln); close(done) }()
+	return ln.Addr().String(), func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("server did not stop")
+		}
+	}, ids
+}
+
+func waitMobChat(t *testing.T, c net.Conn, mobID int, want string) {
+	t.Helper()
+	for i := 0; i < 12; i++ {
+		h, payload, ok := readMaybeHeader(t, c)
+		if !ok {
+			continue
+		}
+		if h.Type != protocol.MsgMessageChat {
+			continue
+		}
+		if int(h.ID) != mobID {
+			t.Fatalf("chat HEADER.ID = %d, want mob %d", h.ID, mobID)
+		}
+		if len(payload) != protocol.MessageLength {
+			t.Fatalf("chat payload length = %d, want %d", len(payload), protocol.MessageLength)
+		}
+		if got := cstr(payload); got != want {
+			t.Fatalf("chat text = %q, want %q", got, want)
+		}
+		return
+	}
+	t.Fatalf("did not receive mob chat %q from %d", want, mobID)
+}
+
+func TestMobFightActionChat(t *testing.T) {
+	tmpl := aggressiveMob()
+	tmpl[16] = 2                                     // friendly: no ambient aggro
+	binary.LittleEndian.PutUint32(tmpl[92+16:], 800) // survive the first player hit
+	binary.LittleEndian.PutUint32(tmpl[92+24:], 800)
+	gen := &world.Generator{
+		MinuteGenerate: -1, MinGroup: 0, MaxGroup: 0, MaxNumMob: 1,
+		SegX: [5]int16{6}, SegY: [5]int16{5},
+		LeaderTmpl:  tmpl,
+		FightAction: [4]string{"Lute!", "Lute!", "Lute!", "Lute!"},
+	}
+	addr, stop, ids := startServerMobAIGenerator(t, combatDB(), 16, gen)
+	defer stop()
+	if len(ids) != 1 {
+		t.Fatalf("generated %d mobs, want 1", len(ids))
+	}
+
+	c := enterWorld(t, addr)
+	defer c.Close()
+	attackFrame(t, c, serverTime, ids[0], 0)
+
+	waitMobChat(t, c, ids[0], "Lute!")
+}
+
+func TestMobDieActionChat(t *testing.T) {
+	tmpl := aggressiveMob()
+	tmpl[16] = 2                                   // friendly: no ambient aggro
+	binary.LittleEndian.PutUint32(tmpl[92+16:], 1) // first player hit kills
+	binary.LittleEndian.PutUint32(tmpl[92+24:], 1)
+	gen := &world.Generator{
+		MinuteGenerate: -1, MinGroup: 0, MaxGroup: 0, MaxNumMob: 1,
+		SegX: [5]int16{6}, SegY: [5]int16{5},
+		LeaderTmpl: tmpl,
+		DieAction:  [4]string{"Adeus!", "Adeus!", "Adeus!", "Adeus!"},
+	}
+	addr, stop, ids := startServerMobAIGenerator(t, combatDB(), 16, gen)
+	defer stop()
+	if len(ids) != 1 {
+		t.Fatalf("generated %d mobs, want 1", len(ids))
+	}
+
+	c := enterWorld(t, addr)
+	defer c.Close()
+	attackFrame(t, c, serverTime, ids[0], 0)
+
+	waitMobChat(t, c, ids[0], "Adeus!")
+}
+
 // actionFrameAt pins the player at (x,y): _MSG_Action sets the entity position
 // to the body's DESTINATION (TargetX/TargetY, legacy pMob.TargetX semantics).
 func actionFrameAt(t *testing.T, c net.Conn, tick uint32, x, y int16) {

--- a/tmserver/internal/handler/mobai_test.go
+++ b/tmserver/internal/handler/mobai_test.go
@@ -852,6 +852,84 @@ func TestEnemyListTieSelectsLaterSlot(t *testing.T) {
 	}
 }
 
+func kefraBossMob(dex uint16) []byte {
+	b := aggressiveMob()
+	copy(b[0:16], "Kefra")
+	b[16] = 7 // hostile to clan 5 mobs, player-friendly like guards
+	binary.LittleEndian.PutUint16(b[92+36:], dex)
+	return b
+}
+
+func TestKefraBossEnemySelectionUsesHalfGrid(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := New(Config{Log: log})
+	w := world.New(world.Config{GridDim: 64}, log, nil, d.Handle)
+	kefraID := w.SpawnMobAt(world.MobSpawn{Template: kefraBossMob(99), X: 10, Y: 10, GenIndex: world.KefraBossGenIndex})
+	nearID := w.SpawnMobAt(world.MobSpawn{Template: aggressiveMob(), X: 25, Y: 10, GenIndex: -1}) // distance 15
+	farID := w.SpawnMobAt(world.MobSpawn{Template: aggressiveMob(), X: 27, Y: 10, GenIndex: -1})  // distance 17
+	kefra := w.Entity(kefraID)
+
+	addEnemyList(kefra, w.Entity(nearID))
+	selectTargetFromEnemyList(w, kefra)
+	if kefra.Target != nearID {
+		t.Fatalf("Kefra selected %d, want target inside HALFGRIDX %d", kefra.Target, nearID)
+	}
+
+	addEnemyList(kefra, w.Entity(farID))
+	w.Entity(nearID).HP = 0
+	selectTargetFromEnemyList(w, kefra)
+	if kefra.Target != 0 {
+		t.Fatalf("Kefra selected out-of-halfgrid target %d, want none", kefra.Target)
+	}
+	if enemyListContains(kefra, farID) {
+		t.Fatalf("out-of-halfgrid target %d still in EnemyList %v", farID, kefra.EnemyList)
+	}
+}
+
+func TestKefraBossAttacksAtFixedRange(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := New(Config{Log: log})
+	clock := &atomic.Uint32{}
+	clock.Store(serverTime)
+	w := world.New(world.Config{GridDim: 64, Now: clock.Load}, log, nil, d.Handle)
+	kefraID := w.SpawnMobAt(world.MobSpawn{Template: kefraBossMob(99), X: 10, Y: 10, GenIndex: world.KefraBossGenIndex})
+	targetID := w.SpawnMobAt(world.MobSpawn{Template: aggressiveMob(), X: 25, Y: 10, GenIndex: -1})
+	kefra, target := w.Entity(kefraID), w.Entity(targetID)
+	beforeHP := target.HP
+	addEnemyList(kefra, target)
+
+	d.mobBattle(w, kefraID, kefra)
+
+	if target.HP >= beforeHP {
+		t.Fatalf("Kefra target HP = %d, want damage at fixed range 25 from %d", target.HP, beforeHP)
+	}
+	if kefra.X != 10 || kefra.Y != 10 {
+		t.Fatalf("Kefra moved to (%d,%d), want fixed position (10,10)", kefra.X, kefra.Y)
+	}
+}
+
+func TestKefraBossDoesNotRetreat(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := New(Config{Log: log})
+	clock := &atomic.Uint32{}
+	clock.Store(serverTime)
+	w := world.New(world.Config{GridDim: 64, Now: clock.Load}, log, nil, d.Handle)
+	kefraID := w.SpawnMobAt(world.MobSpawn{Template: kefraBossMob(0), X: 10, Y: 10, GenIndex: world.KefraBossGenIndex})
+	targetID := w.SpawnMobAt(world.MobSpawn{Template: aggressiveMob(), X: 11, Y: 10, GenIndex: -1})
+	kefra, target := w.Entity(kefraID), w.Entity(targetID)
+	beforeHP := target.HP
+	addEnemyList(kefra, target)
+
+	d.mobBattle(w, kefraID, kefra)
+
+	if kefra.X != 10 || kefra.Y != 10 {
+		t.Fatalf("Kefra retreated to (%d,%d), want fixed position (10,10)", kefra.X, kefra.Y)
+	}
+	if target.HP != beforeHP {
+		t.Fatalf("Kefra attacked while retreat roll should only hold position: HP %d, want %d", target.HP, beforeHP)
+	}
+}
+
 func enemyListContains(e *world.Entity, target int) bool {
 	for _, id := range e.EnemyList {
 		if id == target {

--- a/tmserver/internal/handler/mobkilled.go
+++ b/tmserver/internal/handler/mobkilled.go
@@ -63,10 +63,24 @@ func (d *Dispatcher) mobKilled(w *world.World, killer, mob *world.Entity) {
 		}
 	}
 
+	sendDieAction(w, mob)
+
 	// Despawn: tell in-view clients the mob died (RemoveMob, type 1 = death) and
 	// free its grid cell + entity slot, so the corpse disappears and it can't be
 	// retargeted. Without this the client keeps rendering the dead mob.
 	w.DespawnMob(mob.ID, 1)
+}
+
+func sendDieAction(w *world.World, mob *world.Entity) {
+	if mob == nil {
+		return
+	}
+	say := w.Rand().Intn(4) // MobKilled.cpp draws DieSay after rewards, before DeleteMob.
+	gen := w.GeneratorAt(int(mob.GenIndex))
+	if gen == nil || mob.Leader != 0 || gen.DieAction[say] == "" {
+		return
+	}
+	sendMobChat(w, mob.ID, gen.DieAction[say])
 }
 
 // grantExp awards solo PvE experience to the killer and applies any resulting

--- a/tmserver/internal/handler/summon.go
+++ b/tmserver/internal/handler/summon.go
@@ -274,6 +274,7 @@ func (d *Dispatcher) summonTick(w *world.World, id int, e *world.Entity) {
 		// pet drops the fight and returns (CMob.cpp:268-274).
 		if mobDistance(e.X, e.Y, owner.X, owner.Y) >= summonLeash {
 			e.Target = 0
+			clearEnemyList(e)
 			e.Mode = world.MobIdle
 		} else {
 			d.mobBattle(w, id, e)
@@ -324,8 +325,7 @@ func (d *Dispatcher) commandSummons(w *world.World, ownerID int, target *world.E
 			continue
 		}
 		if abs16(pet.X-target.X) <= battleDragBox && abs16(pet.Y-target.Y) <= battleDragBox {
-			pet.Target = target.ID
-			pet.Mode = world.MobCombat
+			setBattle(w, m, pet, target)
 		}
 	}
 }

--- a/tmserver/internal/handler/view_test.go
+++ b/tmserver/internal/handler/view_test.go
@@ -213,6 +213,57 @@ func TestMoveViewDelta(t *testing.T) {
 	}
 }
 
+func TestPlayersCrossingViewOnMovement(t *testing.T) {
+	addr, stop := startServerView(t, viewDeltaDB(), 64)
+	defer stop()
+
+	a := enterWorld(t, addr) // conn 1 at (5,5)
+	defer a.Close()
+	b := enterWorldAs(t, addr, "tradeb") // conn 2 at (5,45)
+	defer b.Close()
+	drainRaw(t, a)
+	drainRaw(t, b)
+
+	// A walks to the edge of B's view. Both clients must learn the other player
+	// before any movement frame is animated.
+	actionFrameXY(t, a, protocol.MsgAction, serverTime, 5, 5, 5, 29)
+
+	ty, payload, ok := readMaybeRaw(t, b)
+	if !ok || ty != protocol.MsgCreateMob {
+		t.Fatalf("B frame 1 = %#x ok=%v, want CreateMob(A)", ty, ok)
+	}
+	if x, y, id := createMobFields(t, payload); id != 1 || x != 5 || y != 29 {
+		t.Fatalf("B sees A = id %d at (%d,%d), want id 1 at (5,29)", id, x, y)
+	}
+	if ty, _, ok = readMaybeRaw(t, b); !ok || ty != protocol.MsgPKInfo {
+		t.Fatalf("B frame 2 = %#x ok=%v, want PKInfo(A)", ty, ok)
+	}
+	if ty, _, ok = readMaybeRaw(t, b); !ok || ty != protocol.MsgAction {
+		t.Fatalf("B frame 3 = %#x ok=%v, want A movement", ty, ok)
+	}
+
+	ty, payload, ok = readMaybeRaw(t, a)
+	if !ok || ty != protocol.MsgCreateMob {
+		t.Fatalf("A frame 1 = %#x ok=%v, want CreateMob(B)", ty, ok)
+	}
+	if x, y, id := createMobFields(t, payload); id != 2 || x != 5 || y != 45 {
+		t.Fatalf("A sees B = id %d at (%d,%d), want id 2 at (5,45)", id, x, y)
+	}
+	if ty, _, ok = readMaybeRaw(t, a); !ok || ty != protocol.MsgPKInfo {
+		t.Fatalf("A frame 2 = %#x ok=%v, want PKInfo(B)", ty, ok)
+	}
+
+	// B then moves through the already-established view. A should get only the
+	// movement frame, not a duplicate CreateMob.
+	actionFrameXY(t, b, protocol.MsgAction, serverTime+1000, 5, 45, 5, 21)
+	if ty, _, ok = readMaybeRaw(t, a); !ok || ty != protocol.MsgAction {
+		t.Fatalf("A crossing frame = %#x ok=%v, want B movement only", ty, ok)
+	}
+	if ty, _, ok = readMaybeRaw(t, a); ok {
+		t.Fatalf("A got extra frame %#x after in-view crossing, want no duplicate", ty)
+	}
+}
+
 // readMaybeHeaderRaw is readMaybeRaw with the full header, for RemoveMob asserts
 // (HEADER.ID is the removed entity).
 func readMaybeHeaderRaw(t *testing.T, c net.Conn) (protocol.Header, []byte, bool) {

--- a/tmserver/internal/protocol/types.go
+++ b/tmserver/internal/protocol/types.go
@@ -6,6 +6,10 @@ package protocol
 // has a single wire value that matches in any context.
 type Type uint16
 
+// MessageLength is MSG_MessageChat.String[MESSAGE_LENGTH] (Basedef.h:189,
+// 1789): mob action chat and normal public chat are a fixed 96-byte C string.
+const MessageLength = 96
+
 // Direction flag bits (protocol-spec.md §2, Basedef.h:1212-1221).
 const (
 	FlagGame2Client Type = 0x0100 // TMSrv → client
@@ -19,6 +23,13 @@ const (
 	// flagMask covers all direction bits; the remaining low bits are the base.
 	flagMask Type = 0xFF00
 )
+
+// EncodeMessageChatBody returns the fixed MSG_MessageChat.String payload.
+func EncodeMessageChatBody(text string) []byte {
+	body := make([]byte, MessageLength)
+	copy(body, text)
+	return body
+}
 
 // Base returns the message base (the wire value with direction flags stripped).
 func (t Type) Base() Type { return t &^ flagMask }

--- a/tmserver/internal/world/generator.go
+++ b/tmserver/internal/world/generator.go
@@ -22,6 +22,8 @@ type Generator struct {
 	LeaderTmpl     []byte // raw 816-byte STRUCT_MOB; nil = generator unusable
 	FollowerTmpl   []byte // nil = leader-only groups ("Follower: 0")
 	CurrentNumMob  int    // live mobs from this block (SpawnMobAt ++ / DespawnMob --)
+	FightAction    [4]string
+	DieAction      [4]string
 }
 
 // generateWorldCap stops the generator timer from filling every entity slot:

--- a/tmserver/internal/world/generator.go
+++ b/tmserver/internal/world/generator.go
@@ -15,6 +15,7 @@ type Generator struct {
 	MaxGroup       int
 	MaxNumMob      int // population cap (leader and followers both count toward it)
 	RouteType      uint8
+	Formation      int
 	SegX, SegY     [5]int16
 	SegRange       [5]int16
 	SegWait        [5]int16
@@ -28,6 +29,18 @@ type Generator struct {
 // blocks) from being starved by drop-on-full. Deliberate divergence — the
 // original's only cap is MAX_MOB itself.
 const generateWorldCap = 20000
+
+// formationOffsets is g_pFormation[5][12][2] (Basedef.cpp:193), interpreted as
+// [formation][follower slot][x/y]. The Server.cpp use site indexes the array in
+// a decompiled-looking order, but NPCGener contains Formation=4 blocks, so the
+// table's first dimension is the only shape that can represent the content.
+var formationOffsets = [5][MaxParty]struct{ x, y int16 }{
+	{{1, 1}, {-1, 1}, {1, -1}, {-1, -1}, {1, 0}, {-1, 0}, {0, 1}, {0, -1}, {2, 0}, {-2, 0}, {0, 2}, {0, -2}},
+	{{1, 0}, {-1, 0}, {2, 0}, {-2, 0}, {3, 0}, {-3, 0}, {4, 0}, {-4, 0}, {5, 0}, {-5, 0}, {0, 6}, {0, -6}},
+	{{1, 1}, {-1, 1}, {1, -1}, {-1, -1}, {1, 0}, {-1, 0}, {0, 1}, {0, -1}, {2, 0}, {-2, 0}, {0, 2}, {0, -2}},
+	{{1, 0}, {-1, 0}, {2, 0}, {-2, 0}, {3, 0}, {-3, 0}, {4, 0}, {-4, 0}, {5, 0}, {-5, 0}, {0, 6}, {0, -6}},
+	{{2, 0}, {0, 2}, {1, 1}, {0, 1}, {1, 0}, {-1, 3}, {3, -1}, {-1, 2}, {2, -1}, {-1, 1}, {1, -1}, {1, 2}},
+}
 
 // RegisterGenerators installs the generator table (index = NPCGener block =
 // Entity.GenIndex). Wiring-time only, before Run.
@@ -132,11 +145,10 @@ func (w *World) GenerateMob(idx int) []int {
 		return ids
 	}
 	for i := 0; i < n && i < MaxParty; i++ {
-		fsp := sp
+		fsp := followerSpawn(sp, g, i)
 		fsp.Template = g.FollowerTmpl
-		// Followers share the leader's randomized waypoints; the per-follower
-		// g_pFormation offsets are deferred with Formation.
-		fx, fy, fok := w.emptyCellNear(baseX, baseY)
+		fbaseX, fbaseY := spawnAnchor(fsp, baseX, baseY)
+		fx, fy, fok := w.emptyCellNear(fbaseX, fbaseY)
 		if !fok {
 			break
 		}
@@ -154,6 +166,39 @@ func (w *World) GenerateMob(idx int) []int {
 		ids = append(ids, fid)
 	}
 	return ids
+}
+
+func spawnAnchor(sp MobSpawn, fallbackX, fallbackY int16) (int16, int16) {
+	if sp.SegX[0] != 0 {
+		return sp.SegX[0], sp.SegY[0]
+	}
+	for i := range sp.SegX {
+		if sp.SegX[i] != 0 {
+			return sp.SegX[i], sp.SegY[i]
+		}
+	}
+	return fallbackX, fallbackY
+}
+
+func followerSpawn(leader MobSpawn, g *Generator, slot int) MobSpawn {
+	sp := leader
+	if g == nil || g.Formation < 0 || g.Formation >= len(formationOffsets) || slot < 0 || slot >= MaxParty {
+		return sp
+	}
+	off := formationOffsets[g.Formation][slot]
+	for i := 0; i < len(sp.SegX); i++ {
+		if sp.SegX[i] == 0 {
+			continue
+		}
+		if g.SegRange[i] != 0 {
+			sp.SegX[i] = leader.SegX[i] + off.x
+			sp.SegY[i] = leader.SegY[i] + off.y
+		} else {
+			sp.SegX[i] = g.SegX[i]
+			sp.SegY[i] = g.SegY[i]
+		}
+	}
+	return sp
 }
 
 // emptyCellNear finds a mob-free grid cell at or around (x,y), scanning the

--- a/tmserver/internal/world/generator_test.go
+++ b/tmserver/internal/world/generator_test.go
@@ -52,14 +52,21 @@ func TestGenerateMobGroup(t *testing.T) {
 	if leader.Leader != 0 || leader.PartyList[0] != ids[1] || leader.PartyList[1] != ids[2] {
 		t.Fatalf("leader links = Leader %d PartyList %v, want 0 / followers %v", leader.Leader, leader.PartyList[:2], ids[1:])
 	}
-	for _, fid := range ids[1:] {
+	wantOffset := []struct{ x, y int16 }{{1, 1}, {-1, 1}}
+	for i, fid := range ids[1:] {
 		fe := w.Entity(fid)
 		if fe.Leader != ids[0] {
 			t.Fatalf("follower %d Leader = %d, want %d", fid, fe.Leader, ids[0])
 		}
-		// Followers share the leader's randomized waypoints.
-		if fe.SegListX != leader.SegListX || fe.SegListY != leader.SegListY {
-			t.Fatalf("follower waypoints %v differ from leader's %v", fe.SegListX, leader.SegListX)
+		if fe.SegListX[0] != leader.SegListX[0]+wantOffset[i].x ||
+			fe.SegListY[0] != leader.SegListY[0]+wantOffset[i].y {
+			t.Fatalf("follower %d start = %d,%d; leader = %d,%d; want offset %+v",
+				i, fe.SegListX[0], fe.SegListY[0], leader.SegListX[0], leader.SegListY[0], wantOffset[i])
+		}
+		// Waypoints without SegmentRange keep the generator's exact coordinate,
+		// matching GenerateMob's follower branch.
+		if fe.SegListX[4] != 30 || fe.SegListY[4] != 20 {
+			t.Fatalf("follower %d dest = %d,%d, want 30,20", i, fe.SegListX[4], fe.SegListY[4])
 		}
 	}
 	// Waypoint 0 randomized within [seg-Range, seg] (the legacy negative bias);
@@ -79,6 +86,50 @@ func TestGenerateMobGroup(t *testing.T) {
 	// Now saturated: no more spawns until deaths bring the count down.
 	if got := len(w.GenerateMob(0)); got != 0 {
 		t.Fatalf("saturated GenerateMob spawned %d, want 0", got)
+	}
+}
+
+func TestGenerateMobFormationFourOffsetsFollowers(t *testing.T) {
+	w := New(Config{GridDim: 64}, slogDiscard(), nil, nil)
+	g := &Generator{
+		MinuteGenerate: 1,
+		MinGroup:       2, MaxGroup: 2,
+		MaxNumMob:    5,
+		RouteType:    6,
+		Formation:    4,
+		SegX:         [5]int16{24, 0, 0, 0, 28},
+		SegY:         [5]int16{24, 0, 0, 0, 24},
+		SegRange:     [5]int16{1, 0, 0, 0, 1},
+		LeaderTmpl:   genMobTemplate(5),
+		FollowerTmpl: genMobTemplate(5),
+	}
+	w.RegisterGenerators([]*Generator{g})
+
+	ids := w.GenerateMob(0)
+	if len(ids) != 3 {
+		t.Fatalf("GenerateMob spawned %d mobs, want 3", len(ids))
+	}
+	leader := w.Entity(ids[0])
+	tests := []struct {
+		id int
+		x  int16
+		y  int16
+	}{
+		{ids[1], 2, 0},
+		{ids[2], 0, 2},
+	}
+	for _, tt := range tests {
+		follower := w.Entity(tt.id)
+		if follower.SegListX[0] != leader.SegListX[0]+tt.x ||
+			follower.SegListY[0] != leader.SegListY[0]+tt.y {
+			t.Fatalf("follower %d start = %d,%d; leader = %d,%d; want offset %d,%d",
+				tt.id, follower.SegListX[0], follower.SegListY[0], leader.SegListX[0], leader.SegListY[0], tt.x, tt.y)
+		}
+		if follower.SegListX[4] != leader.SegListX[4]+tt.x ||
+			follower.SegListY[4] != leader.SegListY[4]+tt.y {
+			t.Fatalf("follower %d dest = %d,%d; leader = %d,%d; want offset %d,%d",
+				tt.id, follower.SegListX[4], follower.SegListY[4], leader.SegListX[4], leader.SegListY[4], tt.x, tt.y)
+		}
 	}
 }
 

--- a/tmserver/internal/world/session.go
+++ b/tmserver/internal/world/session.go
@@ -95,13 +95,15 @@ type Entity struct {
 	Exp      int64 // STRUCT_MOB.Exp: players accumulate it; for a mob it's the kill reward
 	Coin     int32 // carried gold
 
-	// Mob AI (mobai.go; only meaningful for monsters). Target is the current
-	// combat target's conn (0 = none); AtkTick is the mob's last-attack server
-	// time (cadence); SpawnX/SpawnY is the position the mob (re)spawned at.
-	// Range is the mob's attack reach — the max EF_RANGE over its template's
-	// equips (BASE_GetMobAbility, Basedef.cpp:2415), cached at spawn; 0 means
-	// no ranged gear (the AI falls back to melee adjacency).
+	// Mob AI (mobai.go; only meaningful for monsters). EnemyList is the legacy
+	// CMob.EnemyList[MAX_ENEMY=13]; Target is the currently selected entry
+	// (0 = none). AtkTick is the mob's last-attack server time (cadence);
+	// SpawnX/SpawnY is the position the mob (re)spawned at. Range is the mob's
+	// attack reach — the max EF_RANGE over its template's equips
+	// (BASE_GetMobAbility, Basedef.cpp:2415), cached at spawn; 0 means no ranged
+	// gear (the AI falls back to melee adjacency).
 	Target         int
+	EnemyList      [protocol.MaxTarget]int
 	AtkTick        uint32
 	SpawnX, SpawnY int16
 	Range          int16

--- a/tmserver/internal/world/tick.go
+++ b/tmserver/internal/world/tick.go
@@ -70,8 +70,8 @@ func (w *World) ForEachPlayer(fn func(s *Session, e *Entity)) {
 	}
 }
 
-// FindEnemyFromView returns the id of the first in-play, living player around
-// (x,y) that clan treats as hostile (g_pClanTable), or 0 if none. It ports
+// FindEnemyFromView returns the id of the first living entity around (x,y) that
+// clan treats as hostile (g_pClanTable), or 0 if none. It ports
 // GetEnemyFromView (CMob.cpp:1308-1358) exactly:
 //   - window [x-4, x+5) × [y-4, y+5) (StartX = TargetX-4, Size 9);
 //   - clans 7/8 scan [x-6, x+10) — start −6 with HALFGRIDX=16 width, an
@@ -81,8 +81,10 @@ func (w *World) ForEachPlayer(fn func(s *Session, e *Entity)) {
 //     invisible to aggro (CMob.cpp:1342);
 //   - an out-of-range clan aborts the whole scan (CMob.cpp:1345-1350).
 //
-// Divergence: the original also returns hostile MOBS (mob-vs-mob combat, e.g.
-// town guards); we only acquire players for now — deferred. Loop-only.
+// Summons stay out of spontaneous acquisition so the owner-assist/retaliation
+// flow remains the only pet-vs-mob entry point.
+//
+// Loop-only.
 func (w *World) FindEnemyFromView(x, y int16, clan uint8) int {
 	startX, startY, sizeX, sizeY := int(x)-4, int(y)-4, 9, 9
 	if clan == 7 || clan == 8 {
@@ -94,14 +96,23 @@ func (w *World) FindEnemyFromView(x, y int16, clan uint8) int {
 				continue
 			}
 			id, ok := w.grid.MobAt(gx, gy)
-			if !ok || int(id) >= MaxUser {
-				continue // empty/out-of-bounds cell, or a mob (mob-vs-mob deferred)
+			if !ok {
+				continue // empty/out-of-bounds cell
 			}
 			e := w.entities[id]
-			if e == nil || e.Mode != MobUser || e.HP <= 0 {
+			if e == nil || e.Mode == MobEmpty || e.HP <= 0 {
 				continue
 			}
-			if e.Rsv&RsvHide != 0 {
+			if int(id) < MaxUser && e.Mode != MobUser {
+				continue
+			}
+			if int(id) >= MaxUser && e.Merchant != 0 {
+				continue // shop/bank/quest NPCs are not combat targets
+			}
+			if int(id) >= MaxUser && e.Summoner != 0 {
+				continue // summons use the owner-assist path, not ambient aggro
+			}
+			if int(id) < MaxUser && e.Rsv&RsvHide != 0 {
 				continue // hidden players don't draw aggro (CMob.cpp:1342 Rsv & 0x10)
 			}
 			if clan >= 9 || e.Clan >= 9 {
@@ -112,7 +123,7 @@ func (w *World) FindEnemyFromView(x, y int16, clan uint8) int {
 				w.log.Debug("clan out of range in aggro scan", "clan", clan, "target_clan", e.Clan)
 				return 0
 			}
-			if clanTable[clan][e.Clan] == 0 {
+			if ClanHostile(clan, e.Clan) {
 				return int(id)
 			}
 		}

--- a/tmserver/internal/world/tick_test.go
+++ b/tmserver/internal/world/tick_test.go
@@ -82,6 +82,20 @@ func TestMobAISeams(t *testing.T) {
 		t.Errorf("FindEnemyFromView clan 7 at dx=+9 = %d, want player %d", got, pconn)
 	}
 	w.entities[pconn].Clan = 0
+	w.entities[pconn].HP = 0 // keep the player from winning the mob-vs-mob scans below
+
+	hostile := w.SpawnMob(genMobTemplate(5), 20, 20)
+	if got := w.FindEnemyFromView(18, 20, 7); got != hostile {
+		t.Errorf("FindEnemyFromView hostile mob = %d, want mob %d", got, hostile)
+	}
+	w.SpawnMob(genMobTemplate(2), 30, 30)
+	if got := w.FindEnemyFromView(28, 30, 7); got != 0 {
+		t.Errorf("FindEnemyFromView friendly mob = %d, want 0", got)
+	}
+	w.SpawnMob(genMerchantTemplate(100), 34, 34)
+	if got := w.FindEnemyFromView(32, 34, 5); got != 0 {
+		t.Errorf("FindEnemyFromView merchant NPC = %d, want 0", got)
+	}
 
 	// EntityAt reflects the grid.
 	if id, ok := w.EntityAt(12, 11); !ok || id != near {

--- a/tmserver/internal/world/world.go
+++ b/tmserver/internal/world/world.go
@@ -31,6 +31,10 @@ const (
 	MaxParty       = 12   // party members (MAX_PARTY)
 	DefaultGridDim = 4096
 
+	// KefraBossGenIndex is KEFRA_BOSS (Basedef.h:475), the NPCGener block with
+	// special fixed-range / fixed-position combat rules in CMob.cpp.
+	KefraBossGenIndex = 396
+
 	// GroundItemIDOffset is added to a ground item's index on the wire
 	// (_MSG_GetItem decodes ItemID-10000; handlers/_MSG_GetItem.md).
 	GroundItemIDOffset = 10000


### PR DESCRIPTION
## Resumo
- Fecha os deferidos da issue #121 para IA de mob: guardas mob-vs-mob, EnemyList, Formation, KEFRA_BOSS, FightAction/DieAction, templates ausentes, RT3 e reveal de players cruzando visão.
- Mantém as regras dentro do loop único do mundo e preserva pontos de paridade de RNG onde novos rolls foram introduzidos.
- Adiciona regressões focadas para alvo de mob, formação, chat de mob, boss Kefra, RT3, templates ausentes e visibilidade entre players.

## Validação
- make test

Closes #121