### PR TITLE
Fix town NPC combat immunity

### DIFF
--- a/tmserver/internal/handler/affect_tick.go
+++ b/tmserver/internal/handler/affect_tick.go
@@ -314,7 +314,7 @@ func validThunderTarget(w *world.World, caster, target *world.Entity) bool {
 	if world.IsPlayer(target.ID) {
 		return false // PK-mode/arena attributes are not modeled; avoid implicit PvP ticks.
 	}
-	if target.Merchant&1 != 0 || target.Rsv&world.RsvHide != 0 || target.Clan == 4 || target.Clan == 6 {
+	if target.NonCombatNPC || target.Rsv&world.RsvHide != 0 || target.Clan == 4 || target.Clan == 6 {
 		return false
 	}
 	if (caster.Clan == 7 && target.Clan == 7) || (caster.Clan == 8 && target.Clan == 8) {

--- a/tmserver/internal/handler/combat.go
+++ b/tmserver/internal/handler/combat.go
@@ -153,8 +153,8 @@ func (d *Dispatcher) attack(w *world.World, s *world.Session, h protocol.Header,
 			d.log.Debug("attack: unexpected Dam claim (resolving as melee)",
 				"conn", s.Conn, "claim", claim, "skill", skillnum)
 		}
-		// Untouchable NPCs (shops/banks/quest givers) never take damage.
-		if !world.IsPlayer(tid) && target.Merchant != 0 {
+		// Untouchable NPCs (shops/banks/quest givers/town services) never take damage.
+		if !world.IsPlayer(tid) && target.NonCombatNPC {
 			writeDamage(payload, i, 0)
 			continue
 		}
@@ -481,6 +481,9 @@ func (d *Dispatcher) applyCastAffect(w *world.World, e, target *world.Entity, ti
 		return
 	}
 	if sp.Aggressive != 0 {
+		if !world.IsPlayer(tid) && target.NonCombatNPC {
+			return
+		}
 		leader := e.Leader
 		if leader == 0 {
 			leader = e.ID
@@ -683,7 +686,7 @@ func (d *Dispatcher) applyDivineFury(w *world.World, caster, target *world.Entit
 	if target == nil {
 		return false
 	}
-	if !world.IsPlayer(tid) && target.Merchant != 0 {
+	if !world.IsPlayer(tid) && target.NonCombatNPC {
 		return false
 	}
 	switch target.Equip[0].Index {
@@ -746,6 +749,9 @@ func (d *Dispatcher) applyExterminarMotion(w *world.World, caster, target *world
 		return false
 	}
 	if target.Equip[0].Index == 219 || target.Equip[0].Index == 220 {
+		return false
+	}
+	if !world.IsPlayer(tid) && target.NonCombatNPC {
 		return false
 	}
 	x, y, ok := d.freeCellNear(w, target.X, target.Y)

--- a/tmserver/internal/handler/combat_special_test.go
+++ b/tmserver/internal/handler/combat_special_test.go
@@ -449,14 +449,19 @@ func TestCreateVineRejectsOccupiedTarget(t *testing.T) {
 // returns the world so the test can inspect the spawned entity's state.
 func startServerSkillsTargetMob(t *testing.T, persist world.Persistence, tmpl []byte) (string, func(), *world.World) {
 	t.Helper()
+	return startServerSkillsTargetMobAt(t, persist, tmpl, 16, 6, 5)
+}
+
+func startServerSkillsTargetMobAt(t *testing.T, persist world.Persistence, tmpl []byte, gridDim int, x, y int16) (string, func(), *world.World) {
+	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	d := New(Config{Log: log, Spells: testSpells()})
-	w := world.New(world.Config{GridDim: 16}, log, persist, d.Handle)
-	w.SpawnMob(tmpl, 6, 5)
+	w := world.New(world.Config{GridDim: gridDim}, log, persist, d.Handle)
+	w.SpawnMob(tmpl, x, y)
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() { _ = w.Serve(ctx, ln); close(done) }()
@@ -472,8 +477,13 @@ func startServerSkillsTargetMob(t *testing.T, persist world.Persistence, tmpl []
 
 // targetMob builds an 816-byte STRUCT_MOB with the given Merchant flag and HP.
 func targetMob(name string, merchant byte, hp uint32) []byte {
+	return targetMobWithClan(name, 0, merchant, hp)
+}
+
+func targetMobWithClan(name string, clan, merchant byte, hp uint32) []byte {
 	b := make([]byte, 816)
 	copy(b[0:16], name)
+	b[16] = clan
 	const cs = 92 // CurrentScore offset
 	b[cs+12] = merchant
 	binary.LittleEndian.PutUint32(b[cs+16:], 5000) // MaxHp
@@ -481,11 +491,9 @@ func targetMob(name string, merchant byte, hp uint32) []byte {
 	return b
 }
 
-// castEchoDamage casts skillnum (claim -1) at targetID and returns the resolved
-// Dam[0].Damage from the attacker's own authoritative MsgAttack echo.
-func castEchoDamage(t *testing.T, c net.Conn, targetID, skillnum int) int32 {
+func attackEchoDamage(t *testing.T, c net.Conn, tick uint32, targetID, skillnum int, claim int32) int32 {
 	t.Helper()
-	skillAttackFrame(t, c, serverTime, targetID, skillnum, -1)
+	skillAttackFrame(t, c, tick, targetID, skillnum, claim)
 	ty, payload, ok := readMaybe(t, c)
 	if !ok || ty != protocol.MsgAttack {
 		t.Fatalf("attacker got %#x ok=%v, want MsgAttack echo", ty, ok)
@@ -498,6 +506,13 @@ func castEchoDamage(t *testing.T, c net.Conn, targetID, skillnum int) int32 {
 		t.Fatalf("Dam = %+v, want one entry", got.Dam)
 	}
 	return got.Dam[0].Damage
+}
+
+// castEchoDamage casts skillnum (claim -1) at targetID and returns the resolved
+// Dam[0].Damage from the attacker's own authoritative MsgAttack echo.
+func castEchoDamage(t *testing.T, c net.Conn, targetID, skillnum int) int32 {
+	t.Helper()
+	return attackEchoDamage(t, c, serverTime, targetID, skillnum, -1)
 }
 
 // TestSkillMerchantTakesNoDamage: an untouchable NPC (Merchant != 0) is immune
@@ -513,6 +528,44 @@ func TestSkillMerchantTakesNoDamage(t *testing.T) {
 	}
 	if npc := w.Entity(world.MaxUser); npc == nil || npc.HP != 5000 {
 		t.Fatalf("merchant HP = %v, want it untouched at 5000", npc)
+	}
+}
+
+func TestTownNonCombatNPCTakesNoDamage(t *testing.T) {
+	db := skillCombatDB(1 << 2)
+	db.loadResult.X, db.loadResult.Y = 2086, 2093 // Armia
+	addr, stop, w := startServerSkillsTargetMobAt(t, db, targetMobWithClan("Ehre", 3, 0, 5000), 4096, 2087, 2093)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	if dmg := attackEchoDamage(t, c, serverTime, world.MaxUser, -1, -2); dmg != 0 {
+		t.Errorf("town NPC melee damage = %d, want 0", dmg)
+	}
+	if dmg := attackEchoDamage(t, c, serverTime+1000, world.MaxUser, 2, -1); dmg != 0 {
+		t.Errorf("town NPC skill damage = %d, want 0", dmg)
+	}
+	if npc := w.Entity(world.MaxUser); npc == nil || npc.HP != 5000 || !npc.NonCombatNPC {
+		t.Fatalf("town NPC state = %+v, want HP 5000 and NonCombatNPC", npc)
+	}
+}
+
+func TestHostileCityMobStillTakesDamage(t *testing.T) {
+	db := skillCombatDB(1 << 2)
+	db.loadResult.X, db.loadResult.Y = 2086, 2093 // Armia
+	addr, stop, w := startServerSkillsTargetMobAt(t, db, targetMobWithClan("Orc", 1, 0, 5000), 4096, 2087, 2093)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	if dmg := attackEchoDamage(t, c, serverTime, world.MaxUser, -1, -2); dmg <= 0 {
+		t.Fatalf("hostile city mob melee damage = %d, want > 0", dmg)
+	}
+	if dmg := attackEchoDamage(t, c, serverTime+1000, world.MaxUser, 2, -1); dmg <= 0 {
+		t.Fatalf("hostile city mob skill damage = %d, want > 0", dmg)
+	}
+	if mob := w.Entity(world.MaxUser); mob == nil || mob.NonCombatNPC || mob.HP >= 5000 {
+		t.Fatalf("hostile city mob state = %+v, want combat mob with reduced HP", mob)
 	}
 }
 

--- a/tmserver/internal/handler/mobai.go
+++ b/tmserver/internal/handler/mobai.go
@@ -31,8 +31,9 @@ const (
 
 // Tick is the world's per-tick mob-AI hook (registered via World.SetTickHandler).
 // It runs inside the loop goroutine, so it mutates entities directly. Each live
-// monster (Merchant==0) acquires a nearby hostile player or mob as a target, then
-// chases and melees it. NPCs (shops/quest givers) and dead mobs are skipped.
+// monster acquires a nearby hostile player or mob as a target, then chases and
+// melees it. Non-combat NPCs (shops/quest givers/town services) and dead mobs are
+// skipped.
 //
 // UNVERIFIED / deferred (captura): real pathfinding (we step one Chebyshev
 // tile), roaming/segments/summons, and the player death/resurrection flow (a
@@ -54,8 +55,8 @@ func (d *Dispatcher) Tick(w *world.World) {
 	})
 
 	w.ForEachMob(func(id int, e *world.Entity) {
-		if e.Merchant != 0 || e.HP <= 0 {
-			return // shop/bank/quest NPCs don't fight; dead mobs do nothing
+		if !runsMobAI(e) || e.HP <= 0 {
+			return // town/service NPCs don't fight; dead mobs do nothing
 		}
 		if e.Summoner != 0 {
 			d.summonTick(w, id, e) // summoned pets follow their own AI (summon.go)
@@ -154,7 +155,7 @@ func setGroupBattle(w *world.World, id int, e, target *world.Entity) {
 		return
 	}
 	drag := func(mid int, me *world.Entity) {
-		if mid == id || me == nil || me.HP <= 0 || me.Merchant != 0 {
+		if mid == id || me == nil || me.HP <= 0 || !runsMobAI(me) {
 			return
 		}
 		if abs16(me.X-target.X) <= battleDragBox && abs16(me.Y-target.Y) <= battleDragBox {
@@ -170,6 +171,15 @@ func setGroupBattle(w *world.World, id int, e, target *world.Entity) {
 		}
 		drag(m, w.Entity(m))
 	}
+}
+
+func runsMobAI(e *world.Entity) bool {
+	if e == nil {
+		return false
+	}
+	// City guards are protected from player damage like other town NPCs, but they
+	// still police hostile mobs in town (guard-vs-mob parity).
+	return !e.NonCombatNPC || e.Clan == 7 || e.Clan == 8
 }
 
 func setBattle(w *world.World, id int, e, target *world.Entity) {
@@ -579,7 +589,7 @@ func validTarget(w *world.World, e, target *world.Entity) bool {
 		return false
 	}
 	if !world.IsPlayer(target.ID) {
-		if target.Merchant != 0 || target.Mode == world.MobEmpty {
+		if target.NonCombatNPC || target.Mode == world.MobEmpty {
 			return false
 		}
 		if e.Summoner != 0 {

--- a/tmserver/internal/world/api.go
+++ b/tmserver/internal/world/api.go
@@ -118,6 +118,7 @@ func (w *World) SpawnMobAt(sp MobSpawn) int {
 		SegmentX: x, SegmentY: y,
 		WaitTicks: sp.SegWait[0],
 	}
+	e.NonCombatNPC = nonCombatNPC(e.Merchant, e.Clan, e.X, e.Y)
 	for i, r := range b.Resist {
 		e.Resist[i] = int16(r)
 	}
@@ -199,7 +200,7 @@ func (w *World) DespawnMob(id int, removeType int32) {
 	// Generator population accounting on death (DeleteMob decrements
 	// CurrentNumMob, Server.cpp:7825-7831, clamped at 0).
 	gen := w.GeneratorAt(int(e.GenIndex))
-	if removeType == 1 && e.Merchant == 0 && gen != nil {
+	if removeType == 1 && e.Merchant == 0 && !e.NonCombatNPC && gen != nil {
 		if gen.CurrentNumMob--; gen.CurrentNumMob < 0 {
 			gen.CurrentNumMob = 0
 		}
@@ -233,7 +234,7 @@ func (w *World) DespawnMob(id int, removeType int32) {
 	// givers) don't die, so only schedule monsters (Merchant==0) killed in
 	// combat (removeType 1). Summoned pets never respawn — they carry a
 	// Template too, but their lifecycle belongs to the summoner.
-	if removeType == 1 && e.Merchant == 0 && e.Template != nil && e.Summoner == 0 &&
+	if removeType == 1 && e.Merchant == 0 && !e.NonCombatNPC && e.Template != nil && e.Summoner == 0 &&
 		(gen == nil || gen.MinuteGenerate <= 0) {
 		w.respawnQueue = append(w.respawnQueue, respawnEntry{
 			spawn: MobSpawn{

--- a/tmserver/internal/world/city.go
+++ b/tmserver/internal/world/city.go
@@ -56,3 +56,14 @@ func CitySpawn(city int) (int16, int16) {
 	c := cities[city]
 	return c.spawnX + int16(rand.Intn(15)), c.spawnY + int16(rand.Intn(15))
 }
+
+// nonCombatNPC classifies service/town NPCs independently of the client-visible
+// Merchant byte. Some real city templates ship Merchant==0 (for example combine
+// statues and decorative town actors), so relying on Merchant alone makes them
+// combat targets. Hostile clan mobs inside/near city rectangles stay combat-capable.
+func nonCombatNPC(merchant, clan uint8, x, y int16) bool {
+	if merchant != 0 {
+		return true
+	}
+	return Village(x, y) >= 0 && !ClanHostile(0, clan)
+}

--- a/tmserver/internal/world/city_test.go
+++ b/tmserver/internal/world/city_test.go
@@ -43,3 +43,31 @@ func TestCitySpawn(t *testing.T) {
 		t.Errorf("CitySpawn(4) should fall back to Armia, got village %d", Village(x, y))
 	}
 }
+
+func TestSpawnMobClassifiesTownNPCsAsNonCombat(t *testing.T) {
+	w := New(Config{GridDim: 4096}, slogDiscard(), nil, nil)
+
+	neutral := w.SpawnMob(genMobTemplate(3), 2086, 2093) // friendly city actor
+	if neutral < 0 {
+		t.Fatal("neutral town NPC did not spawn")
+	}
+	if e := w.Entity(neutral); e == nil || !e.NonCombatNPC {
+		t.Fatalf("neutral town NPC NonCombatNPC = %v, want true", e)
+	}
+
+	hostile := w.SpawnMob(genMobTemplate(1), 2087, 2093) // hostile mob inside a city rectangle
+	if hostile < 0 {
+		t.Fatal("hostile city mob did not spawn")
+	}
+	if e := w.Entity(hostile); e == nil || e.NonCombatNPC {
+		t.Fatalf("hostile city mob NonCombatNPC = %v, want false", e)
+	}
+
+	merchant := w.SpawnMob(genMerchantTemplate(1), 0, 0) // merchants are non-combat anywhere
+	if merchant < 0 {
+		t.Fatal("merchant NPC did not spawn")
+	}
+	if e := w.Entity(merchant); e == nil || !e.NonCombatNPC {
+		t.Fatalf("merchant NonCombatNPC = %v, want true", e)
+	}
+}

--- a/tmserver/internal/world/session.go
+++ b/tmserver/internal/world/session.go
@@ -210,9 +210,10 @@ type Entity struct {
 	// Template is the raw STRUCT_MOB bytes this mob was spawned from (boot template,
 	// shared by reference — no copy). Retained so the mob can be re-spawned at its
 	// SpawnX/SpawnY after it dies (world/respawn.go). nil for players.
-	Template []byte
-	Merchant uint8 // bit-packed: spawn city in bits 6-7 (lote2-movimento.md ChangeCity)
-	Grade    uint8 // NPC sub-type for Merchant==100 quest NPCs (EF_GRADE0 of Equip[0])
+	Template     []byte
+	Merchant     uint8 // bit-packed: spawn city in bits 6-7 (lote2-movimento.md ChangeCity)
+	NonCombatNPC bool  // true for town/service NPCs protected from player damage
+	Grade        uint8 // NPC sub-type for Merchant==100 quest NPCs (EF_GRADE0 of Equip[0])
 
 	Class       uint8    // character class (0=TK 1=FM 2=BM 3=HT); drives the visual model
 	AttackRun   uint8    // CurrentScore.AttackRun speed byte — mobs: template value (set at spawn); players: derived live (handler attackRunOf)

--- a/tmserver/internal/world/tick.go
+++ b/tmserver/internal/world/tick.go
@@ -106,8 +106,8 @@ func (w *World) FindEnemyFromView(x, y int16, clan uint8) int {
 			if int(id) < MaxUser && e.Mode != MobUser {
 				continue
 			}
-			if int(id) >= MaxUser && e.Merchant != 0 {
-				continue // shop/bank/quest NPCs are not combat targets
+			if int(id) >= MaxUser && e.NonCombatNPC {
+				continue // town/service NPCs are not combat targets
 			}
 			if int(id) >= MaxUser && e.Summoner != 0 {
 				continue // summons use the owner-assist path, not ambient aggro


### PR DESCRIPTION
## Summary
- classify town/service NPCs separately from the client-visible Merchant byte
- prevent player damage and aggressive skill effects against non-combat town NPCs
- keep hostile city mobs and guard-vs-mob AI working

Fixes #159

## Tests
- make test