### PR TITLE
Fix Feijão Mágico set painting

### DIFF
--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -304,6 +304,8 @@ func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header
 		d.useJoiaPvP(w, s, e, src)
 	case vol == volJoiaRecovery:
 		d.useJoiaRecovery(w, s, e, src)
+	case vol == volMagicBean:
+		d.useMagicBean(w, s, e, body, src)
 	default:
 		// UNVERIFIED consumable (scrolls/teleport/pet food/keys) — not handled yet.
 	}
@@ -658,6 +660,83 @@ func (d *Dispatcher) useJoiaRecovery(w *world.World, s *world.Session, e *world.
 	}
 	consumeOneItem(&e.Carry[src])
 	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
+}
+
+const (
+	volMagicBean       = 186
+	magicBeanBase      = 3407
+	magicBeanRemover   = 10
+	magicBeanPaintLo   = 116
+	magicBeanPaintHi   = 125
+	magicBeanFirstSlot = 1
+	magicBeanLastSlot  = 7
+)
+
+// useMagicBean consumes a Feijao Magico / Removedor de tintura (EF_VOLATILE 186)
+// by stamping only the destination effect id byte, preserving the cValue exactly
+// as _MSG_UseItem.cpp:3767-3861 does. Paint effects reuse the sanc effect slots:
+// 116..125 are colors, while EF_SANC (43) is the remover/neutral marker.
+func (d *Dispatcher) useMagicBean(w *world.World, s *world.Session, e *world.Entity, body protocol.MsgUseItemBody, src int) {
+	dstSlot := int(body.DestPos)
+	if int(body.DestType) != world.ItemPlaceEquip || dstSlot < magicBeanFirstSlot || dstSlot > magicBeanLastSlot {
+		d.magicBeanReject(w, s, e, src, NoticeOnlyToEquips)
+		return
+	}
+	dst := d.itemSlot(w, s, e, int(body.DestType), dstSlot)
+	if dst == nil {
+		return
+	}
+	if dst.Empty() {
+		d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
+		return
+	}
+	if refine.Level(*dst) < 1 {
+		d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
+		return
+	}
+
+	color := int(e.Carry[src].Index) - magicBeanBase
+	effect := uint8(magicBeanPaintLo + color)
+	if color == magicBeanRemover {
+		effect = efSanc
+	}
+
+	i := magicBeanEffectSlot(*dst, color == magicBeanRemover)
+	if i < 0 {
+		d.magicBeanReject(w, s, e, src, NoticeCantRefineMore)
+		return
+	}
+	dst.Effects[i].Effect = effect
+
+	d.notify(w, s, NoticeRefineSuccess)
+	d.refreshScore(e)
+	d.sendScore(w, s, e)
+	consumeOneItem(&e.Carry[src])
+	d.sendSlot(w, s, int(body.DestType), dstSlot, *dst)
+}
+
+func (d *Dispatcher) magicBeanReject(w *world.World, s *world.Session, e *world.Entity, src int, n Notice) {
+	d.notify(w, s, n)
+	d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
+}
+
+func magicBeanEffectSlot(it world.Item, remover bool) int {
+	for i, ef := range it.Effects {
+		if magicBeanSlotWritable(ef, remover) {
+			return i
+		}
+	}
+	return -1
+}
+
+func magicBeanSlotWritable(ef world.Effect, remover bool) bool {
+	if ef.Effect == 0 || ef.Effect >= magicBeanPaintLo && ef.Effect <= magicBeanPaintHi {
+		return true
+	}
+	if !remover && ef.Effect == efSanc {
+		return true
+	}
+	return false
 }
 
 // sendAffect pushes MSG_SendAffect (0x03B9): the full 32-slot buff snapshot, so the

--- a/tmserver/internal/handler/item_test.go
+++ b/tmserver/internal/handler/item_test.go
@@ -318,6 +318,219 @@ func TestUseItemEquip(t *testing.T) {
 	}
 }
 
