### PR TITLE
S→C instrumentation for the client-freeze investigation

### DIFF
--- a/docs/migration/investigacao-freeze-cliente.md
+++ b/docs/migration/investigacao-freeze-cliente.md
@@ -1,0 +1,143 @@
+# Investigação: freeze do cliente ("jogo para de responder e cai")
+
+> **Status:** ABERTO — causa-raiz não confirmada. Instrumentação S→C adicionada em 2026-07-19
+> (branch `investigando-bug-logoff`); aguardando a próxima reprodução com os novos logs.
+> Este arquivo é o estado da investigação para sessões futuras: leia antes de re-derivar
+> qualquer coisa dos logs do Railway.
+
+## Sintoma
+
+Relato do usuário (2026-07-19): "o jogo não está mais respondendo após alguns minutos logado…
+o servidor fica lento e depois cai". Começou em **2026-07-18**; acontece em praticamente toda
+sessão (1,5–4 min de jogo e trava). Não é a rede do notebook.
+
+## Conclusão parcial (o que JÁ está estabelecido — não reinvestigar)
+
+O travamento é **do cliente (WYD.exe), não do servidor**. Evidência colhida via Railway CLI
+(skill `docs/migration/prompts/railway-troubleshooting-skill.md`):
+
+- **tm-server saudável durante todos os incidentes**: CPU <1% (de 8 vCPU), memória ~133–147MB
+  estável (de 8GB), zero `panic`/`level=ERROR`, zero `session out queue full` em 24h.
+- **O loop nunca parou**: processou logins novos *enquanto* outra sessão estava congelada
+  (ex.: conn=2 logou 00:16:02Z com conn=1 travada desde 00:14:16Z).
+- **db-server limpo**: zero ERROR/WARN; logins respondidos em ~100–200ms nas janelas dos incidentes.
+- **Rede Railway limpa**: flow logs todos `OK`/0ms, sem drop/reset no proxy TCP.
+- **Prova-chave**: durante o freeze das 11:36Z (19/07) o servidor seguiu enviando ~14KB/4s
+  e o cliente seguiu **ACKando no TCP** — os bytes chegam, mas o jogo não reage. O cliente
+  recebe e **descarta/não processa**.
+- Toda sessão termina com `err=EOF` = o usuário matou o cliente travado. O "silêncio" C→S
+  antes do EOF é o usuário parado olhando a tela congelada (cliente WYD ocioso não manda nada).
+- O fix "teleport view reconciliation" (86e5513, PR #163, deploy 19/07 11:28Z) **não resolveu**:
+  duas sessões congelaram 11:30–11:37Z com ele em produção.
+
+Descartado portanto: crash/lentidão do servidor, OOM, deploy no meio da sessão, DB, rede/proxy
+Railway, fila S→C cheia (o WARN nunca disparou), notebook do usuário.
+
+## Linha do tempo observada
+
+| Janela (UTC) | Deploy | Código | Sessões | Resultado |
+|---|---|---|---|---|
+| 19/07 00:00–00:36 | `cca81866` (18/07 23:49Z) | main @ 892c27b (pré-fix) | ≥6 | todas EOF; 1 saída limpa (00:01:56–00:04:15), resto freeze |
+| 19/07 11:30–11:37 | `a3fd73d7` (11:28Z) | main @ 3b51252 (com fix #163) | 2 | ambas freeze→kill |
+
+Logs Railway de deploys anteriores a 18/07 23:49Z **já expiraram** — não dá para datar o início
+exato da regressão por logs. O usuário situa o início em **18/07**, dia em que entraram
+(deploys 12:11Z, 12:19Z, 15:44Z, 15:51Z, 18:31Z, 23:49Z):
+
+- #143 gema-estelar, #151 `/reino`, #149 tinturas, #160 removedor-de-tinta,
+  #152 itens-quest, #155 sistema-de-quests (celestial), fix 45e5ed3 (magic bean).
+
+Esse conjunto é a **janela de regressão suspeita** (na noite de 17/07 entraram ainda #146
+template-de-reis, #154 `/cp`, #144 nick, #150, #148 — só relevantes se o problema for anterior
+ao que o usuário percebeu).
+
+## Momentos exatos dos freezes (para correlação)
+
+O cliente congela e o usuário ainda manda comandos sem efeito (toggle PK ×4, whispers
+repetidos) antes de desistir:
+
+- 00:10:44Z — 8s após teleporte para **(1703,1730)** (≈ destino de `/reino` {1702,1728}±3;
+  também ≈ `/arch` {1706,1723}); 2 passos andados e morto.
+- ~00:14:16Z — após 3 teleportes rápidos + tentativa de logout (0x03ae + 0x0215); o relogin
+  veio numa conexão NOVA (cliente antigo ficou pendurado).
+- ~00:17:28Z — spawn na cidade 2 (2456,2007 ≈ Erion), 2 ataques (0x0368), 2 whispers finais.
+- ~00:33:47Z — após vários teleportes; 4× 0x0399 (PK toggle) sem efeito e silêncio.
+- ~11:34:37Z (19/07) — após 2 teleportes de cidade + quit-cancelado + 17 cliques de
+  ApplyBonus (0x0277) a ~1,1s.
+- ~11:36:35Z (19/07) — spawn na **cidade 3 (3664,3128 ≈ `/gelo` {3650,3130})**; 262×
+  ApplyBonus em 48s (cadência ~130ms ≈ RTT = usuário segurando o botão), 1 whisper, morto.
+
+Padrão: o freeze acontece **logo após chegar numa área nova** (teleporte de cidade ou login
+fora de Armia). A única sessão limpa da amostra ficou em **Armia**. MAS a amostra é pequena —
+não tratar como lei.
+
+## Hipóteses vivas (em ordem)
+
+1. **Frame S→C malformado dessincroniza o parser do cliente.** O cliente lê o stream por
+   `Size` do header; um único frame com Size/encoding errado faz TODO o resto decodificar
+   lixo → o cliente passa a dropar tudo silenciosamente (bate com "TCP ACKa, jogo morto").
+   Candidato natural: um `CreateMob` (0x0364) de algum NPC/template específico das áreas de
+   destino, ou algo no burst de chegada. Com a instrumentação nova, o "session last sends"
+   do disconnect mostra exatamente o tail enviado.
+2. **Keyword queue do cliente** (gap conhecido, ver memória `decompiled-client-reference` e
+   `docs/agents/RELATED-PROJECTS-COMPARISON-2026-06-19.md` §4): se alguma mensagem NOVA dos
+   PRs de 17–18/07 arma a `RecvQueue[16]` do cliente, ele passa a rejeitar pacotes com
+   `ErrorCode=3` **em silêncio**. Checar no fonte do tm-project o que escreve em
+   `RecvQueue`/`EncodeByte` e se emitimos esse opcode agora.
+3. **NPC do overlay de moderador com visual inválido** (83 NPCs, `npc config version=151`):
+   um mesh/equip fora de faixa congela o render do cliente quando entra na view — também
+   explicaria a dependência de área. Cruzar `npc_definition` com as áreas dos freezes.
+
+## Instrumentação adicionada (2026-07-19, esta branch)
+
+Tudo pensado para deixar **post-mortem automático em todo disconnect** — não precisa de flag
+para o essencial:
+
+| Log | Onde | Significado |
+|---|---|---|
+| `session send stats` (INFO) | disconnect (`world/sendstats.go`) | total de frames/bytes S→C, high-water da fila e contagem por tipo (`by_type="0x0364:120 …"`, dominante primeiro) |
+| `session last sends` (INFO) | disconnect | os **últimos 64 frames S→C** como `0xTIPO(HEADER.ID)/len/-idade_ms` — o que o cliente recebeu por último antes do usuário matar o processo |
+| `teleport` (INFO) | `handler/movement.go doTeleport` | origem→destino + quantos CreateMob/RemoveMob o teleporte gerou para o cliente |
+| `chat command` (INFO) | `handler/chat.go` | keyword de todo slash command executado (antes era invisível — só se via o 0x0334) |
+| `session out queue high` (WARN) | `world.enqueue` | novo high-water ≥ 50% da capacidade (default 64) — backpressure do writer ANTES do drop |
+| `slow world event` (WARN) | `world.Run` | um evento do loop levou ≥100ms (identifica frame/tick/callback) — se isso aparecer, a hipótese "servidor lento" volta ao jogo |
+| `send packet` (INFO) | `world.enqueue`, **atrás de flag** | espelho S→C do "recv packet": `-log-sends` ou `W2PP_LOG_SENDS=true`. Alto volume; ligar só durante reprodução |
+
+## Playbook da próxima reprodução
+
+1. (Opcional, recomendado com 1 jogador) ligar `W2PP_LOG_SENDS=true` no serviço tm-server do
+   Railway antes do teste — pede confirmação do usuário, é variável de produção.
+2. Jogar até travar. Anotar hora local exata do travamento (não do kill).
+3. Matar o cliente (gera o EOF → dispara os logs de post-mortem).
+4. Colher (ver comandos no skill do Railway):
+   ```bash
+   railway logs --service tm-server --since <UTC-2min> --until <UTC+2min>
+   # focar: "session last sends", "session send stats", "teleport", "chat command",
+   #        "slow world event", "session out queue high"
+   ```
+5. No `session last sends`: identificar o(s) último(s) tipos/tamanhos. Comparar os `len`
+   com o esperado do protocol-spec para o tipo (um len anômalo = hipótese 1 confirmada
+   e aponta o encoder culpado).
+6. Se o tail parecer normal: partir para captura no cliente (Wireshark na máquina Windows,
+   workflow do agente Windows em `docs/migration/SESSION-PRIMER.md`) e validar frame a frame
+   os Size/checksum do stream — e investigar as hipóteses 2 e 3.
+7. Repetir o teste em áreas distintas (ficar só em Armia vs teleportar para `/reino`,
+   `/gelo`, Erion) para confirmar/refutar a dependência de área.
+
+## Higiene encontrada no caminho (não é a causa, mas corrigir)
+
+- `0x03ae` (delay-quit) chega com `routed=false` — sem handler. Benigno no quit limpo
+  (o cliente fecha sozinho ~4s depois), mas merece rota explícita.
+- **Duas migrations com número 0012**: `0012_celestial_quest` e `0012_character_fame` —
+  renumerar antes que o tracker pule uma delas.
+- `0x0334×2 + 0x0291` aparece ~1s após todo char login (sequência automática do cliente
+  e/ou comando de cidade) — não confundir com ação deliberada do usuário ao ler timelines.
+
+## Referências
+
+- Skill de triagem Railway: `docs/migration/prompts/railway-troubleshooting-skill.md`
+  (projeto `wyd`, serviço `tm-server`; converter horário de Brasília para UTC−3→UTC).
+- Memória do agente: `logoff-freeze-client-side` (resumo vivo desta investigação).
+- Cliente descompilado (parser CPSock + keyword queue): https://github.com/EricSantos00/tm-project
+  — análise em `docs/agents/RELATED-PROJECTS-COMPARISON-2026-06-19.md` §4.
+- Fix que NÃO resolveu (não re-tentar o mesmo caminho): PR #163 / commit 86e5513.

--- a/tmserver/cmd/tmserver/main.go
+++ b/tmserver/cmd/tmserver/main.go
@@ -107,6 +107,7 @@ func run(logger *slog.Logger) error {
 	doubleExp := flag.Bool("double-exp", envBool("W2PP_DOUBLE_EXP", false), "DOUBLEMODE: double PvE experience (gameconfig double)")
 	newbieEvent := flag.Bool("newbie-event", envBool("W2PP_NEWBIE_EVENT", false), "NewbieEventServer: +15% exp and newbie under-100 bonus (gameconfig)")
 	kefraLive := flag.Bool("kefra-live", envBool("W2PP_KEFRA_LIVE", false), "KefraLive: when false, PvE exp is halved (default legacy KefraLive=0)")
+	logSends := flag.Bool("log-sends", envBool("W2PP_LOG_SENDS", false), "log every S→C frame (conn/type/id/len) — client-freeze diagnostics (investigacao-freeze-cliente.md); high volume, enable only while reproducing an incident")
 	flag.Parse()
 
 	// Echo the effective wiring at boot: the client-version and the resolved
@@ -242,6 +243,7 @@ func run(logger *slog.Logger) error {
 		MsgBurst:       *msgBurst,
 		StatusFile:     statusFile,
 		ItemRanges:     itemRanges,
+		LogSends:       *logSends,
 	}, logger, persist, dispatch.Handle)
 	// Mob-AI pulse: monsters acquire/chase/melee nearby players each tick (mobai.go).
 	w.SetTickHandler(world.DefaultMobTick, dispatch.Tick)

--- a/tmserver/internal/handler/chat.go
+++ b/tmserver/internal/handler/chat.go
@@ -49,6 +49,10 @@ func (d *Dispatcher) messageWhisper(w *world.World, s *world.Session, _ protocol
 	}
 	name := cstr(body.MobName[:])
 	if d.runCommand(w, s, name, body.String) {
+		// Freeze investigation: commands were invisible in the logs (the recv
+		// packet line only shows 0x0334), so incident timelines could not tell a
+		// teleport command from a plain whisper. Keyword only — no whisper text.
+		d.log.Info("chat command", "conn", s.Conn, "cmd", strings.TrimPrefix(name, "/"))
 		return // a slash command (the client sends "/x" as a whisper to "x")
 	}
 	target, _ := w.SessionByName(name)

--- a/tmserver/internal/handler/movement.go
+++ b/tmserver/internal/handler/movement.go
@@ -244,6 +244,8 @@ func (d *Dispatcher) doTeleport(w *world.World, s *world.Session, x, y int16) {
 		return
 	}
 	oldX, oldY := e.X, e.Y
+	cmBefore := w.SentOfType(s, protocol.MsgCreateMob)
+	rmBefore := w.SentOfType(s, protocol.MsgRemoveMob)
 	w.SetEntityPos(s.Conn, x, y)
 	if c := world.Village(x, y); c >= 0 && c <= 3 {
 		e.LastCity = int16(c)
@@ -256,6 +258,14 @@ func (d *Dispatcher) doTeleport(w *world.World, s *world.Session, x, y int16) {
 	// mobs/NPCs, creates new-window entities and forwards the same jump frame to
 	// watchers, but does not resend the player's own CreateMob/UpdateScore.
 	d.moveMulticast(w, s.Conn, oldX, oldY, protocol.MsgAction, payload)
+	// Freeze investigation (investigacao-freeze-cliente.md): the incidents
+	// cluster right after city teleports, and teleports used to be invisible in
+	// the logs. The CreateMob/RemoveMob deltas size the reveal burst the client
+	// had to absorb at the destination.
+	d.log.Info("teleport", "conn", s.Conn, "name", e.Name,
+		"from_x", oldX, "from_y", oldY, "to_x", x, "to_y", y,
+		"create_mobs", w.SentOfType(s, protocol.MsgCreateMob)-cmBefore,
+		"remove_mobs", w.SentOfType(s, protocol.MsgRemoveMob)-rmBefore)
 }
 
 // noViewMob handles _MSG_NoViewMob (0x0369): the client asks to re-sync one

--- a/tmserver/internal/world/event.go
+++ b/tmserver/internal/world/event.go
@@ -144,6 +144,10 @@ func (w *World) removeSession(s *Session) {
 	if s == nil || w.sessions[s.Conn] != s {
 		return
 	}
+	// S→C post-mortem first, while the slot still identifies the session: what
+	// the client was sent last is the key evidence for a client-side freeze
+	// (docs/migration/investigacao-freeze-cliente.md).
+	w.logSendStats(s)
 	// Persist the live character (purchases/gold/stats) before tearing down.
 	w.SaveCharacterAsync(s)
 	// The account session ends with the connection, so persist and evict the

--- a/tmserver/internal/world/sendstats.go
+++ b/tmserver/internal/world/sendstats.go
@@ -1,0 +1,131 @@
+package world
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+)
+
+// S→C send diagnostics (docs/migration/investigacao-freeze-cliente.md): the
+// 18-19/jul client-freeze incident showed the server healthy while the client
+// silently stopped processing what it received — and nothing logged the S→C
+// side. Every queued frame is counted per type and remembered in a small ring,
+// and the whole picture is dumped when the connection closes, so every freeze
+// leaves a post-mortem of what the client was sent last. All of it is loop-owned
+// session state (enqueue and removeSession both run in the loop), so no locks.
+
+// lastSentRing is how many trailing S→C frames each session remembers. 64 covers
+// the final seconds even under a CreateMob burst while costing ~1KB per session.
+const lastSentRing = 64
+
+// sentRecord is one remembered S→C frame: type, HEADER.ID (the subject entity —
+// which mob/player the message was about), payload length and when it was queued.
+type sentRecord struct {
+	t   protocol.Type
+	id  uint16
+	len uint16
+	at  int64 // unix milliseconds
+}
+
+// noteSend records one queued S→C frame in the session's diagnostics.
+func (s *Session) noteSend(h protocol.Header, payloadLen int) {
+	s.sentFrames++
+	s.sentBytes += uint64(payloadLen + protocol.HeaderSize)
+	if s.sentByType == nil {
+		s.sentByType = make(map[protocol.Type]uint32, 32)
+	}
+	s.sentByType[h.Type]++
+	s.lastSent[s.lastSentIdx%lastSentRing] = sentRecord{
+		t: h.Type, id: h.ID, len: uint16(payloadLen), at: time.Now().UnixMilli(),
+	}
+	s.lastSentIdx++
+}
+
+// SentOfType returns how many S→C frames of type t were queued to s in this
+// session. Loop-only; used by handlers to log per-action deltas (e.g. how many
+// CreateMob/RemoveMob a teleport produced).
+func (w *World) SentOfType(s *Session, t protocol.Type) uint32 { return s.sentByType[t] }
+
+// logSendStats emits the session's S→C post-mortem: totals, the per-type
+// breakdown and the trailing frames with their age relative to the close. Called
+// from removeSession, so every disconnect (including a user killing a frozen
+// client) leaves the evidence in the logs.
+func (w *World) logSendStats(s *Session) {
+	if s.sentFrames == 0 {
+		return
+	}
+	w.log.Info("session send stats",
+		"conn", s.Conn,
+		"frames", s.sentFrames,
+		"bytes", s.sentBytes,
+		"out_high_water", s.outHighWater,
+		"by_type", formatByType(s.sentByType),
+	)
+	w.log.Info("session last sends", "conn", s.Conn, "tail", formatLastSends(&s.lastSent, s.lastSentIdx, time.Now().UnixMilli()))
+}
+
+// formatByType renders a per-type count map as "0x0366:120 0x0181:80 …",
+// descending by count so the dominant traffic reads first.
+func formatByType(m map[protocol.Type]uint32) string {
+	type kv struct {
+		t protocol.Type
+		n uint32
+	}
+	rows := make([]kv, 0, len(m))
+	for t, n := range m {
+		rows = append(rows, kv{t, n})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].n != rows[j].n {
+			return rows[i].n > rows[j].n
+		}
+		return rows[i].t < rows[j].t
+	})
+	var b strings.Builder
+	for i, r := range rows {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(formatSendType(r.t))
+		b.WriteByte(':')
+		b.WriteString(strconv.FormatUint(uint64(r.n), 10))
+	}
+	return b.String()
+}
+
+// formatLastSends renders the ring oldest→newest as
+// "0x0165(30000)/504/-830ms …" — type(HEADER.ID)/payload-len/age-before-close.
+func formatLastSends(ring *[lastSentRing]sentRecord, next int, nowMs int64) string {
+	n := next
+	if n > lastSentRing {
+		n = lastSentRing
+	}
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		r := ring[(next-n+i)%lastSentRing]
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(formatSendType(r.t))
+		b.WriteByte('(')
+		b.WriteString(strconv.FormatUint(uint64(r.id), 10))
+		b.WriteString(")/")
+		b.WriteString(strconv.FormatUint(uint64(r.len), 10))
+		b.WriteString("/-")
+		b.WriteString(strconv.FormatInt(nowMs-r.at, 10))
+		b.WriteString("ms")
+	}
+	return b.String()
+}
+
+// formatSendType renders a message type as 0xNNNN (same shape as the handler
+// package's recv-packet formatType; duplicated because world cannot import
+// handler).
+func formatSendType(t protocol.Type) string {
+	const hexdigits = "0123456789abcdef"
+	v := uint16(t)
+	return "0x" + string([]byte{hexdigits[v>>12&0xf], hexdigits[v>>8&0xf], hexdigits[v>>4&0xf], hexdigits[v&0xf]})
+}

