### PR TITLE
fix(tmserver): teleport quest ticket immediately on right-click

### DIFF
--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -401,10 +401,6 @@ func (d *Dispatcher) useQuest256Ticket(w *world.World, s *world.Session, e *worl
 		d.removeTrade(w, s)
 		return true
 	}
-	if s.QuestTicketTravel {
-		w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
-		return true
-	}
 	if e.ClassMaster != classMasterMortal && e.ClassMaster != classMasterArch {
 		d.notify(w, s, NoticeReqNotMet)
 		w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
@@ -419,20 +415,15 @@ func (d *Dispatcher) useQuest256Ticket(w *world.World, s *world.Session, e *worl
 	itemIdx := e.Carry[src].Index
 	consumeOneItem(&e.Carry[src])
 	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
-	s.QuestTicketTravel = true
-	d.log.Info("quest256 ticket travel started", "conn", s.Conn, "item", itemIdx, "level", e.Level, "quest_flag", step.flag)
-	w.Go(s, func() func(*world.World, *world.Session) {
-		time.Sleep(masterGriffTravelDelay)
-		return func(w *world.World, s *world.Session) {
-			s.QuestTicketTravel = false
-			e := w.Entity(s.Conn)
-			if e == nil || e.HP <= 0 || s.Mode != world.UserPlay {
-				return
-			}
-			d.teleportQuest256Step(w, s, e, step)
-			d.log.Info("quest256 ticket teleport", "conn", s.Conn, "item", itemIdx, "level", e.Level, "quest_flag", step.flag)
-		}
-	})
+	// Teleport immediately: _MSG_Quest.cpp's DoTeleport for these same tickets
+	// (COVEIRO/JARDINEIRO/KAIZEN/HIDRA/ELFOS, :332/:376/:420/:464/:508) is
+	// synchronous, and so are this file's other item-triggered teleports
+	// (usePortalScroll, useGemaEstelar). The 9.5s masterGriffTravelDelay this used
+	// to borrow is justified only for the real _MSG_MasterGriff opcode, which has
+	// a matching client-side travel animation; a bare right-click has none, so the
+	// delay just left the player staring at nothing for ~10s after the item vanished.
+	d.teleportQuest256Step(w, s, e, step)
+	d.log.Info("quest256 ticket teleport", "conn", s.Conn, "item", itemIdx, "level", e.Level, "quest_flag", step.flag)
 	return true
 }
 

--- a/tmserver/internal/handler/quest_test.go
+++ b/tmserver/internal/handler/quest_test.go
@@ -492,8 +492,7 @@ func TestMasterGriffWarpIDZeroDefaultsToFirstDestination(t *testing.T) {
 	}
 }
 
