### PR TITLE
Fix tinturas refining instead of transforming into Feijão Mágico

### DIFF
--- a/docs/migration/game-rules.md
+++ b/docs/migration/game-rules.md
@@ -366,6 +366,22 @@ equipado** (`Server.cpp:4884`) — é o cooldown entre tentativas.
 `MountProcess(conn, 0)` (`:914`) é **no-op**: com `Mount == NULL` o `IsEqual` fica 1 e a função
 retorna de cara (`Server.cpp:4639-4643`). Não há nada para portar ali.
 
+#### 3.6.1. Tinturas → Feijão Mágico (issue #130) — **UNVERIFIED, decisão de migração**
+
+`Tintura_*` (**3397-3406**, 10 cores) não têm `EF_VOLATILE` nem `EF_NOSANC` — sem o fix, caíam no
+caminho de "equipamento padrão" acima e ganhavam um `EF_SANC` falso via `refine.Bootstrap`. O
+comportamento esperado (relatado na issue): arrastar uma poeira de Ori **ou** de Lac sobre uma
+tintura consome a poeira e transforma o item no `Feijão_Mágico` da mesma cor (**3407-3416** =
+`tintura + 10`, mesma ordem de cores que `useMagicBean` já usa para o caminho inverso, `item.go:1072`).
+
+> ⚠️ **Nenhuma evidência no legado**: os dois branches de poeira (`_MSG_UseItem.cpp:140-980`) e uma
+> busca no `Source/` inteiro por `3397`-`3417`/`Tintura`/`Feijão` não encontram nenhum caso especial
+> para essa transformação — o único hit em `3407` é o branch, já portado, de *usar* um Feijão Mágico
+> sobre um equipamento (`:3767-3861`, `useMagicBean`). A conversão é portanto uma decisão de
+> migração (não um port): determinística, sem roll de sucesso, já que a tintura não carrega
+> `EF_SANC` para rolar contra. Implementado em `refineTintura` (`refine.go`), curto-circuitado
+> **antes** de `refine.Bootstrap`.
+
 ---
 
 ## 4. Combate (dano) — **fórmulas verificadas**

--- a/tmserver/internal/handler/refine.go
+++ b/tmserver/internal/handler/refine.go
@@ -71,6 +71,18 @@ const (
 
 func isEgg(it world.Item) bool { return it.Index >= eggLo && it.Index < eggHi }
 
+// Tintura items (3397-3406) don't refine — a dust converts them straight into
+// the matching Feijão Mágico (3407-3416 = tintura + 10, mirroring the color
+// order useMagicBean's color math already relies on, item.go:1072). This must
+// run before refine.Bootstrap would plant a bogus EF_SANC pair into a fresh
+// tintura's zeroed effect slots (issue #130).
+const (
+	tinturaLo = 3397 // Tintura_Azul
+	tinturaHi = 3406 // Tintura_Azul_Claro
+)
+
+func isTintura(it world.Item) bool { return it.Index >= tinturaLo && it.Index <= tinturaHi }
+
 // itemInstanceAbility sums ONLY an item's instance effects, which is what
 // BASE_GetBonusItemAbility does (Basedef.cpp:2048) — unlike itemAbility (=
 // BASE_GetItemAbility) it never reads the catalog.
@@ -114,6 +126,11 @@ func (d *Dispatcher) refineItem(w *world.World, s *world.Session, e *world.Entit
 	dst := d.itemSlot(w, s, e, int(body.DestType), int(body.DestPos))
 	if dst == nil || dst.Empty() {
 		return // no such target slot — the legacy just logs and drops the message
+	}
+
+	if isTintura(*dst) {
+		d.refineTintura(w, s, e, dst, body, src)
+		return
 	}
 
 	// A dust only refines equipment: a target that is itself a consumable (which
@@ -189,6 +206,17 @@ func (d *Dispatcher) refineItem(w *world.World, s *world.Session, e *world.Entit
 		return
 	}
 	d.refineFail(w, s, e, t, src, anvil, level, pity)
+}
+
+// refineTintura converts a tintura into its matching Feijão Mágico. This is a
+// deterministic conversion, not a success-rate roll — tinturas carry no
+// EF_SANC to roll against, and no legacy source for this branch exists (see
+// game-rules.md §3.6.1); it's a migration design decision, not a port.
+func (d *Dispatcher) refineTintura(w *world.World, s *world.Session, e *world.Entity, dst *world.Item, body protocol.MsgUseItemBody, src int) {
+	dst.Index = int16(magicBeanBase + (int(dst.Index) - tinturaLo))
+	d.notify(w, s, NoticeRefineSuccess)
+	d.sendSlot(w, s, int(body.DestType), int(body.DestPos), *dst)
+	consumeOneItem(&e.Carry[src])
 }
 
 // refineTarget is the item being refined, together with where it lives so the

--- a/tmserver/internal/handler/refine_test.go
+++ b/tmserver/internal/handler/refine_test.go
@@ -267,6 +267,41 @@ func TestRefineLacto100AlwaysSucceeds(t *testing.T) {
 	}
 }
 
+// A tintura never refines: any dust converts it straight into its matching
+// Feijão Mágico (issue #130), bypassing EF_SANC entirely.
+func TestRefineTinturaBecomesFeijaoMagico(t *testing.T) {
+	cases := []struct {
+		name    string
+		dust    int16
+		tintura int16
+	}{
+		{"low bound, Ori", itemPoeiraOri, tinturaLo},
+		{"middle color, Lac", itemPoeiraLac, tinturaLo + 3},
+		{"high bound, Lac", itemPoeiraLac, tinturaHi},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			// alwaysRate(0): every ordinary refine roll would fail — proves the
+			// transform is deterministic and never touches the success-rate roll.
+			f := newRefineFixture(t, alwaysRate(0), nil)
+			f.e.Carry[1] = world.Item{Index: tt.tintura}
+
+			f.refine(tt.dust)
+
+			wantFeijao := tt.tintura + (magicBeanBase - tinturaLo)
+			if got := f.target().Index; got != wantFeijao {
+				t.Errorf("index = %d, want %d (matching Feijão Mágico)", got, wantFeijao)
+			}
+			if !f.e.Carry[0].Empty() {
+				t.Errorf("dust not consumed: %+v", f.e.Carry[0])
+			}
+			if got := refine.Level(f.target()); got != 0 {
+				t.Errorf("level = %d, want 0 (a tintura must never gain EF_SANC)", got)
+			}
+		})
+	}
+}
+
 // TestRefineRNGGolden pins the rand() call order against the MSVC stream from the
 // CRT default seed 1, which is where every world starts:
 //


### PR DESCRIPTION
## Summary
- Tintura items (3397-3406) had no `EF_VOLATILE`/`EF_NOSANC`, so dust-refine fell through into the generic equipment path and bootstrapped a fake `EF_SANC` level onto them instead of transforming them.
- `refineItem` now short-circuits before the sanc machinery: dragging a Poeira de Ori or Lac onto a tintura consumes the dust and converts it into the matching `Feijão_Mágico` (tintura index + 10), deterministically, matching `useMagicBean`'s existing color math.
- Documented as an UNVERIFIED migration decision in `docs/migration/game-rules.md` §3.6.1 — no legacy `_MSG_UseItem.cpp` precedent exists for this transform.

Closes #130

## Test plan
- [x] `go test -race ./internal/handler/... ./internal/refine/...`
- [x] `go vet ./internal/handler/...`
- [x] `golangci-lint run ./tmserver/internal/handler/...`
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)