### PR TITLE
Close duel/PvP ranking gaps for issue #118

### DIFF
--- a/docs/integrations/ranking-nextjs.md
+++ b/docs/integrations/ranking-nextjs.md
@@ -186,3 +186,85 @@ Campos mínimos para uma tabela:
 
 Mapeamento visual de `class`, `clan` e `class_master` fica do lado do front-end.
 O backend retorna os valores numéricos do jogo.
+
+## 9. Ranking de Duelo/PvP (`ListDuelRanking`)
+
+> Feature **separada** do ranking Top EXP das seções anteriores: mesma origem
+> de dados de personagem, mas lida de uma tabela própria
+> (`character_pvp_stats`, não `character`) e só compartilha com o Top EXP o
+> serviço gRPC (`RankingWebService`) e as regras de paginação. É o ranking de
+> vitórias/derrotas em duelo 1v1 (issue #118, `_MSG_ReqRanking`/`DoRanking`).
+
+Contrato:
+
+```proto
+service RankingWebService {
+  rpc ListDuelRanking(ListDuelRankingRequest) returns (ListDuelRankingResponse);
+}
+
+message ListDuelRankingRequest {
+  int32 limit = 1;  // default 50, max 100
+  int32 offset = 2; // negative values are treated as 0
+}
+
+message DuelRankingEntry {
+  int32 rank = 1; // 1-based rank in the full ordered list
+  string name = 2;
+  int32 class = 3;
+  int32 clan = 4;
+  uint32 guild_id = 5;
+  int32 wins = 6;
+  int32 losses = 7;
+}
+
+message ListDuelRankingResponse {
+  repeated DuelRankingEntry entries = 1;
+  int32 total_count = 2;
+}
+```
+
+Paginação: mesmas regras da seção 3 (`limit<=0` → 50, `limit>100` → 100,
+`offset<0` → 0, `rank` já vem 1-based calculado pelo backend).
+
+Ordenação: `wins` descendente, `losses` ascendente (desempate por menos
+derrotas), `name` ascendente (desempate final determinístico).
+
+Observações:
+
+- **Empates não entram no placar.** Só duelos concluídos por eliminação ou
+  desconexão do oponente incrementam `wins`/`losses`; um empate por timeout
+  do relógio da arena não é persistido.
+- `wins`/`losses` são `int32` — ao contrário de `exp` (Top EXP, seção 5), não
+  precisam de serialização como `string` para evitar perda de precisão no
+  browser.
+- Assim como o Top EXP, este ranking é público nesta versão (sem sessão).
+
+Payload HTTP sugerido no BFF (mesmo padrão da seção 5, endpoint diferente):
+
+```http
+GET /api/ranking/duel?limit=50&offset=0
+```
+
+```json
+{
+  "entries": [
+    {
+      "rank": 1,
+      "name": "PlayerName",
+      "class": 0,
+      "clan": 1,
+      "guildId": 123,
+      "wins": 42,
+      "losses": 7
+    }
+  ],
+  "totalCount": 250
+}
+```
+
+Campos mínimos para uma tabela: posição (`rank`), personagem (`name`),
+vitórias (`wins`), derrotas (`losses`), classe (`class`), guilda (`guild_id`
+quando `!= 0`), reino/clan (`clan`). O handler Next.js segue o mesmo formato
+do exemplo da seção 6, trocando `rankingClient.listExpRanking` por
+`rankingClient.listDuelRanking` e removendo a conversão de `exp` para
+`string`.

--- a/tmserver/internal/handler/duel.go
+++ b/tmserver/internal/handler/duel.go
@@ -33,8 +33,10 @@ var duelInviteTimeout = 30 * time.Second
 // decrements once every 5 ProcessRanking calls, itself gated to run every 4th
 // second (ProcessSecMinTimer.cpp:1575) — a real-time cadence we don't reproduce
 // 1:1. We run the countdown once per tick instead, giving a fixed, documented
-// cap. UNVERIFIED exact legacy wall-clock duration.
-const duelTicks = 121
+// cap. UNVERIFIED exact legacy wall-clock duration. A var (not const, mirrors
+// duelInviteTimeout) so tests can shrink it instead of waiting out the real
+// countdown.
+var duelTicks = 121
 
 // duelArena is the server-wide active duel (legacy RankingProgress/Ranking1/
 // Ranking2/RankingTime, Server.cpp — process-wide globals, not per-pair: only
@@ -103,6 +105,12 @@ func (d *Dispatcher) reqRankingRequest(w *world.World, s *world.Session, target 
 		d.notify(w, s, NoticeDenyWhisper)
 		return
 	}
+	// UNVERIFIED (issue #118): no legacy capture confirms a city restriction;
+	// this is a best-effort gate, not a confirmed parity rule.
+	if inSafeCity(w, s.Conn) || inSafeCity(w, target) {
+		d.notify(w, s, NoticeDuelInCity)
+		return
+	}
 	s.DuelTarget = target
 	s.DuelTargetExpiry = time.Now().Add(duelInviteTimeout).Unix()
 	// Forward the invite: Parm1 = the requester's own conn (so the target's
@@ -126,6 +134,12 @@ func (d *Dispatcher) reqRankingAccept(w *world.World, s *world.Session, requeste
 	if d.duel.active {
 		d.notify(w, s, NoticeDuelBattleInProgress)
 		d.notify(w, reqSess, NoticeDuelBattleInProgress)
+		return
+	}
+	// UNVERIFIED (issue #118): same best-effort city gate as the request path.
+	if inSafeCity(w, s.Conn) || inSafeCity(w, requester) {
+		d.notify(w, s, NoticeDuelInCity)
+		d.notify(w, reqSess, NoticeDuelInCity)
 		return
 	}
 	reqSess.DuelTarget = 0

--- a/tmserver/internal/handler/duel_test.go
+++ b/tmserver/internal/handler/duel_test.go
@@ -278,3 +278,133 @@ func TestDuelingHelper(t *testing.T) {
 		t.Error("dueling should be false when no duel is active")
 	}
 }
+
+// duelCityDB is duelDB with "tester" spawned inside Armia (2096,2096, the same
+// point TestVillage in world/city_test.go asserts resolves to city 0) so
+// requests/accepts from that conn hit the best-effort city gate; "tradeb"
+// stays outside any city.
+func duelCityDB() *fakeDB {
+	db := newDB()
+	db.loads = map[int64]world.CharacterState{
+		7:  {Slot: 0, Name: "Hero", X: 2096, Y: 2096, HP: 1000, MaxHP: 1000, Damage: 500, AC: 0},
+		11: {Slot: 0, Name: "HeroB", X: 5, Y: 5, HP: 50, MaxHP: 50, Damage: 0, AC: 0},
+	}
+	return db
+}
+
+// TestDuelRequestBlockedInSafeCity: the best-effort city gate (issue #118,
+// UNVERIFIED) rejects a duel request from inside a safe city instead of
+// forwarding the invite.
+func TestDuelRequestBlockedInSafeCity(t *testing.T) {
+	addr, stop := startServerDuel(t, duelCityDB())
+	defer stop()
+	a := enterWorldAs(t, addr, "tester") // conn 1, inside Armia
+	defer a.Close()
+	b := enterWorldAs(t, addr, "tradeb") // conn 2, outside any city
+	defer b.Close()
+
+	reqRankingFrame(t, a, 2, 0)
+	wantNotice(t, a, NoticeDuelInCity)
+	if ty, _, ok := readMaybe(t, b); ok {
+		t.Errorf("B got %#x for a request blocked by the city gate; want nothing", ty)
+	}
+}
+
+// wantNoticeWithin is wantNotice bounded by wall-clock time instead of a
+// fixed read count. The arena's per-tick closing-wall broadcasts (up to a
+// dozen MsgEnvEffect frames per tick once past stage 1) can outrun
+// wantNotice's fixed 20-read budget well before a duel-resolution notice
+// arrives, so a long-running scenario like a draw needs a budget that keeps
+// reading through that noise instead of giving up on read count alone.
+func wantNoticeWithin(t *testing.T, c net.Conn, want Notice, budget time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		ty, payload, ok := readMaybe(t, c)
+		if !ok {
+			continue
+		}
+		if ty != protocol.MsgMessageBoxOk {
+			continue
+		}
+		if parm, decOK := protocol.StandardParm(payload); decOK && Notice(parm) == want {
+			return
+		}
+	}
+	t.Fatalf("did not observe notice %v within %v", want, budget)
+}
+
+// TestDuelDrawOnTimeout: when the arena countdown runs out with both
+// duelists still alive and in bounds, the duel resolves as a draw — both
+// sides are notified and, unlike a win, nothing is persisted.
+func TestDuelDrawOnTimeout(t *testing.T) {
+	orig := duelTicks
+	// Must resolve after startedDuel's drainDuelStart returns: that helper
+	// drains frames until a ~300ms read times out, so a countdown shorter
+	// than that would race the draw notice into being silently swallowed by
+	// the drain instead of observed below.
+	duelTicks = 100
+	defer func() { duelTicks = orig }()
+
+	db := duelDB()
+	a, b, stop := startedDuel(t, db)
+	defer stop()
+	defer a.Close()
+	defer b.Close()
+
+	wantNoticeWithin(t, a, NoticeDuelDraw, 5*time.Second)
+	wantNoticeWithin(t, b, NoticeDuelDraw, 5*time.Second)
+
+	if _, ok := db.lastDuelResult(t); ok {
+		t.Error("RecordDuelResult was called for a draw; draws must not be persisted")
+	}
+}
+
+// TestDuelStageThresholds is a table-driven unit test of duelStage's bucket
+// boundaries (Server.cpp:8834-8869's three closing-wall stages).
+func TestDuelStageThresholds(t *testing.T) {
+	cases := []struct {
+		ticksLeft int
+		want      int
+	}{
+		{181, 0}, {180, 0},
+		{179, 1}, {120, 1},
+		{119, 2}, {60, 2},
+		{59, 3}, {0, 3}, {-1, 3},
+	}
+	for _, c := range cases {
+		if got := duelStage(c.ticksLeft); got != c.want {
+			t.Errorf("duelStage(%d) = %d, want %d", c.ticksLeft, got, c.want)
+		}
+	}
+}
+
+// TestDuelWallDamageFloorsHP is a pure unit test of duelWallDamage: it floors
+// HP down by 2000, or to 1 if the duelist has less than that, and never
+// drives HP to 0 or below (SendDamage's punishing effect, Server.cpp:5970-6009).
+func TestDuelWallDamageFloorsHP(t *testing.T) {
+	cases := []struct {
+		name   string
+		hp     int32
+		wantHP int32
+	}{
+		{"high HP loses exactly 2000", 5000, 3000},
+		{"HP just above the floor", 2001, 1},
+		{"low HP floors to 1, not 0 or negative", 50, 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := &world.Session{}
+			// MaxHP must be high enough that setReqHp's effectiveMaxHP clamp
+			// (item.go) never kicks in and masks the damage this test checks.
+			e := &world.Entity{HP: c.hp, MaxHP: 10000}
+			duelWallDamage(s, e)
+			if e.HP != c.wantHP {
+				t.Errorf("HP = %d, want %d", e.HP, c.wantHP)
+			}
+			if e.HP <= 0 {
+				t.Error("duelWallDamage must never drive HP to 0 or below")
+			}
+		})
+	}
+}