--- a/tmserver/internal/world/sendstats_test.go
+++ b/tmserver/internal/world/sendstats_test.go
@@ -1,0 +1,79 @@
+package world
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+)
+
+// TestNoteSendTracking: every queued frame must land in the counters and the
+// ring, and the ring must keep only the trailing lastSentRing frames in order —
+// that tail is the freeze post-mortem, so its ordering is load-bearing.
+func TestNoteSendTracking(t *testing.T) {
+	s := &Session{Conn: 7}
+	for i := 0; i < lastSentRing+3; i++ {
+		s.noteSend(protocol.Header{Type: protocol.MsgAction, ID: uint16(i)}, 28)
+	}
+	s.noteSend(protocol.Header{Type: protocol.MsgCreateMob, ID: 30000}, 504)
+
+	if want := uint64(lastSentRing + 4); s.sentFrames != want {
+		t.Fatalf("sentFrames = %d, want %d", s.sentFrames, want)
+	}
+	wantBytes := uint64((lastSentRing+3)*(28+protocol.HeaderSize) + 504 + protocol.HeaderSize)
+	if s.sentBytes != wantBytes {
+		t.Fatalf("sentBytes = %d, want %d", s.sentBytes, wantBytes)
+	}
+	if n := s.sentByType[protocol.MsgAction]; n != uint32(lastSentRing+3) {
+		t.Fatalf("sentByType[MsgAction] = %d, want %d", n, lastSentRing+3)
+	}
+	if n := s.sentByType[protocol.MsgCreateMob]; n != 1 {
+		t.Fatalf("sentByType[MsgCreateMob] = %d, want 1", n)
+	}
+
+	tail := formatLastSends(&s.lastSent, s.lastSentIdx, s.lastSent[(s.lastSentIdx-1)%lastSentRing].at)
+	records := strings.Fields(tail)
+	if len(records) != lastSentRing {
+		t.Fatalf("tail records = %d, want %d (full ring)", len(records), lastSentRing)
+	}
+	// Newest entry last: the CreateMob with its HEADER.ID and payload length.
+	if last := records[len(records)-1]; last != "0x0364(30000)/504/-0ms" {
+		t.Fatalf("newest tail record = %q, want %q", last, "0x0364(30000)/504/-0ms")
+	}
+	// Oldest surviving entry is frame #4 (three MsgAction were overwritten by the
+	// wrap plus one by the CreateMob).
+	if first := records[0]; !strings.HasPrefix(first, "0x036c(4)/28/") {
+		t.Fatalf("oldest tail record = %q, want prefix %q", first, "0x036c(4)/28/")
+	}
+}
+
+// TestFormatByTypeOrdering: the per-type breakdown must read dominant-first so
+// the disconnect post-mortem leads with the traffic that mattered.
+func TestFormatByTypeOrdering(t *testing.T) {
+	got := formatByType(map[protocol.Type]uint32{
+		protocol.MsgAction:    3,
+		protocol.MsgCreateMob: 12,
+		protocol.MsgRemoveMob: 3,
+	})
+	want := "0x0364:12 0x0165:3 0x036c:3"
+	if got != want {
+		t.Fatalf("formatByType = %q, want %q", got, want)
+	}
+}
+
+// TestEnqueueHighWater: enqueue must track the out-queue high-water mark (writer
+// backpressure evidence) without ever blocking the loop.
+func TestEnqueueHighWater(t *testing.T) {
+	w := New(Config{OutBuffer: 8}, nil, nil, nil)
+	s := &Session{Conn: 1, out: make(chan outFrame, 8), closeCh: make(chan struct{})}
+	w.sessions[1] = s
+	for i := 0; i < 5; i++ {
+		w.enqueue(s, protocol.Header{Type: protocol.MsgAction}, nil)
+	}
+	if s.outHighWater != 5 {
+		t.Fatalf("outHighWater = %d, want 5", s.outHighWater)
+	}
+	if s.sentFrames != 5 {
+		t.Fatalf("sentFrames = %d, want 5", s.sentFrames)
+	}
+}