-func TestQuest256TicketTravelsAfterDelay(t *testing.T) {
-	withMasterGriffTravelDelay(t, 20*time.Millisecond)
+func TestQuest256TicketTravelsImmediately(t *testing.T) {
 	tests := []struct {
 		name  string
 		item  int16
@@ -536,33 +535,7 @@ func TestQuest256TicketTravelsAfterDelay(t *testing.T) {
 	}
 }
 
-func TestQuest256TicketDoesNotTeleportImmediately(t *testing.T) {
-	withMasterGriffTravelDelay(t, 500*time.Millisecond)
-	st := world.CharacterState{
-		Slot: 0, Name: "Hero", Level: 50, X: 2113, Y: 2079,
-		HP: 1000, MaxHP: 1000, LastCity: 0, ClassMaster: classMasterMortal,
-	}
-	st.Carry[0] = world.Item{Index: 4038}
-	addr, stop, _ := startServerMestreGrifo(t, st, false)
-	defer stop()
-	c := enterWorld(t, addr)
-	defer c.Close()
-
-	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
-	send(t, c, protocol.MsgUseItem, body.Encode())
-	expect(t, c, protocol.MsgSendItem)
-	if ty, _, ok := readMaybe(t, c); ok && ty == protocol.MsgAction {
-		t.Fatalf("ticket teleported immediately with %#x; want delayed travel", ty)
-	}
-	time.Sleep(masterGriffTravelDelay + 50*time.Millisecond)
-	action := expectAction(t, c)
-	if !inRange(action.TargetX, 2398) || !inRange(action.TargetY, 2105) {
-		t.Fatalf("delayed ticket target = %d,%d, want Coveiro", action.TargetX, action.TargetY)
-	}
-}
-
 func TestQuest256TicketInvalidLevelDoesNotConsume(t *testing.T) {
-	withMasterGriffTravelDelay(t, 20*time.Millisecond)
 	st := world.CharacterState{
 		Slot: 0, Name: "Hero", Level: 38, X: 2113, Y: 2079,
 		HP: 1000, MaxHP: 1000, LastCity: 0, ClassMaster: classMasterMortal,
@@ -587,13 +560,16 @@ func TestQuest256TicketInvalidLevelDoesNotConsume(t *testing.T) {
 	}
 }
 
-func TestQuest256TicketPendingBlocksDoubleUse(t *testing.T) {
-	withMasterGriffTravelDelay(t, 500*time.Millisecond)
+// TestQuest256TicketSecondUseOnEmptySlotIsNoop: with the ticket consumed
+// synchronously (no more pending-delay window), a second right-click lands on
+// an already-empty slot. useItem's top-of-function Empty() guard makes that a
+// clean no-op — no second consume, no second teleport.
+func TestQuest256TicketSecondUseOnEmptySlotIsNoop(t *testing.T) {
 	st := world.CharacterState{
 		Slot: 0, Name: "Hero", Level: 50, X: 2113, Y: 2079,
 		HP: 1000, MaxHP: 1000, LastCity: 0, ClassMaster: classMasterMortal,
 	}
-	st.Carry[0] = world.Item{Index: 4038, Effects: [3]world.Effect{{Effect: efAmount, Value: 2}}}
+	st.Carry[0] = world.Item{Index: 4038}
 	addr, stop, _ := startServerMestreGrifo(t, st, false)
 	defer stop()
 	c := enterWorld(t, addr)
@@ -602,21 +578,13 @@ func TestQuest256TicketPendingBlocksDoubleUse(t *testing.T) {
 	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
 	send(t, c, protocol.MsgUseItem, body.Encode())
 	first := expect(t, c, protocol.MsgSendItem)
-	if idx, amount := le16(first[4:6]), first[7]; idx != 4038 || amount != 1 {
-		t.Fatalf("first consume idx=%d amount=%d, want ticket amount 1", idx, amount)
+	if idx := le16(first[4:6]); idx != 0 {
+		t.Fatalf("first consume idx=%d, want slot cleared", idx)
 	}
-	send(t, c, protocol.MsgUseItem, body.Encode())
-	second := expect(t, c, protocol.MsgSendItem)
-	if idx, amount := le16(second[4:6]), second[7]; idx != 4038 || amount != 1 {
-		t.Fatalf("pending resync idx=%d amount=%d, want ticket still amount 1", idx, amount)
-	}
+	expectAction(t, c)
 
-	time.Sleep(masterGriffTravelDelay + 50*time.Millisecond)
-	action := expectAction(t, c)
-	if !inRange(action.TargetX, 2398) || !inRange(action.TargetY, 2105) {
-		t.Fatalf("pending ticket target = %d,%d, want Coveiro", action.TargetX, action.TargetY)
-	}
-	if ty, _, ok := readMaybe(t, c); ok && ty == protocol.MsgAction {
-		t.Fatalf("pending ticket queued a second teleport: %#x", ty)
+	send(t, c, protocol.MsgUseItem, body.Encode())
+	if ty, _, ok := readMaybe(t, c); ok {
+		t.Fatalf("second use on empty slot produced %#x; want no-op", ty)
 	}
 }

--- a/tmserver/internal/world/session.go
+++ b/tmserver/internal/world/session.go
@@ -76,7 +76,6 @@ type Session struct {
 	ReqMp             int32           // CUser.ReqMp: server-owned MP target for regen/potions
 	CriticalProgress  uint16          // CUser.cProgress used by BASE_GetDoubleCritical
 	ShortSkill        [16]uint8       // client hotbar layout (CUser.CharShortSkill, _MSG_SetShortSkill)
-	QuestTicketTravel bool            // right-click Quest 256 ticket travel is pending; blocks double-use
 	LoginSpawnX       int16           // last server-injected login spawn, for movement diagnostics
 	LoginSpawnY       int16
 	LoginTick         uint32


### PR DESCRIPTION
## Summary
- Right-clicking a Quest 256 ticket (items 4038-4042: Vela do Coveiro / Colheita do Jardineiro / Cura do Batedor / Mana do Batedor / Emblema do Guarda) now consumes the item and teleports **immediately**, instead of silently waiting ~9.5s with no feedback — the likely cause of issue #38's "right-click does nothing" report.
- That delay was borrowed from the unrelated Mestre Grifo NPC-dialog flow (which has a real client-side travel animation to justify it); a bare item right-click has none, and the legacy `_MSG_Quest.cpp` `DoTeleport` for these same tickets is synchronous, as are this codebase's other item-triggered teleports (`usePortalScroll`, `useGemaEstelar`).
- Removed the now-unused `Session.QuestTicketTravel` pending-state field — `useItem`'s existing empty-slot guard already makes a same-tick double click a clean no-op.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./tmserver/...` (full suite, including updated quest tests)
- [ ] Live-client re-test: right-click a ticket with a level-appropriate Mortal/Arch character and confirm instant consume + teleport

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)