### PR TITLE
fix(tmserver): handle Frango Assado consumable (Vol 63)

### DIFF
--- a/tmserver/internal/handler/affect_score.go
+++ b/tmserver/internal/handler/affect_score.go
@@ -176,7 +176,7 @@ func applyAffectScoreWithItemAbility(e *world.Entity, itemAbility func(world.Ite
 			e.Rsv |= world.RsvHide
 		case 29:
 			applySoulScore(e)
-		case 30:
+		case world.AffectForceMobDamage:
 			e.AffForceMobDamage += level
 		case 31: // Escudo Dourado: AC + Level/2 + Value
 			e.AffAC += level/2 + value

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -134,6 +134,7 @@ const (
 	volDivine30   = 66
 	volVigor      = 58
 	volSilverBar  = 185
+	volFrango     = 63
 	// affect tick units (Basedef.h): one tick = 8s of real time.
 	affect1H          = 450
 	affect1D          = 10800
@@ -186,6 +187,8 @@ func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header
 		d.useDivine(w, s, e, src, vol)
 	case vol == volVigor:
 		d.useVigor(w, s, e, src, int(e.Carry[src].Index))
+	case vol == volFrango:
+		d.useFrangoAssado(w, s, e, src)
 	case vol == volSilverBar:
 		d.useSilverBar(w, s, e, src)
 	case vol == volJoiaPvP:
@@ -401,6 +404,24 @@ func (d *Dispatcher) useVigor(w *world.World, s *world.Session, e *world.Entity,
 	}
 	e.Affect[slot] = world.Affect{Type: world.AffectVigor, Level: 1, Time: ticks}
 	e.Carry[src] = world.Item{}
+	d.refreshScore(e)
+	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
+	d.sendScore(w, s, e)
+	d.sendAffect(w, s, e)
+}
+
+// useFrangoAssado consumes a Frango Assado (EF_VOLATILE 63): Affect 30 adds a flat
+// +2000 ForceMobDamage for 4h (_MSG_UseItem.cpp:2308-2341, Basedef.cpp:4427). Unlike
+// the healing potions this is not a heal — it's a mob-damage buff read at score time.
+func (d *Dispatcher) useFrangoAssado(w *world.World, s *world.Session, e *world.Entity, src int) {
+	slot := e.EmptyAffect(world.AffectForceMobDamage)
+	if slot < 0 {
+		d.notify(w, s, NoticeCantEatMore)
+		w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
+		return
+	}
+	e.Affect[slot] = world.Affect{Type: world.AffectForceMobDamage, Level: 2000, Time: affect1H * 4}
+	consumeOneItem(&e.Carry[src])
 	d.refreshScore(e)
 	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
 	d.sendScore(w, s, e)

--- a/tmserver/internal/handler/item_test.go
+++ b/tmserver/internal/handler/item_test.go
@@ -797,6 +797,53 @@ func TestUseExpChestStack(t *testing.T) {
 	}
 }
 
+// TestUseFrangoAssado is the issue #134 regression: using the item did nothing
+// because Vol 63 had no case in the useItem switch. It should consume the item
+// and grant Affect 30 (AffectForceMobDamage) for 4h (_MSG_UseItem.cpp:2308-2341).
+func TestUseFrangoAssado(t *testing.T) {
+	addr, stop := startServerClockVol(t, expChestDB(), map[int]int{4140: volFrango})
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+
+	sawSendItem, sawAffect, sawScore := false, false, false
+	for range 6 {
+		ty, payload, ok := readMaybe(t, c)
+		if !ok {
+			break
+		}
+		switch ty {
+		case protocol.MsgSendItem:
+			sawSendItem = true
+			if le16(payload[4:6]) != 0 {
+				t.Errorf("carry slot 0 item = %d, want empty after use", le16(payload[4:6]))
+			}
+		case protocol.MsgSendAffect:
+			sawAffect = true
+			if payload[0] != world.AffectForceMobDamage {
+				t.Errorf("affect type = %d, want %d", payload[0], world.AffectForceMobDamage)
+			}
+			if got := binary.LittleEndian.Uint32(payload[4:8]); got != affect1H*4 {
+				t.Errorf("affect time = %d, want %d", got, affect1H*4)
+			}
+		case protocol.MsgUpdateScore:
+			sawScore = true
+		}
+	}
+	if !sawSendItem {
+		t.Error("missing MsgSendItem after using frango assado")
+	}
+	if !sawAffect {
+		t.Error("missing MsgSendAffect after using frango assado")
+	}
+	if !sawScore {
+		t.Error("missing MsgUpdateScore after using frango assado")
+	}
+}
+
 // setHpMpFields decodes MSG_SetHpMp (protocol/score.go:110): Hp, Mp, ReqHp, ReqMp.
 func setHpMpFields(t *testing.T, p []byte) (hp, mp, reqHp, reqMp int32) {
 	t.Helper()

--- a/tmserver/internal/world/affect.go
+++ b/tmserver/internal/world/affect.go
@@ -6,9 +6,10 @@ const MaxAffect = 32
 
 // Affect types the score model reacts to (BASE_GetCurrentScore, captura §C).
 const (
-	AffectExpChest = 39 // Baú de Experiência: +100 ExpBonus (Basedef.cpp:4451)
-	AffectDivine   = 34 // Poção Divina: +20% MaxHp/MaxMp/Damage
-	AffectVigor    = 35 // Poção de Vigor: +10% MaxHp/MaxMp
+	AffectExpChest       = 39 // Baú de Experiência: +100 ExpBonus (Basedef.cpp:4451)
+	AffectDivine         = 34 // Poção Divina: +20% MaxHp/MaxMp/Damage
+	AffectVigor          = 35 // Poção de Vigor: +10% MaxHp/MaxMp
+	AffectForceMobDamage = 30 // Frango Assado: +2000 flat mob-damage, 4h (Basedef.cpp:4427)
 )
 
 // Affect mirrors STRUCT_AFFECT (8 bytes): a timed buff/debuff. Type==0 is an empty


### PR DESCRIPTION
## Summary
- Fixes #134: using "Frango Assado" did nothing because its `EF_VOLATILE=63` class had no case in the `useItem` dispatcher (silently hit the `default:` no-op).
- Adds `useFrangoAssado` (modeled on the existing `useVigor`/`useExpChest` handlers), granting the legacy's 4h flat `AffForceMobDamage` buff (Affect 30) and consuming one item stack, per `_MSG_UseItem.cpp:2308-2341` / `Basedef.cpp:4427`.
- The scoring side (`case 30: e.AffForceMobDamage += level` in `affect_score.go`) was already implemented and wired into combat — this only adds the missing item-use write path.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run` (0 issues)
- [x] `go test -race ./tmserver/internal/handler/...` and `./tmserver/internal/world/...`
- [x] New regression test `TestUseFrangoAssado` covers the consume → buff → score/affect sync path

🤖 Generated with [Claude Code](https://claude.com/claude-code)