--- a/tmserver/internal/world/session.go
+++ b/tmserver/internal/world/session.go
@@ -83,6 +83,16 @@ type Session struct {
 
 	seen map[int]struct{} // entity ids already create-mob'd to this client (view set)
 
+	// S→C send diagnostics (sendstats.go): per-type counts, totals, the trailing
+	// frames and the out-queue high-water mark, dumped on disconnect so a frozen
+	// client leaves a post-mortem. Loop-owned like every other Session field.
+	sentFrames   uint64
+	sentBytes    uint64
+	sentByType   map[protocol.Type]uint32
+	lastSent     [lastSentRing]sentRecord
+	lastSentIdx  int
+	outHighWater int
+
 	conn    net.Conn
 	out     chan outFrame
 	closeCh chan struct{}

--- a/tmserver/internal/world/world.go
+++ b/tmserver/internal/world/world.go
@@ -11,6 +11,7 @@ package world
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -102,6 +103,12 @@ type Config struct {
 	// template equips (BASE_GetMobAbility, Basedef.cpp:2415). Immutable after
 	// boot; nil means no catalog (every mob fights at melee reach).
 	ItemRanges map[int]int16
+
+	// LogSends logs every queued S→C frame (conn/type/id/len) at INFO — the
+	// outbound mirror of the dispatcher's "recv packet" log. High volume: enable
+	// only while reproducing an incident (freeze investigation,
+	// docs/migration/investigacao-freeze-cliente.md).
+	LogSends bool
 
 	// StatusFile is the path to the channel-status page (serv00.htm) the client
 	// fetches over HTTP before opening the CPSock game connection. When set, the
@@ -211,7 +218,7 @@ func (w *World) Run(ctx context.Context) error {
 			w.shutdown()
 			return ctx.Err()
 		case cb := <-w.callbacks:
-			cb.apply(w)
+			w.applyTimed(cb)
 			continue
 		default:
 		}
@@ -220,10 +227,37 @@ func (w *World) Run(ctx context.Context) error {
 			w.shutdown()
 			return ctx.Err()
 		case cb := <-w.callbacks:
-			cb.apply(w)
+			w.applyTimed(cb)
 		case ev := <-w.events:
-			ev.apply(w)
+			w.applyTimed(ev)
 		}
+	}
+}
+
+// slowEventThreshold is how long one loop event may take before it is logged:
+// anything past this stalls every session at once (the loop is single-owner), so
+// a "slow world event" WARN is the smoking gun for server-side global lag.
+const slowEventThreshold = 100 * time.Millisecond
+
+// applyTimed applies one loop event and warns when it exceeds slowEventThreshold,
+// identifying the event (frame type/conn, tick, callback) so a stall can be
+// traced to its handler (freeze investigation instrumentation).
+func (w *World) applyTimed(ev event) {
+	start := time.Now()
+	ev.apply(w)
+	d := time.Since(start)
+	if d < slowEventThreshold {
+		return
+	}
+	switch e := ev.(type) {
+	case frameEvent:
+		w.log.Warn("slow world event", "dur_ms", d.Milliseconds(), "kind", "frame", "conn", e.s.Conn, "type", formatSendType(e.header.Type))
+	case tickEvent:
+		w.log.Warn("slow world event", "dur_ms", d.Milliseconds(), "kind", "tick")
+	case callbackEvent:
+		w.log.Warn("slow world event", "dur_ms", d.Milliseconds(), "kind", "callback", "conn", e.conn)
+	default:
+		w.log.Warn("slow world event", "dur_ms", d.Milliseconds(), "kind", fmt.Sprintf("%T", ev))
 	}
 }
 
