### PR TITLE
fix(npcadmin): curate king templates

### DIFF
--- a/api/web/v1/web.pb.go
+++ b/api/web/v1/web.pb.go
@@ -1967,7 +1967,7 @@ func (x *DeleteNpcRequest) GetNpcId() int64 {
 	return 0
 }
 
-// MerchantTemplate is one merchant-type STRUCT_MOB template found under
+// MerchantTemplate is one supported STRUCT_MOB template found under
 // Release/TMsrv/run/npc/.
 type MerchantTemplate struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`

--- a/api/web/v1/web.proto
+++ b/api/web/v1/web.proto
@@ -145,11 +145,10 @@ service NpcAdminService {
   rpc SetItemPrice(SetItemPriceRequest) returns (AdminAck);
   // DeleteNpc removes a definition.
   rpc DeleteNpc(DeleteNpcRequest) returns (AdminAck);
-  // ListMerchantTemplates returns the merchant NPC templates found in the
-  // content tree (Release/TMsrv/run/npc/, CurrentScore.Merchant != 0), so the
-  // moderator UI can offer a searchable picker instead of a free-text
-  // template_name field. Scanned once at web-api boot from -content/W2PP_CONTENT;
-  // empty when that flag is unset.
+  // ListMerchantTemplates returns the supported NPC templates found in the
+  // content tree (Release/TMsrv/run/npc/), so the moderator UI can offer a
+  // searchable picker instead of a free-text template_name field. Scanned once
+  // at web-api boot from -content/W2PP_CONTENT; empty when that flag is unset.
   rpc ListMerchantTemplates(ListMerchantTemplatesRequest) returns (ListMerchantTemplatesResponse);
   // ListItemCatalog returns the item catalog (Release/Common/ItemList.csv:
   // item_index, name), so the shop-item editor (SetNpcShop/SetItemPrice) can
@@ -257,7 +256,7 @@ message DeleteNpcRequest {
   int64 npc_id = 2;
 }
 
-// MerchantTemplate is one merchant-type STRUCT_MOB template found under
+// MerchantTemplate is one supported STRUCT_MOB template found under
 // Release/TMsrv/run/npc/.
 message MerchantTemplate {
   string template_name = 1; // exact value for UpsertNpc.template_name (no .txt)

--- a/api/web/v1/web_grpc.pb.go
+++ b/api/web/v1/web_grpc.pb.go
@@ -447,11 +447,10 @@ type NpcAdminServiceClient interface {
 	SetItemPrice(ctx context.Context, in *SetItemPriceRequest, opts ...grpc.CallOption) (*AdminAck, error)
 	// DeleteNpc removes a definition.
 	DeleteNpc(ctx context.Context, in *DeleteNpcRequest, opts ...grpc.CallOption) (*AdminAck, error)
-	// ListMerchantTemplates returns the merchant NPC templates found in the
-	// content tree (Release/TMsrv/run/npc/, CurrentScore.Merchant != 0), so the
-	// moderator UI can offer a searchable picker instead of a free-text
-	// template_name field. Scanned once at web-api boot from -content/W2PP_CONTENT;
-	// empty when that flag is unset.
+	// ListMerchantTemplates returns the supported NPC templates found in the
+	// content tree (Release/TMsrv/run/npc/), so the moderator UI can offer a
+	// searchable picker instead of a free-text template_name field. Scanned once
+	// at web-api boot from -content/W2PP_CONTENT; empty when that flag is unset.
 	ListMerchantTemplates(ctx context.Context, in *ListMerchantTemplatesRequest, opts ...grpc.CallOption) (*ListMerchantTemplatesResponse, error)
 	// ListItemCatalog returns the item catalog (Release/Common/ItemList.csv:
 	// item_index, name), so the shop-item editor (SetNpcShop/SetItemPrice) can
@@ -597,11 +596,10 @@ type NpcAdminServiceServer interface {
 	SetItemPrice(context.Context, *SetItemPriceRequest) (*AdminAck, error)
 	// DeleteNpc removes a definition.
 	DeleteNpc(context.Context, *DeleteNpcRequest) (*AdminAck, error)
-	// ListMerchantTemplates returns the merchant NPC templates found in the
-	// content tree (Release/TMsrv/run/npc/, CurrentScore.Merchant != 0), so the
-	// moderator UI can offer a searchable picker instead of a free-text
-	// template_name field. Scanned once at web-api boot from -content/W2PP_CONTENT;
-	// empty when that flag is unset.
+	// ListMerchantTemplates returns the supported NPC templates found in the
+	// content tree (Release/TMsrv/run/npc/), so the moderator UI can offer a
+	// searchable picker instead of a free-text template_name field. Scanned once
+	// at web-api boot from -content/W2PP_CONTENT; empty when that flag is unset.
 	ListMerchantTemplates(context.Context, *ListMerchantTemplatesRequest) (*ListMerchantTemplatesResponse, error)
 	// ListItemCatalog returns the item catalog (Release/Common/ItemList.csv:
 	// item_index, name), so the shop-item editor (SetNpcShop/SetItemPrice) can

--- a/docs/migration/handlers/npc-map.md
+++ b/docs/migration/handlers/npc-map.md
@@ -57,7 +57,7 @@ O **`Merchant`** do NPC decide o que o clique manda:
 | 101 | 8 | Cecilia, U_Ni_Corn | _MSG_Quest | ❌ montaria unicórnio? |
 | 104/105/107 | 4/2/1 | Uxmal, Treinador2/3, TrainerChief | _MSG_Quest (tutoriais) | ❌ |
 | 110 | 1 | Unicornio_Puro | _MSG_Quest | ❌ |
-| 111 | 4 | Rei_Glantuar, Rei_Harabard | _MSG_Quest (KING) | ❌ |
+| 111 | 4 | Rei_Glantuar, Rei_Harabard | _MSG_Quest (KING) | ⚠️ King Arch ✅; reino pendente |
 | 113 | 5 | Mercador_Noel, Arqueologo | _MSG_Quest | ❌ |
 | 120 | 4 | Carbuncle_Wind, Ajudante | _MSG_Quest (CARBUNCLE_WIND) | ❌ |
 | 128 | 5 | Gate_Keeper, Town_Watcher | _MSG_Quest | ❌ guardas/teleporte |
@@ -85,6 +85,7 @@ quests grade 11–16/24–30) **não**.
 - **Cargo/banco** (Merchant 2): `reqShopList` → `openCargo`, deposit/withdraw.
 - **Combine/refino**: família `combineItem` (Odin/Lindy/Shany/… via opcodes dedicados).
 - **Perzen** (Merchant 100 grade 7/8/9): troca esfera→montaria.
+- **King Arch** (Merchant 111): cria personagem Arch a partir dos reis canônicos.
 - **Mestre Grifo** (`_MSG_MasterGriff` 0x0AD9): teleporta, após a animação de viagem do cliente, para
   Defensor de Almas `(2372,2099)`, Jardim dos Deuses `(2220,1714)`, Calabouco `(2365,2279)` ou
   Submundo `(1826,1771)`.

--- a/docs/migration/npc-default-roster.md
+++ b/docs/migration/npc-default-roster.md
@@ -12,8 +12,9 @@ A "nova estrutura de NPC" (`npc_definition`, `dbserver import-npcs`) já sabia *
 merchant — qualquer bloco de `NPCGener.txt` cujo template líder tenha `CurrentScore.Merchant != 0`.
 Rodando contra o conteúdo real deste repo (`go run ./dbserver/cmd/dbserver import-npcs -content
 ./Release`, dry run): **544 blocos de spawn merchant**, de **205 templates únicos**, cobrindo
-**muito mais códigos `Merchant`** do que os 4 que o `NpcAdminService` sabe validar
-(`npcadmin.validMerchant = {0,1,2,19,100}`).
+**muito mais códigos `Merchant`** do que os códigos seedados no roster padrão. O
+`NpcAdminService` também valida `111` para os reis canônicos (`Rei_Harabard`/`Rei_Glantuar`), mas
+eles não fazem parte deste seed curado da issue #29.
 
 O que faltava não era identificação — era **curadoria**: decidir qual subconjunto conta como o
 roster "padrão" (estável, documentado, com identidade), em vez de importar cegamente tudo que o
@@ -22,10 +23,9 @@ hoje (64, 96, 100+ variantes de raid/quest ainda não implementadas — ver `npc
 
 ## 2. Critério de curadoria
 