+const (
+	itemMagicBeanBlue    = 3407
+	itemMagicBeanLight   = 3416
+	itemMagicBeanRemover = 3417
+)
+
+func magicBeanDB(bean, equip world.Item) *fakeDB {
+	db := newDB()
+	st := world.CharacterState{Slot: 0, Name: "Hero", X: 5, Y: 5, HP: 1000, MaxHP: 1000}
+	st.Carry[0] = bean
+	st.Equip[1] = equip
+	db.loadResult = st
+	return db
+}
+
+func useMagicBeanFrame(t *testing.T, c net.Conn, dstSlot int) {
+	t.Helper()
+	body := protocol.MsgUseItemBody{
+		SourType: world.ItemPlaceCarry, SourPos: 0,
+		DestType: world.ItemPlaceEquip, DestPos: int32(dstSlot),
+	}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+}
+
+func magicBeanVols(bean int16) map[int]int {
+	return map[int]int{int(bean): volMagicBean}
+}
+
+func TestUseMagicBeanPaintsEquippedSet(t *testing.T) {
+	armor := world.Item{Index: itemArmor, Effects: [3]world.Effect{{Effect: efSanc, Value: 9}}}
+	addr, stop := startServerClockVol(t, magicBeanDB(world.Item{Index: itemMagicBeanBlue}, armor), magicBeanVols(itemMagicBeanBlue))
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	useMagicBeanFrame(t, c, 1)
+
+	if code := noticeCode(t, expect(t, c, protocol.MsgMessageBoxOk)); code != NoticeRefineSuccess {
+		t.Fatalf("notice = %d, want RefineSuccess", code)
+	}
+	expect(t, c, protocol.MsgUpdateScore)
+	item := expect(t, c, protocol.MsgSendItem)
+	if got := le16(item[0:2]); got != world.ItemPlaceEquip {
+		t.Fatalf("send item place = %d, want equip", got)
+	}
+	if got := le16(item[2:4]); got != 1 {
+		t.Fatalf("send item slot = %d, want 1", got)
+	}
+	if got := le16(item[4:6]); got != itemArmor {
+		t.Fatalf("painted item index = %d, want armor", got)
+	}
+	if item[6] != magicBeanPaintLo || item[7] != 9 {
+		t.Fatalf("effect0 = %d.%d, want paint %d preserving sanc value 9", item[6], item[7], magicBeanPaintLo)
+	}
+}
+
+func TestUseMagicBeanHighestColorAndRemover(t *testing.T) {
+	tests := []struct {
+		name string
+		bean int16
+		dst  world.Item
+		want uint8
+	}{
+		{
+			name: "light blue writes 125",
+			bean: itemMagicBeanLight,
+			dst:  world.Item{Index: itemArmor, Effects: [3]world.Effect{{Effect: efSanc, Value: 8}}},
+			want: magicBeanPaintHi,
+		},
+		{
+			name: "remover writes EF_SANC",
+			bean: itemMagicBeanRemover,
+			dst:  world.Item{Index: itemArmor, Effects: [3]world.Effect{{Effect: magicBeanPaintLo + 4, Value: 8}}},
+			want: efSanc,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addr, stop := startServerClockVol(t, magicBeanDB(world.Item{Index: tt.bean}, tt.dst), magicBeanVols(tt.bean))
+			defer stop()
+			c := enterWorld(t, addr)
+			defer c.Close()
+
+			useMagicBeanFrame(t, c, 1)
+
+			expect(t, c, protocol.MsgMessageBoxOk)
+			expect(t, c, protocol.MsgUpdateScore)
+			item := expect(t, c, protocol.MsgSendItem)
+			if item[6] != tt.want || item[7] != 8 {
+				t.Fatalf("effect0 = %d.%d, want %d.8", item[6], item[7], tt.want)
+			}
+		})
+	}
+}
+
+func TestUseMagicBeanRejectsMissingSanc(t *testing.T) {
+	tests := []struct {
+		name  string
+		equip world.Item
+	}{
+		{name: "empty equip slot"},
+		{name: "unrefined item", equip: world.Item{Index: itemArmor}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addr, stop := startServerClockVol(t, magicBeanDB(world.Item{Index: itemMagicBeanBlue}, tt.equip), magicBeanVols(itemMagicBeanBlue))
+			defer stop()
+			c := enterWorld(t, addr)
+			defer c.Close()
+
+			useMagicBeanFrame(t, c, 1)
+
+			item := expect(t, c, protocol.MsgSendItem)
+			if got := le16(item[0:2]); got != world.ItemPlaceCarry {
+				t.Fatalf("reject send item place = %d, want carry", got)
+			}
+			if got := le16(item[4:6]); got != itemMagicBeanBlue {
+				t.Fatalf("reject source item = %d, want magic bean", got)
+			}
+			if ty, _, ok := readMaybe(t, c); ok {
+				t.Fatalf("missing-sanc magic bean use produced extra frame %#x", ty)
+			}
+		})
+	}
+}
+
+func TestUseMagicBeanRejectsNonSetSlot(t *testing.T) {
+	armor := world.Item{Index: itemArmor, Effects: [3]world.Effect{{Effect: efSanc, Value: 9}}}
+	addr, stop := startServerClockVol(t, magicBeanDB(world.Item{Index: itemMagicBeanBlue}, armor), magicBeanVols(itemMagicBeanBlue))
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	useMagicBeanFrame(t, c, 0)
+
+	if code := noticeCode(t, expect(t, c, protocol.MsgMessageBoxOk)); code != NoticeOnlyToEquips {
+		t.Fatalf("notice = %d, want OnlyToEquips", code)
+	}
+	item := expect(t, c, protocol.MsgSendItem)
+	if got := le16(item[0:2]); got != world.ItemPlaceCarry {
+		t.Fatalf("reject send item place = %d, want carry", got)
+	}
+	if got := le16(item[4:6]); got != itemMagicBeanBlue {
+		t.Fatalf("reject source item = %d, want magic bean", got)
+	}
+}
+
+func TestUseMagicBeanStackPersistsOneConsumed(t *testing.T) {
+	armor := world.Item{Index: itemArmor, Effects: [3]world.Effect{{Effect: efSanc, Value: 9}}}
+	bean := world.Item{Index: itemMagicBeanBlue, Effects: [3]world.Effect{{Effect: efAmount, Value: 3}}}
+	db := magicBeanDB(bean, armor)
+	addr, stop := startServerClockVol(t, db, magicBeanVols(itemMagicBeanBlue))
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	useMagicBeanFrame(t, c, 1)
+	expect(t, c, protocol.MsgSendItem)
+
+	send(t, c, protocol.MsgCharacterLogout, nil)
+	expect(t, c, protocol.MsgCNFCharacterLogout)
+
+	save, n := db.lastSavedChar()
+	if n == 0 {
+		t.Fatal("character was not saved on logout")
+	}
+	carry0, ok := savedItemAt(save.Carry, 0)
+	if !ok {
+		t.Fatal("saved carry slot 0 is empty; want stacked magic bean")
+	}
+	if carry0.Index != itemMagicBeanBlue || carry0.Eff1 != efAmount || carry0.EffV1 != 2 {
+		t.Fatalf("saved carry0 = %+v, want magic bean amount 2", carry0)
+	}
+	equip1, ok := savedItemAt(save.Equip, 1)
+	if !ok {
+		t.Fatal("saved equip slot 1 is empty; want painted armor")
+	}
+	if equip1.Eff1 != magicBeanPaintLo || equip1.EffV1 != 9 {
+		t.Fatalf("saved equip1 effects = %+v, want paint %d value 9", equip1, magicBeanPaintLo)
+	}
+}
+
+func TestMagicBeanEffectSlotScan(t *testing.T) {
+	it := world.Item{Effects: [3]world.Effect{
+		{Effect: efDamage, Value: 1},
+		{Effect: efAc, Value: 2},
+		{Effect: efHp, Value: 3},
+	}}
+	if got := magicBeanEffectSlot(it, false); got != -1 {
+		t.Fatalf("paint slot = %d, want -1 for three real effects", got)
+	}
+	it.Effects[1] = world.Effect{Effect: efSanc, Value: 9}
+	if got := magicBeanEffectSlot(it, false); got != 1 {
+		t.Fatalf("paint slot = %d, want EF_SANC slot 1", got)
+	}
+	if got := magicBeanEffectSlot(it, true); got != -1 {
+		t.Fatalf("remover slot = %d, want -1 when only EF_SANC is available", got)
+	}
+	it.Effects[2] = world.Effect{Effect: magicBeanPaintLo + 2, Value: 9}
+	if got := magicBeanEffectSlot(it, true); got != 2 {
+		t.Fatalf("remover slot = %d, want paint slot 2", got)
+	}
+}
+
+func savedItemAt(items []world.SavedItem, slot int) (world.SavedItem, bool) {
+	for _, it := range items {
+		if it.Slot == slot {
+			return it, true
+		}
+	}
+	return world.SavedItem{}, false
+}
+
 // TestTradingItemCarryMove is the most basic case the user hit: drag an item from
 // one inventory slot to an empty one via _MSG_TradingItem (0x0376). The item moves
 // and both slots are refreshed (the empty source, the now-filled destination).


### PR DESCRIPTION
## Summary
- handle EF_VOLATILE 186 magic beans/remover in _MSG_UseItem
- paint valid equipped set slots with effects 116..125 or clear paint with EF_SANC
- add socket-backed regressions for paint, remover, reject, and stack persistence paths

## Tests
- go test ./tmserver/internal/handler
- go test ./tmserver/internal/...
- make test

Closes #128