@@ -470,8 +504,22 @@ func (w *World) SaveCargoThen(s *Session, then func(*World, *Session)) {
 // session is dropped instead of stalling the whole world (head-of-line safety).
 func (w *World) enqueue(s *Session, h protocol.Header, payload []byte) {
 	h.ClientTick = w.cfg.Now()
+	s.noteSend(h, len(payload))
+	if w.cfg.LogSends {
+		w.log.Info("send packet", "conn", s.Conn, "type", formatSendType(h.Type), "id", h.ID, "len", len(payload))
+	}
 	select {
 	case s.out <- outFrame{header: h, payload: payload}:
+		// Track writer backpressure: a growing queue means the socket (or the
+		// client) is not draining what the loop produces. Warn on each new
+		// high-water mark past half capacity — bounded, and it precedes the
+		// hard "queue full" drop below.
+		if d := len(s.out); d > s.outHighWater {
+			s.outHighWater = d
+			if d >= w.cfg.OutBuffer/2 {
+				w.log.Warn("session out queue high", "conn", s.Conn, "depth", d, "cap", w.cfg.OutBuffer)
+			}
+		}
 	default:
 		w.log.Warn("session out queue full; dropping connection", "conn", s.Conn)
 		w.dropSession(s)


### PR DESCRIPTION
## Summary

Production incident (started 18/jul): the game freezes for the player after a few minutes and every session ends with the user killing the client (`err=EOF`). Railway triage showed the **server fully healthy** during every incident (CPU <1%, flat memory, no errors, world loop responsive, db-server and network clean) while the client kept ACKing S→C traffic it no longer processed — a client-side freeze caused by something we send. Nothing logged the S→C side, so the offending frame could not be identified. The teleport-view fix (#163) did not resolve it.

This PR adds the instrumentation needed to catch it on the next reproduction, plus the investigation state doc:

- **`session send stats` / `session last sends`** (INFO, every disconnect): per-type S→C counts, totals, out-queue high-water, and the trailing **64 frames** as `0xTYPE(ID)/len/-age_ms` — an automatic post-mortem of what the client received last before being killed.
- **`teleport`** (INFO): origin→destination plus CreateMob/RemoveMob deltas — incidents cluster right after city teleports, which previously left no log line at all.
- **`chat command`** (INFO): the slash-command keyword (no whisper text) — previously indistinguishable from a plain whisper (`0x0334`).
- **`session out queue high`** (WARN): new high-water marks ≥ 50% of the out-queue capacity (writer backpressure, precedes the hard drop).
- **`slow world event`** (WARN): any single loop event ≥ 100ms, identified as frame (type/conn), tick or callback — if this fires, server-side global lag is back on the table.
- **`-log-sends` / `W2PP_LOG_SENDS`**: per-frame S→C log (outbound mirror of `recv packet`), high volume, reproduction-only.
- **`docs/migration/investigacao-freeze-cliente.md`**: established facts, incident timeline (UTC + deploys), 18/jul regression window, ranked hypotheses (malformed S→C frame desyncing the client parser; tm-project keyword queue; moderator-overlay NPC visuals) and the step-by-step reproduction playbook.

All diagnostics state is loop-owned session data (no locks), preserving the single-owner invariant.

## Test plan

- [x] `go build ./...`, `go vet`, `golangci-lint run` clean
- [x] New table-driven tests: ring ordering/wrap, per-type formatting, high-water tracking (`sendstats_test.go`)
- [x] Full `go test -race ./...` passes
- [ ] After deploy: reproduce a freeze and read `session last sends` for the killed connection (playbook in the doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)