-1. **Só os 4 códigos editáveis hoje**: `Merchant ∈ {1 (loja), 2 (guarda de carga/banco), 19 (loja
-   tipo 3), 100 (quest)}` — os mesmos que `npcadmin.validMerchant` aceita. Qualquer coisa fora disso
-   (raids do Zakum, chefes com `Merchant` usado como gatilho de quest não implementada, etc.) fica de
-   fora do roster.
+1. **Só os 4 códigos seedados no roster padrão**: `Merchant ∈ {1 (loja), 2 (guarda de carga/banco),
+   19 (loja tipo 3), 100 (quest)}`. Qualquer coisa fora disso (raids do Zakum, chefes com
+   `Merchant` usado como gatilho de quest não implementada, reis `111`, etc.) fica de fora do roster.
 2. **Um representante por arquétipo**, não por variante regional/tier. Vários templates são cópias
    do mesmo NPC para outro continente ou versão: `Acessorios`/`Acessorios2..6`/`AcessoriosErion`
    (mesma loja, cópias diferentes) colapsam para `Acessorios`; `Set_BM`/`Set_BM_Erion` (mesmo

--- a/tmserver/internal/handler/misc.go
+++ b/tmserver/internal/handler/misc.go
@@ -171,7 +171,6 @@ func (d *Dispatcher) quest(w *world.World, s *world.Session, _ protocol.Header, 
 
 const (
 	kingQuestMerchant = 111
-	kingQuestGrade    = 4
 
 	idealStoneEquipSlot = 10
 	sephirotEquipSlot   = 11
@@ -183,11 +182,10 @@ func isKingQuestNPC(npc *world.Entity) bool {
 	if npc == nil {
 		return false
 	}
-	// The Go loader stores CurrentScore.Merchant (111) plus EF_GRADE0 (4), while
-	// the legacy switch routes KING from MOB.Merchant 14/15. Accept both shapes so
-	// tests and future loaders can use either representation.
-	return npc.Merchant == kingQuestMerchant && npc.Grade == kingQuestGrade ||
-		npc.Merchant == 14 || npc.Merchant == 15
+	// The Go loader stores real King templates by CurrentScore.Merchant (111),
+	// while the legacy switch routes KING from top-level MOB.Merchant 14/15.
+	// Accept both shapes so content and future loaders can use either source.
+	return npc.Merchant == kingQuestMerchant || npc.Merchant == 14 || npc.Merchant == 15
 }
 
 func (d *Dispatcher) kingArch(w *world.World, s *world.Session, e *world.Entity, confirm int) {

--- a/tmserver/internal/handler/quest_test.go
+++ b/tmserver/internal/handler/quest_test.go
@@ -82,8 +82,28 @@ func kingTemplate() []byte {
 	binary.LittleEndian.PutUint16(b[40:], 5)      // SPX
 	binary.LittleEndian.PutUint16(b[42:], 5)      // SPY
 	binary.LittleEndian.PutUint16(b[140:], 11)    // Equip[0].index
-	b[140+2], b[140+3] = 100, 4                   // EF_GRADE0 = KING
 	return b
+}
+
+func TestIsKingQuestNPCShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		npc  *world.Entity
+		want bool
+	}{
+		{"real current score merchant", &world.Entity{Merchant: 111}, true},
+		{"legacy top-level harabard", &world.Entity{Merchant: 14}, true},
+		{"legacy top-level glantuar", &world.Entity{Merchant: 15}, true},
+		{"unsupported variant", &world.Entity{Merchant: 96}, false},
+		{"nil", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isKingQuestNPC(tt.npc); got != tt.want {
+				t.Errorf("isKingQuestNPC() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
 func startServerKing(t *testing.T, db *fakeDB) (string, func(), int) {

--- a/webserver/internal/npcadmin/service.go
+++ b/webserver/internal/npcadmin/service.go
@@ -242,12 +242,13 @@ func classifyWrite(err error, op string) (Result, error) {
 	}
 }
 
-// validMerchant accepts the merchant sub-types the game knows: 0 (none/monster),
-// 1 (shop), 2 (cargo guard), 19 (shop type 3), 100 (quest NPC). Others are
-// rejected until confirmed by capture (npc-editing-plan.md §9.4).
+// validMerchant accepts the merchant sub-types the admin panel can materialize:
+// 0 (none/monster), 1 (shop), 2 (cargo guard), 19 (shop type 3), 100 (supported
+// quest NPC), and 111 (canonical King templates). Others are rejected until
+// confirmed by capture (npc-editing-plan.md §9.4).
 func validMerchant(m int16) bool {
 	switch m {
-	case 0, 1, 2, 19, 100:
+	case 0, 1, 2, 19, 100, 111:
 		return true
 	default:
 		return false

--- a/webserver/internal/npcadmin/service_test.go
+++ b/webserver/internal/npcadmin/service_test.go
@@ -119,9 +119,11 @@ func TestUpsertValidation(t *testing.T) {
 		want Result
 	}{
 		{"ok", domain.NPCDefinition{Slug: "s", TemplateName: "t", Merchant: 1}, OK},
+		{"king ok", domain.NPCDefinition{Slug: "king", TemplateName: "Rei_Harabard", Merchant: 111}, OK},
 		{"empty slug", domain.NPCDefinition{TemplateName: "t"}, Invalid},
 		{"empty template", domain.NPCDefinition{Slug: "s"}, Invalid},
 		{"bad merchant", domain.NPCDefinition{Slug: "s", TemplateName: "t", Merchant: 7}, Invalid},
+		{"unsupported king variant merchant", domain.NPCDefinition{Slug: "s", TemplateName: "t", Merchant: 96}, Invalid},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/webserver/internal/npctemplates/npctemplates.go
+++ b/webserver/internal/npctemplates/npctemplates.go
@@ -1,10 +1,9 @@
-// Package npctemplates scans the read-only content tree for merchant NPC
+// Package npctemplates scans the read-only content tree for supported NPC
 // templates, so the moderator UI can offer a searchable picker for
 // NpcAdminService.UpsertNpc's template_name instead of free text (a typo there
 // leaves the definition in Postgres but the tmServer silently skips the spawn —
-// npc-editing-plan.md). It reuses internal/savefmt.DecodeMob, the same decoder
-// dbserver's `import-npcs` importer (buildNPCDefinitions) uses to identify
-// merchants, so both agree on what counts as one.
+// npc-editing-plan.md). The picker is intentionally curated: the raw content
+// tree has legacy quest variants that the panel cannot use safely yet.
 //
 // STRUCT_MOB.Name is ISO-8859-1 (same source tree, same encoding as
 // itemcatalog's ItemList.csv) — see cString for the transcoding, needed here
@@ -21,7 +20,22 @@ import (
 	"github.com/jeanluca/w2pp-openwyd/internal/savefmt"
 )
 
-// Template is one merchant-type STRUCT_MOB template found under
+const (
+	merchantShop      = 1
+	merchantCargo     = 2
+	merchantShopType3 = 19
+	merchantQuest     = 100
+	merchantKing      = 111
+
+	efGrade0 = 100
+)
+
+var canonicalKingTemplates = map[string]struct{}{
+	"Rei_Harabard": {},
+	"Rei_Glantuar": {},
+}
+
+// Template is one supported STRUCT_MOB template found under
 // Release/TMsrv/run/npc/.
 type Template struct {
 	TemplateName string
@@ -30,10 +44,10 @@ type Template struct {
 }
 
 // Scan reads every file in <contentDir>/TMsrv/run/npc/, decodes it as a
-// STRUCT_MOB and keeps only the ones with CurrentScore.Merchant != 0 (the same
-// field buildNPCDefinitions filters on), sorted by TemplateName. A file that
-// isn't a valid 816-byte STRUCT_MOB is logged and skipped rather than failing
-// the whole scan — the npc/ directory can contain non-template files.
+// STRUCT_MOB and keeps only the templates supported by the admin panel today,
+// sorted by TemplateName. A file that isn't a valid 816-byte STRUCT_MOB is
+// logged and skipped rather than failing the whole scan - the npc/ directory can
+// contain non-template files.
 func Scan(contentDir string, logger *slog.Logger) ([]Template, error) {
 	dir := filepath.Join(contentDir, "TMsrv", "run", "npc")
 	entries, err := os.ReadDir(dir)
@@ -57,8 +71,8 @@ func Scan(contentDir string, logger *slog.Logger) ([]Template, error) {
 			logger.Warn("npc template decode failed", "name", name, "err", err)
 			continue
 		}
-		if mob.CurrentScore.Merchant == 0 {
-			continue // monster / non-shop NPC, not offered in the picker
+		if !supportedTemplate(name, mob) {
+			continue
 		}
 		out = append(out, Template{
 			TemplateName: name,
@@ -71,9 +85,33 @@ func Scan(contentDir string, logger *slog.Logger) ([]Template, error) {
 	return out, nil
 }
 
+func supportedTemplate(name string, mob savefmt.Mob) bool {
+	switch mob.CurrentScore.Merchant {
+	case merchantShop, merchantCargo, merchantShopType3:
+		return true
+	case merchantQuest:
+		grade := questGrade(mob)
+		return grade >= 7 && grade <= 9
+	case merchantKing:
+		_, ok := canonicalKingTemplates[name]
+		return ok
+	default:
+		return false
+	}
+}
+
+func questGrade(mob savefmt.Mob) uint8 {
+	for _, ef := range mob.Equip[0].Effects {
+		if ef.Effect == efGrade0 {
+			return ef.Value
+		}
+	}
+	return 0
+}
+
 // cString trims a fixed-size name field at the first NUL byte and converts it
 // from ISO-8859-1 to UTF-8 (each Latin-1 byte's value IS its Unicode code
-// point, by definition of that encoding) — without this, accented names come
+// point, by definition of that encoding) - without this, accented names come
 // out mojibake over gRPC/JSON, same bug class as itemcatalog.latin1ToUTF8.
 func cString(b []byte) string {
 	for i, c := range b {

--- a/webserver/internal/npctemplates/npctemplates_test.go
+++ b/webserver/internal/npctemplates/npctemplates_test.go
@@ -20,7 +20,14 @@ func mobBytes(name string, merchant byte) []byte {
 	return b
 }
 
-func TestScanFiltersToMerchants(t *testing.T) {
+func mobBytesWithGrade(name string, merchant, grade byte) []byte {
+	b := mobBytes(name, merchant)
+	b[140+2] = 100
+	b[140+3] = grade
+	return b
+}
+
+func TestScanFiltersToSupportedTemplates(t *testing.T) {
 	dir := t.TempDir()
 	npcDir := filepath.Join(dir, "TMsrv", "run", "npc")
 	if err := os.MkdirAll(npcDir, 0o755); err != nil {
@@ -34,7 +41,12 @@ func TestScanFiltersToMerchants(t *testing.T) {
 	}
 	write("HekalMerchant", mobBytes("Hekal", 1))
 	write("AkeMerchant", mobBytes("Ake", 19))
+	write("CargoGuard", mobBytes("Cargo", 2))
 	write("SomeMonster", mobBytes("Monster", 0))
+	write("King_Harabard", mobBytes("King_Harabard", 96))
+	write("BlackOracle", mobBytes("BlackOracle", 78))
+	write("Perzen", mobBytesWithGrade("Perzen", 100, 10))
+	write("Perzen_Normal", mobBytesWithGrade("Perzen_Normal", 100, 7))
 	write("Broken", []byte{1, 2, 3}) // wrong size, must be skipped, not fatal
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -45,7 +57,48 @@ func TestScanFiltersToMerchants(t *testing.T) {
 
 	want := []Template{
 		{TemplateName: "AkeMerchant", DisplayName: "Ake", Merchant: 19},
+		{TemplateName: "CargoGuard", DisplayName: "Cargo", Merchant: 2},
 		{TemplateName: "HekalMerchant", DisplayName: "Hekal", Merchant: 1},
+		{TemplateName: "Perzen_Normal", DisplayName: "Perzen_Normal", Merchant: 100},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d templates, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("templates[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestScanKeepsOnlyCanonicalKingTemplates(t *testing.T) {
+	dir := t.TempDir()
+	npcDir := filepath.Join(dir, "TMsrv", "run", "npc")
+	if err := os.MkdirAll(npcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	write := func(name string, b []byte) {
+		if err := os.WriteFile(filepath.Join(npcDir, name), b, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("KingHarabard", mobBytes("KingHarabard", 111))
+	write("King_Harabard", mobBytes("King_Harabard", 96))
+	write("Rei_Harabard", mobBytes("Rei_Harabard", 111))
+	write("KingGlantuar", mobBytes("KingGlantuar", 111))
+	write("King_Glantuar", mobBytes("King_Glantuar", 96))
+	write("Rei_Glantuar", mobBytes("Rei_Glantuar", 111))
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	got, err := Scan(dir, logger)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	want := []Template{
+		{TemplateName: "Rei_Glantuar", DisplayName: "Rei_Glantuar", Merchant: 111},
+		{TemplateName: "Rei_Harabard", DisplayName: "Rei_Harabard", Merchant: 111},
 	}
 	if len(got) != len(want) {
 		t.Fatalf("got %d templates, want %d: %+v", len(got), len(want), got)


### PR DESCRIPTION
## Summary
- curate the NPC template picker to show only supported templates
- keep only canonical King templates (Rei_Harabard/Rei_Glantuar) and filter legacy variants
- accept Merchant 111 in npcadmin and make tmserver recognize real King templates

Fixes #132

## Tests
- go test ./webserver/internal/npctemplates ./webserver/internal/npcadmin ./webserver/internal/grpcsrv ./tmserver/internal/handler
- make test