--- a/tmserver/internal/handler/notice.go
+++ b/tmserver/internal/handler/notice.go
@@ -60,6 +60,13 @@ const (
 	NoticeDuelLose             // you lost the duel
 	NoticeDuelDraw             // the duel ended in a draw (timeout)
 
+	// NoticeDuelInCity: neither this code nor the underlying rule is
+	// confirmed against a legacy capture — the issue #118 scope explicitly
+	// leaves "duelo só fora de cidade?" as an open question. Blocking duel
+	// request/accept while either side stands in a safe city is a best-effort
+	// guess pending real verification.
+	NoticeDuelInCity
+
 	// NoticeCantUseHere (_NN_Cant_Use_That_Here) is sent for consumables whose
 	// real _MSG_UseItem.cpp behavior depends on data absent from this repo, and
 	// for Gema Estelar / Portal Scroll zone gates (issues #135 and #140).

--- a/webserver/internal/grpcsrv/ranking_test.go
+++ b/webserver/internal/grpcsrv/ranking_test.go
@@ -65,3 +65,31 @@ func TestListExpRankingInfraError(t *testing.T) {
 		t.Fatal("expected gRPC error on infra failure")
 	}
 }
+
+func TestListDuelRankingMapping(t *testing.T) {
+	fake := &fakeRanking{}
+	s := NewRanking(fake)
+
+	resp, err := s.ListDuelRanking(context.Background(), &webv1.ListDuelRankingRequest{Limit: 25, Offset: 2})
+	if err != nil {
+		t.Fatalf("ListDuelRanking: %v", err)
+	}
+	if fake.limit != 25 || fake.offset != 2 {
+		t.Fatalf("forwarded limit=%d offset=%d; want 25/2", fake.limit, fake.offset)
+	}
+	if resp.GetTotalCount() != 4 || len(resp.GetEntries()) != 1 {
+		t.Fatalf("response total=%d entries=%d; want 4/1", resp.GetTotalCount(), len(resp.GetEntries()))
+	}
+	got := resp.GetEntries()[0]
+	if got.GetRank() != 1 || got.GetName() != "Hero" || got.GetClass() != 1 ||
+		got.GetClan() != 7 || got.GetGuildId() != 99 || got.GetWins() != 5 || got.GetLosses() != 1 {
+		t.Fatalf("entry mapping mismatch: %+v", got)
+	}
+}
+
+func TestListDuelRankingInfraError(t *testing.T) {
+	s := NewRanking(&fakeRanking{err: errors.New("db down")})
+	if _, err := s.ListDuelRanking(context.Background(), &webv1.ListDuelRankingRequest{}); err == nil {
+		t.Fatal("expected gRPC error on infra failure")
+	}
+}


### PR DESCRIPTION
## Summary
- Best-effort safe-city gate on duel request/accept via `inSafeCity` (marked UNVERIFIED — issue #118 leaves the city rule as an open question pending a real client capture)
- Test coverage for previously-untested paths: draw/timeout resolution (`concludeDuelDraw`) and the closing-wall mechanic (`duelStage`, `duelWallDamage`)
- Missing `ListDuelRanking` gRPC mapping test in `webserver/internal/grpcsrv/ranking_test.go` (RPC was implemented but untested)
- New `docs/integrations/ranking-nextjs.md` §9 documenting `ListDuelRanking` for the Next.js BFF (previously only the unrelated Top-EXP ranking was documented there)

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` on touched files (clean)
- [x] `go test -race ./...` (full module, all packages pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)