### PR TITLE
fix(tmserver): handle base change gems

### DIFF
--- a/tmserver/internal/handler/gemas_test.go
+++ b/tmserver/internal/handler/gemas_test.go
@@ -1,0 +1,187 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/refine"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+const (
+	itemGemaDiamante = 3900
+	itemGemaGarnet   = 3903
+	itemAnctBase     = 6000
+	itemPlusEleven   = 6100
+)
+
+func TestBaseGemChangesAnctGradeVariant(t *testing.T) {
+	gems := []struct {
+		name string
+		vol  int
+		want int16
+	}{
+		{"diamante", volGemDiamond, itemAnctBase},
+		{"esmeralda", volGemEmerald, itemAnctBase + 1},
+		{"coral", volGemCoral, itemAnctBase + 2},
+		{"garnet", volGemGarnet, itemAnctBase + 3},
+	}
+	for grade := 5; grade <= 8; grade++ {
+		start := int16(itemAnctBase + grade - 5)
+		for _, gem := range gems {
+			t.Run(fmt.Sprintf("grade%d_%s", grade, gem.name), func(t *testing.T) {
+				d, w, s, e := baseGemFixture(map[int]int{int(start): grade})
+				e.Carry[0] = world.Item{Index: itemGemaDiamante}
+				e.Equip[1] = world.Item{Index: start}
+
+				d.useBaseGem(w, s, e, baseGemUseBody(world.ItemPlaceEquip, 1), 0, gem.vol)
+
+				if got := e.Equip[1].Index; got != gem.want {
+					t.Errorf("grade %d changed index to %d, want %d", grade, got, gem.want)
+				}
+				if !e.Carry[0].Empty() {
+					t.Errorf("source gem not consumed: %+v", e.Carry[0])
+				}
+			})
+		}
+	}
+}
+
+func TestBaseGemChangesPackedGemOnPlusTenThroughFifteen(t *testing.T) {
+	for level := 10; level <= 15; level++ {
+		t.Run(fmt.Sprintf("plus%d", level), func(t *testing.T) {
+			d, w, s, e := baseGemFixture(nil)
+			target := world.Item{Index: itemPlusEleven, Effects: [3]world.Effect{{Effect: efSanc}}}
+			refine.Set(&target, level, 0)
+			e.Carry[0] = world.Item{Index: itemGemaDiamante}
+			e.Equip[1] = target
+
+			d.useBaseGem(w, s, e, baseGemUseBody(world.ItemPlaceEquip, 1), 0, volGemCoral)
+
+			if got := refine.Level(e.Equip[1]); got != level {
+				t.Errorf("level = %d, want %d", got, level)
+			}
+			if got := refine.Gem(e.Equip[1]); got != 2 {
+				t.Errorf("gem = %d, want 2 (Coral)", got)
+			}
+			if e.Equip[1].Index != itemPlusEleven {
+				t.Errorf("index = %d, want unchanged %d", e.Equip[1].Index, itemPlusEleven)
+			}
+			if !e.Carry[0].Empty() {
+				t.Errorf("source gem not consumed: %+v", e.Carry[0])
+			}
+		})
+	}
+}
+
+func TestBaseGemRefusesNonAnctBelowPlusTen(t *testing.T) {
+	d, w, s, e := baseGemFixture(map[int]int{itemAnctBase: 4})
+	e.Carry[0] = world.Item{Index: itemGemaDiamante}
+	e.Equip[1] = world.Item{Index: itemAnctBase}
+
+	d.useBaseGem(w, s, e, baseGemUseBody(world.ItemPlaceEquip, 1), 0, volGemGarnet)
+
+	if e.Carry[0].Empty() {
+		t.Fatal("refused gem use consumed the source")
+	}
+	if e.Equip[1].Index != itemAnctBase {
+		t.Errorf("target index = %d, want unchanged %d", e.Equip[1].Index, itemAnctBase)
+	}
+}
+
+func TestBaseGemRejectsInvalidDestination(t *testing.T) {
+	d, w, s, e := baseGemFixture(map[int]int{itemAnctBase: 5})
+	e.Carry[0] = world.Item{Index: itemGemaDiamante}
+	e.Carry[1] = world.Item{Index: itemAnctBase}
+
+	d.useBaseGem(w, s, e, baseGemUseBody(world.ItemPlaceCarry, 1), 0, volGemGarnet)
+
+	if e.Carry[0].Empty() {
+		t.Fatal("invalid destination consumed the source")
+	}
+	if e.Carry[1].Index != itemAnctBase {
+		t.Errorf("carry target index = %d, want unchanged %d", e.Carry[1].Index, itemAnctBase)
+	}
+}
+
+func TestBaseGemOverTheWire(t *testing.T) {
+	db := newDB()
+	st := world.CharacterState{Slot: 0, Name: "Hero", X: 5, Y: 5, HP: 1000, MaxHP: 1000}
+	st.Carry[0] = world.Item{Index: itemGemaGarnet}
+	st.Equip[1] = world.Item{Index: itemAnctBase}
+	db.loadResult = st
+
+	addr, stop := startServerClockBaseGem(t, db)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	body := baseGemUseBody(world.ItemPlaceEquip, 1)
+	send(t, c, protocol.MsgUseItem, body.Encode())
+
+	for i := 0; i < 8; i++ {
+		ty, payload, ok := readMaybe(t, c)
+		if !ok {
+			t.Fatal("connection went quiet before destination item update")
+		}
+		if ty != protocol.MsgSendItem {
+			continue
+		}
+		if int(le16(payload[0:2])) != world.ItemPlaceEquip || int(le16(payload[2:4])) != 1 {
+			continue
+		}
+		if got := le16(payload[4:6]); got != itemAnctBase+3 {
+			t.Fatalf("destination index = %d, want Garnet variant %d", got, itemAnctBase+3)
+		}
+		return
+	}
+	t.Fatal("no destination MsgSendItem after base gem use")
+}
+
+func baseGemFixture(grades map[int]int) (*Dispatcher, *world.World, *world.Session, *world.Entity) {
+	log := slog.New(slog.DiscardHandler)
+	d := New(Config{Log: log, ItemGrades: grades})
+	w := world.New(world.Config{GridDim: 16}, log, nil, nil)
+	return d, w, &world.Session{Conn: 1, Mode: world.UserPlay}, &world.Entity{ID: 1, HP: 100}
+}
+
+func baseGemUseBody(destType, destPos int) protocol.MsgUseItemBody {
+	return protocol.MsgUseItemBody{
+		SourType: world.ItemPlaceCarry,
+		SourPos:  0,
+		DestType: int32(destType),
+		DestPos:  int32(destPos),
+	}
+}
+
+func startServerClockBaseGem(t *testing.T, persist world.Persistence) (string, func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := New(Config{
+		Log:           log,
+		ItemVolatiles: map[int]int{itemGemaGarnet: volGemGarnet},
+		ItemGrades:    map[int]int{itemAnctBase: 5},
+	})
+	w := world.New(world.Config{GridDim: 16}, log, persist, d.Handle)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = w.Serve(ctx, ln); close(done) }()
+	return ln.Addr().String(), func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("server did not stop")
+		}
+	}
+}

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -244,6 +244,10 @@ const (
 	volVigor      = 58
 	volSilverBar  = 185
 	volFrango     = 63
+	volGemDiamond = 180
+	volGemEmerald = 181
+	volGemCoral   = 182
+	volGemGarnet  = 183
 	// affect tick units (Basedef.h): one tick = 8s of real time.
 	affect1H          = 450
 	affect1D          = 10800
@@ -300,6 +304,8 @@ func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header
 		d.useFrangoAssado(w, s, e, src)
 	case vol == volSilverBar:
 		d.useSilverBar(w, s, e, src)
+	case vol >= volGemDiamond && vol <= volGemGarnet:
+		d.useBaseGem(w, s, e, body, src, vol)
 	case vol == volJoiaPvP:
 		d.useJoiaPvP(w, s, e, src)
 	case vol == volJoiaRecovery:
@@ -580,6 +586,68 @@ func (d *Dispatcher) useSilverBar(w *world.World, s *world.Session, e *world.Ent
 	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
 	d.sendEtc(w, s, e)
 	d.log.Info("silver bar used", "conn", s.Conn, "item", itemIdx, "gold", gold, "coin", e.Coin)
+}
+
+// baseGemVariant maps the four base-change gems to the +10..+15 packed gem
+// index used by BASE_SetItemSanc (_MSG_UseItem.cpp:3890-4201).
+func baseGemVariant(vol int) (int, bool) {
+	switch vol {
+	case volGemDiamond:
+		return 0, true
+	case volGemEmerald:
+		return 1, true
+	case volGemCoral:
+		return 2, true
+	case volGemGarnet:
+		return 3, true
+	default:
+		return 0, false
+	}
+}
+
+// useBaseGem handles Gema de Diamante/Esmeralda/Coral/Garnet (Vol 180..183).
+// They change an equipped ANCT grade-5..8 item to the selected base variant and,
+// on +10..+15 targets, rewrite the packed sanc gem index. The legacy accepts only
+// equipped gear except body slot 0 and accessory slots 8..15.
+func (d *Dispatcher) useBaseGem(w *world.World, s *world.Session, e *world.Entity, body protocol.MsgUseItemBody, src, vol int) {
+	gem, ok := baseGemVariant(vol)
+	if !ok {
+		return
+	}
+
+	dstSlot := int(body.DestPos)
+	if int(body.DestType) != world.ItemPlaceEquip || dstSlot == 0 || (dstSlot >= 8 && dstSlot < world.MaxEquip) {
+		d.baseGemReject(w, s, e, src, NoticeOnlyToEquips)
+		return
+	}
+	dst := d.itemSlot(w, s, e, int(body.DestType), dstSlot)
+	if dst == nil {
+		return
+	}
+
+	level := refine.Level(*dst)
+	grade := d.itemGrades[int(dst.Index)]
+	if level < gemSancLvl && grade < 5 {
+		d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
+		return
+	}
+
+	if grade >= 5 && grade <= 8 {
+		dst.Index += int16(gem - (grade - 5))
+	}
+	if level >= gemSancLvl {
+		refine.Set(dst, level, gem)
+	}
+
+	d.refreshScore(e)
+	d.sendScore(w, s, e)
+	consumeOneItem(&e.Carry[src])
+	d.sendSlot(w, s, world.ItemPlaceEquip, dstSlot, *dst)
+}
+
+func (d *Dispatcher) baseGemReject(w *world.World, s *world.Session, e *world.Entity, src int, n Notice) {
+	d.notify(w, s, n)
+	d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
 }
 
 // Jóia (cash jewel) volatiles. Vol 242 is the PvP buff set (grants affect type


### PR DESCRIPTION
## Summary
- handle Gema de Diamante, Esmeralda, Coral, and Garnet use-item Vol 180..183
- change ANCT grade 5..8 base variants and +10..+15 packed gem encoding
- add direct handler and over-the-wire regression coverage

Closes #129.

## Tests
- go test ./tmserver/internal/handler ./tmserver/internal/refine
- make test