### PR TITLE
feat(gm): comandos de GM/moderação in-game (issue #122)

### DIFF
--- a/api/db/v1/db.pb.go
+++ b/api/db/v1/db.pb.go
@@ -148,9 +148,14 @@ func (x *AccountLoginRequest) GetClientVersion() int32 {
 }
 
 type AccountLoginResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Result        LoginResult            `protobuf:"varint,1,opt,name=result,proto3,enum=db.v1.LoginResult" json:"result,omitempty"`
-	AccountId     int64                  `protobuf:"varint,2,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Result    LoginResult            `protobuf:"varint,1,opt,name=result,proto3,enum=db.v1.LoginResult" json:"result,omitempty"`
+	AccountId int64                  `protobuf:"varint,2,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
+	// role is account.role ('player'/'moderator'/'admin'). It is carried to the
+	// tmServer so the game loop can gate in-game GM/moderation commands (issue
+	// #122) — the explicit server-side authority that replaces the legacy fragile
+	// "character Level >= 1000" backdoor.
+	Role          string `protobuf:"bytes,3,opt,name=role,proto3" json:"role,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -197,6 +202,13 @@ func (x *AccountLoginResponse) GetAccountId() int64 {
 		return x.AccountId
 	}
 	return 0
+}
+
+func (x *AccountLoginResponse) GetRole() string {
+	if x != nil {
+		return x.Role
+	}
+	return ""
 }
 
 type ListCharactersRequest struct {
@@ -1877,6 +1889,103 @@ func (x *SaveCargoWithDeliveriesRequest) GetLostIds() []int64 {
 	return nil
 }
 
+type SetAccountBlockedRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	AccountName   string                 `protobuf:"bytes,1,opt,name=account_name,json=accountName,proto3" json:"account_name,omitempty"` // canonical lowercase
+	Blocked       bool                   `protobuf:"varint,2,opt,name=blocked,proto3" json:"blocked,omitempty"`                           // true = ban, false = unban
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetAccountBlockedRequest) Reset() {
+	*x = SetAccountBlockedRequest{}
+	mi := &file_api_db_v1_db_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetAccountBlockedRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetAccountBlockedRequest) ProtoMessage() {}
+
+func (x *SetAccountBlockedRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_db_v1_db_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetAccountBlockedRequest.ProtoReflect.Descriptor instead.
+func (*SetAccountBlockedRequest) Descriptor() ([]byte, []int) {
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *SetAccountBlockedRequest) GetAccountName() string {
+	if x != nil {
+		return x.AccountName
+	}
+	return ""
+}
+
+func (x *SetAccountBlockedRequest) GetBlocked() bool {
+	if x != nil {
+		return x.Blocked
+	}
+	return false
+}
+
+// ok is false when no account matched the name (nothing changed).
+type SetAccountBlockedResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Ok            bool                   `protobuf:"varint,1,opt,name=ok,proto3" json:"ok,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetAccountBlockedResponse) Reset() {
+	*x = SetAccountBlockedResponse{}
+	mi := &file_api_db_v1_db_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetAccountBlockedResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetAccountBlockedResponse) ProtoMessage() {}
+
+func (x *SetAccountBlockedResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_db_v1_db_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetAccountBlockedResponse.ProtoReflect.Descriptor instead.
+func (*SetAccountBlockedResponse) Descriptor() ([]byte, []int) {
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *SetAccountBlockedResponse) GetOk() bool {
+	if x != nil {
+		return x.Ok
+	}
+	return false
+}
+
 type NpcConfigVersionRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -1885,7 +1994,7 @@ type NpcConfigVersionRequest struct {
 
 func (x *NpcConfigVersionRequest) Reset() {
 	*x = NpcConfigVersionRequest{}
-	mi := &file_api_db_v1_db_proto_msgTypes[26]
+	mi := &file_api_db_v1_db_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1897,7 +2006,7 @@ func (x *NpcConfigVersionRequest) String() string {
 func (*NpcConfigVersionRequest) ProtoMessage() {}
 
 func (x *NpcConfigVersionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_db_v1_db_proto_msgTypes[26]
+	mi := &file_api_db_v1_db_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1910,7 +2019,7 @@ func (x *NpcConfigVersionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NpcConfigVersionRequest.ProtoReflect.Descriptor instead.
 func (*NpcConfigVersionRequest) Descriptor() ([]byte, []int) {
-	return file_api_db_v1_db_proto_rawDescGZIP(), []int{26}
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{28}
 }
 
 type NpcConfigVersionResponse struct {
@@ -1922,7 +2031,7 @@ type NpcConfigVersionResponse struct {
 
 func (x *NpcConfigVersionResponse) Reset() {
 	*x = NpcConfigVersionResponse{}
-	mi := &file_api_db_v1_db_proto_msgTypes[27]
+	mi := &file_api_db_v1_db_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1934,7 +2043,7 @@ func (x *NpcConfigVersionResponse) String() string {
 func (*NpcConfigVersionResponse) ProtoMessage() {}
 
 func (x *NpcConfigVersionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_db_v1_db_proto_msgTypes[27]
+	mi := &file_api_db_v1_db_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1947,7 +2056,7 @@ func (x *NpcConfigVersionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NpcConfigVersionResponse.ProtoReflect.Descriptor instead.
 func (*NpcConfigVersionResponse) Descriptor() ([]byte, []int) {
-	return file_api_db_v1_db_proto_rawDescGZIP(), []int{27}
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *NpcConfigVersionResponse) GetVersion() int64 {
@@ -1965,7 +2074,7 @@ type ListNpcDefinitionsRequest struct {
 
 func (x *ListNpcDefinitionsRequest) Reset() {
 	*x = ListNpcDefinitionsRequest{}
-	mi := &file_api_db_v1_db_proto_msgTypes[28]
+	mi := &file_api_db_v1_db_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1977,7 +2086,7 @@ func (x *ListNpcDefinitionsRequest) String() string {
 func (*ListNpcDefinitionsRequest) ProtoMessage() {}
 
 func (x *ListNpcDefinitionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_db_v1_db_proto_msgTypes[28]
+	mi := &file_api_db_v1_db_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1990,7 +2099,7 @@ func (x *ListNpcDefinitionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNpcDefinitionsRequest.ProtoReflect.Descriptor instead.
 func (*ListNpcDefinitionsRequest) Descriptor() ([]byte, []int) {
-	return file_api_db_v1_db_proto_rawDescGZIP(), []int{28}
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{30}
 }
 
 type ListNpcDefinitionsResponse struct {
@@ -2004,7 +2113,7 @@ type ListNpcDefinitionsResponse struct {
 
 func (x *ListNpcDefinitionsResponse) Reset() {
 	*x = ListNpcDefinitionsResponse{}
-	mi := &file_api_db_v1_db_proto_msgTypes[29]
+	mi := &file_api_db_v1_db_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2016,7 +2125,7 @@ func (x *ListNpcDefinitionsResponse) String() string {
 func (*ListNpcDefinitionsResponse) ProtoMessage() {}
 
 func (x *ListNpcDefinitionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_db_v1_db_proto_msgTypes[29]
+	mi := &file_api_db_v1_db_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2029,7 +2138,7 @@ func (x *ListNpcDefinitionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNpcDefinitionsResponse.ProtoReflect.Descriptor instead.
 func (*ListNpcDefinitionsResponse) Descriptor() ([]byte, []int) {
-	return file_api_db_v1_db_proto_rawDescGZIP(), []int{29}
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ListNpcDefinitionsResponse) GetVersion() int64 {
@@ -2074,7 +2183,7 @@ type NpcShopItem struct {
 
 func (x *NpcShopItem) Reset() {
 	*x = NpcShopItem{}
-	mi := &file_api_db_v1_db_proto_msgTypes[30]
+	mi := &file_api_db_v1_db_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2086,7 +2195,7 @@ func (x *NpcShopItem) String() string {
 func (*NpcShopItem) ProtoMessage() {}
 
 func (x *NpcShopItem) ProtoReflect() protoreflect.Message {
-	mi := &file_api_db_v1_db_proto_msgTypes[30]
+	mi := &file_api_db_v1_db_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2099,7 +2208,7 @@ func (x *NpcShopItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NpcShopItem.ProtoReflect.Descriptor instead.
 func (*NpcShopItem) Descriptor() ([]byte, []int) {
-	return file_api_db_v1_db_proto_rawDescGZIP(), []int{30}
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *NpcShopItem) GetSlot() int32 {
@@ -2184,7 +2293,7 @@ type NpcDefinition struct {
 
 func (x *NpcDefinition) Reset() {
 	*x = NpcDefinition{}
-	mi := &file_api_db_v1_db_proto_msgTypes[31]
+	mi := &file_api_db_v1_db_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2196,7 +2305,7 @@ func (x *NpcDefinition) String() string {
 func (*NpcDefinition) ProtoMessage() {}
 
 func (x *NpcDefinition) ProtoReflect() protoreflect.Message {
-	mi := &file_api_db_v1_db_proto_msgTypes[31]
+	mi := &file_api_db_v1_db_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2209,7 +2318,7 @@ func (x *NpcDefinition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NpcDefinition.ProtoReflect.Descriptor instead.
 func (*NpcDefinition) Descriptor() ([]byte, []int) {
-	return file_api_db_v1_db_proto_rawDescGZIP(), []int{31}
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *NpcDefinition) GetId() int64 {
@@ -2299,7 +2408,7 @@ type ItemPrice struct {
 
 func (x *ItemPrice) Reset() {
 	*x = ItemPrice{}
-	mi := &file_api_db_v1_db_proto_msgTypes[32]
+	mi := &file_api_db_v1_db_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2311,7 +2420,7 @@ func (x *ItemPrice) String() string {
 func (*ItemPrice) ProtoMessage() {}
 
 func (x *ItemPrice) ProtoReflect() protoreflect.Message {
-	mi := &file_api_db_v1_db_proto_msgTypes[32]
+	mi := &file_api_db_v1_db_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2324,7 +2433,7 @@ func (x *ItemPrice) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ItemPrice.ProtoReflect.Descriptor instead.
 func (*ItemPrice) Descriptor() ([]byte, []int) {
-	return file_api_db_v1_db_proto_rawDescGZIP(), []int{32}
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ItemPrice) GetItemIndex() int32 {
@@ -2349,11 +2458,12 @@ const file_api_db_v1_db_proto_rawDesc = "" +
 	"\x13AccountLoginRequest\x12!\n" +
 	"\faccount_name\x18\x01 \x01(\tR\vaccountName\x12\x1a\n" +
 	"\bpassword\x18\x02 \x01(\tR\bpassword\x12%\n" +
-	"\x0eclient_version\x18\x03 \x01(\x05R\rclientVersion\"a\n" +
+	"\x0eclient_version\x18\x03 \x01(\x05R\rclientVersion\"u\n" +
 	"\x14AccountLoginResponse\x12*\n" +
 	"\x06result\x18\x01 \x01(\x0e2\x12.db.v1.LoginResultR\x06result\x12\x1d\n" +
 	"\n" +
-	"account_id\x18\x02 \x01(\x03R\taccountId\"6\n" +
+	"account_id\x18\x02 \x01(\x03R\taccountId\x12\x12\n" +
+	"\x04role\x18\x03 \x01(\tR\x04role\"6\n" +
 	"\x15ListCharactersRequest\x12\x1d\n" +
 	"\n" +
 	"account_id\x18\x01 \x01(\x03R\taccountId\"\xbd\x02\n" +
@@ -2501,7 +2611,12 @@ const file_api_db_v1_db_proto_rawDesc = "" +
 	"cargo_coin\x18\x02 \x01(\x05R\tcargoCoin\x12!\n" +
 	"\x05items\x18\x03 \x03(\v2\v.db.v1.ItemR\x05items\x12#\n" +
 	"\rdelivered_ids\x18\x04 \x03(\x03R\fdeliveredIds\x12\x19\n" +
-	"\blost_ids\x18\x05 \x03(\x03R\alostIds\"\x19\n" +
+	"\blost_ids\x18\x05 \x03(\x03R\alostIds\"W\n" +
+	"\x18SetAccountBlockedRequest\x12!\n" +
+	"\faccount_name\x18\x01 \x01(\tR\vaccountName\x12\x18\n" +
+	"\ablocked\x18\x02 \x01(\bR\ablocked\"+\n" +
+	"\x19SetAccountBlockedResponse\x12\x0e\n" +
+	"\x02ok\x18\x01 \x01(\bR\x02ok\"\x19\n" +
 	"\x17NpcConfigVersionRequest\"4\n" +
 	"\x18NpcConfigVersionResponse\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\x03R\aversion\"\x1b\n" +
@@ -2545,7 +2660,7 @@ const file_api_db_v1_db_proto_rawDesc = "" +
 	"\x17LOGIN_RESULT_NO_ACCOUNT\x10\x02\x12\x1d\n" +
 	"\x19LOGIN_RESULT_BAD_PASSWORD\x10\x03\x12\x18\n" +
 	"\x14LOGIN_RESULT_BLOCKED\x10\x04\x12 \n" +
-	"\x1cLOGIN_RESULT_ALREADY_PLAYING\x10\x052\x82\a\n" +
+	"\x1cLOGIN_RESULT_ALREADY_PLAYING\x10\x052\xda\a\n" +
 	"\x0eAccountService\x12G\n" +
 	"\fAccountLogin\x12\x1a.db.v1.AccountLoginRequest\x1a\x1b.db.v1.AccountLoginResponse\x12M\n" +
 	"\x0eListCharacters\x12\x1c.db.v1.ListCharactersRequest\x1a\x1d.db.v1.ListCharactersResponse\x12J\n" +
@@ -2557,7 +2672,8 @@ const file_api_db_v1_db_proto_rawDesc = "" +
 	"\tLoadCargo\x12\x17.db.v1.LoadCargoRequest\x1a\x18.db.v1.LoadCargoResponse\x12>\n" +
 	"\tSaveCargo\x12\x17.db.v1.SaveCargoRequest\x1a\x18.db.v1.SaveCargoResponse\x12b\n" +
 	"\x15ListPendingDeliveries\x12#.db.v1.ListPendingDeliveriesRequest\x1a$.db.v1.ListPendingDeliveriesResponse\x12Z\n" +
-	"\x17SaveCargoWithDeliveries\x12%.db.v1.SaveCargoWithDeliveriesRequest\x1a\x18.db.v1.SaveCargoResponse2\xc2\x01\n" +
+	"\x17SaveCargoWithDeliveries\x12%.db.v1.SaveCargoWithDeliveriesRequest\x1a\x18.db.v1.SaveCargoResponse\x12V\n" +
+	"\x11SetAccountBlocked\x12\x1f.db.v1.SetAccountBlockedRequest\x1a .db.v1.SetAccountBlockedResponse2\xc2\x01\n" +
 	"\x10NpcConfigService\x12S\n" +
 	"\x10NpcConfigVersion\x12\x1e.db.v1.NpcConfigVersionRequest\x1a\x1f.db.v1.NpcConfigVersionResponse\x12Y\n" +
 	"\x12ListNpcDefinitions\x12 .db.v1.ListNpcDefinitionsRequest\x1a!.db.v1.ListNpcDefinitionsResponseB1Z/github.com/jeanluca/w2pp-openwyd/api/db/v1;dbv1b\x06proto3"
@@ -2575,7 +2691,7 @@ func file_api_db_v1_db_proto_rawDescGZIP() []byte {
 }
 
 var file_api_db_v1_db_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_api_db_v1_db_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_api_db_v1_db_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_api_db_v1_db_proto_goTypes = []any{
 	(LoginResult)(0),                       // 0: db.v1.LoginResult
 	(*AccountLoginRequest)(nil),            // 1: db.v1.AccountLoginRequest
@@ -2604,13 +2720,15 @@ var file_api_db_v1_db_proto_goTypes = []any{
 	(*ListPendingDeliveriesRequest)(nil),   // 24: db.v1.ListPendingDeliveriesRequest
 	(*ListPendingDeliveriesResponse)(nil),  // 25: db.v1.ListPendingDeliveriesResponse
 	(*SaveCargoWithDeliveriesRequest)(nil), // 26: db.v1.SaveCargoWithDeliveriesRequest
-	(*NpcConfigVersionRequest)(nil),        // 27: db.v1.NpcConfigVersionRequest
-	(*NpcConfigVersionResponse)(nil),       // 28: db.v1.NpcConfigVersionResponse
-	(*ListNpcDefinitionsRequest)(nil),      // 29: db.v1.ListNpcDefinitionsRequest
-	(*ListNpcDefinitionsResponse)(nil),     // 30: db.v1.ListNpcDefinitionsResponse
-	(*NpcShopItem)(nil),                    // 31: db.v1.NpcShopItem
-	(*NpcDefinition)(nil),                  // 32: db.v1.NpcDefinition
-	(*ItemPrice)(nil),                      // 33: db.v1.ItemPrice
+	(*SetAccountBlockedRequest)(nil),       // 27: db.v1.SetAccountBlockedRequest
+	(*SetAccountBlockedResponse)(nil),      // 28: db.v1.SetAccountBlockedResponse
+	(*NpcConfigVersionRequest)(nil),        // 29: db.v1.NpcConfigVersionRequest
+	(*NpcConfigVersionResponse)(nil),       // 30: db.v1.NpcConfigVersionResponse
+	(*ListNpcDefinitionsRequest)(nil),      // 31: db.v1.ListNpcDefinitionsRequest
+	(*ListNpcDefinitionsResponse)(nil),     // 32: db.v1.ListNpcDefinitionsResponse
+	(*NpcShopItem)(nil),                    // 33: db.v1.NpcShopItem
+	(*NpcDefinition)(nil),                  // 34: db.v1.NpcDefinition
+	(*ItemPrice)(nil),                      // 35: db.v1.ItemPrice
 }
 var file_api_db_v1_db_proto_depIdxs = []int32{
 	0,  // 0: db.v1.AccountLoginResponse.result:type_name -> db.v1.LoginResult
@@ -2625,9 +2743,9 @@ var file_api_db_v1_db_proto_depIdxs = []int32{
 	8,  // 9: db.v1.Delivery.item:type_name -> db.v1.Item
 	23, // 10: db.v1.ListPendingDeliveriesResponse.deliveries:type_name -> db.v1.Delivery
 	8,  // 11: db.v1.SaveCargoWithDeliveriesRequest.items:type_name -> db.v1.Item
-	32, // 12: db.v1.ListNpcDefinitionsResponse.definitions:type_name -> db.v1.NpcDefinition
-	33, // 13: db.v1.ListNpcDefinitionsResponse.price_overrides:type_name -> db.v1.ItemPrice
-	31, // 14: db.v1.NpcDefinition.shop:type_name -> db.v1.NpcShopItem
+	34, // 12: db.v1.ListNpcDefinitionsResponse.definitions:type_name -> db.v1.NpcDefinition
+	35, // 13: db.v1.ListNpcDefinitionsResponse.price_overrides:type_name -> db.v1.ItemPrice
+	33, // 14: db.v1.NpcDefinition.shop:type_name -> db.v1.NpcShopItem
 	1,  // 15: db.v1.AccountService.AccountLogin:input_type -> db.v1.AccountLoginRequest
 	3,  // 16: db.v1.AccountService.ListCharacters:input_type -> db.v1.ListCharactersRequest
 	6,  // 17: db.v1.AccountService.LoadCharacter:input_type -> db.v1.LoadCharacterRequest
@@ -2639,23 +2757,25 @@ var file_api_db_v1_db_proto_depIdxs = []int32{
 	21, // 23: db.v1.AccountService.SaveCargo:input_type -> db.v1.SaveCargoRequest
 	24, // 24: db.v1.AccountService.ListPendingDeliveries:input_type -> db.v1.ListPendingDeliveriesRequest
 	26, // 25: db.v1.AccountService.SaveCargoWithDeliveries:input_type -> db.v1.SaveCargoWithDeliveriesRequest
-	27, // 26: db.v1.NpcConfigService.NpcConfigVersion:input_type -> db.v1.NpcConfigVersionRequest
-	29, // 27: db.v1.NpcConfigService.ListNpcDefinitions:input_type -> db.v1.ListNpcDefinitionsRequest
-	2,  // 28: db.v1.AccountService.AccountLogin:output_type -> db.v1.AccountLoginResponse
-	5,  // 29: db.v1.AccountService.ListCharacters:output_type -> db.v1.ListCharactersResponse
-	10, // 30: db.v1.AccountService.LoadCharacter:output_type -> db.v1.LoadCharacterResponse
-	12, // 31: db.v1.AccountService.SaveCharacter:output_type -> db.v1.SaveCharacterResponse
-	14, // 32: db.v1.AccountService.CreateCharacter:output_type -> db.v1.CreateCharacterResponse
-	16, // 33: db.v1.AccountService.CreateArchCharacter:output_type -> db.v1.CreateArchCharacterResponse
-	18, // 34: db.v1.AccountService.DeleteCharacter:output_type -> db.v1.DeleteCharacterResponse
-	20, // 35: db.v1.AccountService.LoadCargo:output_type -> db.v1.LoadCargoResponse
-	22, // 36: db.v1.AccountService.SaveCargo:output_type -> db.v1.SaveCargoResponse
-	25, // 37: db.v1.AccountService.ListPendingDeliveries:output_type -> db.v1.ListPendingDeliveriesResponse
-	22, // 38: db.v1.AccountService.SaveCargoWithDeliveries:output_type -> db.v1.SaveCargoResponse
-	28, // 39: db.v1.NpcConfigService.NpcConfigVersion:output_type -> db.v1.NpcConfigVersionResponse
-	30, // 40: db.v1.NpcConfigService.ListNpcDefinitions:output_type -> db.v1.ListNpcDefinitionsResponse
-	28, // [28:41] is the sub-list for method output_type
-	15, // [15:28] is the sub-list for method input_type
+	27, // 26: db.v1.AccountService.SetAccountBlocked:input_type -> db.v1.SetAccountBlockedRequest
+	29, // 27: db.v1.NpcConfigService.NpcConfigVersion:input_type -> db.v1.NpcConfigVersionRequest
+	31, // 28: db.v1.NpcConfigService.ListNpcDefinitions:input_type -> db.v1.ListNpcDefinitionsRequest
+	2,  // 29: db.v1.AccountService.AccountLogin:output_type -> db.v1.AccountLoginResponse
+	5,  // 30: db.v1.AccountService.ListCharacters:output_type -> db.v1.ListCharactersResponse
+	10, // 31: db.v1.AccountService.LoadCharacter:output_type -> db.v1.LoadCharacterResponse
+	12, // 32: db.v1.AccountService.SaveCharacter:output_type -> db.v1.SaveCharacterResponse
+	14, // 33: db.v1.AccountService.CreateCharacter:output_type -> db.v1.CreateCharacterResponse
+	16, // 34: db.v1.AccountService.CreateArchCharacter:output_type -> db.v1.CreateArchCharacterResponse
+	18, // 35: db.v1.AccountService.DeleteCharacter:output_type -> db.v1.DeleteCharacterResponse
+	20, // 36: db.v1.AccountService.LoadCargo:output_type -> db.v1.LoadCargoResponse
+	22, // 37: db.v1.AccountService.SaveCargo:output_type -> db.v1.SaveCargoResponse
+	25, // 38: db.v1.AccountService.ListPendingDeliveries:output_type -> db.v1.ListPendingDeliveriesResponse
+	22, // 39: db.v1.AccountService.SaveCargoWithDeliveries:output_type -> db.v1.SaveCargoResponse
+	28, // 40: db.v1.AccountService.SetAccountBlocked:output_type -> db.v1.SetAccountBlockedResponse
+	30, // 41: db.v1.NpcConfigService.NpcConfigVersion:output_type -> db.v1.NpcConfigVersionResponse
+	32, // 42: db.v1.NpcConfigService.ListNpcDefinitions:output_type -> db.v1.ListNpcDefinitionsResponse
+	29, // [29:43] is the sub-list for method output_type
+	15, // [15:29] is the sub-list for method input_type
 	15, // [15:15] is the sub-list for extension type_name
 	15, // [15:15] is the sub-list for extension extendee
 	0,  // [0:15] is the sub-list for field type_name
@@ -2672,7 +2792,7 @@ func file_api_db_v1_db_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_db_v1_db_proto_rawDesc), len(file_api_db_v1_db_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   33,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/api/db/v1/db.proto
+++ b/api/db/v1/db.proto
@@ -42,6 +42,12 @@ service AccountService {
   // marks the drained mailbox rows delivered/lost in the SAME transaction — the
   // anti-dup boundary for the drain (web-platform-plan.md §mailbox).
   rpc SaveCargoWithDeliveries(SaveCargoWithDeliveriesRequest) returns (SaveCargoResponse);
+  // SetAccountBlocked flips account.is_blocked by account name — the write side of
+  // the in-game GM ban/unban command (issue #122). Login already rejects blocked
+  // accounts (LOGIN_RESULT_BLOCKED), so a ban denies re-login immediately and an
+  // unban restores it. Administrative-ban ownership may later move to binServer
+  // entitlement (web-platform-plan.md §binServer); until then this is the gate.
+  rpc SetAccountBlocked(SetAccountBlockedRequest) returns (SetAccountBlockedResponse);
 }
 
 enum LoginResult {
@@ -62,6 +68,11 @@ message AccountLoginRequest {
 message AccountLoginResponse {
   LoginResult result = 1;
   int64 account_id = 2;
+  // role is account.role ('player'/'moderator'/'admin'). It is carried to the
+  // tmServer so the game loop can gate in-game GM/moderation commands (issue
+  // #122) — the explicit server-side authority that replaces the legacy fragile
+  // "character Level >= 1000" backdoor.
+  string role = 3;
 }
 
 message ListCharactersRequest { int64 account_id = 1; }
@@ -223,6 +234,13 @@ message SaveCargoWithDeliveriesRequest {
   repeated int64 delivered_ids = 4; // rows applied to the cargo
   repeated int64 lost_ids = 5;      // rows dropped (cargo was full)
 }
+
+message SetAccountBlockedRequest {
+  string account_name = 1; // canonical lowercase
+  bool blocked = 2;        // true = ban, false = unban
+}
+// ok is false when no account matched the name (nothing changed).
+message SetAccountBlockedResponse { bool ok = 1; }
 
 // NpcConfigService serves the moderator-editable NPC configuration to tmServer
 // (npc-editing-plan.md). It is READ-ONLY from tmServer's side: the web-api writes

--- a/api/db/v1/db_grpc.pb.go
+++ b/api/db/v1/db_grpc.pb.go
@@ -38,6 +38,7 @@ const (
 	AccountService_SaveCargo_FullMethodName               = "/db.v1.AccountService/SaveCargo"
 	AccountService_ListPendingDeliveries_FullMethodName   = "/db.v1.AccountService/ListPendingDeliveries"
 	AccountService_SaveCargoWithDeliveries_FullMethodName = "/db.v1.AccountService/SaveCargoWithDeliveries"
+	AccountService_SetAccountBlocked_FullMethodName       = "/db.v1.AccountService/SetAccountBlocked"
 )
 
 // AccountServiceClient is the client API for AccountService service.
@@ -75,6 +76,12 @@ type AccountServiceClient interface {
 	// marks the drained mailbox rows delivered/lost in the SAME transaction — the
 	// anti-dup boundary for the drain (web-platform-plan.md §mailbox).
 	SaveCargoWithDeliveries(ctx context.Context, in *SaveCargoWithDeliveriesRequest, opts ...grpc.CallOption) (*SaveCargoResponse, error)
+	// SetAccountBlocked flips account.is_blocked by account name — the write side of
+	// the in-game GM ban/unban command (issue #122). Login already rejects blocked
+	// accounts (LOGIN_RESULT_BLOCKED), so a ban denies re-login immediately and an
+	// unban restores it. Administrative-ban ownership may later move to binServer
+	// entitlement (web-platform-plan.md §binServer); until then this is the gate.
+	SetAccountBlocked(ctx context.Context, in *SetAccountBlockedRequest, opts ...grpc.CallOption) (*SetAccountBlockedResponse, error)
 }
 
 type accountServiceClient struct {
@@ -195,6 +202,16 @@ func (c *accountServiceClient) SaveCargoWithDeliveries(ctx context.Context, in *
 	return out, nil
 }
 
+func (c *accountServiceClient) SetAccountBlocked(ctx context.Context, in *SetAccountBlockedRequest, opts ...grpc.CallOption) (*SetAccountBlockedResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SetAccountBlockedResponse)
+	err := c.cc.Invoke(ctx, AccountService_SetAccountBlocked_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // AccountServiceServer is the server API for AccountService service.
 // All implementations must embed UnimplementedAccountServiceServer
 // for forward compatibility.
@@ -230,6 +247,12 @@ type AccountServiceServer interface {
 	// marks the drained mailbox rows delivered/lost in the SAME transaction — the
 	// anti-dup boundary for the drain (web-platform-plan.md §mailbox).
 	SaveCargoWithDeliveries(context.Context, *SaveCargoWithDeliveriesRequest) (*SaveCargoResponse, error)
+	// SetAccountBlocked flips account.is_blocked by account name — the write side of
+	// the in-game GM ban/unban command (issue #122). Login already rejects blocked
+	// accounts (LOGIN_RESULT_BLOCKED), so a ban denies re-login immediately and an
+	// unban restores it. Administrative-ban ownership may later move to binServer
+	// entitlement (web-platform-plan.md §binServer); until then this is the gate.
+	SetAccountBlocked(context.Context, *SetAccountBlockedRequest) (*SetAccountBlockedResponse, error)
 	mustEmbedUnimplementedAccountServiceServer()
 }
 
@@ -272,6 +295,9 @@ func (UnimplementedAccountServiceServer) ListPendingDeliveries(context.Context, 
 }
 func (UnimplementedAccountServiceServer) SaveCargoWithDeliveries(context.Context, *SaveCargoWithDeliveriesRequest) (*SaveCargoResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SaveCargoWithDeliveries not implemented")
+}
+func (UnimplementedAccountServiceServer) SetAccountBlocked(context.Context, *SetAccountBlockedRequest) (*SetAccountBlockedResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetAccountBlocked not implemented")
 }
 func (UnimplementedAccountServiceServer) mustEmbedUnimplementedAccountServiceServer() {}
 func (UnimplementedAccountServiceServer) testEmbeddedByValue()                        {}
@@ -492,6 +518,24 @@ func _AccountService_SaveCargoWithDeliveries_Handler(srv interface{}, ctx contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _AccountService_SetAccountBlocked_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetAccountBlockedRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AccountServiceServer).SetAccountBlocked(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AccountService_SetAccountBlocked_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AccountServiceServer).SetAccountBlocked(ctx, req.(*SetAccountBlockedRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // AccountService_ServiceDesc is the grpc.ServiceDesc for AccountService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -542,6 +586,10 @@ var AccountService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SaveCargoWithDeliveries",
 			Handler:    _AccountService_SaveCargoWithDeliveries_Handler,
+		},
+		{
+			MethodName: "SetAccountBlocked",
+			Handler:    _AccountService_SetAccountBlocked_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/dbserver/internal/grpcsrv/server.go
+++ b/dbserver/internal/grpcsrv/server.go
@@ -32,6 +32,7 @@ type Store interface {
 	SaveCargo(ctx context.Context, accountID int64, coin int32, items []domain.Item) error
 	PendingItemDeliveries(ctx context.Context, accountID int64) ([]domain.Delivery, error)
 	SaveCargoWithDeliveries(ctx context.Context, accountID int64, coin int32, items []domain.Item, deliveredIDs, lostIDs []int64) error
+	SetBlockedByName(ctx context.Context, name string, blocked bool) error
 }
 
 // Server implements dbv1.AccountServiceServer.
@@ -72,6 +73,7 @@ func (s *Server) AccountLogin(ctx context.Context, req *dbv1.AccountLoginRequest
 	return &dbv1.AccountLoginResponse{
 		Result:    dbv1.LoginResult_LOGIN_RESULT_OK,
 		AccountId: auth.ID,
+		Role:      auth.Role, // carried to tmServer for in-game GM authz (issue #122)
 	}, nil
 }
 
@@ -181,6 +183,19 @@ func (s *Server) SaveCargoWithDeliveries(ctx context.Context, req *dbv1.SaveCarg
 		return nil, status.Errorf(codes.Internal, "save cargo with deliveries: %v", err)
 	}
 	return &dbv1.SaveCargoResponse{Ok: true}, nil
+}
+
+// SetAccountBlocked flips account.is_blocked by name — the write side of the
+// in-game GM ban/unban command (issue #122). A missing account returns ok=false.
+func (s *Server) SetAccountBlocked(ctx context.Context, req *dbv1.SetAccountBlockedRequest) (*dbv1.SetAccountBlockedResponse, error) {
+	err := s.store.SetBlockedByName(ctx, req.GetAccountName(), req.GetBlocked())
+	if errors.Is(err, store.ErrNotFound) {
+		return &dbv1.SetAccountBlockedResponse{Ok: false}, nil
+	}
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "set account blocked: %v", err)
+	}
+	return &dbv1.SetAccountBlockedResponse{Ok: true}, nil
 }
 
 // CreateCharacter creates a character in a free slot. A taken slot/name (unique

--- a/dbserver/internal/grpcsrv/server_test.go
+++ b/dbserver/internal/grpcsrv/server_test.go
@@ -125,6 +125,16 @@ func (f *fakeStore) PendingItemDeliveries(_ context.Context, accountID int64) ([
 	return f.pendingDeliveries[accountID], nil
 }
 
+func (f *fakeStore) SetBlockedByName(_ context.Context, name string, blocked bool) error {
+	a, ok := f.byName[name]
+	if !ok {
+		return store.ErrNotFound
+	}
+	a.IsBlocked = blocked
+	f.byName[name] = a
+	return nil
+}
+
 func (f *fakeStore) SaveCargoWithDeliveries(_ context.Context, accountID int64, coin int32, items []domain.Item, deliveredIDs, lostIDs []int64) error {
 	if f.saveCargoDeliveriesErr != nil {
 		return f.saveCargoDeliveriesErr
@@ -180,6 +190,48 @@ func TestAccountLogin(t *testing.T) {
 				t.Errorf("account_id = %d, want %d", resp.GetAccountId(), tc.wantID)
 			}
 		})
+	}
+}
+
+func TestAccountLoginRoleReturned(t *testing.T) {
+	pw := "pw"
+	fs := &fakeStore{byName: map[string]store.AccountAuth{
+		"mod": {ID: 5, PassHash: mustHash(t, pw), Role: "moderator"},
+	}}
+	resp, err := New(fs).AccountLogin(context.Background(),
+		&dbv1.AccountLoginRequest{AccountName: "mod", Password: pw})
+	if err != nil {
+		t.Fatalf("AccountLogin: %v", err)
+	}
+	if resp.GetResult() != dbv1.LoginResult_LOGIN_RESULT_OK || resp.GetRole() != "moderator" {
+		t.Errorf("result=%v role=%q, want OK/moderator", resp.GetResult(), resp.GetRole())
+	}
+}
+
+func TestSetAccountBlocked(t *testing.T) {
+	fs := &fakeStore{byName: map[string]store.AccountAuth{"victim": {ID: 9}}}
+	s := New(fs)
+
+	resp, err := s.SetAccountBlocked(context.Background(),
+		&dbv1.SetAccountBlockedRequest{AccountName: "victim", Blocked: true})
+	if err != nil {
+		t.Fatalf("SetAccountBlocked: %v", err)
+	}
+	if !resp.GetOk() {
+		t.Fatal("ok=false, want true")
+	}
+	if !fs.byName["victim"].IsBlocked {
+		t.Error("account not blocked in store")
+	}
+
+	// Unknown account → ok=false, no error.
+	resp, err = s.SetAccountBlocked(context.Background(),
+		&dbv1.SetAccountBlockedRequest{AccountName: "ghost", Blocked: true})
+	if err != nil {
+		t.Fatalf("SetAccountBlocked(ghost): %v", err)
+	}
+	if resp.GetOk() {
+		t.Error("ok=true for unknown account, want false")
 	}
 }
 

--- a/docs/game.md
+++ b/docs/game.md
@@ -26,6 +26,30 @@
 > Bônus já implementados (existem na fonte legada, fora da lista acima): `/selados`,
 > `/amagos`, `/agua` (teleportes).
 
+# Comandos de GM / moderação
+
+> Digitados como `/gm <subcomando> <args>` — o cliente envia como sussurro ao alvo
+> `gm` com o resto da linha no corpo (o mesmo truque do `_MSG_MessageWhisper`).
+> Autoridade vem da coluna `account.role` (`moderator`/`admin`), carregada no login
+> — **não** do frágil "Level ≥ 1000" do legado. Comando negado é silencioso. Toda
+> execução é auditada (slog: conta, alvo, args). Implementação: `handler/gm.go`.
+
+✅ /gm kick \<jogador\>: desconecta um jogador online (não derruba GM de nível igual/superior) <br/>
+✅ /gm notice \<texto\> (ou /gm aviso): anúncio global a todos os jogadores <br/>
+✅ /gm goto \<jogador\> (ou /gm ir): teleporta você até o jogador <br/>
+✅ /gm summon \<jogador\> (ou /gm puxar): puxa o jogador até você <br/>
+✅ /gm spawn \<id\>: cria uma criatura de teste (índice do roster de summons) na sua posição <br/>
+✅ /gm item \<id\>: coloca um item (por índice) no seu inventário <br/>
+✅ /gm setlevel \<n\>: sobe o seu nível para n (apenas sobe — não rebaixa) <br/>
+✅ /gm setgold \<n\>: define o seu ouro carregado <br/>
+✅ /gm ban \<jogador|conta\>: bloqueia a conta (via `account.is_blocked`) e derruba se online <br/>
+✅ /gm unban \<jogador|conta\>: remove o bloqueio da conta <br/>
+
+> `notice` sai como linha de chat prefixada `[GM]` (o pacote de aviso dedicado é
+> UNVERIFIED até uma captura). `ban`/`unban` gravam em `account.is_blocked` — o login
+> já rejeita contas bloqueadas; a migração do ban administrativo para o binServer
+> (entitlement) fica para uma issue futura (`web-platform-plan.md §binServer`).
+
 # Evoluções 
 NPC Evoluções vende poeira, upe o seu Mortal, Arch, Celestial e Sub Celestial com ela.
 

--- a/docs/migration/gm-commands-plan.md
+++ b/docs/migration/gm-commands-plan.md
@@ -1,0 +1,68 @@
+# GM / moderation in-game commands (issue #122)
+
+Status: **IMPLEMENTED** (first batch).
+
+Ports the legacy GM/moderation command surface (`Source/Comandos GM.txt`,
+`Source/Code/TMSrv/imple.cpp` `ProcessImple`) to the Go rewrite as an authorized,
+audited in-game command bus. Replaces the legacy authority model — a fragile
+inflated character `Level >= 1000` plus a `DBSRV/Run/admin.txt` IP whitelist — with
+an explicit server-side role.
+
+## Authority
+
+- Privilege = **`account.role`** (`'player'`/`'moderator'`/`'admin'`, migration
+  `0005`, already used by the web-api for admin RPCs). It is now also returned at
+  login so the game loop can gate commands.
+- Flow: `store.AccountByName` (selects `role`) → `AccountLoginResponse.role`
+  (`api/db/v1`) → `world.LoginOutcome.Role` → `world.Session.AccessLevel`
+  (`world.ParseAccess`, fail-closed). Two GM tiers today: `moderator` runs the
+  whole first batch; `admin` is reserved for future destructive/server-wide ops.
+- The gate lives in `handler/gm.go` `runGMCommand`: `AccessLevel < AccessModerator`
+  is silently denied (legacy behaviour) and logged. `kick` additionally refuses a
+  target of equal-or-higher tier (legacy `imple.cpp:1824`).
+
+## Entry point & syntax
+
+`/gm <sub> <args>` — the client sends `/gm` as a whisper to target `"gm"` with the
+rest of the line in the whisper `String`. Intercepted in `handler/chat.go`
+`runCommand` (the same `_MSG_MessageWhisper` quirk the teleport commands use),
+which now forwards the args string. Single entry point centralizes the authz gate
+and the audit log, mirroring `ProcessImple`.
+
+## First batch
+
+`kick`, `notice`/`aviso`, `goto`/`ir`, `summon`/`puxar`, `spawn`, `item`,
+`setlevel`, `setgold`, `ban`, `unban` (see `docs/game.md`). All world-state
+mutations run **inside the single-owner loop** and reuse existing handler helpers
+(`doTeleport`, `SpawnMobAt`+`revealSpawned`, `AddToCarry`, `applyMortalLevelUps`,
+`sendEtc`, `Close`) — no new world mechanics. `notice` broadcasts via
+`ForEachPlaying(-1)`. `spawn` uses the in-memory summon-template roster (the only
+ID-indexed mob catalog held by the dispatcher).
+
+## Ban
+
+- `/gm ban`/`unban` write **`account.is_blocked`** through a new dbServer RPC
+  `SetAccountBlocked` (off the loop via `World.Go`). Login already rejects blocked
+  accounts (`LOGIN_RESULT_BLOCKED`), so a ban denies re-login immediately and, if
+  the target is online, kicks it; unban restores.
+- Argument resolves to the online player's account when present, else is taken as
+  an account name (so an offline account can still be un/banned).
+- **Deferred:** moving administrative ban to binServer entitlement
+  (`web-platform-plan.md §binServer`, the `is_blocked` vs `StatusBlocked`
+  source-of-truth question). Until then `is_blocked` is the single ban gate.
+
+## Audit
+
+Every command execution is logged with `slog` (account, id, role, subcommand,
+args) before dispatch — the structured equivalent of the legacy `Log("adm ...")`.
+No DB audit table this batch (unlike `npc_audit`); slog covers the acceptance
+criterion.
+
+## UNVERIFIED / follow-ups
+
+- The dedicated golden **announce wire** (big centred notice) is not captured;
+  `notice` ships as a `[GM]`-prefixed chat line for now (`notice.go §UNVERIFIED`).
+- `setlevel` only levels **up** (reuses `applyMortalLevelUps`); a downlevel would
+  need to unwind the derived score — out of scope.
+- Later batches from `Comandos GM.txt` (events, guild/castle war, rates, weather,
+  mute/snoop) and the binServer ban migration are separate tasks.

--- a/internal/store/store_live.go
+++ b/internal/store/store_live.go
@@ -59,6 +59,22 @@ func (s *Store) AccountAuthByID(ctx context.Context, id int64) (AccountAuth, err
 	return a, nil
 }
 
+// SetBlockedByName flips account.is_blocked for a canonical (lowercase) account
+// name — the write side of the in-game GM ban/unban command (issue #122). Login
+// gates on this flag (AccountByName → LOGIN_RESULT_BLOCKED), so a ban denies
+// re-login immediately. Returns ErrNotFound when no account matched the name.
+func (s *Store) SetBlockedByName(ctx context.Context, name string, blocked bool) error {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE account SET is_blocked = $2 WHERE name = $1`, name, blocked)
+	if err != nil {
+		return fmt.Errorf("store: set blocked %q: %w", name, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // ListCharacters returns the character-selection projection (slot, name, class,
 // level, exp, guild) for an account, ordered by slot.
 func (s *Store) ListCharacters(ctx context.Context, accountID int64) ([]domain.Character, error) {

--- a/internal/store/store_live_integration_test.go
+++ b/internal/store/store_live_integration_test.go
@@ -245,3 +245,28 @@ func TestExpRankingOrder(t *testing.T) {
 		t.Fatalf("empty page len=%d total=%d, want len=0 total=5", len(page), total)
 	}
 }
+
+func TestSetBlockedByName(t *testing.T) {
+	s, ctx := freshStore(t)
+	if _, err := s.SaveAccount(ctx, domain.Account{Name: "victim", PassHash: "h"}); err != nil {
+		t.Fatalf("SaveAccount: %v", err)
+	}
+
+	if err := s.SetBlockedByName(ctx, "victim", true); err != nil {
+		t.Fatalf("SetBlockedByName(true): %v", err)
+	}
+	if auth, err := s.AccountByName(ctx, "victim"); err != nil || !auth.IsBlocked {
+		t.Fatalf("after ban: blocked=%v err=%v, want blocked=true", auth.IsBlocked, err)
+	}
+
+	if err := s.SetBlockedByName(ctx, "victim", false); err != nil {
+		t.Fatalf("SetBlockedByName(false): %v", err)
+	}
+	if auth, err := s.AccountByName(ctx, "victim"); err != nil || auth.IsBlocked {
+		t.Fatalf("after unban: blocked=%v err=%v, want blocked=false", auth.IsBlocked, err)
+	}
+
+	if err := s.SetBlockedByName(ctx, "ghost", true); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("SetBlockedByName(ghost) = %v, want ErrNotFound", err)
+	}
+}

--- a/tmserver/internal/dbclient/client.go
+++ b/tmserver/internal/dbclient/client.go
@@ -43,6 +43,7 @@ func (c *Client) AccountLogin(ctx context.Context, name, password string) (world
 	out := world.LoginOutcome{
 		Result:    loginResultFromProto(resp.GetResult()),
 		AccountID: resp.GetAccountId(),
+		Role:      resp.GetRole(),
 	}
 	if out.Result != world.LoginOK {
 		return out, nil
@@ -225,6 +226,17 @@ func (c *Client) SaveCargoWithDeliveries(ctx context.Context, save world.CargoSa
 	})
 	if err != nil {
 		return fmt.Errorf("dbclient: save cargo with deliveries: %w", err)
+	}
+	return nil
+}
+
+// SetAccountBlocked flips account.is_blocked by name (GM ban/unban, issue #122).
+func (c *Client) SetAccountBlocked(ctx context.Context, name string, blocked bool) error {
+	if _, err := c.api.SetAccountBlocked(ctx, &dbv1.SetAccountBlockedRequest{
+		AccountName: name,
+		Blocked:     blocked,
+	}); err != nil {
+		return fmt.Errorf("dbclient: set account blocked: %w", err)
 	}
 	return nil
 }

--- a/tmserver/internal/dbclient/client_test.go
+++ b/tmserver/internal/dbclient/client_test.go
@@ -28,6 +28,7 @@ type fakeAPI struct {
 
 	deliveriesResp       *dbv1.ListPendingDeliveriesResponse
 	savedCargoDeliveries *dbv1.SaveCargoWithDeliveriesRequest
+	blockedReq           *dbv1.SetAccountBlockedRequest
 }
 
 func (f *fakeAPI) AccountLogin(_ context.Context, _ *dbv1.AccountLoginRequest, _ ...grpc.CallOption) (*dbv1.AccountLoginResponse, error) {
@@ -73,6 +74,10 @@ func (f *fakeAPI) SaveCargoWithDeliveries(_ context.Context, req *dbv1.SaveCargo
 	f.savedCargoDeliveries = req
 	return &dbv1.SaveCargoResponse{Ok: true}, nil
 }
+func (f *fakeAPI) SetAccountBlocked(_ context.Context, req *dbv1.SetAccountBlockedRequest, _ ...grpc.CallOption) (*dbv1.SetAccountBlockedResponse, error) {
+	f.blockedReq = req
+	return &dbv1.SetAccountBlockedResponse{Ok: true}, nil
+}
 
 func newClient(api dbv1.AccountServiceClient) *Client { return &Client{api: api} }
 
@@ -103,6 +108,30 @@ func TestAccountLoginMapping(t *testing.T) {
 	// Cargo is fetched in the same login round-trip and mapped positionally.
 	if out.Cargo.AccountID != 1 || out.Cargo.Coin != 4200 || out.Cargo.Items[2].Index != 999 {
 		t.Fatalf("cargo not loaded on login: %+v", out.Cargo)
+	}
+}
+
+func TestAccountLoginRoleMapped(t *testing.T) {
+	api := &fakeAPI{
+		loginResp: &dbv1.AccountLoginResponse{Result: dbv1.LoginResult_LOGIN_RESULT_OK, AccountId: 1, Role: "moderator"},
+		listResp:  &dbv1.ListCharactersResponse{},
+	}
+	out, err := newClient(api).AccountLogin(context.Background(), "mod", "pw")
+	if err != nil {
+		t.Fatalf("AccountLogin: %v", err)
+	}
+	if out.Role != "moderator" {
+		t.Fatalf("role = %q, want moderator", out.Role)
+	}
+}
+
+func TestSetAccountBlocked(t *testing.T) {
+	api := &fakeAPI{}
+	if err := newClient(api).SetAccountBlocked(context.Background(), "victim", true); err != nil {
+		t.Fatalf("SetAccountBlocked: %v", err)
+	}
+	if api.blockedReq == nil || api.blockedReq.GetAccountName() != "victim" || !api.blockedReq.GetBlocked() {
+		t.Fatalf("request not forwarded: %+v", api.blockedReq)
 	}
 }
 

--- a/tmserver/internal/handler/chat.go
+++ b/tmserver/internal/handler/chat.go
@@ -47,7 +47,7 @@ func (d *Dispatcher) messageWhisper(w *world.World, s *world.Session, _ protocol
 		return
 	}
 	name := cstr(body.MobName[:])
-	if d.runCommand(w, s, name) {
+	if d.runCommand(w, s, name, body.String) {
 		return // a slash command (the client sends "/x" as a whisper to "x")
 	}
 	target, _ := w.SessionByName(name)
@@ -81,7 +81,7 @@ var teleportCmds = map[string][2]int16{
 // UNVERIFIED / deferred: the unlock/quest/guild commands (destravar40/90, arcana,
 // create/sair/guild, crias) depend on the Arch/Celestial, quest and guild systems that
 // are not modeled yet, so they are not handled here.
-func (d *Dispatcher) runCommand(w *world.World, s *world.Session, name string) bool {
+func (d *Dispatcher) runCommand(w *world.World, s *world.Session, name string, args []byte) bool {
 	cmd := strings.TrimPrefix(name, "/")
 	if dest, ok := teleportCmds[cmd]; ok {
 		if e := w.Entity(s.Conn); e != nil {
@@ -95,6 +95,12 @@ func (d *Dispatcher) runCommand(w *world.World, s *world.Session, name string) b
 	}
 	if cmd == "sair" || cmd == "abandonar" {
 		d.leaveGuild(w, s)
+		return true
+	}
+	if cmd == "gm" {
+		// GM/moderation command bus (issue #122). args is the whisper's String — the
+		// rest of the typed line (e.g. "/gm kick foo" → args = "kick foo").
+		d.runGMCommand(w, s, args)
 		return true
 	}
 	return false

--- a/tmserver/internal/handler/gm.go
+++ b/tmserver/internal/handler/gm.go
@@ -1,0 +1,271 @@
+package handler
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/level"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// gmCommandTimeout bounds the off-loop dbServer round-trip for ban/unban.
+const gmCommandTimeout = 10 * time.Second
+
+// runGMCommand is the in-game GM/moderation command bus (issue #122). It is the
+// modern replacement for the legacy imple.cpp ProcessImple: the client sends
+// "/gm <sub> <args>" as a whisper to target "gm", so args is the whisper's String
+// (the rest of the typed line). Authority is the session's AccessLevel — derived
+// from the account.role at login — NOT the fragile legacy "character Level >= 1000".
+//
+// Every command is authorized against the moderator tier and audit-logged (slog)
+// before dispatch, mirroring the legacy Log("adm ...") that preceded every
+// admin action. A denied command is silent (as in the original).
+func (d *Dispatcher) runGMCommand(w *world.World, s *world.Session, args []byte) {
+	if s.Mode != world.UserPlay {
+		return
+	}
+	if s.AccessLevel < world.AccessModerator {
+		// Silent denial + audit of the attempt (a non-GM probing the bus).
+		d.log.Warn("gm command denied: not a moderator",
+			"conn", s.Conn, "account", s.AccountName, "role", s.AccessLevel)
+		return
+	}
+	line := strings.TrimSpace(cstr(args))
+	if line == "" {
+		return
+	}
+	sub := strings.ToLower(firstToken(line))
+	rest := strings.TrimSpace(strings.TrimPrefix(line, firstToken(line)))
+
+	// Audit BEFORE dispatch: account, target/args and the authority that ran it.
+	d.log.Info("gm command",
+		"account", s.AccountName, "id", s.AccountID, "role", s.AccessLevel,
+		"cmd", sub, "args", rest)
+
+	switch sub {
+	case "kick":
+		d.gmKick(w, s, rest)
+	case "notice", "aviso":
+		d.gmNotice(w, s, rest)
+	case "goto", "ir":
+		d.gmGoto(w, s, rest)
+	case "summon", "puxar":
+		d.gmSummon(w, s, rest)
+	case "spawn":
+		d.gmSpawn(w, s, rest)
+	case "item":
+		d.gmItem(w, s, rest)
+	case "setlevel":
+		d.gmSetLevel(w, s, rest)
+	case "setgold":
+		d.gmSetGold(w, s, rest)
+	case "ban":
+		d.gmBan(w, s, rest, true)
+	case "unban":
+		d.gmBan(w, s, rest, false)
+	default:
+		d.log.Warn("gm command: unknown subcommand", "account", s.AccountName, "cmd", sub)
+	}
+}
+
+// gmKick disconnects an online player by character name. Mirrors the legacy guard
+// (imple.cpp:1824): a moderator cannot kick another moderator/admin of equal or
+// higher tier.
+func (d *Dispatcher) gmKick(w *world.World, s *world.Session, rest string) {
+	name := firstToken(rest)
+	if name == "" {
+		return
+	}
+	target, _ := w.SessionByName(name)
+	if target == nil {
+		d.notify(w, s, NoticeNotConnected)
+		return
+	}
+	if target.AccessLevel >= s.AccessLevel {
+		d.log.Warn("gm kick denied: target outranks caller",
+			"account", s.AccountName, "target", name, "targetRole", target.AccessLevel)
+		return
+	}
+	d.log.Info("gm kick", "account", s.AccountName, "target", name, "targetConn", target.Conn)
+	w.Close(target) // full teardown + character save (removeSession)
+}
+
+// gmNotice broadcasts a server-wide announcement to every in-play player.
+//
+// UNVERIFIED: the dedicated golden announce wire (the big centred notice) is not
+// captured (notice.go §UNVERIFIED). As a first pass this ships as a normal chat
+// line prefixed "[GM]" delivered to all players; the special notice format is
+// pinned once a capture exists.
+func (d *Dispatcher) gmNotice(w *world.World, s *world.Session, text string) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return
+	}
+	msg := "[GM] " + text
+	payload := append([]byte(msg), 0) // NUL-terminated, like a normal chat line
+	// HEADER.ID = the GM's conn: the client renders it as a chat line (the announce
+	// source). No distance filter — ForEachPlaying(-1) reaches every session.
+	w.ForEachPlaying(-1, func(vs *world.Session, _ *world.Entity) {
+		w.SendTo(vs, protocol.Header{Type: protocol.MsgMessageChat, ID: uint16(s.Conn)}, payload)
+	})
+	d.log.Info("gm notice", "account", s.AccountName, "text", text)
+}
+
+// gmGoto teleports the caller to a named online player.
+func (d *Dispatcher) gmGoto(w *world.World, s *world.Session, rest string) {
+	name := firstToken(rest)
+	if name == "" {
+		return
+	}
+	_, te := w.SessionByName(name)
+	if te == nil {
+		d.notify(w, s, NoticeNotConnected)
+		return
+	}
+	d.doTeleport(w, s, te.X, te.Y)
+}
+
+// gmSummon pulls a named online player to the caller's position.
+func (d *Dispatcher) gmSummon(w *world.World, s *world.Session, rest string) {
+	name := firstToken(rest)
+	if name == "" {
+		return
+	}
+	target, _ := w.SessionByName(name)
+	if target == nil {
+		d.notify(w, s, NoticeNotConnected)
+		return
+	}
+	ce := w.Entity(s.Conn)
+	if ce == nil {
+		return
+	}
+	d.doTeleport(w, target, ce.X, ce.Y) // move the TARGET session to the caller
+}
+
+// gmSpawn spawns one test creature at the caller's position from the BM summon
+// roster (the only ID-indexed mob-template catalog held in memory; SummonMobs).
+// The id is the roster index — e.g. Sleipnir/Svaldfire slots.
+func (d *Dispatcher) gmSpawn(w *world.World, s *world.Session, rest string) {
+	id, err := strconv.Atoi(firstToken(rest))
+	if err != nil || id < 0 || id >= len(d.summonMobs) || d.summonMobs[id] == nil {
+		d.log.Warn("gm spawn: no such template", "account", s.AccountName, "id", firstToken(rest))
+		return
+	}
+	e := w.Entity(s.Conn)
+	if e == nil {
+		return
+	}
+	newID := w.SpawnMobAt(world.MobSpawn{Template: d.summonMobs[id], X: e.X, Y: e.Y, GenIndex: -1})
+	if newID < 0 {
+		d.log.Warn("gm spawn: world full", "account", s.AccountName)
+		return
+	}
+	d.revealSpawned(w, []int{newID})
+	d.log.Info("gm spawn", "account", s.AccountName, "template", id, "mobConn", newID)
+}
+
+// gmItem grants a test item (by index, no effects) into the caller's inventory.
+func (d *Dispatcher) gmItem(w *world.World, s *world.Session, rest string) {
+	id, err := strconv.Atoi(firstToken(rest))
+	if err != nil || id <= 0 || id >= world.MaxItem {
+		return
+	}
+	e := w.Entity(s.Conn)
+	if e == nil {
+		return
+	}
+	slot := w.AddToCarry(e, world.Item{Index: int16(id)})
+	if slot < 0 {
+		d.notify(w, s, NoticeNoEmptySlot)
+		return
+	}
+	w.Send(s, protocol.MsgCNFGetItem, slotPayload(slot))
+	d.log.Info("gm item", "account", s.AccountName, "item", id, "slot", slot)
+}
+
+// gmSetLevel raises the caller to the given level for testing. It reuses the
+// MORTAL level-up path (applyMortalLevelUps), so it only levels UP — setting a
+// level at or below the current one is a no-op (documented; a downlevel would
+// need to unwind the derived score and is out of scope).
+func (d *Dispatcher) gmSetLevel(w *world.World, s *world.Session, rest string) {
+	n, err := strconv.Atoi(firstToken(rest))
+	if err != nil {
+		return
+	}
+	if n < 1 {
+		n = 1
+	}
+	if int32(n) > level.MaxLevel {
+		n = int(level.MaxLevel)
+	}
+	e := w.Entity(s.Conn)
+	if e == nil {
+		return
+	}
+	if e.Exp < level.NextLevelExp(int32(n)-1) {
+		e.Exp = level.NextLevelExp(int32(n) - 1)
+	}
+	d.applyMortalLevelUps(w, s, e)
+	d.log.Info("gm setlevel", "account", s.AccountName, "target", n, "level", e.Level)
+}
+
+// gmSetGold sets the caller's carried gold for testing.
+func (d *Dispatcher) gmSetGold(w *world.World, s *world.Session, rest string) {
+	n, err := strconv.Atoi(firstToken(rest))
+	if err != nil || n < 0 {
+		return
+	}
+	e := w.Entity(s.Conn)
+	if e == nil {
+		return
+	}
+	e.Coin = int32(n)
+	d.sendEtc(w, s, e) // UpdateEtc carries Coin
+	d.log.Info("gm setgold", "account", s.AccountName, "gold", n)
+}
+
+// gmBan bans (blocked=true) or unbans (blocked=false) an account. The argument is
+// a character name when the player is online (the ban lands on that character's
+// account and the player is kicked), otherwise it is taken as the account name.
+// The blocked flag is persisted via dbServer off the loop; login already rejects
+// blocked accounts (LOGIN_RESULT_BLOCKED), so a ban denies re-login immediately.
+func (d *Dispatcher) gmBan(w *world.World, s *world.Session, rest string, blocked bool) {
+	name := firstToken(rest)
+	if name == "" {
+		return
+	}
+	// Resolve the account: prefer an online player's account (canonical lowercase,
+	// set at login); fall back to treating the argument as an account name.
+	accountName := strings.ToLower(name)
+	if ts, _ := w.SessionByName(name); ts != nil {
+		accountName = ts.AccountName
+	}
+	p := w.Persistence()
+	action := "unban"
+	if blocked {
+		action = "ban"
+	}
+	d.log.Info("gm "+action, "account", s.AccountName, "target", name, "targetAccount", accountName)
+	w.Go(s, func() func(*world.World, *world.Session) {
+		ctx, cancel := context.WithTimeout(context.Background(), gmCommandTimeout)
+		defer cancel()
+		err := p.SetAccountBlocked(ctx, accountName, blocked)
+		return func(w *world.World, s *world.Session) {
+			if err != nil {
+				d.log.Error("gm "+action+" failed", "account", s.AccountName, "target", accountName, "err", err)
+				return
+			}
+			// On a successful ban, kick the player if still online (re-resolve — the
+			// session may have changed while the RPC was in flight).
+			if blocked {
+				if ts, _ := w.SessionByName(name); ts != nil {
+					w.Close(ts)
+				}
+			}
+		}
+	})
+}

--- a/tmserver/internal/handler/gm_test.go
+++ b/tmserver/internal/handler/gm_test.go
@@ -1,0 +1,255 @@
+package handler
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// TestParseAccess covers the account.role → AccessLevel mapping (fail-closed:
+// anything unrecognized is a plain player).
+func TestParseAccess(t *testing.T) {
+	cases := []struct {
+		role string
+		want world.AccessLevel
+	}{
+		{"admin", world.AccessAdmin},
+		{"moderator", world.AccessModerator},
+		{"player", world.AccessPlayer},
+		{"", world.AccessPlayer},
+		{"MODERATOR", world.AccessPlayer}, // case-sensitive: DB stores lowercase
+		{"gm", world.AccessPlayer},
+	}
+	for _, c := range cases {
+		if got := world.ParseAccess(c.role); got != c.want {
+			t.Errorf("ParseAccess(%q) = %v, want %v", c.role, got, c.want)
+		}
+	}
+}
+
+// gmDB seeds a moderator, a second moderator, a plain player and a victim, all at
+// (5,5) so they share a view. Passwords are "secret" (enterWorldAs default).
+func gmDB() *fakeDB {
+	db := &fakeDB{accounts: map[string]*fakeAccount{
+		"mod":    {id: 20, pass: "secret", role: "moderator", chars: []world.CharSummary{{Slot: 0, Name: "Mod"}}},
+		"mod2":   {id: 21, pass: "secret", role: "moderator", chars: []world.CharSummary{{Slot: 0, Name: "Mod2"}}},
+		"player": {id: 22, pass: "secret", role: "player", chars: []world.CharSummary{{Slot: 0, Name: "Player"}}},
+		"victim": {id: 23, pass: "secret", role: "player", chars: []world.CharSummary{{Slot: 0, Name: "Victim"}}},
+	}}
+	db.loads = map[int64]world.CharacterState{
+		20: {Slot: 0, Name: "Mod", Class: 0, Level: 10, X: 5, Y: 5, HP: 1000, MaxHP: 1000},
+		21: {Slot: 0, Name: "Mod2", Class: 0, Level: 10, X: 5, Y: 5, HP: 1000, MaxHP: 1000},
+		22: {Slot: 0, Name: "Player", Class: 0, Level: 10, X: 5, Y: 5, HP: 1000, MaxHP: 1000},
+		23: {Slot: 0, Name: "Victim", Class: 0, Level: 10, X: 5, Y: 5, HP: 1000, MaxHP: 1000},
+	}
+	return db
+}
+
+// gmFrame sends "/gm <line>" the way the client does: a whisper to target "gm"
+// whose String is the rest of the command line.
+func gmFrame(t *testing.T, c net.Conn, line string) {
+	t.Helper()
+	whisperFrame(t, c, "gm", line)
+}
+
+// TestGMGateDeniesPlayer verifies a plain player is silently refused the bus.
+func TestGMGateDeniesPlayer(t *testing.T) {
+	addr, stop, _ := startServerClock(t, gmDB())
+	defer stop()
+	c := enterWorldAs(t, addr, "player")
+	defer c.Close()
+
+	gmFrame(t, c, "setgold 999999")
+	if ty, _, ok := readMaybe(t, c); ok {
+		t.Errorf("player got %#x; a non-GM must be silently denied", ty)
+	}
+}
+
+// TestGMSetGold verifies a moderator's /gm setgold mutates gold and pushes UpdateEtc.
+func TestGMSetGold(t *testing.T) {
+	addr, stop, _ := startServerClock(t, gmDB())
+	defer stop()
+	c := enterWorldAs(t, addr, "mod")
+	defer c.Close()
+
+	gmFrame(t, c, "setgold 424242")
+	etc := expect(t, c, protocol.MsgUpdateEtc)
+	if got := int32(le(etc[28:32])); got != 424242 { // char coin @body28
+		t.Errorf("gold = %d, want 424242", got)
+	}
+}
+
+// TestGMItem verifies /gm item grants an item into the first free inventory slot.
+func TestGMItem(t *testing.T) {
+	addr, stop, _ := startServerClock(t, gmDB())
+	defer stop()
+	c := enterWorldAs(t, addr, "mod")
+	defer c.Close()
+
+	gmFrame(t, c, "item 1234")
+	got := expect(t, c, protocol.MsgCNFGetItem)
+	if slot := le(got[0:4]); slot != 0 {
+		t.Errorf("granted slot = %d, want 0 (first free)", slot)
+	}
+}
+
+// TestGMSetLevel verifies /gm setlevel raises the moderator to the target level.
+func TestGMSetLevel(t *testing.T) {
+	addr, stop, _ := startServerClock(t, gmDB())
+	defer stop()
+	c := enterWorldAs(t, addr, "mod")
+	defer c.Close()
+
+	gmFrame(t, c, "setlevel 55")
+	// Level-up pushes UpdateScore + UpdateEtc + a level-up motion; assert one arrives.
+	if ty, _, ok := readMaybe(t, c); !ok || (ty != protocol.MsgUpdateScore && ty != protocol.MsgUpdateEtc) {
+		t.Errorf("got %#x ok=%v, want a level-up score/etc packet", ty, ok)
+	}
+}
+
+// TestGMNotice verifies /gm notice reaches every player as a chat line, prefixed.
+func TestGMNotice(t *testing.T) {
+	addr, stop, _ := startServerClock(t, gmDB())
+	defer stop()
+	mod := enterWorldAs(t, addr, "mod")
+	defer mod.Close()
+	other := enterWorldAs(t, addr, "player")
+	defer other.Close()
+
+	gmFrame(t, mod, "notice server restarting")
+	p := expect(t, other, protocol.MsgMessageChat)
+	if got := cstr(p); got != "[GM] server restarting" {
+		t.Errorf("notice text = %q, want %q", got, "[GM] server restarting")
+	}
+}
+
+// TestGMGoto verifies /gm goto teleports the caller (MsgAction jump).
+func TestGMGoto(t *testing.T) {
+	addr, stop, _ := startServerClock(t, gmDB())
+	defer stop()
+	mod := enterWorldAs(t, addr, "mod")
+	defer mod.Close()
+	victim := enterWorldAs(t, addr, "victim")
+	defer victim.Close()
+
+	gmFrame(t, mod, "goto Victim")
+	if ty, _, ok := readMaybe(t, mod); !ok || ty != protocol.MsgAction {
+		t.Errorf("got %#x ok=%v, want MsgAction (teleport to player)", ty, ok)
+	}
+}
+
+// TestGMSummon verifies /gm summon pulls the target (they receive the MsgAction jump).
+func TestGMSummon(t *testing.T) {
+	addr, stop, _ := startServerClock(t, gmDB())
+	defer stop()
+	mod := enterWorldAs(t, addr, "mod")
+	defer mod.Close()
+	victim := enterWorldAs(t, addr, "victim")
+	defer victim.Close()
+
+	gmFrame(t, mod, "summon Victim")
+	if ty, _, ok := readMaybe(t, victim); !ok || ty != protocol.MsgAction {
+		t.Errorf("victim got %#x ok=%v, want MsgAction (summoned)", ty, ok)
+	}
+}
+
+// TestGMKick verifies a moderator can disconnect a lower-tier player.
+func TestGMKick(t *testing.T) {
+	addr, stop, _ := startServerClock(t, gmDB())
+	defer stop()
+	mod := enterWorldAs(t, addr, "mod")
+	defer mod.Close()
+	victim := enterWorldAs(t, addr, "victim")
+	defer victim.Close()
+
+	gmFrame(t, mod, "kick Victim")
+	expectDisconnect(t, victim)
+}
+
+// TestGMKickGuard verifies a moderator cannot kick an equal-or-higher tier admin.
+func TestGMKickGuard(t *testing.T) {
+	addr, stop, _ := startServerClock(t, gmDB())
+	defer stop()
+	mod := enterWorldAs(t, addr, "mod")
+	defer mod.Close()
+	mod2 := enterWorldAs(t, addr, "mod2")
+	defer mod2.Close()
+
+	gmFrame(t, mod, "kick Mod2")
+	expectStillConnected(t, mod2)
+}
+
+// TestGMBan verifies /gm ban persists the block and kicks the online player.
+func TestGMBan(t *testing.T) {
+	db := gmDB()
+	addr, stop, _ := startServerClock(t, db)
+	defer stop()
+	mod := enterWorldAs(t, addr, "mod")
+	defer mod.Close()
+	victim := enterWorldAs(t, addr, "victim")
+	defer victim.Close()
+
+	gmFrame(t, mod, "ban Victim")
+	expectDisconnect(t, victim)
+	blocked, ok := db.blockedState(t, "victim")
+	if !ok || !blocked {
+		t.Errorf("ban recorded blocked=%v ok=%v, want blocked=true for account 'victim'", blocked, ok)
+	}
+}
+
+// TestGMUnban verifies /gm unban persists blocked=false (by account name; the
+// target need not be online).
+func TestGMUnban(t *testing.T) {
+	db := gmDB()
+	addr, stop, _ := startServerClock(t, db)
+	defer stop()
+	mod := enterWorldAs(t, addr, "mod")
+	defer mod.Close()
+
+	gmFrame(t, mod, "unban victim")
+	blocked, ok := db.blockedState(t, "victim")
+	if !ok || blocked {
+		t.Errorf("unban recorded blocked=%v ok=%v, want blocked=false", blocked, ok)
+	}
+}
+
+// expectDisconnect drains any queued frames then asserts the socket was closed by
+// the server (a non-timeout read error), i.e. the client was kicked.
+func expectDisconnect(t *testing.T, c net.Conn) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		_ = c.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		var b [256]byte
+		_, err := c.Read(b[:])
+		if err == nil {
+			if time.Now().After(deadline) {
+				t.Fatal("still connected after kick (kept receiving data)")
+			}
+			continue // drain frames flushed just before close
+		}
+		if ne, ok := err.(net.Error); ok && ne.Timeout() {
+			t.Fatal("expected disconnect, got read timeout (still connected)")
+		}
+		return // EOF / connection reset = disconnected as expected
+	}
+}
+
+// expectStillConnected asserts the socket stays open (an idle read times out
+// rather than returning EOF).
+func expectStillConnected(t *testing.T, c net.Conn) {
+	t.Helper()
+	_ = c.SetReadDeadline(time.Now().Add(400 * time.Millisecond))
+	var b [1]byte
+	_, err := c.Read(b[:])
+	if err == nil {
+		return // received data → still connected
+	}
+	if ne, ok := err.(net.Error); ok && ne.Timeout() {
+		return // idle but open
+	}
+	t.Fatalf("expected still-connected, got %v (disconnected)", err)
+}

--- a/tmserver/internal/handler/handler_test.go
+++ b/tmserver/internal/handler/handler_test.go
@@ -20,6 +20,7 @@ import (
 type fakeAccount struct {
 	id             int64
 	pass           string
+	role           string // account.role ('player'/'moderator'/'admin'); GM authz
 	blocked        bool
 	alreadyPlaying bool
 	chars          []world.CharSummary
@@ -46,10 +47,11 @@ type fakeDB struct {
 
 	pending map[int64][]world.Delivery // accountID -> mailbox rows (donate drain)
 
-	mu          sync.Mutex
-	savedChars  []world.CharacterSave // captured SaveOnShutdown calls
-	savedCargos []world.CargoSave     // captured SaveCargo calls
-	drainSaves  []drainSave           // captured SaveCargoWithDeliveries calls
+	mu           sync.Mutex
+	savedChars   []world.CharacterSave // captured SaveOnShutdown calls
+	savedCargos  []world.CargoSave     // captured SaveCargo calls
+	drainSaves   []drainSave           // captured SaveCargoWithDeliveries calls
+	blockedNames map[string]bool       // captured SetAccountBlocked calls (GM ban/unban)
 }
 
 // drainSave captures one SaveCargoWithDeliveries call for assertions.
@@ -75,6 +77,35 @@ func (f *fakeDB) SaveCargo(_ context.Context, save world.CargoSave) error {
 
 func (f *fakeDB) ListPendingDeliveries(_ context.Context, accountID int64) ([]world.Delivery, error) {
 	return f.pending[accountID], nil
+}
+
+// SetAccountBlocked records the GM ban/unban write (overrides the NopPersistence
+// error so the ban callback proceeds to the online-kick).
+func (f *fakeDB) SetAccountBlocked(_ context.Context, name string, blocked bool) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.blockedNames == nil {
+		f.blockedNames = make(map[string]bool)
+	}
+	f.blockedNames[name] = blocked
+	return nil
+}
+
+// blockedState reports the last recorded block state for an account name, waiting
+// briefly for the async ban RPC round-trip to land.
+func (f *fakeDB) blockedState(t *testing.T, name string) (bool, bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		f.mu.Lock()
+		v, ok := f.blockedNames[name]
+		f.mu.Unlock()
+		if ok {
+			return v, true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false, false
 }
 
 func (f *fakeDB) SaveCargoWithDeliveries(_ context.Context, save world.CargoSave, deliveredIDs, lostIDs []int64) error {
@@ -144,7 +175,7 @@ func (f *fakeDB) AccountLogin(_ context.Context, name, pass string) (world.Login
 		cargo := a.cargo
 		cargo.AccountID = a.id
 		return world.LoginOutcome{
-			Result: world.LoginOK, AccountID: a.id, Characters: a.chars, Cargo: cargo,
+			Result: world.LoginOK, AccountID: a.id, Role: a.role, Characters: a.chars, Cargo: cargo,
 			PendingDeliveries: f.pending[a.id],
 		}, nil
 	}

--- a/tmserver/internal/handler/login.go
+++ b/tmserver/internal/handler/login.go
@@ -79,7 +79,8 @@ func (d *Dispatcher) completeAccountLogin(w *world.World, s *world.Session, out 
 	case world.LoginOK:
 		delete(d.fails, s.AccountName)
 		s.AccountID = out.AccountID
-		d.log.Info("account login: OK", "conn", s.Conn, "account", s.AccountName, "id", out.AccountID, "chars", len(out.Characters))
+		s.AccessLevel = world.ParseAccess(out.Role) // GM/moderation privilege (issue #122)
+		d.log.Info("account login: OK", "conn", s.Conn, "account", s.AccountName, "id", out.AccountID, "role", s.AccessLevel, "chars", len(out.Characters))
 		// Install the account-shared cargo, loaded in the same backend round-trip.
 		// It lives for the whole account session and is released on disconnect.
 		cargo := out.Cargo

--- a/tmserver/internal/world/persistence.go
+++ b/tmserver/internal/world/persistence.go
@@ -50,6 +50,7 @@ type CharSummary struct {
 type LoginOutcome struct {
 	Result            LoginResult
 	AccountID         int64
+	Role              string // account.role ('player'/'moderator'/'admin'); GM authz (issue #122)
 	Characters        []CharSummary
 	Cargo             CargoState
 	PendingDeliveries []Delivery
@@ -210,6 +211,9 @@ type Persistence interface {
 	// drained mailbox rows delivered/lost in one backend transaction — the anti-dup
 	// boundary for the drain.
 	SaveCargoWithDeliveries(ctx context.Context, save CargoSave, deliveredIDs, lostIDs []int64) error
+	// SetAccountBlocked flips account.is_blocked by name — the write side of the
+	// in-game GM ban/unban command (issue #122). Called off the loop via World.Go.
+	SetAccountBlocked(ctx context.Context, name string, blocked bool) error
 }
 
 // errNoPersistence is returned by NopPersistence for operations that need a DB.
@@ -269,4 +273,9 @@ func (NopPersistence) ListPendingDeliveries(context.Context, int64) ([]Delivery,
 // SaveCargoWithDeliveries drops the snapshot (no backend to persist to).
 func (NopPersistence) SaveCargoWithDeliveries(context.Context, CargoSave, []int64, []int64) error {
 	return nil
+}
+
+// SetAccountBlocked is unsupported without a backend (ban needs the account DB).
+func (NopPersistence) SetAccountBlocked(context.Context, string, bool) error {
+	return errNoPersistence
 }

--- a/tmserver/internal/world/session.go
+++ b/tmserver/internal/world/session.go
@@ -13,6 +13,44 @@ type outFrame struct {
 	payload []byte
 }
 
+// AccessLevel is a session's GM/moderation privilege tier, derived from the
+// account.role string at login (issue #122). It replaces the legacy fragile
+// "character Level >= 1000" backdoor with an explicit server-side authority.
+// Ordered so a gate can compare with >= (a higher tier passes lower-tier gates).
+type AccessLevel uint8
+
+// Access tiers. Player is the zero value: an unknown/absent role is never a GM.
+const (
+	AccessPlayer    AccessLevel = iota // no GM privilege
+	AccessModerator                    // in-game moderation (the first-batch commands)
+	AccessAdmin                        // reserved for future destructive/server-wide ops
+)
+
+// ParseAccess maps an account.role string ('player'/'moderator'/'admin') to its
+// AccessLevel. Any unrecognized value is AccessPlayer (fail closed).
+func ParseAccess(role string) AccessLevel {
+	switch role {
+	case "admin":
+		return AccessAdmin
+	case "moderator":
+		return AccessModerator
+	default:
+		return AccessPlayer
+	}
+}
+
+// String renders the tier for audit logs.
+func (a AccessLevel) String() string {
+	switch a {
+	case AccessAdmin:
+		return "admin"
+	case AccessModerator:
+		return "moderator"
+	default:
+		return "player"
+	}
+}
+
 // Session is a player's connection/session state (CUser subset,
 // domain-model.md §2.1). It is owned by the loop goroutine; the conn/out/closeCh
 // plumbing is shared with this session's reader and writer goroutines only.
@@ -20,6 +58,7 @@ type Session struct {
 	Conn              int // index into pUser/pMob; also HEADER.ID on the wire
 	AccountName       string
 	AccountID         int64
+	AccessLevel       AccessLevel // account.role tier; gates in-game GM commands (issue #122)
 	Slot              int
 	Mode              Mode
 	IP                string


### PR DESCRIPTION
Fecha #122. Porta a superfície de comandos de GM/moderação do legado
(`Source/Comandos GM.txt`, `imple.cpp` `ProcessImple`) como um barramento
in-game autorizado e auditado, trocando o frágil "character Level >= 1000" por
uma autoridade explícita do servidor.

## Autoridade
- Privilégio = `account.role` (`moderator`/`admin`, migração 0005) — já existia,
  agora retornado no login. Fluxo: `store.AccountByName` → `AccountLoginResponse.role`
  → `world.LoginOutcome.Role` → `world.Session.AccessLevel` (`world.ParseAccess`,
  fail-closed). **Sem migração nova.** Dois níveis: `moderator` (esta leva) e
  `admin` (reservado).
- Gate em `handler/gm.go` `runGMCommand`: abaixo de `AccessModerator` é negado em
  silêncio (comportamento legado) e logado. `kick` recusa alvo de nível igual/superior.

## Sintaxe
`/gm <sub> <args>` — o cliente envia como sussurro ao alvo `gm` com o resto da
linha no corpo (mesmo truque de `_MSG_MessageWhisper` dos teleportes).
Interceptado em `handler/chat.go` `runCommand`. Ponto de entrada único centraliza
authz + auditoria, espelhando `ProcessImple`.

## Primeira leva (tudo no loop single-owner, reusando helpers existentes)
`kick`, `notice`/`aviso`, `goto`/`ir`, `summon`/`puxar`, `spawn`, `item`,
`setlevel`, `setgold`, `ban`, `unban`. Reusa `doTeleport`, `SpawnMobAt`+`revealSpawned`,
`AddToCarry`, `applyMortalLevelUps`, `sendEtc`, `Close`; `notice` via `ForEachPlaying(-1)`.

## Ban
`ban`/`unban` gravam `account.is_blocked` via novo RPC dbServer `SetAccountBlocked`
(off-loop). Login já rejeita bloqueados (`LOGIN_RESULT_BLOCKED`), então o ban nega
relogin na hora e derruba se online; unban restaura. Migração do ban administrativo
para o binServer (entitlement) fica para issue futura.

## Auditoria
Cada execução logada com slog (conta, id, role, subcomando, args) antes do
dispatch — equivalente estruturado do `Log("adm ...")` legado.

## Testes / verificação
- `gm_test.go` (ParseAccess table-driven, gate, cada comando, guarda do kick, ban
  derruba+persiste); testes de role/SetAccountBlocked em dbclient e dbserver;
  integração store `SetBlockedByName`.
- `go build ./...`, `go vet ./...`, `golangci-lint` limpos; `go test -race` passa
  em handler, world, dbclient, grpcsrv, store.

## Deferrals (sinalizados no código/docs)
- Pacote de aviso "golden" dedicado é UNVERIFIED; `notice` sai como linha de chat
  prefixada `[GM]`.
- `setlevel` apenas sobe (reusa `applyMortalLevelUps`).
- Migração do ban para binServer entitlement e as levas seguintes de comandos.

Docs: `docs/game.md` (seção GM) + `docs/migration/gm-commands-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)