### PR TITLE
Add web DropTool catalog endpoints

### DIFF
--- a/api/web/v1/web.pb.go
+++ b/api/web/v1/web.pb.go
@@ -2472,6 +2472,526 @@ func (x *ListItemCatalogResponse) GetItems() []*ItemCatalogEntry {
 	return nil
 }
 
+type DropItemMob struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TemplateName  string                 `protobuf:"bytes,1,opt,name=template_name,json=templateName,proto3" json:"template_name,omitempty"` // Release/TMsrv/run/npc file name
+	MobName       string                 `protobuf:"bytes,2,opt,name=mob_name,json=mobName,proto3" json:"mob_name,omitempty"`                // STRUCT_MOB.Name decoded as Latin-1
+	MobLevel      int32                  `protobuf:"varint,3,opt,name=mob_level,json=mobLevel,proto3" json:"mob_level,omitempty"`            // STRUCT_MOB.CurrentScore.Level
+	Slot          int32                  `protobuf:"varint,4,opt,name=slot,proto3" json:"slot,omitempty"`                                    // Carry[] slot; controls the base drop divisor
+	RateDivisor   int32                  `protobuf:"varint,5,opt,name=rate_divisor,json=rateDivisor,proto3" json:"rate_divisor,omitempty"`   // g_pDropRate[slot]; larger means rarer
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DropItemMob) Reset() {
+	*x = DropItemMob{}
+	mi := &file_api_web_v1_web_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DropItemMob) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DropItemMob) ProtoMessage() {}
+
+func (x *DropItemMob) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DropItemMob.ProtoReflect.Descriptor instead.
+func (*DropItemMob) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *DropItemMob) GetTemplateName() string {
+	if x != nil {
+		return x.TemplateName
+	}
+	return ""
+}
+
+func (x *DropItemMob) GetMobName() string {
+	if x != nil {
+		return x.MobName
+	}
+	return ""
+}
+
+func (x *DropItemMob) GetMobLevel() int32 {
+	if x != nil {
+		return x.MobLevel
+	}
+	return 0
+}
+
+func (x *DropItemMob) GetSlot() int32 {
+	if x != nil {
+		return x.Slot
+	}
+	return 0
+}
+
+func (x *DropItemMob) GetRateDivisor() int32 {
+	if x != nil {
+		return x.RateDivisor
+	}
+	return 0
+}
+
+type DropItemEntry struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ItemIndex     int32                  `protobuf:"varint,1,opt,name=item_index,json=itemIndex,proto3" json:"item_index,omitempty"`
+	ItemName      string                 `protobuf:"bytes,2,opt,name=item_name,json=itemName,proto3" json:"item_name,omitempty"`
+	Mobs          []*DropItemMob         `protobuf:"bytes,3,rep,name=mobs,proto3" json:"mobs,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DropItemEntry) Reset() {
+	*x = DropItemEntry{}
+	mi := &file_api_web_v1_web_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DropItemEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DropItemEntry) ProtoMessage() {}
+
+func (x *DropItemEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DropItemEntry.ProtoReflect.Descriptor instead.
+func (*DropItemEntry) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *DropItemEntry) GetItemIndex() int32 {
+	if x != nil {
+		return x.ItemIndex
+	}
+	return 0
+}
+
+func (x *DropItemEntry) GetItemName() string {
+	if x != nil {
+		return x.ItemName
+	}
+	return ""
+}
+
+func (x *DropItemEntry) GetMobs() []*DropItemMob {
+	if x != nil {
+		return x.Mobs
+	}
+	return nil
+}
+
+type ListDropItemsRequest struct {
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId          int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	ItemIndex            int32                  `protobuf:"varint,2,opt,name=item_index,json=itemIndex,proto3" json:"item_index,omitempty"`                                      // 0 = no exact item filter
+	ItemQuery            string                 `protobuf:"bytes,3,opt,name=item_query,json=itemQuery,proto3" json:"item_query,omitempty"`                                       // substring match on item name or index
+	MobQuery             string                 `protobuf:"bytes,4,opt,name=mob_query,json=mobQuery,proto3" json:"mob_query,omitempty"`                                          // substring match on mob/template name
+	IncludeZeroDropItems bool                   `protobuf:"varint,5,opt,name=include_zero_drop_items,json=includeZeroDropItems,proto3" json:"include_zero_drop_items,omitempty"` // include catalog items with no matching mobs
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *ListDropItemsRequest) Reset() {
+	*x = ListDropItemsRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListDropItemsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListDropItemsRequest) ProtoMessage() {}
+
+func (x *ListDropItemsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListDropItemsRequest.ProtoReflect.Descriptor instead.
+func (*ListDropItemsRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *ListDropItemsRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+func (x *ListDropItemsRequest) GetItemIndex() int32 {
+	if x != nil {
+		return x.ItemIndex
+	}
+	return 0
+}
+
+func (x *ListDropItemsRequest) GetItemQuery() string {
+	if x != nil {
+		return x.ItemQuery
+	}
+	return ""
+}
+
+func (x *ListDropItemsRequest) GetMobQuery() string {
+	if x != nil {
+		return x.MobQuery
+	}
+	return ""
+}
+
+func (x *ListDropItemsRequest) GetIncludeZeroDropItems() bool {
+	if x != nil {
+		return x.IncludeZeroDropItems
+	}
+	return false
+}
+
+type ListDropItemsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Result        AdminResult            `protobuf:"varint,1,opt,name=result,proto3,enum=web.v1.AdminResult" json:"result,omitempty"`
+	Items         []*DropItemEntry       `protobuf:"bytes,2,rep,name=items,proto3" json:"items,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListDropItemsResponse) Reset() {
+	*x = ListDropItemsResponse{}
+	mi := &file_api_web_v1_web_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListDropItemsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListDropItemsResponse) ProtoMessage() {}
+
+func (x *ListDropItemsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListDropItemsResponse.ProtoReflect.Descriptor instead.
+func (*ListDropItemsResponse) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *ListDropItemsResponse) GetResult() AdminResult {
+	if x != nil {
+		return x.Result
+	}
+	return AdminResult_ADMIN_RESULT_UNSPECIFIED
+}
+
+func (x *ListDropItemsResponse) GetItems() []*DropItemEntry {
+	if x != nil {
+		return x.Items
+	}
+	return nil
+}
+
+type MobDropItem struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Slot          int32                  `protobuf:"varint,1,opt,name=slot,proto3" json:"slot,omitempty"` // Carry[] slot; controls the base drop divisor
+	ItemIndex     int32                  `protobuf:"varint,2,opt,name=item_index,json=itemIndex,proto3" json:"item_index,omitempty"`
+	ItemName      string                 `protobuf:"bytes,3,opt,name=item_name,json=itemName,proto3" json:"item_name,omitempty"`
+	RateDivisor   int32                  `protobuf:"varint,4,opt,name=rate_divisor,json=rateDivisor,proto3" json:"rate_divisor,omitempty"` // g_pDropRate[slot]; larger means rarer
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MobDropItem) Reset() {
+	*x = MobDropItem{}
+	mi := &file_api_web_v1_web_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MobDropItem) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MobDropItem) ProtoMessage() {}
+
+func (x *MobDropItem) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MobDropItem.ProtoReflect.Descriptor instead.
+func (*MobDropItem) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *MobDropItem) GetSlot() int32 {
+	if x != nil {
+		return x.Slot
+	}
+	return 0
+}
+
+func (x *MobDropItem) GetItemIndex() int32 {
+	if x != nil {
+		return x.ItemIndex
+	}
+	return 0
+}
+
+func (x *MobDropItem) GetItemName() string {
+	if x != nil {
+		return x.ItemName
+	}
+	return ""
+}
+
+func (x *MobDropItem) GetRateDivisor() int32 {
+	if x != nil {
+		return x.RateDivisor
+	}
+	return 0
+}
+
+type MobDropEntry struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TemplateName  string                 `protobuf:"bytes,1,opt,name=template_name,json=templateName,proto3" json:"template_name,omitempty"` // Release/TMsrv/run/npc file name
+	MobName       string                 `protobuf:"bytes,2,opt,name=mob_name,json=mobName,proto3" json:"mob_name,omitempty"`                // STRUCT_MOB.Name decoded as Latin-1
+	MobLevel      int32                  `protobuf:"varint,3,opt,name=mob_level,json=mobLevel,proto3" json:"mob_level,omitempty"`            // STRUCT_MOB.CurrentScore.Level
+	Items         []*MobDropItem         `protobuf:"bytes,4,rep,name=items,proto3" json:"items,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MobDropEntry) Reset() {
+	*x = MobDropEntry{}
+	mi := &file_api_web_v1_web_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MobDropEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MobDropEntry) ProtoMessage() {}
+
+func (x *MobDropEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MobDropEntry.ProtoReflect.Descriptor instead.
+func (*MobDropEntry) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *MobDropEntry) GetTemplateName() string {
+	if x != nil {
+		return x.TemplateName
+	}
+	return ""
+}
+
+func (x *MobDropEntry) GetMobName() string {
+	if x != nil {
+		return x.MobName
+	}
+	return ""
+}
+
+func (x *MobDropEntry) GetMobLevel() int32 {
+	if x != nil {
+		return x.MobLevel
+	}
+	return 0
+}
+
+func (x *MobDropEntry) GetItems() []*MobDropItem {
+	if x != nil {
+		return x.Items
+	}
+	return nil
+}
+
+type ListMobDropsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId   int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	MobQuery      string                 `protobuf:"bytes,2,opt,name=mob_query,json=mobQuery,proto3" json:"mob_query,omitempty"`     // substring match on mob/template name
+	ItemIndex     int32                  `protobuf:"varint,3,opt,name=item_index,json=itemIndex,proto3" json:"item_index,omitempty"` // 0 = no exact item filter
+	ItemQuery     string                 `protobuf:"bytes,4,opt,name=item_query,json=itemQuery,proto3" json:"item_query,omitempty"`  // substring match on item name or index
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListMobDropsRequest) Reset() {
+	*x = ListMobDropsRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListMobDropsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListMobDropsRequest) ProtoMessage() {}
+
+func (x *ListMobDropsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListMobDropsRequest.ProtoReflect.Descriptor instead.
+func (*ListMobDropsRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *ListMobDropsRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+func (x *ListMobDropsRequest) GetMobQuery() string {
+	if x != nil {
+		return x.MobQuery
+	}
+	return ""
+}
+
+func (x *ListMobDropsRequest) GetItemIndex() int32 {
+	if x != nil {
+		return x.ItemIndex
+	}
+	return 0
+}
+
+func (x *ListMobDropsRequest) GetItemQuery() string {
+	if x != nil {
+		return x.ItemQuery
+	}
+	return ""
+}
+
+type ListMobDropsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Result        AdminResult            `protobuf:"varint,1,opt,name=result,proto3,enum=web.v1.AdminResult" json:"result,omitempty"`
+	Mobs          []*MobDropEntry        `protobuf:"bytes,2,rep,name=mobs,proto3" json:"mobs,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListMobDropsResponse) Reset() {
+	*x = ListMobDropsResponse{}
+	mi := &file_api_web_v1_web_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListMobDropsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListMobDropsResponse) ProtoMessage() {}
+
+func (x *ListMobDropsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListMobDropsResponse.ProtoReflect.Descriptor instead.
+func (*ListMobDropsResponse) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *ListMobDropsResponse) GetResult() AdminResult {
+	if x != nil {
+		return x.Result
+	}
+	return AdminResult_ADMIN_RESULT_UNSPECIFIED
+}
+
+func (x *ListMobDropsResponse) GetMobs() []*MobDropEntry {
+	if x != nil {
+		return x.Mobs
+	}
+	return nil
+}
+
 // ItemPrice is a global per-item price override (item_price table); an item
 // absent from ListItemPrices uses the content catalog's base price.
 type ItemPrice struct {
@@ -2484,7 +3004,7 @@ type ItemPrice struct {
 
 func (x *ItemPrice) Reset() {
 	*x = ItemPrice{}
-	mi := &file_api_web_v1_web_proto_msgTypes[32]
+	mi := &file_api_web_v1_web_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2496,7 +3016,7 @@ func (x *ItemPrice) String() string {
 func (*ItemPrice) ProtoMessage() {}
 
 func (x *ItemPrice) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[32]
+	mi := &file_api_web_v1_web_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2509,7 +3029,7 @@ func (x *ItemPrice) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ItemPrice.ProtoReflect.Descriptor instead.
 func (*ItemPrice) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{32}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *ItemPrice) GetItemIndex() int32 {
@@ -2535,7 +3055,7 @@ type ListItemPricesRequest struct {
 
 func (x *ListItemPricesRequest) Reset() {
 	*x = ListItemPricesRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[33]
+	mi := &file_api_web_v1_web_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2547,7 +3067,7 @@ func (x *ListItemPricesRequest) String() string {
 func (*ListItemPricesRequest) ProtoMessage() {}
 
 func (x *ListItemPricesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[33]
+	mi := &file_api_web_v1_web_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2560,7 +3080,7 @@ func (x *ListItemPricesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListItemPricesRequest.ProtoReflect.Descriptor instead.
 func (*ListItemPricesRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{33}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ListItemPricesRequest) GetModeratorId() int64 {
@@ -2580,7 +3100,7 @@ type ListItemPricesResponse struct {
 
 func (x *ListItemPricesResponse) Reset() {
 	*x = ListItemPricesResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[34]
+	mi := &file_api_web_v1_web_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2592,7 +3112,7 @@ func (x *ListItemPricesResponse) String() string {
 func (*ListItemPricesResponse) ProtoMessage() {}
 
 func (x *ListItemPricesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[34]
+	mi := &file_api_web_v1_web_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2605,7 +3125,7 @@ func (x *ListItemPricesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListItemPricesResponse.ProtoReflect.Descriptor instead.
 func (*ListItemPricesResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{34}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *ListItemPricesResponse) GetResult() AdminResult {
@@ -2635,7 +3155,7 @@ type MapZone struct {
 
 func (x *MapZone) Reset() {
 	*x = MapZone{}
-	mi := &file_api_web_v1_web_proto_msgTypes[35]
+	mi := &file_api_web_v1_web_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2647,7 +3167,7 @@ func (x *MapZone) String() string {
 func (*MapZone) ProtoMessage() {}
 
 func (x *MapZone) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[35]
+	mi := &file_api_web_v1_web_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2660,7 +3180,7 @@ func (x *MapZone) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MapZone.ProtoReflect.Descriptor instead.
 func (*MapZone) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{35}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *MapZone) GetId() int32 {
@@ -2686,7 +3206,7 @@ type ListMapZonesRequest struct {
 
 func (x *ListMapZonesRequest) Reset() {
 	*x = ListMapZonesRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[36]
+	mi := &file_api_web_v1_web_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2698,7 +3218,7 @@ func (x *ListMapZonesRequest) String() string {
 func (*ListMapZonesRequest) ProtoMessage() {}
 
 func (x *ListMapZonesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[36]
+	mi := &file_api_web_v1_web_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2711,7 +3231,7 @@ func (x *ListMapZonesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMapZonesRequest.ProtoReflect.Descriptor instead.
 func (*ListMapZonesRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{36}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *ListMapZonesRequest) GetModeratorId() int64 {
@@ -2731,7 +3251,7 @@ type ListMapZonesResponse struct {
 
 func (x *ListMapZonesResponse) Reset() {
 	*x = ListMapZonesResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[37]
+	mi := &file_api_web_v1_web_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2743,7 +3263,7 @@ func (x *ListMapZonesResponse) String() string {
 func (*ListMapZonesResponse) ProtoMessage() {}
 
 func (x *ListMapZonesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[37]
+	mi := &file_api_web_v1_web_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2756,7 +3276,7 @@ func (x *ListMapZonesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMapZonesResponse.ProtoReflect.Descriptor instead.
 func (*ListMapZonesResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{37}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *ListMapZonesResponse) GetResult() AdminResult {
@@ -2797,7 +3317,7 @@ type DonateShopItem struct {
 
 func (x *DonateShopItem) Reset() {
 	*x = DonateShopItem{}
-	mi := &file_api_web_v1_web_proto_msgTypes[38]
+	mi := &file_api_web_v1_web_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2809,7 +3329,7 @@ func (x *DonateShopItem) String() string {
 func (*DonateShopItem) ProtoMessage() {}
 
 func (x *DonateShopItem) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[38]
+	mi := &file_api_web_v1_web_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2822,7 +3342,7 @@ func (x *DonateShopItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DonateShopItem.ProtoReflect.Descriptor instead.
 func (*DonateShopItem) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{38}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *DonateShopItem) GetId() int64 {
@@ -2925,7 +3445,7 @@ type ListShopItemsRequest struct {
 
 func (x *ListShopItemsRequest) Reset() {
 	*x = ListShopItemsRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[39]
+	mi := &file_api_web_v1_web_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2937,7 +3457,7 @@ func (x *ListShopItemsRequest) String() string {
 func (*ListShopItemsRequest) ProtoMessage() {}
 
 func (x *ListShopItemsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[39]
+	mi := &file_api_web_v1_web_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2950,7 +3470,7 @@ func (x *ListShopItemsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListShopItemsRequest.ProtoReflect.Descriptor instead.
 func (*ListShopItemsRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{39}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *ListShopItemsRequest) GetModeratorId() int64 {
@@ -2970,7 +3490,7 @@ type ListShopItemsResponse struct {
 
 func (x *ListShopItemsResponse) Reset() {
 	*x = ListShopItemsResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[40]
+	mi := &file_api_web_v1_web_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2982,7 +3502,7 @@ func (x *ListShopItemsResponse) String() string {
 func (*ListShopItemsResponse) ProtoMessage() {}
 
 func (x *ListShopItemsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[40]
+	mi := &file_api_web_v1_web_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2995,7 +3515,7 @@ func (x *ListShopItemsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListShopItemsResponse.ProtoReflect.Descriptor instead.
 func (*ListShopItemsResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{40}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *ListShopItemsResponse) GetResult() AdminResult {
@@ -3023,7 +3543,7 @@ type UpsertShopItemRequest struct {
 
 func (x *UpsertShopItemRequest) Reset() {
 	*x = UpsertShopItemRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[41]
+	mi := &file_api_web_v1_web_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3035,7 +3555,7 @@ func (x *UpsertShopItemRequest) String() string {
 func (*UpsertShopItemRequest) ProtoMessage() {}
 
 func (x *UpsertShopItemRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[41]
+	mi := &file_api_web_v1_web_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3048,7 +3568,7 @@ func (x *UpsertShopItemRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpsertShopItemRequest.ProtoReflect.Descriptor instead.
 func (*UpsertShopItemRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{41}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *UpsertShopItemRequest) GetModeratorId() int64 {
@@ -3075,7 +3595,7 @@ type UpsertShopItemResponse struct {
 
 func (x *UpsertShopItemResponse) Reset() {
 	*x = UpsertShopItemResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[42]
+	mi := &file_api_web_v1_web_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3087,7 +3607,7 @@ func (x *UpsertShopItemResponse) String() string {
 func (*UpsertShopItemResponse) ProtoMessage() {}
 
 func (x *UpsertShopItemResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[42]
+	mi := &file_api_web_v1_web_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3100,7 +3620,7 @@ func (x *UpsertShopItemResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpsertShopItemResponse.ProtoReflect.Descriptor instead.
 func (*UpsertShopItemResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{42}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *UpsertShopItemResponse) GetResult() AdminResult {
@@ -3128,7 +3648,7 @@ type SetShopItemEnabledRequest struct {
 
 func (x *SetShopItemEnabledRequest) Reset() {
 	*x = SetShopItemEnabledRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[43]
+	mi := &file_api_web_v1_web_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3140,7 +3660,7 @@ func (x *SetShopItemEnabledRequest) String() string {
 func (*SetShopItemEnabledRequest) ProtoMessage() {}
 
 func (x *SetShopItemEnabledRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[43]
+	mi := &file_api_web_v1_web_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3153,7 +3673,7 @@ func (x *SetShopItemEnabledRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetShopItemEnabledRequest.ProtoReflect.Descriptor instead.
 func (*SetShopItemEnabledRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{43}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *SetShopItemEnabledRequest) GetModeratorId() int64 {
@@ -3187,7 +3707,7 @@ type DeleteShopItemRequest struct {
 
 func (x *DeleteShopItemRequest) Reset() {
 	*x = DeleteShopItemRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[44]
+	mi := &file_api_web_v1_web_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3199,7 +3719,7 @@ func (x *DeleteShopItemRequest) String() string {
 func (*DeleteShopItemRequest) ProtoMessage() {}
 
 func (x *DeleteShopItemRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[44]
+	mi := &file_api_web_v1_web_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3212,7 +3732,7 @@ func (x *DeleteShopItemRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteShopItemRequest.ProtoReflect.Descriptor instead.
 func (*DeleteShopItemRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{44}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *DeleteShopItemRequest) GetModeratorId() int64 {
@@ -3241,7 +3761,7 @@ type CreditDonateBalanceRequest struct {
 
 func (x *CreditDonateBalanceRequest) Reset() {
 	*x = CreditDonateBalanceRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[45]
+	mi := &file_api_web_v1_web_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3253,7 +3773,7 @@ func (x *CreditDonateBalanceRequest) String() string {
 func (*CreditDonateBalanceRequest) ProtoMessage() {}
 
 func (x *CreditDonateBalanceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[45]
+	mi := &file_api_web_v1_web_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3266,7 +3786,7 @@ func (x *CreditDonateBalanceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreditDonateBalanceRequest.ProtoReflect.Descriptor instead.
 func (*CreditDonateBalanceRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{45}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *CreditDonateBalanceRequest) GetModeratorId() int64 {
@@ -3307,7 +3827,7 @@ type CreditDonateBalanceResponse struct {
 
 func (x *CreditDonateBalanceResponse) Reset() {
 	*x = CreditDonateBalanceResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[46]
+	mi := &file_api_web_v1_web_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3319,7 +3839,7 @@ func (x *CreditDonateBalanceResponse) String() string {
 func (*CreditDonateBalanceResponse) ProtoMessage() {}
 
 func (x *CreditDonateBalanceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[46]
+	mi := &file_api_web_v1_web_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3332,7 +3852,7 @@ func (x *CreditDonateBalanceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreditDonateBalanceResponse.ProtoReflect.Descriptor instead.
 func (*CreditDonateBalanceResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{46}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *CreditDonateBalanceResponse) GetResult() AdminResult {
@@ -3357,7 +3877,7 @@ type ListStoreItemsRequest struct {
 
 func (x *ListStoreItemsRequest) Reset() {
 	*x = ListStoreItemsRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[47]
+	mi := &file_api_web_v1_web_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3369,7 +3889,7 @@ func (x *ListStoreItemsRequest) String() string {
 func (*ListStoreItemsRequest) ProtoMessage() {}
 
 func (x *ListStoreItemsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[47]
+	mi := &file_api_web_v1_web_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3382,7 +3902,7 @@ func (x *ListStoreItemsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListStoreItemsRequest.ProtoReflect.Descriptor instead.
 func (*ListStoreItemsRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{47}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{55}
 }
 
 type ListStoreItemsResponse struct {
@@ -3394,7 +3914,7 @@ type ListStoreItemsResponse struct {
 
 func (x *ListStoreItemsResponse) Reset() {
 	*x = ListStoreItemsResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[48]
+	mi := &file_api_web_v1_web_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3406,7 +3926,7 @@ func (x *ListStoreItemsResponse) String() string {
 func (*ListStoreItemsResponse) ProtoMessage() {}
 
 func (x *ListStoreItemsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[48]
+	mi := &file_api_web_v1_web_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3419,7 +3939,7 @@ func (x *ListStoreItemsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListStoreItemsResponse.ProtoReflect.Descriptor instead.
 func (*ListStoreItemsResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{48}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *ListStoreItemsResponse) GetItems() []*DonateShopItem {
@@ -3438,7 +3958,7 @@ type GetBalanceRequest struct {
 
 func (x *GetBalanceRequest) Reset() {
 	*x = GetBalanceRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[49]
+	mi := &file_api_web_v1_web_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3450,7 +3970,7 @@ func (x *GetBalanceRequest) String() string {
 func (*GetBalanceRequest) ProtoMessage() {}
 
 func (x *GetBalanceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[49]
+	mi := &file_api_web_v1_web_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3463,7 +3983,7 @@ func (x *GetBalanceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBalanceRequest.ProtoReflect.Descriptor instead.
 func (*GetBalanceRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{49}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *GetBalanceRequest) GetAccountId() int64 {
@@ -3482,7 +4002,7 @@ type GetBalanceResponse struct {
 
 func (x *GetBalanceResponse) Reset() {
 	*x = GetBalanceResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[50]
+	mi := &file_api_web_v1_web_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3494,7 +4014,7 @@ func (x *GetBalanceResponse) String() string {
 func (*GetBalanceResponse) ProtoMessage() {}
 
 func (x *GetBalanceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[50]
+	mi := &file_api_web_v1_web_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3507,7 +4027,7 @@ func (x *GetBalanceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBalanceResponse.ProtoReflect.Descriptor instead.
 func (*GetBalanceResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{50}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *GetBalanceResponse) GetBalance() int32 {
@@ -3527,7 +4047,7 @@ type BuyRequest struct {
 
 func (x *BuyRequest) Reset() {
 	*x = BuyRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[51]
+	mi := &file_api_web_v1_web_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3539,7 +4059,7 @@ func (x *BuyRequest) String() string {
 func (*BuyRequest) ProtoMessage() {}
 
 func (x *BuyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[51]
+	mi := &file_api_web_v1_web_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3552,7 +4072,7 @@ func (x *BuyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuyRequest.ProtoReflect.Descriptor instead.
 func (*BuyRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{51}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *BuyRequest) GetAccountId() int64 {
@@ -3579,7 +4099,7 @@ type BuyResponse struct {
 
 func (x *BuyResponse) Reset() {
 	*x = BuyResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[52]
+	mi := &file_api_web_v1_web_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3591,7 +4111,7 @@ func (x *BuyResponse) String() string {
 func (*BuyResponse) ProtoMessage() {}
 
 func (x *BuyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[52]
+	mi := &file_api_web_v1_web_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3604,7 +4124,7 @@ func (x *BuyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuyResponse.ProtoReflect.Descriptor instead.
 func (*BuyResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{52}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *BuyResponse) GetResult() BuyResult {
@@ -3644,7 +4164,7 @@ type DailyRewardItem struct {
 
 func (x *DailyRewardItem) Reset() {
 	*x = DailyRewardItem{}
-	mi := &file_api_web_v1_web_proto_msgTypes[53]
+	mi := &file_api_web_v1_web_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3656,7 +4176,7 @@ func (x *DailyRewardItem) String() string {
 func (*DailyRewardItem) ProtoMessage() {}
 
 func (x *DailyRewardItem) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[53]
+	mi := &file_api_web_v1_web_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3669,7 +4189,7 @@ func (x *DailyRewardItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DailyRewardItem.ProtoReflect.Descriptor instead.
 func (*DailyRewardItem) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{53}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *DailyRewardItem) GetId() int64 {
@@ -3765,7 +4285,7 @@ type ListRewardItemsRequest struct {
 
 func (x *ListRewardItemsRequest) Reset() {
 	*x = ListRewardItemsRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[54]
+	mi := &file_api_web_v1_web_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3777,7 +4297,7 @@ func (x *ListRewardItemsRequest) String() string {
 func (*ListRewardItemsRequest) ProtoMessage() {}
 
 func (x *ListRewardItemsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[54]
+	mi := &file_api_web_v1_web_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3790,7 +4310,7 @@ func (x *ListRewardItemsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRewardItemsRequest.ProtoReflect.Descriptor instead.
 func (*ListRewardItemsRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{54}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *ListRewardItemsRequest) GetModeratorId() int64 {
@@ -3810,7 +4330,7 @@ type ListRewardItemsResponse struct {
 
 func (x *ListRewardItemsResponse) Reset() {
 	*x = ListRewardItemsResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[55]
+	mi := &file_api_web_v1_web_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3822,7 +4342,7 @@ func (x *ListRewardItemsResponse) String() string {
 func (*ListRewardItemsResponse) ProtoMessage() {}
 
 func (x *ListRewardItemsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[55]
+	mi := &file_api_web_v1_web_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3835,7 +4355,7 @@ func (x *ListRewardItemsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRewardItemsResponse.ProtoReflect.Descriptor instead.
 func (*ListRewardItemsResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{55}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *ListRewardItemsResponse) GetResult() AdminResult {
@@ -3863,7 +4383,7 @@ type UpsertRewardItemRequest struct {
 
 func (x *UpsertRewardItemRequest) Reset() {
 	*x = UpsertRewardItemRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[56]
+	mi := &file_api_web_v1_web_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3875,7 +4395,7 @@ func (x *UpsertRewardItemRequest) String() string {
 func (*UpsertRewardItemRequest) ProtoMessage() {}
 
 func (x *UpsertRewardItemRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[56]
+	mi := &file_api_web_v1_web_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3888,7 +4408,7 @@ func (x *UpsertRewardItemRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpsertRewardItemRequest.ProtoReflect.Descriptor instead.
 func (*UpsertRewardItemRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{56}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *UpsertRewardItemRequest) GetModeratorId() int64 {
@@ -3915,7 +4435,7 @@ type UpsertRewardItemResponse struct {
 
 func (x *UpsertRewardItemResponse) Reset() {
 	*x = UpsertRewardItemResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[57]
+	mi := &file_api_web_v1_web_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3927,7 +4447,7 @@ func (x *UpsertRewardItemResponse) String() string {
 func (*UpsertRewardItemResponse) ProtoMessage() {}
 
 func (x *UpsertRewardItemResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[57]
+	mi := &file_api_web_v1_web_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3940,7 +4460,7 @@ func (x *UpsertRewardItemResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpsertRewardItemResponse.ProtoReflect.Descriptor instead.
 func (*UpsertRewardItemResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{57}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *UpsertRewardItemResponse) GetResult() AdminResult {
@@ -3968,7 +4488,7 @@ type SetRewardItemEnabledRequest struct {
 
 func (x *SetRewardItemEnabledRequest) Reset() {
 	*x = SetRewardItemEnabledRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[58]
+	mi := &file_api_web_v1_web_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3980,7 +4500,7 @@ func (x *SetRewardItemEnabledRequest) String() string {
 func (*SetRewardItemEnabledRequest) ProtoMessage() {}
 
 func (x *SetRewardItemEnabledRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[58]
+	mi := &file_api_web_v1_web_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3993,7 +4513,7 @@ func (x *SetRewardItemEnabledRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetRewardItemEnabledRequest.ProtoReflect.Descriptor instead.
 func (*SetRewardItemEnabledRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{58}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *SetRewardItemEnabledRequest) GetModeratorId() int64 {
@@ -4027,7 +4547,7 @@ type DeleteRewardItemRequest struct {
 
 func (x *DeleteRewardItemRequest) Reset() {
 	*x = DeleteRewardItemRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[59]
+	mi := &file_api_web_v1_web_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4039,7 +4559,7 @@ func (x *DeleteRewardItemRequest) String() string {
 func (*DeleteRewardItemRequest) ProtoMessage() {}
 
 func (x *DeleteRewardItemRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[59]
+	mi := &file_api_web_v1_web_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4052,7 +4572,7 @@ func (x *DeleteRewardItemRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteRewardItemRequest.ProtoReflect.Descriptor instead.
 func (*DeleteRewardItemRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{59}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *DeleteRewardItemRequest) GetModeratorId() int64 {
@@ -4077,7 +4597,7 @@ type ListRewardsRequest struct {
 
 func (x *ListRewardsRequest) Reset() {
 	*x = ListRewardsRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[60]
+	mi := &file_api_web_v1_web_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4089,7 +4609,7 @@ func (x *ListRewardsRequest) String() string {
 func (*ListRewardsRequest) ProtoMessage() {}
 
 func (x *ListRewardsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[60]
+	mi := &file_api_web_v1_web_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4102,7 +4622,7 @@ func (x *ListRewardsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRewardsRequest.ProtoReflect.Descriptor instead.
 func (*ListRewardsRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{60}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{68}
 }
 
 type ListRewardsResponse struct {
@@ -4114,7 +4634,7 @@ type ListRewardsResponse struct {
 
 func (x *ListRewardsResponse) Reset() {
 	*x = ListRewardsResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[61]
+	mi := &file_api_web_v1_web_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4126,7 +4646,7 @@ func (x *ListRewardsResponse) String() string {
 func (*ListRewardsResponse) ProtoMessage() {}
 
 func (x *ListRewardsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[61]
+	mi := &file_api_web_v1_web_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4139,7 +4659,7 @@ func (x *ListRewardsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRewardsResponse.ProtoReflect.Descriptor instead.
 func (*ListRewardsResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{61}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *ListRewardsResponse) GetItems() []*DailyRewardItem {
@@ -4158,7 +4678,7 @@ type GetClaimStatusRequest struct {
 
 func (x *GetClaimStatusRequest) Reset() {
 	*x = GetClaimStatusRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[62]
+	mi := &file_api_web_v1_web_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4170,7 +4690,7 @@ func (x *GetClaimStatusRequest) String() string {
 func (*GetClaimStatusRequest) ProtoMessage() {}
 
 func (x *GetClaimStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[62]
+	mi := &file_api_web_v1_web_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4183,7 +4703,7 @@ func (x *GetClaimStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetClaimStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetClaimStatusRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{62}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *GetClaimStatusRequest) GetAccountId() int64 {
@@ -4204,7 +4724,7 @@ type GetClaimStatusResponse struct {
 
 func (x *GetClaimStatusResponse) Reset() {
 	*x = GetClaimStatusResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[63]
+	mi := &file_api_web_v1_web_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4216,7 +4736,7 @@ func (x *GetClaimStatusResponse) String() string {
 func (*GetClaimStatusResponse) ProtoMessage() {}
 
 func (x *GetClaimStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[63]
+	mi := &file_api_web_v1_web_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4229,7 +4749,7 @@ func (x *GetClaimStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetClaimStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetClaimStatusResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{63}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *GetClaimStatusResponse) GetClaimedToday() bool {
@@ -4263,7 +4783,7 @@ type ClaimRequest struct {
 
 func (x *ClaimRequest) Reset() {
 	*x = ClaimRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[64]
+	mi := &file_api_web_v1_web_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4275,7 +4795,7 @@ func (x *ClaimRequest) String() string {
 func (*ClaimRequest) ProtoMessage() {}
 
 func (x *ClaimRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[64]
+	mi := &file_api_web_v1_web_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4288,7 +4808,7 @@ func (x *ClaimRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClaimRequest.ProtoReflect.Descriptor instead.
 func (*ClaimRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{64}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *ClaimRequest) GetAccountId() int64 {
@@ -4314,7 +4834,7 @@ type ClaimResponse struct {
 
 func (x *ClaimResponse) Reset() {
 	*x = ClaimResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[65]
+	mi := &file_api_web_v1_web_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4326,7 +4846,7 @@ func (x *ClaimResponse) String() string {
 func (*ClaimResponse) ProtoMessage() {}
 
 func (x *ClaimResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[65]
+	mi := &file_api_web_v1_web_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4339,7 +4859,7 @@ func (x *ClaimResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClaimResponse.ProtoReflect.Descriptor instead.
 func (*ClaimResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{65}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *ClaimResponse) GetResult() ClaimResult {
@@ -4358,7 +4878,7 @@ type GetPayerProfileRequest struct {
 
 func (x *GetPayerProfileRequest) Reset() {
 	*x = GetPayerProfileRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[66]
+	mi := &file_api_web_v1_web_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4370,7 +4890,7 @@ func (x *GetPayerProfileRequest) String() string {
 func (*GetPayerProfileRequest) ProtoMessage() {}
 
 func (x *GetPayerProfileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[66]
+	mi := &file_api_web_v1_web_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4383,7 +4903,7 @@ func (x *GetPayerProfileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPayerProfileRequest.ProtoReflect.Descriptor instead.
 func (*GetPayerProfileRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{66}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *GetPayerProfileRequest) GetAccountId() int64 {
@@ -4404,7 +4924,7 @@ type GetPayerProfileResponse struct {
 
 func (x *GetPayerProfileResponse) Reset() {
 	*x = GetPayerProfileResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[67]
+	mi := &file_api_web_v1_web_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4416,7 +4936,7 @@ func (x *GetPayerProfileResponse) String() string {
 func (*GetPayerProfileResponse) ProtoMessage() {}
 
 func (x *GetPayerProfileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[67]
+	mi := &file_api_web_v1_web_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4429,7 +4949,7 @@ func (x *GetPayerProfileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPayerProfileResponse.ProtoReflect.Descriptor instead.
 func (*GetPayerProfileResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{67}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *GetPayerProfileResponse) GetFound() bool {
@@ -4464,7 +4984,7 @@ type SavePayerProfileRequest struct {
 
 func (x *SavePayerProfileRequest) Reset() {
 	*x = SavePayerProfileRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[68]
+	mi := &file_api_web_v1_web_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4476,7 +4996,7 @@ func (x *SavePayerProfileRequest) String() string {
 func (*SavePayerProfileRequest) ProtoMessage() {}
 
 func (x *SavePayerProfileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[68]
+	mi := &file_api_web_v1_web_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4489,7 +5009,7 @@ func (x *SavePayerProfileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SavePayerProfileRequest.ProtoReflect.Descriptor instead.
 func (*SavePayerProfileRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{68}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *SavePayerProfileRequest) GetAccountId() int64 {
@@ -4522,7 +5042,7 @@ type SavePayerProfileResponse struct {
 
 func (x *SavePayerProfileResponse) Reset() {
 	*x = SavePayerProfileResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[69]
+	mi := &file_api_web_v1_web_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4534,7 +5054,7 @@ func (x *SavePayerProfileResponse) String() string {
 func (*SavePayerProfileResponse) ProtoMessage() {}
 
 func (x *SavePayerProfileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[69]
+	mi := &file_api_web_v1_web_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4547,7 +5067,7 @@ func (x *SavePayerProfileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SavePayerProfileResponse.ProtoReflect.Descriptor instead.
 func (*SavePayerProfileResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{69}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *SavePayerProfileResponse) GetResult() AdminResult {
@@ -4570,7 +5090,7 @@ type CreateTopupOrderRequest struct {
 
 func (x *CreateTopupOrderRequest) Reset() {
 	*x = CreateTopupOrderRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[70]
+	mi := &file_api_web_v1_web_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4582,7 +5102,7 @@ func (x *CreateTopupOrderRequest) String() string {
 func (*CreateTopupOrderRequest) ProtoMessage() {}
 
 func (x *CreateTopupOrderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[70]
+	mi := &file_api_web_v1_web_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4595,7 +5115,7 @@ func (x *CreateTopupOrderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTopupOrderRequest.ProtoReflect.Descriptor instead.
 func (*CreateTopupOrderRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{70}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *CreateTopupOrderRequest) GetAccountId() int64 {
@@ -4643,7 +5163,7 @@ type CreateTopupOrderResponse struct {
 
 func (x *CreateTopupOrderResponse) Reset() {
 	*x = CreateTopupOrderResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[71]
+	mi := &file_api_web_v1_web_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4655,7 +5175,7 @@ func (x *CreateTopupOrderResponse) String() string {
 func (*CreateTopupOrderResponse) ProtoMessage() {}
 
 func (x *CreateTopupOrderResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[71]
+	mi := &file_api_web_v1_web_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4668,7 +5188,7 @@ func (x *CreateTopupOrderResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTopupOrderResponse.ProtoReflect.Descriptor instead.
 func (*CreateTopupOrderResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{71}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *CreateTopupOrderResponse) GetResult() AdminResult {
@@ -4694,7 +5214,7 @@ type ConfirmTopupOrderRequest struct {
 
 func (x *ConfirmTopupOrderRequest) Reset() {
 	*x = ConfirmTopupOrderRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[72]
+	mi := &file_api_web_v1_web_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4706,7 +5226,7 @@ func (x *ConfirmTopupOrderRequest) String() string {
 func (*ConfirmTopupOrderRequest) ProtoMessage() {}
 
 func (x *ConfirmTopupOrderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[72]
+	mi := &file_api_web_v1_web_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4719,7 +5239,7 @@ func (x *ConfirmTopupOrderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfirmTopupOrderRequest.ProtoReflect.Descriptor instead.
 func (*ConfirmTopupOrderRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{72}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *ConfirmTopupOrderRequest) GetExternalReference() string {
@@ -4739,7 +5259,7 @@ type ConfirmTopupOrderResponse struct {
 
 func (x *ConfirmTopupOrderResponse) Reset() {
 	*x = ConfirmTopupOrderResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[73]
+	mi := &file_api_web_v1_web_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4751,7 +5271,7 @@ func (x *ConfirmTopupOrderResponse) String() string {
 func (*ConfirmTopupOrderResponse) ProtoMessage() {}
 
 func (x *ConfirmTopupOrderResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[73]
+	mi := &file_api_web_v1_web_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4764,7 +5284,7 @@ func (x *ConfirmTopupOrderResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfirmTopupOrderResponse.ProtoReflect.Descriptor instead.
 func (*ConfirmTopupOrderResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{73}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *ConfirmTopupOrderResponse) GetResult() TopupResult {
@@ -4791,7 +5311,7 @@ type GetTopupOrderRequest struct {
 
 func (x *GetTopupOrderRequest) Reset() {
 	*x = GetTopupOrderRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[74]
+	mi := &file_api_web_v1_web_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4803,7 +5323,7 @@ func (x *GetTopupOrderRequest) String() string {
 func (*GetTopupOrderRequest) ProtoMessage() {}
 
 func (x *GetTopupOrderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[74]
+	mi := &file_api_web_v1_web_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4816,7 +5336,7 @@ func (x *GetTopupOrderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTopupOrderRequest.ProtoReflect.Descriptor instead.
 func (*GetTopupOrderRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{74}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *GetTopupOrderRequest) GetExternalReference() string {
@@ -4844,7 +5364,7 @@ type GetTopupOrderResponse struct {
 
 func (x *GetTopupOrderResponse) Reset() {
 	*x = GetTopupOrderResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[75]
+	mi := &file_api_web_v1_web_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4856,7 +5376,7 @@ func (x *GetTopupOrderResponse) String() string {
 func (*GetTopupOrderResponse) ProtoMessage() {}
 
 func (x *GetTopupOrderResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[75]
+	mi := &file_api_web_v1_web_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4869,7 +5389,7 @@ func (x *GetTopupOrderResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTopupOrderResponse.ProtoReflect.Descriptor instead.
 func (*GetTopupOrderResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{75}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *GetTopupOrderResponse) GetStatus() TopupStatus {
@@ -5056,7 +5576,50 @@ const file_api_web_v1_web_proto_rawDesc = "" +
 	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\"v\n" +
 	"\x17ListItemCatalogResponse\x12+\n" +
 	"\x06result\x18\x01 \x01(\x0e2\x13.web.v1.AdminResultR\x06result\x12.\n" +
-	"\x05items\x18\x02 \x03(\v2\x18.web.v1.ItemCatalogEntryR\x05items\"@\n" +
+	"\x05items\x18\x02 \x03(\v2\x18.web.v1.ItemCatalogEntryR\x05items\"\xa1\x01\n" +
+	"\vDropItemMob\x12#\n" +
+	"\rtemplate_name\x18\x01 \x01(\tR\ftemplateName\x12\x19\n" +
+	"\bmob_name\x18\x02 \x01(\tR\amobName\x12\x1b\n" +
+	"\tmob_level\x18\x03 \x01(\x05R\bmobLevel\x12\x12\n" +
+	"\x04slot\x18\x04 \x01(\x05R\x04slot\x12!\n" +
+	"\frate_divisor\x18\x05 \x01(\x05R\vrateDivisor\"t\n" +
+	"\rDropItemEntry\x12\x1d\n" +
+	"\n" +
+	"item_index\x18\x01 \x01(\x05R\titemIndex\x12\x1b\n" +
+	"\titem_name\x18\x02 \x01(\tR\bitemName\x12'\n" +
+	"\x04mobs\x18\x03 \x03(\v2\x13.web.v1.DropItemMobR\x04mobs\"\xcb\x01\n" +
+	"\x14ListDropItemsRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\x12\x1d\n" +
+	"\n" +
+	"item_index\x18\x02 \x01(\x05R\titemIndex\x12\x1d\n" +
+	"\n" +
+	"item_query\x18\x03 \x01(\tR\titemQuery\x12\x1b\n" +
+	"\tmob_query\x18\x04 \x01(\tR\bmobQuery\x125\n" +
+	"\x17include_zero_drop_items\x18\x05 \x01(\bR\x14includeZeroDropItems\"q\n" +
+	"\x15ListDropItemsResponse\x12+\n" +
+	"\x06result\x18\x01 \x01(\x0e2\x13.web.v1.AdminResultR\x06result\x12+\n" +
+	"\x05items\x18\x02 \x03(\v2\x15.web.v1.DropItemEntryR\x05items\"\x80\x01\n" +
+	"\vMobDropItem\x12\x12\n" +
+	"\x04slot\x18\x01 \x01(\x05R\x04slot\x12\x1d\n" +
+	"\n" +
+	"item_index\x18\x02 \x01(\x05R\titemIndex\x12\x1b\n" +
+	"\titem_name\x18\x03 \x01(\tR\bitemName\x12!\n" +
+	"\frate_divisor\x18\x04 \x01(\x05R\vrateDivisor\"\x96\x01\n" +
+	"\fMobDropEntry\x12#\n" +
+	"\rtemplate_name\x18\x01 \x01(\tR\ftemplateName\x12\x19\n" +
+	"\bmob_name\x18\x02 \x01(\tR\amobName\x12\x1b\n" +
+	"\tmob_level\x18\x03 \x01(\x05R\bmobLevel\x12)\n" +
+	"\x05items\x18\x04 \x03(\v2\x13.web.v1.MobDropItemR\x05items\"\x93\x01\n" +
+	"\x13ListMobDropsRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\x12\x1b\n" +
+	"\tmob_query\x18\x02 \x01(\tR\bmobQuery\x12\x1d\n" +
+	"\n" +
+	"item_index\x18\x03 \x01(\x05R\titemIndex\x12\x1d\n" +
+	"\n" +
+	"item_query\x18\x04 \x01(\tR\titemQuery\"m\n" +
+	"\x14ListMobDropsResponse\x12+\n" +
+	"\x06result\x18\x01 \x01(\x0e2\x13.web.v1.AdminResultR\x06result\x12(\n" +
+	"\x04mobs\x18\x02 \x03(\v2\x14.web.v1.MobDropEntryR\x04mobs\"@\n" +
 	"\tItemPrice\x12\x1d\n" +
 	"\n" +
 	"item_index\x18\x01 \x01(\x05R\titemIndex\x12\x14\n" +
@@ -5267,7 +5830,7 @@ const file_api_web_v1_web_proto_rawDesc = "" +
 	"\x0eListExpRanking\x12\x1d.web.v1.ListExpRankingRequest\x1a\x1e.web.v1.ListExpRankingResponse\x12R\n" +
 	"\x0fListDuelRanking\x12\x1e.web.v1.ListDuelRankingRequest\x1a\x1f.web.v1.ListDuelRankingResponse2l\n" +
 	"\x13CharacterWebService\x12U\n" +
-	"\x10ListMyCharacters\x12\x1f.web.v1.ListMyCharactersRequest\x1a .web.v1.ListMyCharactersResponse2\x9b\x06\n" +
+	"\x10ListMyCharacters\x12\x1f.web.v1.ListMyCharactersRequest\x1a .web.v1.ListMyCharactersResponse2\xb4\a\n" +
 	"\x0fNpcAdminService\x12=\n" +
 	"\bListNpcs\x12\x17.web.v1.ListNpcsRequest\x1a\x18.web.v1.ListNpcsResponse\x127\n" +
 	"\x06GetNpc\x12\x15.web.v1.GetNpcRequest\x1a\x16.web.v1.GetNpcResponse\x12@\n" +
@@ -5278,7 +5841,9 @@ const file_api_web_v1_web_proto_rawDesc = "" +
 	"\fSetItemPrice\x12\x1b.web.v1.SetItemPriceRequest\x1a\x10.web.v1.AdminAck\x127\n" +
 	"\tDeleteNpc\x12\x18.web.v1.DeleteNpcRequest\x1a\x10.web.v1.AdminAck\x12d\n" +
 	"\x15ListMerchantTemplates\x12$.web.v1.ListMerchantTemplatesRequest\x1a%.web.v1.ListMerchantTemplatesResponse\x12R\n" +
-	"\x0fListItemCatalog\x12\x1e.web.v1.ListItemCatalogRequest\x1a\x1f.web.v1.ListItemCatalogResponse\x12O\n" +
+	"\x0fListItemCatalog\x12\x1e.web.v1.ListItemCatalogRequest\x1a\x1f.web.v1.ListItemCatalogResponse\x12L\n" +
+	"\rListDropItems\x12\x1c.web.v1.ListDropItemsRequest\x1a\x1d.web.v1.ListDropItemsResponse\x12I\n" +
+	"\fListMobDrops\x12\x1b.web.v1.ListMobDropsRequest\x1a\x1c.web.v1.ListMobDropsResponse\x12O\n" +
 	"\x0eListItemPrices\x12\x1d.web.v1.ListItemPricesRequest\x1a\x1e.web.v1.ListItemPricesResponse\x12I\n" +
 	"\fListMapZones\x12\x1b.web.v1.ListMapZonesRequest\x1a\x1c.web.v1.ListMapZonesResponse2\xa1\x03\n" +
 	"\x12DonateAdminService\x12L\n" +
@@ -5321,7 +5886,7 @@ func file_api_web_v1_web_proto_rawDescGZIP() []byte {
 }
 
 var file_api_web_v1_web_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_api_web_v1_web_proto_msgTypes = make([]protoimpl.MessageInfo, 76)
+var file_api_web_v1_web_proto_msgTypes = make([]protoimpl.MessageInfo, 84)
 var file_api_web_v1_web_proto_goTypes = []any{
 	(CreateResult)(0),                     // 0: web.v1.CreateResult
 	(AdminResult)(0),                      // 1: web.v1.AdminResult
@@ -5362,50 +5927,58 @@ var file_api_web_v1_web_proto_goTypes = []any{
 	(*ItemCatalogEntry)(nil),              // 36: web.v1.ItemCatalogEntry
 	(*ListItemCatalogRequest)(nil),        // 37: web.v1.ListItemCatalogRequest
 	(*ListItemCatalogResponse)(nil),       // 38: web.v1.ListItemCatalogResponse
-	(*ItemPrice)(nil),                     // 39: web.v1.ItemPrice
-	(*ListItemPricesRequest)(nil),         // 40: web.v1.ListItemPricesRequest
-	(*ListItemPricesResponse)(nil),        // 41: web.v1.ListItemPricesResponse
-	(*MapZone)(nil),                       // 42: web.v1.MapZone
-	(*ListMapZonesRequest)(nil),           // 43: web.v1.ListMapZonesRequest
-	(*ListMapZonesResponse)(nil),          // 44: web.v1.ListMapZonesResponse
-	(*DonateShopItem)(nil),                // 45: web.v1.DonateShopItem
-	(*ListShopItemsRequest)(nil),          // 46: web.v1.ListShopItemsRequest
-	(*ListShopItemsResponse)(nil),         // 47: web.v1.ListShopItemsResponse
-	(*UpsertShopItemRequest)(nil),         // 48: web.v1.UpsertShopItemRequest
-	(*UpsertShopItemResponse)(nil),        // 49: web.v1.UpsertShopItemResponse
-	(*SetShopItemEnabledRequest)(nil),     // 50: web.v1.SetShopItemEnabledRequest
-	(*DeleteShopItemRequest)(nil),         // 51: web.v1.DeleteShopItemRequest
-	(*CreditDonateBalanceRequest)(nil),    // 52: web.v1.CreditDonateBalanceRequest
-	(*CreditDonateBalanceResponse)(nil),   // 53: web.v1.CreditDonateBalanceResponse
-	(*ListStoreItemsRequest)(nil),         // 54: web.v1.ListStoreItemsRequest
-	(*ListStoreItemsResponse)(nil),        // 55: web.v1.ListStoreItemsResponse
-	(*GetBalanceRequest)(nil),             // 56: web.v1.GetBalanceRequest
-	(*GetBalanceResponse)(nil),            // 57: web.v1.GetBalanceResponse
-	(*BuyRequest)(nil),                    // 58: web.v1.BuyRequest
-	(*BuyResponse)(nil),                   // 59: web.v1.BuyResponse
-	(*DailyRewardItem)(nil),               // 60: web.v1.DailyRewardItem
-	(*ListRewardItemsRequest)(nil),        // 61: web.v1.ListRewardItemsRequest
-	(*ListRewardItemsResponse)(nil),       // 62: web.v1.ListRewardItemsResponse
-	(*UpsertRewardItemRequest)(nil),       // 63: web.v1.UpsertRewardItemRequest
-	(*UpsertRewardItemResponse)(nil),      // 64: web.v1.UpsertRewardItemResponse
-	(*SetRewardItemEnabledRequest)(nil),   // 65: web.v1.SetRewardItemEnabledRequest
-	(*DeleteRewardItemRequest)(nil),       // 66: web.v1.DeleteRewardItemRequest
-	(*ListRewardsRequest)(nil),            // 67: web.v1.ListRewardsRequest
-	(*ListRewardsResponse)(nil),           // 68: web.v1.ListRewardsResponse
-	(*GetClaimStatusRequest)(nil),         // 69: web.v1.GetClaimStatusRequest
-	(*GetClaimStatusResponse)(nil),        // 70: web.v1.GetClaimStatusResponse
-	(*ClaimRequest)(nil),                  // 71: web.v1.ClaimRequest
-	(*ClaimResponse)(nil),                 // 72: web.v1.ClaimResponse
-	(*GetPayerProfileRequest)(nil),        // 73: web.v1.GetPayerProfileRequest
-	(*GetPayerProfileResponse)(nil),       // 74: web.v1.GetPayerProfileResponse
-	(*SavePayerProfileRequest)(nil),       // 75: web.v1.SavePayerProfileRequest
-	(*SavePayerProfileResponse)(nil),      // 76: web.v1.SavePayerProfileResponse
-	(*CreateTopupOrderRequest)(nil),       // 77: web.v1.CreateTopupOrderRequest
-	(*CreateTopupOrderResponse)(nil),      // 78: web.v1.CreateTopupOrderResponse
-	(*ConfirmTopupOrderRequest)(nil),      // 79: web.v1.ConfirmTopupOrderRequest
-	(*ConfirmTopupOrderResponse)(nil),     // 80: web.v1.ConfirmTopupOrderResponse
-	(*GetTopupOrderRequest)(nil),          // 81: web.v1.GetTopupOrderRequest
-	(*GetTopupOrderResponse)(nil),         // 82: web.v1.GetTopupOrderResponse
+	(*DropItemMob)(nil),                   // 39: web.v1.DropItemMob
+	(*DropItemEntry)(nil),                 // 40: web.v1.DropItemEntry
+	(*ListDropItemsRequest)(nil),          // 41: web.v1.ListDropItemsRequest
+	(*ListDropItemsResponse)(nil),         // 42: web.v1.ListDropItemsResponse
+	(*MobDropItem)(nil),                   // 43: web.v1.MobDropItem
+	(*MobDropEntry)(nil),                  // 44: web.v1.MobDropEntry
+	(*ListMobDropsRequest)(nil),           // 45: web.v1.ListMobDropsRequest
+	(*ListMobDropsResponse)(nil),          // 46: web.v1.ListMobDropsResponse
+	(*ItemPrice)(nil),                     // 47: web.v1.ItemPrice
+	(*ListItemPricesRequest)(nil),         // 48: web.v1.ListItemPricesRequest
+	(*ListItemPricesResponse)(nil),        // 49: web.v1.ListItemPricesResponse
+	(*MapZone)(nil),                       // 50: web.v1.MapZone
+	(*ListMapZonesRequest)(nil),           // 51: web.v1.ListMapZonesRequest
+	(*ListMapZonesResponse)(nil),          // 52: web.v1.ListMapZonesResponse
+	(*DonateShopItem)(nil),                // 53: web.v1.DonateShopItem
+	(*ListShopItemsRequest)(nil),          // 54: web.v1.ListShopItemsRequest
+	(*ListShopItemsResponse)(nil),         // 55: web.v1.ListShopItemsResponse
+	(*UpsertShopItemRequest)(nil),         // 56: web.v1.UpsertShopItemRequest
+	(*UpsertShopItemResponse)(nil),        // 57: web.v1.UpsertShopItemResponse
+	(*SetShopItemEnabledRequest)(nil),     // 58: web.v1.SetShopItemEnabledRequest
+	(*DeleteShopItemRequest)(nil),         // 59: web.v1.DeleteShopItemRequest
+	(*CreditDonateBalanceRequest)(nil),    // 60: web.v1.CreditDonateBalanceRequest
+	(*CreditDonateBalanceResponse)(nil),   // 61: web.v1.CreditDonateBalanceResponse
+	(*ListStoreItemsRequest)(nil),         // 62: web.v1.ListStoreItemsRequest
+	(*ListStoreItemsResponse)(nil),        // 63: web.v1.ListStoreItemsResponse
+	(*GetBalanceRequest)(nil),             // 64: web.v1.GetBalanceRequest
+	(*GetBalanceResponse)(nil),            // 65: web.v1.GetBalanceResponse
+	(*BuyRequest)(nil),                    // 66: web.v1.BuyRequest
+	(*BuyResponse)(nil),                   // 67: web.v1.BuyResponse
+	(*DailyRewardItem)(nil),               // 68: web.v1.DailyRewardItem
+	(*ListRewardItemsRequest)(nil),        // 69: web.v1.ListRewardItemsRequest
+	(*ListRewardItemsResponse)(nil),       // 70: web.v1.ListRewardItemsResponse
+	(*UpsertRewardItemRequest)(nil),       // 71: web.v1.UpsertRewardItemRequest
+	(*UpsertRewardItemResponse)(nil),      // 72: web.v1.UpsertRewardItemResponse
+	(*SetRewardItemEnabledRequest)(nil),   // 73: web.v1.SetRewardItemEnabledRequest
+	(*DeleteRewardItemRequest)(nil),       // 74: web.v1.DeleteRewardItemRequest
+	(*ListRewardsRequest)(nil),            // 75: web.v1.ListRewardsRequest
+	(*ListRewardsResponse)(nil),           // 76: web.v1.ListRewardsResponse
+	(*GetClaimStatusRequest)(nil),         // 77: web.v1.GetClaimStatusRequest
+	(*GetClaimStatusResponse)(nil),        // 78: web.v1.GetClaimStatusResponse
+	(*ClaimRequest)(nil),                  // 79: web.v1.ClaimRequest
+	(*ClaimResponse)(nil),                 // 80: web.v1.ClaimResponse
+	(*GetPayerProfileRequest)(nil),        // 81: web.v1.GetPayerProfileRequest
+	(*GetPayerProfileResponse)(nil),       // 82: web.v1.GetPayerProfileResponse
+	(*SavePayerProfileRequest)(nil),       // 83: web.v1.SavePayerProfileRequest
+	(*SavePayerProfileResponse)(nil),      // 84: web.v1.SavePayerProfileResponse
+	(*CreateTopupOrderRequest)(nil),       // 85: web.v1.CreateTopupOrderRequest
+	(*CreateTopupOrderResponse)(nil),      // 86: web.v1.CreateTopupOrderResponse
+	(*ConfirmTopupOrderRequest)(nil),      // 87: web.v1.ConfirmTopupOrderRequest
+	(*ConfirmTopupOrderResponse)(nil),     // 88: web.v1.ConfirmTopupOrderResponse
+	(*GetTopupOrderRequest)(nil),          // 89: web.v1.GetTopupOrderRequest
+	(*GetTopupOrderResponse)(nil),         // 90: web.v1.GetTopupOrderResponse
 }
 var file_api_web_v1_web_proto_depIdxs = []int32{
 	0,  // 0: web.v1.CreateAccountResponse.result:type_name -> web.v1.CreateResult
@@ -5424,105 +5997,115 @@ var file_api_web_v1_web_proto_depIdxs = []int32{
 	33, // 13: web.v1.ListMerchantTemplatesResponse.templates:type_name -> web.v1.MerchantTemplate
 	1,  // 14: web.v1.ListItemCatalogResponse.result:type_name -> web.v1.AdminResult
 	36, // 15: web.v1.ListItemCatalogResponse.items:type_name -> web.v1.ItemCatalogEntry
-	1,  // 16: web.v1.ListItemPricesResponse.result:type_name -> web.v1.AdminResult
-	39, // 17: web.v1.ListItemPricesResponse.prices:type_name -> web.v1.ItemPrice
-	1,  // 18: web.v1.ListMapZonesResponse.result:type_name -> web.v1.AdminResult
-	42, // 19: web.v1.ListMapZonesResponse.zones:type_name -> web.v1.MapZone
-	1,  // 20: web.v1.ListShopItemsResponse.result:type_name -> web.v1.AdminResult
-	45, // 21: web.v1.ListShopItemsResponse.items:type_name -> web.v1.DonateShopItem
-	45, // 22: web.v1.UpsertShopItemRequest.item:type_name -> web.v1.DonateShopItem
-	1,  // 23: web.v1.UpsertShopItemResponse.result:type_name -> web.v1.AdminResult
-	1,  // 24: web.v1.CreditDonateBalanceResponse.result:type_name -> web.v1.AdminResult
-	45, // 25: web.v1.ListStoreItemsResponse.items:type_name -> web.v1.DonateShopItem
-	2,  // 26: web.v1.BuyResponse.result:type_name -> web.v1.BuyResult
-	1,  // 27: web.v1.ListRewardItemsResponse.result:type_name -> web.v1.AdminResult
-	60, // 28: web.v1.ListRewardItemsResponse.items:type_name -> web.v1.DailyRewardItem
-	60, // 29: web.v1.UpsertRewardItemRequest.item:type_name -> web.v1.DailyRewardItem
-	1,  // 30: web.v1.UpsertRewardItemResponse.result:type_name -> web.v1.AdminResult
-	60, // 31: web.v1.ListRewardsResponse.items:type_name -> web.v1.DailyRewardItem
-	3,  // 32: web.v1.ClaimResponse.result:type_name -> web.v1.ClaimResult
-	1,  // 33: web.v1.SavePayerProfileResponse.result:type_name -> web.v1.AdminResult
-	4,  // 34: web.v1.CreateTopupOrderRequest.payment_method:type_name -> web.v1.PaymentMethod
-	1,  // 35: web.v1.CreateTopupOrderResponse.result:type_name -> web.v1.AdminResult
-	5,  // 36: web.v1.ConfirmTopupOrderResponse.result:type_name -> web.v1.TopupResult
-	6,  // 37: web.v1.GetTopupOrderResponse.status:type_name -> web.v1.TopupStatus
-	7,  // 38: web.v1.AccountWebService.CreateAccount:input_type -> web.v1.CreateAccountRequest
-	9,  // 39: web.v1.AccountWebService.VerifyCredentials:input_type -> web.v1.VerifyCredentialsRequest
-	11, // 40: web.v1.RankingWebService.ListExpRanking:input_type -> web.v1.ListExpRankingRequest
-	14, // 41: web.v1.RankingWebService.ListDuelRanking:input_type -> web.v1.ListDuelRankingRequest
-	17, // 42: web.v1.CharacterWebService.ListMyCharacters:input_type -> web.v1.ListMyCharactersRequest
-	23, // 43: web.v1.NpcAdminService.ListNpcs:input_type -> web.v1.ListNpcsRequest
-	25, // 44: web.v1.NpcAdminService.GetNpc:input_type -> web.v1.GetNpcRequest
-	27, // 45: web.v1.NpcAdminService.UpsertNpc:input_type -> web.v1.UpsertNpcRequest
-	29, // 46: web.v1.NpcAdminService.SetNpcVisibility:input_type -> web.v1.SetNpcVisibilityRequest
-	30, // 47: web.v1.NpcAdminService.SetNpcShop:input_type -> web.v1.SetNpcShopRequest
-	31, // 48: web.v1.NpcAdminService.SetItemPrice:input_type -> web.v1.SetItemPriceRequest
-	32, // 49: web.v1.NpcAdminService.DeleteNpc:input_type -> web.v1.DeleteNpcRequest
-	34, // 50: web.v1.NpcAdminService.ListMerchantTemplates:input_type -> web.v1.ListMerchantTemplatesRequest
-	37, // 51: web.v1.NpcAdminService.ListItemCatalog:input_type -> web.v1.ListItemCatalogRequest
-	40, // 52: web.v1.NpcAdminService.ListItemPrices:input_type -> web.v1.ListItemPricesRequest
-	43, // 53: web.v1.NpcAdminService.ListMapZones:input_type -> web.v1.ListMapZonesRequest
-	46, // 54: web.v1.DonateAdminService.ListShopItems:input_type -> web.v1.ListShopItemsRequest
-	48, // 55: web.v1.DonateAdminService.UpsertShopItem:input_type -> web.v1.UpsertShopItemRequest
-	50, // 56: web.v1.DonateAdminService.SetShopItemEnabled:input_type -> web.v1.SetShopItemEnabledRequest
-	51, // 57: web.v1.DonateAdminService.DeleteShopItem:input_type -> web.v1.DeleteShopItemRequest
-	52, // 58: web.v1.DonateAdminService.CreditDonateBalance:input_type -> web.v1.CreditDonateBalanceRequest
-	54, // 59: web.v1.DonateShopService.ListShopItems:input_type -> web.v1.ListStoreItemsRequest
-	56, // 60: web.v1.DonateShopService.GetBalance:input_type -> web.v1.GetBalanceRequest
-	58, // 61: web.v1.DonateShopService.Buy:input_type -> web.v1.BuyRequest
-	61, // 62: web.v1.DailyRewardAdminService.ListRewardItems:input_type -> web.v1.ListRewardItemsRequest
-	63, // 63: web.v1.DailyRewardAdminService.UpsertRewardItem:input_type -> web.v1.UpsertRewardItemRequest
-	65, // 64: web.v1.DailyRewardAdminService.SetRewardItemEnabled:input_type -> web.v1.SetRewardItemEnabledRequest
-	66, // 65: web.v1.DailyRewardAdminService.DeleteRewardItem:input_type -> web.v1.DeleteRewardItemRequest
-	67, // 66: web.v1.DailyRewardService.ListRewards:input_type -> web.v1.ListRewardsRequest
-	69, // 67: web.v1.DailyRewardService.GetClaimStatus:input_type -> web.v1.GetClaimStatusRequest
-	71, // 68: web.v1.DailyRewardService.Claim:input_type -> web.v1.ClaimRequest
-	73, // 69: web.v1.DonateTopupService.GetPayerProfile:input_type -> web.v1.GetPayerProfileRequest
-	75, // 70: web.v1.DonateTopupService.SavePayerProfile:input_type -> web.v1.SavePayerProfileRequest
-	77, // 71: web.v1.DonateTopupService.CreateTopupOrder:input_type -> web.v1.CreateTopupOrderRequest
-	79, // 72: web.v1.DonateTopupService.ConfirmTopupOrder:input_type -> web.v1.ConfirmTopupOrderRequest
-	81, // 73: web.v1.DonateTopupService.GetTopupOrder:input_type -> web.v1.GetTopupOrderRequest
-	8,  // 74: web.v1.AccountWebService.CreateAccount:output_type -> web.v1.CreateAccountResponse
-	10, // 75: web.v1.AccountWebService.VerifyCredentials:output_type -> web.v1.VerifyCredentialsResponse
-	13, // 76: web.v1.RankingWebService.ListExpRanking:output_type -> web.v1.ListExpRankingResponse
-	16, // 77: web.v1.RankingWebService.ListDuelRanking:output_type -> web.v1.ListDuelRankingResponse
-	19, // 78: web.v1.CharacterWebService.ListMyCharacters:output_type -> web.v1.ListMyCharactersResponse
-	24, // 79: web.v1.NpcAdminService.ListNpcs:output_type -> web.v1.ListNpcsResponse
-	26, // 80: web.v1.NpcAdminService.GetNpc:output_type -> web.v1.GetNpcResponse
-	28, // 81: web.v1.NpcAdminService.UpsertNpc:output_type -> web.v1.UpsertNpcResponse
-	20, // 82: web.v1.NpcAdminService.SetNpcVisibility:output_type -> web.v1.AdminAck
-	20, // 83: web.v1.NpcAdminService.SetNpcShop:output_type -> web.v1.AdminAck
-	20, // 84: web.v1.NpcAdminService.SetItemPrice:output_type -> web.v1.AdminAck
-	20, // 85: web.v1.NpcAdminService.DeleteNpc:output_type -> web.v1.AdminAck
-	35, // 86: web.v1.NpcAdminService.ListMerchantTemplates:output_type -> web.v1.ListMerchantTemplatesResponse
-	38, // 87: web.v1.NpcAdminService.ListItemCatalog:output_type -> web.v1.ListItemCatalogResponse
-	41, // 88: web.v1.NpcAdminService.ListItemPrices:output_type -> web.v1.ListItemPricesResponse
-	44, // 89: web.v1.NpcAdminService.ListMapZones:output_type -> web.v1.ListMapZonesResponse
-	47, // 90: web.v1.DonateAdminService.ListShopItems:output_type -> web.v1.ListShopItemsResponse
-	49, // 91: web.v1.DonateAdminService.UpsertShopItem:output_type -> web.v1.UpsertShopItemResponse
-	20, // 92: web.v1.DonateAdminService.SetShopItemEnabled:output_type -> web.v1.AdminAck
-	20, // 93: web.v1.DonateAdminService.DeleteShopItem:output_type -> web.v1.AdminAck
-	53, // 94: web.v1.DonateAdminService.CreditDonateBalance:output_type -> web.v1.CreditDonateBalanceResponse
-	55, // 95: web.v1.DonateShopService.ListShopItems:output_type -> web.v1.ListStoreItemsResponse
-	57, // 96: web.v1.DonateShopService.GetBalance:output_type -> web.v1.GetBalanceResponse
-	59, // 97: web.v1.DonateShopService.Buy:output_type -> web.v1.BuyResponse
-	62, // 98: web.v1.DailyRewardAdminService.ListRewardItems:output_type -> web.v1.ListRewardItemsResponse
-	64, // 99: web.v1.DailyRewardAdminService.UpsertRewardItem:output_type -> web.v1.UpsertRewardItemResponse
-	20, // 100: web.v1.DailyRewardAdminService.SetRewardItemEnabled:output_type -> web.v1.AdminAck
-	20, // 101: web.v1.DailyRewardAdminService.DeleteRewardItem:output_type -> web.v1.AdminAck
-	68, // 102: web.v1.DailyRewardService.ListRewards:output_type -> web.v1.ListRewardsResponse
-	70, // 103: web.v1.DailyRewardService.GetClaimStatus:output_type -> web.v1.GetClaimStatusResponse
-	72, // 104: web.v1.DailyRewardService.Claim:output_type -> web.v1.ClaimResponse
-	74, // 105: web.v1.DonateTopupService.GetPayerProfile:output_type -> web.v1.GetPayerProfileResponse
-	76, // 106: web.v1.DonateTopupService.SavePayerProfile:output_type -> web.v1.SavePayerProfileResponse
-	78, // 107: web.v1.DonateTopupService.CreateTopupOrder:output_type -> web.v1.CreateTopupOrderResponse
-	80, // 108: web.v1.DonateTopupService.ConfirmTopupOrder:output_type -> web.v1.ConfirmTopupOrderResponse
-	82, // 109: web.v1.DonateTopupService.GetTopupOrder:output_type -> web.v1.GetTopupOrderResponse
-	74, // [74:110] is the sub-list for method output_type
-	38, // [38:74] is the sub-list for method input_type
-	38, // [38:38] is the sub-list for extension type_name
-	38, // [38:38] is the sub-list for extension extendee
-	0,  // [0:38] is the sub-list for field type_name
+	39, // 16: web.v1.DropItemEntry.mobs:type_name -> web.v1.DropItemMob
+	1,  // 17: web.v1.ListDropItemsResponse.result:type_name -> web.v1.AdminResult
+	40, // 18: web.v1.ListDropItemsResponse.items:type_name -> web.v1.DropItemEntry
+	43, // 19: web.v1.MobDropEntry.items:type_name -> web.v1.MobDropItem
+	1,  // 20: web.v1.ListMobDropsResponse.result:type_name -> web.v1.AdminResult
+	44, // 21: web.v1.ListMobDropsResponse.mobs:type_name -> web.v1.MobDropEntry
+	1,  // 22: web.v1.ListItemPricesResponse.result:type_name -> web.v1.AdminResult
+	47, // 23: web.v1.ListItemPricesResponse.prices:type_name -> web.v1.ItemPrice
+	1,  // 24: web.v1.ListMapZonesResponse.result:type_name -> web.v1.AdminResult
+	50, // 25: web.v1.ListMapZonesResponse.zones:type_name -> web.v1.MapZone
+	1,  // 26: web.v1.ListShopItemsResponse.result:type_name -> web.v1.AdminResult
+	53, // 27: web.v1.ListShopItemsResponse.items:type_name -> web.v1.DonateShopItem
+	53, // 28: web.v1.UpsertShopItemRequest.item:type_name -> web.v1.DonateShopItem
+	1,  // 29: web.v1.UpsertShopItemResponse.result:type_name -> web.v1.AdminResult
+	1,  // 30: web.v1.CreditDonateBalanceResponse.result:type_name -> web.v1.AdminResult
+	53, // 31: web.v1.ListStoreItemsResponse.items:type_name -> web.v1.DonateShopItem
+	2,  // 32: web.v1.BuyResponse.result:type_name -> web.v1.BuyResult
+	1,  // 33: web.v1.ListRewardItemsResponse.result:type_name -> web.v1.AdminResult
+	68, // 34: web.v1.ListRewardItemsResponse.items:type_name -> web.v1.DailyRewardItem
+	68, // 35: web.v1.UpsertRewardItemRequest.item:type_name -> web.v1.DailyRewardItem
+	1,  // 36: web.v1.UpsertRewardItemResponse.result:type_name -> web.v1.AdminResult
+	68, // 37: web.v1.ListRewardsResponse.items:type_name -> web.v1.DailyRewardItem
+	3,  // 38: web.v1.ClaimResponse.result:type_name -> web.v1.ClaimResult
+	1,  // 39: web.v1.SavePayerProfileResponse.result:type_name -> web.v1.AdminResult
+	4,  // 40: web.v1.CreateTopupOrderRequest.payment_method:type_name -> web.v1.PaymentMethod
+	1,  // 41: web.v1.CreateTopupOrderResponse.result:type_name -> web.v1.AdminResult
+	5,  // 42: web.v1.ConfirmTopupOrderResponse.result:type_name -> web.v1.TopupResult
+	6,  // 43: web.v1.GetTopupOrderResponse.status:type_name -> web.v1.TopupStatus
+	7,  // 44: web.v1.AccountWebService.CreateAccount:input_type -> web.v1.CreateAccountRequest
+	9,  // 45: web.v1.AccountWebService.VerifyCredentials:input_type -> web.v1.VerifyCredentialsRequest
+	11, // 46: web.v1.RankingWebService.ListExpRanking:input_type -> web.v1.ListExpRankingRequest
+	14, // 47: web.v1.RankingWebService.ListDuelRanking:input_type -> web.v1.ListDuelRankingRequest
+	17, // 48: web.v1.CharacterWebService.ListMyCharacters:input_type -> web.v1.ListMyCharactersRequest
+	23, // 49: web.v1.NpcAdminService.ListNpcs:input_type -> web.v1.ListNpcsRequest
+	25, // 50: web.v1.NpcAdminService.GetNpc:input_type -> web.v1.GetNpcRequest
+	27, // 51: web.v1.NpcAdminService.UpsertNpc:input_type -> web.v1.UpsertNpcRequest
+	29, // 52: web.v1.NpcAdminService.SetNpcVisibility:input_type -> web.v1.SetNpcVisibilityRequest
+	30, // 53: web.v1.NpcAdminService.SetNpcShop:input_type -> web.v1.SetNpcShopRequest
+	31, // 54: web.v1.NpcAdminService.SetItemPrice:input_type -> web.v1.SetItemPriceRequest
+	32, // 55: web.v1.NpcAdminService.DeleteNpc:input_type -> web.v1.DeleteNpcRequest
+	34, // 56: web.v1.NpcAdminService.ListMerchantTemplates:input_type -> web.v1.ListMerchantTemplatesRequest
+	37, // 57: web.v1.NpcAdminService.ListItemCatalog:input_type -> web.v1.ListItemCatalogRequest
+	41, // 58: web.v1.NpcAdminService.ListDropItems:input_type -> web.v1.ListDropItemsRequest
+	45, // 59: web.v1.NpcAdminService.ListMobDrops:input_type -> web.v1.ListMobDropsRequest
+	48, // 60: web.v1.NpcAdminService.ListItemPrices:input_type -> web.v1.ListItemPricesRequest
+	51, // 61: web.v1.NpcAdminService.ListMapZones:input_type -> web.v1.ListMapZonesRequest
+	54, // 62: web.v1.DonateAdminService.ListShopItems:input_type -> web.v1.ListShopItemsRequest
+	56, // 63: web.v1.DonateAdminService.UpsertShopItem:input_type -> web.v1.UpsertShopItemRequest
+	58, // 64: web.v1.DonateAdminService.SetShopItemEnabled:input_type -> web.v1.SetShopItemEnabledRequest
+	59, // 65: web.v1.DonateAdminService.DeleteShopItem:input_type -> web.v1.DeleteShopItemRequest
+	60, // 66: web.v1.DonateAdminService.CreditDonateBalance:input_type -> web.v1.CreditDonateBalanceRequest
+	62, // 67: web.v1.DonateShopService.ListShopItems:input_type -> web.v1.ListStoreItemsRequest
+	64, // 68: web.v1.DonateShopService.GetBalance:input_type -> web.v1.GetBalanceRequest
+	66, // 69: web.v1.DonateShopService.Buy:input_type -> web.v1.BuyRequest
+	69, // 70: web.v1.DailyRewardAdminService.ListRewardItems:input_type -> web.v1.ListRewardItemsRequest
+	71, // 71: web.v1.DailyRewardAdminService.UpsertRewardItem:input_type -> web.v1.UpsertRewardItemRequest
+	73, // 72: web.v1.DailyRewardAdminService.SetRewardItemEnabled:input_type -> web.v1.SetRewardItemEnabledRequest
+	74, // 73: web.v1.DailyRewardAdminService.DeleteRewardItem:input_type -> web.v1.DeleteRewardItemRequest
+	75, // 74: web.v1.DailyRewardService.ListRewards:input_type -> web.v1.ListRewardsRequest
+	77, // 75: web.v1.DailyRewardService.GetClaimStatus:input_type -> web.v1.GetClaimStatusRequest
+	79, // 76: web.v1.DailyRewardService.Claim:input_type -> web.v1.ClaimRequest
+	81, // 77: web.v1.DonateTopupService.GetPayerProfile:input_type -> web.v1.GetPayerProfileRequest
+	83, // 78: web.v1.DonateTopupService.SavePayerProfile:input_type -> web.v1.SavePayerProfileRequest
+	85, // 79: web.v1.DonateTopupService.CreateTopupOrder:input_type -> web.v1.CreateTopupOrderRequest
+	87, // 80: web.v1.DonateTopupService.ConfirmTopupOrder:input_type -> web.v1.ConfirmTopupOrderRequest
+	89, // 81: web.v1.DonateTopupService.GetTopupOrder:input_type -> web.v1.GetTopupOrderRequest
+	8,  // 82: web.v1.AccountWebService.CreateAccount:output_type -> web.v1.CreateAccountResponse
+	10, // 83: web.v1.AccountWebService.VerifyCredentials:output_type -> web.v1.VerifyCredentialsResponse
+	13, // 84: web.v1.RankingWebService.ListExpRanking:output_type -> web.v1.ListExpRankingResponse
+	16, // 85: web.v1.RankingWebService.ListDuelRanking:output_type -> web.v1.ListDuelRankingResponse
+	19, // 86: web.v1.CharacterWebService.ListMyCharacters:output_type -> web.v1.ListMyCharactersResponse
+	24, // 87: web.v1.NpcAdminService.ListNpcs:output_type -> web.v1.ListNpcsResponse
+	26, // 88: web.v1.NpcAdminService.GetNpc:output_type -> web.v1.GetNpcResponse
+	28, // 89: web.v1.NpcAdminService.UpsertNpc:output_type -> web.v1.UpsertNpcResponse
+	20, // 90: web.v1.NpcAdminService.SetNpcVisibility:output_type -> web.v1.AdminAck
+	20, // 91: web.v1.NpcAdminService.SetNpcShop:output_type -> web.v1.AdminAck
+	20, // 92: web.v1.NpcAdminService.SetItemPrice:output_type -> web.v1.AdminAck
+	20, // 93: web.v1.NpcAdminService.DeleteNpc:output_type -> web.v1.AdminAck
+	35, // 94: web.v1.NpcAdminService.ListMerchantTemplates:output_type -> web.v1.ListMerchantTemplatesResponse
+	38, // 95: web.v1.NpcAdminService.ListItemCatalog:output_type -> web.v1.ListItemCatalogResponse
+	42, // 96: web.v1.NpcAdminService.ListDropItems:output_type -> web.v1.ListDropItemsResponse
+	46, // 97: web.v1.NpcAdminService.ListMobDrops:output_type -> web.v1.ListMobDropsResponse
+	49, // 98: web.v1.NpcAdminService.ListItemPrices:output_type -> web.v1.ListItemPricesResponse
+	52, // 99: web.v1.NpcAdminService.ListMapZones:output_type -> web.v1.ListMapZonesResponse
+	55, // 100: web.v1.DonateAdminService.ListShopItems:output_type -> web.v1.ListShopItemsResponse
+	57, // 101: web.v1.DonateAdminService.UpsertShopItem:output_type -> web.v1.UpsertShopItemResponse
+	20, // 102: web.v1.DonateAdminService.SetShopItemEnabled:output_type -> web.v1.AdminAck
+	20, // 103: web.v1.DonateAdminService.DeleteShopItem:output_type -> web.v1.AdminAck
+	61, // 104: web.v1.DonateAdminService.CreditDonateBalance:output_type -> web.v1.CreditDonateBalanceResponse
+	63, // 105: web.v1.DonateShopService.ListShopItems:output_type -> web.v1.ListStoreItemsResponse
+	65, // 106: web.v1.DonateShopService.GetBalance:output_type -> web.v1.GetBalanceResponse
+	67, // 107: web.v1.DonateShopService.Buy:output_type -> web.v1.BuyResponse
+	70, // 108: web.v1.DailyRewardAdminService.ListRewardItems:output_type -> web.v1.ListRewardItemsResponse
+	72, // 109: web.v1.DailyRewardAdminService.UpsertRewardItem:output_type -> web.v1.UpsertRewardItemResponse
+	20, // 110: web.v1.DailyRewardAdminService.SetRewardItemEnabled:output_type -> web.v1.AdminAck
+	20, // 111: web.v1.DailyRewardAdminService.DeleteRewardItem:output_type -> web.v1.AdminAck
+	76, // 112: web.v1.DailyRewardService.ListRewards:output_type -> web.v1.ListRewardsResponse
+	78, // 113: web.v1.DailyRewardService.GetClaimStatus:output_type -> web.v1.GetClaimStatusResponse
+	80, // 114: web.v1.DailyRewardService.Claim:output_type -> web.v1.ClaimResponse
+	82, // 115: web.v1.DonateTopupService.GetPayerProfile:output_type -> web.v1.GetPayerProfileResponse
+	84, // 116: web.v1.DonateTopupService.SavePayerProfile:output_type -> web.v1.SavePayerProfileResponse
+	86, // 117: web.v1.DonateTopupService.CreateTopupOrder:output_type -> web.v1.CreateTopupOrderResponse
+	88, // 118: web.v1.DonateTopupService.ConfirmTopupOrder:output_type -> web.v1.ConfirmTopupOrderResponse
+	90, // 119: web.v1.DonateTopupService.GetTopupOrder:output_type -> web.v1.GetTopupOrderResponse
+	82, // [82:120] is the sub-list for method output_type
+	44, // [44:82] is the sub-list for method input_type
+	44, // [44:44] is the sub-list for extension type_name
+	44, // [44:44] is the sub-list for extension extendee
+	0,  // [0:44] is the sub-list for field type_name
 }
 
 func init() { file_api_web_v1_web_proto_init() }
@@ -5536,7 +6119,7 @@ func file_api_web_v1_web_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_web_v1_web_proto_rawDesc), len(file_api_web_v1_web_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   76,
+			NumMessages:   84,
 			NumExtensions: 0,
 			NumServices:   9,
 		},

--- a/api/web/v1/web.proto
+++ b/api/web/v1/web.proto
@@ -177,6 +177,13 @@ service NpcAdminService {
   // offer a searchable picker instead of a raw item_index typed by hand.
   // Scanned once at web-api boot from -content/W2PP_CONTENT; empty when unset.
   rpc ListItemCatalog(ListItemCatalogRequest) returns (ListItemCatalogResponse);
+  // ListDropItems returns the DropTool-style item-centric report from the
+  // content tree: item -> mobs/slots that can drop it. This is read-only
+  // content metadata; the tmServer runtime still owns actual drop rolls.
+  rpc ListDropItems(ListDropItemsRequest) returns (ListDropItemsResponse);
+  // ListMobDrops returns the DropTool-style mob-centric report from the
+  // content tree: mob template -> Carry[] drop slots.
+  rpc ListMobDrops(ListMobDropsRequest) returns (ListMobDropsResponse);
   // ListItemPrices returns every global item price override currently set
   // (item_price table). An item absent from the list has no override — it
   // uses the content catalog's base price.
@@ -308,6 +315,59 @@ message ListItemCatalogRequest { int64 moderator_id = 1; }
 message ListItemCatalogResponse {
   AdminResult result = 1;
   repeated ItemCatalogEntry items = 2;
+}
+
+message DropItemMob {
+  string template_name = 1; // Release/TMsrv/run/npc file name
+  string mob_name = 2;      // STRUCT_MOB.Name decoded as Latin-1
+  int32 mob_level = 3;      // STRUCT_MOB.CurrentScore.Level
+  int32 slot = 4;           // Carry[] slot; controls the base drop divisor
+  int32 rate_divisor = 5;   // g_pDropRate[slot]; larger means rarer
+}
+
+message DropItemEntry {
+  int32 item_index = 1;
+  string item_name = 2;
+  repeated DropItemMob mobs = 3;
+}
+
+message ListDropItemsRequest {
+  int64 moderator_id = 1;
+  int32 item_index = 2;               // 0 = no exact item filter
+  string item_query = 3;              // substring match on item name or index
+  string mob_query = 4;               // substring match on mob/template name
+  bool include_zero_drop_items = 5;   // include catalog items with no matching mobs
+}
+
+message ListDropItemsResponse {
+  AdminResult result = 1;
+  repeated DropItemEntry items = 2;
+}
+
+message MobDropItem {
+  int32 slot = 1;          // Carry[] slot; controls the base drop divisor
+  int32 item_index = 2;
+  string item_name = 3;
+  int32 rate_divisor = 4;  // g_pDropRate[slot]; larger means rarer
+}
+
+message MobDropEntry {
+  string template_name = 1; // Release/TMsrv/run/npc file name
+  string mob_name = 2;      // STRUCT_MOB.Name decoded as Latin-1
+  int32 mob_level = 3;      // STRUCT_MOB.CurrentScore.Level
+  repeated MobDropItem items = 4;
+}
+
+message ListMobDropsRequest {
+  int64 moderator_id = 1;
+  string mob_query = 2;   // substring match on mob/template name
+  int32 item_index = 3;   // 0 = no exact item filter
+  string item_query = 4;  // substring match on item name or index
+}
+
+message ListMobDropsResponse {
+  AdminResult result = 1;
+  repeated MobDropEntry mobs = 2;
 }
 
 // ItemPrice is a global per-item price override (item_price table); an item

--- a/api/web/v1/web_grpc.pb.go
+++ b/api/web/v1/web_grpc.pb.go
@@ -459,6 +459,8 @@ const (
 	NpcAdminService_DeleteNpc_FullMethodName             = "/web.v1.NpcAdminService/DeleteNpc"
 	NpcAdminService_ListMerchantTemplates_FullMethodName = "/web.v1.NpcAdminService/ListMerchantTemplates"
 	NpcAdminService_ListItemCatalog_FullMethodName       = "/web.v1.NpcAdminService/ListItemCatalog"
+	NpcAdminService_ListDropItems_FullMethodName         = "/web.v1.NpcAdminService/ListDropItems"
+	NpcAdminService_ListMobDrops_FullMethodName          = "/web.v1.NpcAdminService/ListMobDrops"
 	NpcAdminService_ListItemPrices_FullMethodName        = "/web.v1.NpcAdminService/ListItemPrices"
 	NpcAdminService_ListMapZones_FullMethodName          = "/web.v1.NpcAdminService/ListMapZones"
 )
@@ -498,6 +500,13 @@ type NpcAdminServiceClient interface {
 	// offer a searchable picker instead of a raw item_index typed by hand.
 	// Scanned once at web-api boot from -content/W2PP_CONTENT; empty when unset.
 	ListItemCatalog(ctx context.Context, in *ListItemCatalogRequest, opts ...grpc.CallOption) (*ListItemCatalogResponse, error)
+	// ListDropItems returns the DropTool-style item-centric report from the
+	// content tree: item -> mobs/slots that can drop it. This is read-only
+	// content metadata; the tmServer runtime still owns actual drop rolls.
+	ListDropItems(ctx context.Context, in *ListDropItemsRequest, opts ...grpc.CallOption) (*ListDropItemsResponse, error)
+	// ListMobDrops returns the DropTool-style mob-centric report from the
+	// content tree: mob template -> Carry[] drop slots.
+	ListMobDrops(ctx context.Context, in *ListMobDropsRequest, opts ...grpc.CallOption) (*ListMobDropsResponse, error)
 	// ListItemPrices returns every global item price override currently set
 	// (item_price table). An item absent from the list has no override — it
 	// uses the content catalog's base price.
@@ -606,6 +615,26 @@ func (c *npcAdminServiceClient) ListItemCatalog(ctx context.Context, in *ListIte
 	return out, nil
 }
 
+func (c *npcAdminServiceClient) ListDropItems(ctx context.Context, in *ListDropItemsRequest, opts ...grpc.CallOption) (*ListDropItemsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListDropItemsResponse)
+	err := c.cc.Invoke(ctx, NpcAdminService_ListDropItems_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *npcAdminServiceClient) ListMobDrops(ctx context.Context, in *ListMobDropsRequest, opts ...grpc.CallOption) (*ListMobDropsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListMobDropsResponse)
+	err := c.cc.Invoke(ctx, NpcAdminService_ListMobDrops_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *npcAdminServiceClient) ListItemPrices(ctx context.Context, in *ListItemPricesRequest, opts ...grpc.CallOption) (*ListItemPricesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ListItemPricesResponse)
@@ -661,6 +690,13 @@ type NpcAdminServiceServer interface {
 	// offer a searchable picker instead of a raw item_index typed by hand.
 	// Scanned once at web-api boot from -content/W2PP_CONTENT; empty when unset.
 	ListItemCatalog(context.Context, *ListItemCatalogRequest) (*ListItemCatalogResponse, error)
+	// ListDropItems returns the DropTool-style item-centric report from the
+	// content tree: item -> mobs/slots that can drop it. This is read-only
+	// content metadata; the tmServer runtime still owns actual drop rolls.
+	ListDropItems(context.Context, *ListDropItemsRequest) (*ListDropItemsResponse, error)
+	// ListMobDrops returns the DropTool-style mob-centric report from the
+	// content tree: mob template -> Carry[] drop slots.
+	ListMobDrops(context.Context, *ListMobDropsRequest) (*ListMobDropsResponse, error)
 	// ListItemPrices returns every global item price override currently set
 	// (item_price table). An item absent from the list has no override — it
 	// uses the content catalog's base price.
@@ -705,6 +741,12 @@ func (UnimplementedNpcAdminServiceServer) ListMerchantTemplates(context.Context,
 }
 func (UnimplementedNpcAdminServiceServer) ListItemCatalog(context.Context, *ListItemCatalogRequest) (*ListItemCatalogResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListItemCatalog not implemented")
+}
+func (UnimplementedNpcAdminServiceServer) ListDropItems(context.Context, *ListDropItemsRequest) (*ListDropItemsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListDropItems not implemented")
+}
+func (UnimplementedNpcAdminServiceServer) ListMobDrops(context.Context, *ListMobDropsRequest) (*ListMobDropsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListMobDrops not implemented")
 }
 func (UnimplementedNpcAdminServiceServer) ListItemPrices(context.Context, *ListItemPricesRequest) (*ListItemPricesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListItemPrices not implemented")
@@ -895,6 +937,42 @@ func _NpcAdminService_ListItemCatalog_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _NpcAdminService_ListDropItems_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListDropItemsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NpcAdminServiceServer).ListDropItems(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: NpcAdminService_ListDropItems_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NpcAdminServiceServer).ListDropItems(ctx, req.(*ListDropItemsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _NpcAdminService_ListMobDrops_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListMobDropsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NpcAdminServiceServer).ListMobDrops(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: NpcAdminService_ListMobDrops_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NpcAdminServiceServer).ListMobDrops(ctx, req.(*ListMobDropsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _NpcAdminService_ListItemPrices_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ListItemPricesRequest)
 	if err := dec(in); err != nil {
@@ -973,6 +1051,14 @@ var NpcAdminService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListItemCatalog",
 			Handler:    _NpcAdminService_ListItemCatalog_Handler,
+		},
+		{
+			MethodName: "ListDropItems",
+			Handler:    _NpcAdminService_ListDropItems_Handler,
+		},
+		{
+			MethodName: "ListMobDrops",
+			Handler:    _NpcAdminService_ListMobDrops_Handler,
 		},
 		{
 			MethodName: "ListItemPrices",

--- a/docs/integrations/drop-tool-nextjs.md
+++ b/docs/integrations/drop-tool-nextjs.md
@@ -1,0 +1,223 @@
+# Integração Next.js ↔ web-api: DropTool de drops
+
+> Guia de integração para o **projeto Next.js** consumir a funcionalidade equivalente ao
+> **DropTool.exe legado** no portal web. Fonte da verdade do contrato: `api/web/v1/web.proto`
+> (serviço `NpcAdminService`, RPCs `ListDropItems` e `ListMobDrops`). Contexto de arquitetura:
+> `docs/migration/game-rules.md` §2.2 e `Source/Code/DropTool/main.cpp`.
+
+## 1. Topologia
+
+```
+Browser ──HTTPS──> Next.js (Route Handlers / Server Actions = BFF)
+                        │  só server-side; cookie de sessão httpOnly
+                        │ gRPC + mTLS
+                        ▼
+                     web-api (serviço Go, :7600)
+                        │
+                        └── lê catálogo em memória escaneado no boot:
+                            Release/Common/ItemList.csv
+                            Release/TMsrv/run/npc/*
+```
+
+Regras:
+
+- O browser nunca fala gRPC nem vê certificado mTLS.
+- O Next.js deriva `moderator_id` do cookie de sessão; nunca aceita esse campo do browser.
+- O `web-api` revalida `account.role in ('moderator','admin')` em toda chamada.
+- A ferramenta é **somente leitura**: não altera banco, arquivos de conteúdo, nem estado vivo do
+  `tmServer`.
+
+## 2. Pré-requisitos
+
+1. `webserver` rodando com `-content <Release/>` ou `W2PP_CONTENT=<Release/>`.
+2. Conta logada com `role = 'moderator'` ou `'admin'`.
+3. Portal com stubs atualizados a partir de `api/web/v1/web.proto`.
+
+Se `-content`/`W2PP_CONTENT` estiver vazio ou o scan falhar, as RPCs retornam
+`ADMIN_RESULT_OK` com listas vazias. Isso deve ser tratado como catálogo indisponível, não como erro
+de permissão.
+
+## 3. O Que a Ferramenta Mostra
+
+O DropTool legado fazia duas leituras:
+
+- `item -> mobs que dropam`: relatório `ItemDropList.txt`.
+- `mob -> itens no Carry[]`: relatório `MobDropList.txt`.
+
+No servidor Go, a origem é a mesma estrutura legada:
+
+- cada arquivo válido em `Release/TMsrv/run/npc/` deve ter 816 bytes (`STRUCT_MOB`);
+- os drops de mob vêm dos 64 slots `STRUCT_MOB.Carry[]`;
+- `slot` é importante: a raridade base vem de `g_pDropRate[slot]`, não do item.
+
+`rate_divisor` exposto no contrato é o divisor base do slot. Quanto maior, mais raro. Ele **não** é a
+chance final em runtime, porque a morte do mob ainda aplica bônus de drop do jogador/evento e ajustes
+por nível em `tmServer`.
+
+## 4. Contrato gRPC
+
+As duas RPCs ficam em `web.v1.NpcAdminService` e usam `AdminResult` no corpo. Erro gRPC significa
+falha de infraestrutura.
+
+| `AdminResult` | HTTP sugerido no BFF | Significado |
+|---------------|----------------------|-------------|
+| `ADMIN_RESULT_OK` | 200 | sucesso |
+| `ADMIN_RESULT_FORBIDDEN` | 403 | usuário não é moderador/admin |
+| `ADMIN_RESULT_INVALID` | 400 / 422 | request inválido |
+| `ADMIN_RESULT_NOT_FOUND` | 404 | reservado; não esperado nessas leituras |
+| `ADMIN_RESULT_UNSPECIFIED` | 500 | estado inesperado |
+
+### `ListDropItems`
+
+Visão por item: retorna itens e a lista de mobs/slots que podem dropar cada item.
+
+```proto
+rpc ListDropItems(ListDropItemsRequest) returns (ListDropItemsResponse);
+
+message ListDropItemsRequest {
+  int64 moderator_id = 1;
+  int32 item_index = 2;               // 0 = sem filtro exato
+  string item_query = 3;              // substring em nome do item ou índice
+  string mob_query = 4;               // substring em nome/template do mob
+  bool include_zero_drop_items = 5;   // inclui itens sem mobs, estilo relatório legado
+}
+
+message ListDropItemsResponse {
+  AdminResult result = 1;
+  repeated DropItemEntry items = 2;
+}
+
+message DropItemEntry {
+  int32 item_index = 1;
+  string item_name = 2;
+  repeated DropItemMob mobs = 3;
+}
+
+message DropItemMob {
+  string template_name = 1;
+  string mob_name = 2;
+  int32 mob_level = 3;
+  int32 slot = 4;
+  int32 rate_divisor = 5;
+}
+```
+
+Sem filtros, `ListDropItems` retorna apenas itens que têm pelo menos um drop. Para reproduzir o
+comportamento do `ItemDropList.txt` legado, envie `include_zero_drop_items = true`.
+
+### `ListMobDrops`
+
+Visão por mob: retorna templates de mob e seus slots de drop.
+
+```proto
+rpc ListMobDrops(ListMobDropsRequest) returns (ListMobDropsResponse);
+
+message ListMobDropsRequest {
+  int64 moderator_id = 1;
+  string mob_query = 2;   // substring em nome/template do mob
+  int32 item_index = 3;   // 0 = sem filtro exato
+  string item_query = 4;  // substring em nome do item ou índice
+}
+
+message ListMobDropsResponse {
+  AdminResult result = 1;
+  repeated MobDropEntry mobs = 2;
+}
+
+message MobDropEntry {
+  string template_name = 1;
+  string mob_name = 2;
+  int32 mob_level = 3;
+  repeated MobDropItem items = 4;
+}
+
+message MobDropItem {
+  int32 slot = 1;
+  int32 item_index = 2;
+  string item_name = 3;
+  int32 rate_divisor = 4;
+}
+```
+
+Sem filtros de item, `ListMobDrops` pode retornar mobs sem drops (`items = []`). Com `item_index` ou
+`item_query`, retorna apenas mobs que possuem pelo menos um drop correspondente.
+
+## 5. Rotas BFF Sugeridas
+
+| Rota HTTP | RPC | Query params |
+|-----------|-----|--------------|
+| `GET /api/admin/drops/items` | `ListDropItems` | `itemIndex`, `itemQuery`, `mobQuery`, `includeZero` |
+| `GET /api/admin/drops/mobs` | `ListMobDrops` | `mobQuery`, `itemIndex`, `itemQuery` |
+
+O BFF deve:
+
+- validar sessão e papel antes de chamar o gRPC;
+- preencher `moderator_id` com `account_id` da sessão;
+- mapear `AdminResult` para HTTP conforme a tabela acima;
+- transformar erro gRPC/reject em `502` ou `500`;
+- nunca expor endereço/certificados do `web-api` ao browser.
+
+Exemplo de shape HTTP para `GET /api/admin/drops/items?itemQuery=adaga`:
+
+```json
+{
+  "items": [
+    {
+      "itemIndex": 1000,
+      "itemName": "Adaga",
+      "mobs": [
+        {
+          "templateName": "Alpha",
+          "mobName": "Alpha",
+          "mobLevel": 37,
+          "slot": 0,
+          "rateDivisor": 900
+        }
+      ]
+    }
+  ]
+}
+```
+
+## 6. UI Recomendada
+
+Crie uma tela de moderação com duas abas:
+
+- **Por item**: busca por nome/índice do item, filtro opcional por mob, tabela de itens com contador de
+  mobs e expansão mostrando `mob_name`, `template_name`, `mob_level`, `slot`, `rate_divisor`.
+- **Por mob**: busca por nome/template do mob, filtro opcional por item, tabela de mobs com expansão
+  mostrando `slot`, `item_index`, `item_name`, `rate_divisor`.
+
+Estados obrigatórios:
+
+- carregando;
+- catálogo vazio/indisponível (`items=[]` ou `mobs=[]` com `200`);
+- sem resultado para filtros;
+- `403` sem acesso;
+- erro temporário de upstream.
+
+Para UX, explique `rate_divisor` como "divisor base do slot; maior = mais raro". Não apresente como
+porcentagem final.
+
+## 7. Notas Operacionais
+
+- O scan acontece uma vez no boot do `webserver`; alterações nos arquivos de `Release/` exigem restart
+  do `webserver` para aparecer no portal.
+- `ItensExceptions.txt` é opcional em `<Release>/TMsrv/run/ItensExceptions.txt`. Se existir e for
+  válido, seus ranges `from,to` são aplicados ao scan, como no DropTool legado. Se não existir, nenhum
+  item é excluído.
+- `ItemDropList.txt` existente no `Release/` continua sendo artefato gerado legado. O portal deve usar
+  as RPCs novas, não ler esse arquivo.
+- Essa tela não edita drops. Se futuramente houver edição de drops, ela deve virar outro contrato com
+  validação e persistência explícitas.
+
+## 8. Checklist de Implementação no Portal
+
+- [ ] Regenerar stubs a partir de `api/web/v1/web.proto`.
+- [ ] Adicionar cliente server-side para `NpcAdminService`.
+- [ ] Criar rotas BFF `GET /api/admin/drops/items` e `GET /api/admin/drops/mobs`.
+- [ ] Derivar `moderator_id` da sessão em todas as chamadas.
+- [ ] Mapear `AdminResult` para HTTP.
+- [ ] Implementar tela com abas "Por item" e "Por mob".
+- [ ] Tratar catálogo vazio como estado esperado quando `W2PP_CONTENT` não estiver configurado.
+- [ ] Exibir `rate_divisor` como divisor base, não chance final.

--- a/webserver/cmd/webserver/main.go
+++ b/webserver/cmd/webserver/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/dailyreward"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/donateshop"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/donatetopup"
+	"github.com/jeanluca/w2pp-openwyd/webserver/internal/droptool"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/grpcsrv"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/itemcatalog"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/npcadmin"
@@ -98,6 +99,18 @@ func run(logger *slog.Logger) error {
 		} else {
 			logger.Info("scanned item catalog", "count", len(items))
 			npcAdmin.SetItems(items)
+		}
+
+		exclusions, err := droptool.LoadContentExclusions(*contentDir)
+		if err != nil {
+			logger.Warn("drop exclusion scan failed; continuing without exclusions", "content", *contentDir, "err", err)
+		}
+		drops, err := droptool.Scan(*contentDir, logger, droptool.Options{Exclusions: exclusions})
+		if err != nil {
+			logger.Warn("drop catalog scan failed; DropTool endpoints will be empty", "content", *contentDir, "err", err)
+		} else {
+			logger.Info("scanned drop catalog", "items", len(drops.Items), "mobs", len(drops.Mobs), "drops", len(drops.Drops))
+			npcAdmin.SetDropCatalog(drops)
 		}
 	}
 	webv1.RegisterAccountWebServiceServer(srv, grpcsrv.New(account.New(st)))

--- a/webserver/internal/droptool/droptool.go
+++ b/webserver/internal/droptool/droptool.go
@@ -1,0 +1,389 @@
+// Package droptool builds the web-api's read-only equivalent of the legacy
+// DropTool.exe report. The legacy tool scanned STRUCT_MOB templates under
+// TMsrv/run/npc and inverted each mob's Carry[] table into item->mob and
+// mob->item reports; it was not consumed by the game server at runtime.
+package droptool
+
+import (
+	"bufio"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/savefmt"
+	"github.com/jeanluca/w2pp-openwyd/webserver/internal/itemcatalog"
+)
+
+// ItemEntry is one item known to the drop report.
+type ItemEntry struct {
+	Index int32
+	Name  string
+}
+
+// MobEntry is one decoded mob template from Release/TMsrv/run/npc.
+type MobEntry struct {
+	TemplateName string
+	DisplayName  string
+	Level        int32
+}
+
+// DropEntry is one non-empty STRUCT_MOB.Carry slot.
+type DropEntry struct {
+	TemplateName string
+	MobName      string
+	MobLevel     int32
+	Slot         int32
+	ItemIndex    int32
+	ItemName     string
+	RateDivisor  int32
+}
+
+// ItemDropEntry is the item-centric projection served to the portal.
+type ItemDropEntry struct {
+	ItemIndex int32
+	ItemName  string
+	Mobs      []ItemDropMob
+}
+
+// ItemDropMob is one mob/slot where an item can drop.
+type ItemDropMob struct {
+	TemplateName string
+	MobName      string
+	MobLevel     int32
+	Slot         int32
+	RateDivisor  int32
+}
+
+// MobDropEntry is the mob-centric projection served to the portal.
+type MobDropEntry struct {
+	TemplateName string
+	MobName      string
+	MobLevel     int32
+	Items        []MobDropItem
+}
+
+// MobDropItem is one drop slot in a mob template.
+type MobDropItem struct {
+	Slot        int32
+	ItemIndex   int32
+	ItemName    string
+	RateDivisor int32
+}
+
+// ExclusionRange mirrors the optional ItensExceptions.txt "from,to" ranges the
+// legacy DropTool used to suppress known catalog buckets from item->mob matches.
+type ExclusionRange struct {
+	From int32
+	To   int32
+}
+
+// Options controls a content-tree scan.
+type Options struct {
+	Exclusions []ExclusionRange
+}
+
+// Filter controls the in-memory projections returned by Catalog.
+type Filter struct {
+	ItemIndex            int32
+	ItemQuery            string
+	MobQuery             string
+	IncludeZeroDropItems bool
+}
+
+// Catalog is a scan of the content tree. It is immutable after construction and
+// safe to share between requests.
+type Catalog struct {
+	Items []ItemEntry
+	Mobs  []MobEntry
+	Drops []DropEntry
+}
+
+// LoadContentExclusions reads the optional legacy ItensExceptions.txt beside
+// the TMsrv run files. A missing file is normal and means no exclusions.
+func LoadContentExclusions(contentDir string) ([]ExclusionRange, error) {
+	return LoadExclusions(filepath.Join(contentDir, "TMsrv", "run", "ItensExceptions.txt"))
+}
+
+// LoadExclusions parses an ItensExceptions.txt-style file. Lines beginning with
+// '#' and blank lines are ignored; each data line is "from,to".
+func LoadExclusions(path string) ([]ExclusionRange, error) {
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("droptool: open exclusions %s: %w", path, err)
+	}
+	defer f.Close()
+
+	var out []ExclusionRange
+	sc := bufio.NewScanner(f)
+	for lineNo := 1; sc.Scan(); lineNo++ {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fromRaw, toRaw, ok := strings.Cut(line, ",")
+		if !ok {
+			return nil, fmt.Errorf("droptool: exclusions %s:%d: want from,to", path, lineNo)
+		}
+		from, err := strconv.Atoi(strings.TrimSpace(fromRaw))
+		if err != nil {
+			return nil, fmt.Errorf("droptool: exclusions %s:%d: parse from: %w", path, lineNo, err)
+		}
+		to, err := strconv.Atoi(strings.TrimSpace(toRaw))
+		if err != nil {
+			return nil, fmt.Errorf("droptool: exclusions %s:%d: parse to: %w", path, lineNo, err)
+		}
+		out = append(out, ExclusionRange{From: int32(from), To: int32(to)})
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("droptool: scan exclusions %s: %w", path, err)
+	}
+	return out, nil
+}
+
+// SlotDropRate is g_pDropRate[64], duplicated from the runtime package because
+// webserver cannot import tmserver/internal/loot. The values are from
+// Basedef.cpp and docs/migration/game-rules.md §2.2; larger divisors are rarer.
+var SlotDropRate [savefmt.MaxCarry]int
+
+func init() {
+	fill := func(from, to, v int) {
+		for i := from; i <= to; i++ {
+			SlotDropRate[i] = v
+		}
+	}
+	fill(0, 7, 900)
+	fill(8, 11, 4)
+	fill(12, 15, 900)
+	fill(16, 23, 20000)
+	fill(24, 47, 2000)
+	fill(48, 55, 3000)
+	SlotDropRate[56] = 1
+	for i, v := range []int{35, 500, 2500, 5000, 5000, 10000, 20000} {
+		SlotDropRate[57+i] = v
+	}
+}
+
+// Scan reads <contentDir>/Common/ItemList.csv and <contentDir>/TMsrv/run/npc/.
+// Invalid non-STRUCT_MOB files are logged and skipped, matching the existing
+// content scanners used by the moderator UI.
+func Scan(contentDir string, logger *slog.Logger, opts Options) (Catalog, error) {
+	items, err := itemcatalog.Scan(contentDir)
+	if err != nil {
+		return Catalog{}, fmt.Errorf("droptool: item catalog: %w", err)
+	}
+
+	itemByIndex := make(map[int32]string, len(items))
+	out := Catalog{Items: make([]ItemEntry, 0, len(items))}
+	for _, item := range items {
+		itemByIndex[item.Index] = item.Name
+		out.Items = append(out.Items, ItemEntry{Index: item.Index, Name: item.Name})
+	}
+
+	npcDir := filepath.Join(contentDir, "TMsrv", "run", "npc")
+	entries, err := os.ReadDir(npcDir)
+	if err != nil {
+		return Catalog{}, fmt.Errorf("droptool: read %s: %w", npcDir, err)
+	}
+
+	knownItems := make(map[int32]bool, len(out.Items))
+	for _, item := range out.Items {
+		knownItems[item.Index] = true
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		templateName := entry.Name()
+		b, err := os.ReadFile(filepath.Join(npcDir, templateName))
+		if err != nil {
+			logger.Warn("drop template read failed", "name", templateName, "err", err)
+			continue
+		}
+		mob, err := savefmt.DecodeMob(b)
+		if err != nil {
+			logger.Warn("drop template decode failed", "name", templateName, "err", err)
+			continue
+		}
+		mobName := cString(mob.Name[:])
+		mobEntry := MobEntry{
+			TemplateName: templateName,
+			DisplayName:  mobName,
+			Level:        mob.CurrentScore.Level,
+		}
+		out.Mobs = append(out.Mobs, mobEntry)
+
+		for slot, item := range mob.Carry {
+			itemIndex := int32(item.Index)
+			if itemIndex <= 0 || excluded(itemIndex, opts.Exclusions) {
+				continue
+			}
+			itemName := itemByIndex[itemIndex]
+			out.Drops = append(out.Drops, DropEntry{
+				TemplateName: templateName,
+				MobName:      mobName,
+				MobLevel:     mob.CurrentScore.Level,
+				Slot:         int32(slot),
+				ItemIndex:    itemIndex,
+				ItemName:     itemName,
+				RateDivisor:  int32(SlotDropRate[slot]),
+			})
+			if !knownItems[itemIndex] {
+				knownItems[itemIndex] = true
+				out.Items = append(out.Items, ItemEntry{Index: itemIndex, Name: itemName})
+			}
+		}
+	}
+
+	sort.Slice(out.Items, func(i, j int) bool { return out.Items[i].Index < out.Items[j].Index })
+	sort.Slice(out.Mobs, func(i, j int) bool {
+		return out.Mobs[i].TemplateName < out.Mobs[j].TemplateName
+	})
+	sort.Slice(out.Drops, func(i, j int) bool {
+		a, b := out.Drops[i], out.Drops[j]
+		if a.ItemIndex != b.ItemIndex {
+			return a.ItemIndex < b.ItemIndex
+		}
+		if a.TemplateName != b.TemplateName {
+			return a.TemplateName < b.TemplateName
+		}
+		return a.Slot < b.Slot
+	})
+	return out, nil
+}
+
+// ListDropItems returns the item-centric report. By default it includes only
+// items that have at least one matching drop, while IncludeZeroDropItems mirrors
+// the legacy report's item headers with zero mobs.
+func (c Catalog) ListDropItems(filter Filter) []ItemDropEntry {
+	itemQuery := normalize(filter.ItemQuery)
+	mobQuery := normalize(filter.MobQuery)
+
+	dropsByItem := make(map[int32][]DropEntry)
+	for _, drop := range c.Drops {
+		if !matchesMob(drop.TemplateName, drop.MobName, mobQuery) {
+			continue
+		}
+		dropsByItem[drop.ItemIndex] = append(dropsByItem[drop.ItemIndex], drop)
+	}
+
+	var out []ItemDropEntry
+	for _, item := range c.Items {
+		if !matchesItem(item.Index, item.Name, filter.ItemIndex, itemQuery) {
+			continue
+		}
+		drops := dropsByItem[item.Index]
+		if len(drops) == 0 && (!filter.IncludeZeroDropItems || mobQuery != "") {
+			continue
+		}
+		entry := ItemDropEntry{ItemIndex: item.Index, ItemName: item.Name}
+		for _, drop := range drops {
+			entry.Mobs = append(entry.Mobs, ItemDropMob{
+				TemplateName: drop.TemplateName,
+				MobName:      drop.MobName,
+				MobLevel:     drop.MobLevel,
+				Slot:         drop.Slot,
+				RateDivisor:  drop.RateDivisor,
+			})
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// ListMobDrops returns the mob-centric report. Without item filters it includes
+// all decoded mob templates, including templates with no drop slots.
+func (c Catalog) ListMobDrops(filter Filter) []MobDropEntry {
+	itemQuery := normalize(filter.ItemQuery)
+	mobQuery := normalize(filter.MobQuery)
+
+	dropsByMob := make(map[string][]DropEntry)
+	for _, drop := range c.Drops {
+		if !matchesItem(drop.ItemIndex, drop.ItemName, filter.ItemIndex, itemQuery) {
+			continue
+		}
+		dropsByMob[drop.TemplateName] = append(dropsByMob[drop.TemplateName], drop)
+	}
+
+	var out []MobDropEntry
+	for _, mob := range c.Mobs {
+		if !matchesMob(mob.TemplateName, mob.DisplayName, mobQuery) {
+			continue
+		}
+		drops := dropsByMob[mob.TemplateName]
+		if len(drops) == 0 && (filter.ItemIndex > 0 || itemQuery != "") {
+			continue
+		}
+		entry := MobDropEntry{
+			TemplateName: mob.TemplateName,
+			MobName:      mob.DisplayName,
+			MobLevel:     mob.Level,
+		}
+		for _, drop := range drops {
+			entry.Items = append(entry.Items, MobDropItem{
+				Slot:        drop.Slot,
+				ItemIndex:   drop.ItemIndex,
+				ItemName:    drop.ItemName,
+				RateDivisor: drop.RateDivisor,
+			})
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func excluded(itemIndex int32, ranges []ExclusionRange) bool {
+	for _, r := range ranges {
+		from, to := r.From, r.To
+		if from > to {
+			from, to = to, from
+		}
+		if itemIndex >= from && itemIndex <= to {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesItem(index int32, name string, exactIndex int32, query string) bool {
+	if exactIndex > 0 && index != exactIndex {
+		return false
+	}
+	if query == "" {
+		return true
+	}
+	return strings.Contains(normalize(name), query) ||
+		strings.Contains(strconv.FormatInt(int64(index), 10), query)
+}
+
+func matchesMob(templateName, mobName, query string) bool {
+	if query == "" {
+		return true
+	}
+	return strings.Contains(normalize(templateName), query) ||
+		strings.Contains(normalize(mobName), query)
+}
+
+func normalize(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+func cString(b []byte) string {
+	for i, c := range b {
+		if c == 0 {
+			b = b[:i]
+			break
+		}
+	}
+	runes := make([]rune, len(b))
+	for i, c := range b {
+		runes[i] = rune(c)
+	}
+	return string(runes)
+}

--- a/webserver/internal/droptool/droptool_test.go
+++ b/webserver/internal/droptool/droptool_test.go
@@ -1,0 +1,208 @@
+package droptool
+
+import (
+	"encoding/binary"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/savefmt"
+)
+
+func writeItemList(t *testing.T, dir string, rows ...[]byte) {
+	t.Helper()
+	commonDir := filepath.Join(dir, "Common")
+	if err := os.MkdirAll(commonDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var content []byte
+	for _, row := range rows {
+		content = append(content, row...)
+		content = append(content, '\n')
+	}
+	if err := os.WriteFile(filepath.Join(commonDir, "ItemList.csv"), content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeMob(t *testing.T, dir, fileName string, name []byte, level int32, carries map[int]int16) {
+	t.Helper()
+	npcDir := filepath.Join(dir, "TMsrv", "run", "npc")
+	if err := os.MkdirAll(npcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b := make([]byte, savefmt.MobSize)
+	copy(b[0:16], name)
+	binary.LittleEndian.PutUint32(b[92:], uint32(level))
+	for slot, index := range carries {
+		binary.LittleEndian.PutUint16(b[268+slot*savefmt.ItemSize:], uint16(index))
+	}
+	if err := os.WriteFile(filepath.Join(npcDir, fileName), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeBrokenMob(t *testing.T, dir, fileName string) {
+	t.Helper()
+	npcDir := filepath.Join(dir, "TMsrv", "run", "npc")
+	if err := os.MkdirAll(npcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(npcDir, fileName), []byte{1, 2, 3}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestScanBuildsItemAndMobViews(t *testing.T) {
+	dir := t.TempDir()
+	writeItemList(t, dir,
+		[]byte("1000,Adaga,0"),
+		[]byte("1001,Espada,0"),
+	)
+	writeMob(t, dir, "Alpha", []byte("Alpha"), 37, map[int]int16{0: 1000, 8: 1001})
+	writeMob(t, dir, "Beta", []byte("Beta"), 41, map[int]int16{0: 1000})
+	writeBrokenMob(t, dir, "Broken")
+
+	catalog, err := Scan(dir, testLogger(), Options{})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	items := catalog.ListDropItems(Filter{})
+	if len(items) != 2 {
+		t.Fatalf("items = %+v, want 2 item entries", items)
+	}
+	if items[0].ItemIndex != 1000 || items[0].ItemName != "Adaga" || len(items[0].Mobs) != 2 {
+		t.Fatalf("items[0] = %+v, want Adaga with two mobs", items[0])
+	}
+	if items[0].Mobs[0].TemplateName != "Alpha" || items[0].Mobs[0].Slot != 0 || items[0].Mobs[0].RateDivisor != 900 {
+		t.Errorf("items[0].mobs[0] = %+v, want Alpha slot 0 rate 900", items[0].Mobs[0])
+	}
+	if items[1].ItemIndex != 1001 || items[1].Mobs[0].Slot != 8 || items[1].Mobs[0].RateDivisor != 4 {
+		t.Errorf("items[1] = %+v, want Espada at slot 8 rate 4", items[1])
+	}
+
+	mobs := catalog.ListMobDrops(Filter{})
+	if len(mobs) != 2 {
+		t.Fatalf("mobs = %+v, want 2 mob entries", mobs)
+	}
+	if mobs[0].TemplateName != "Alpha" || mobs[0].MobName != "Alpha" || mobs[0].MobLevel != 37 || len(mobs[0].Items) != 2 {
+		t.Errorf("mobs[0] = %+v, want Alpha level 37 with two drops", mobs[0])
+	}
+}
+
+func TestScanExclusionsAndZeroDropItems(t *testing.T) {
+	dir := t.TempDir()
+	writeItemList(t, dir,
+		[]byte("1000,Adaga,0"),
+		[]byte("1001,Espada,0"),
+		[]byte("1002,Arco,0"),
+	)
+	writeMob(t, dir, "Alpha", []byte("Alpha"), 37, map[int]int16{0: 1000, 1: 1001})
+
+	catalog, err := Scan(dir, testLogger(), Options{
+		Exclusions: []ExclusionRange{{From: 1001, To: 1001}},
+	})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	items := catalog.ListDropItems(Filter{})
+	if len(items) != 1 || items[0].ItemIndex != 1000 {
+		t.Fatalf("items = %+v, want only non-excluded dropped item 1000", items)
+	}
+
+	allItems := catalog.ListDropItems(Filter{IncludeZeroDropItems: true})
+	if len(allItems) != 3 {
+		t.Fatalf("allItems = %+v, want all 3 catalog items", allItems)
+	}
+	if allItems[1].ItemIndex != 1001 || len(allItems[1].Mobs) != 0 {
+		t.Errorf("allItems[1] = %+v, want excluded item with zero mobs", allItems[1])
+	}
+}
+
+func TestFilters(t *testing.T) {
+	dir := t.TempDir()
+	writeItemList(t, dir,
+		[]byte("1000,Adaga,0"),
+		[]byte("1001,Espada,0"),
+	)
+	writeMob(t, dir, "Alpha", []byte("Alpha"), 37, map[int]int16{0: 1000, 8: 1001})
+	writeMob(t, dir, "Beta", []byte("Beta"), 41, map[int]int16{0: 1000})
+
+	catalog, err := Scan(dir, testLogger(), Options{})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	items := catalog.ListDropItems(Filter{MobQuery: "bet"})
+	if len(items) != 1 || items[0].ItemIndex != 1000 || len(items[0].Mobs) != 1 || items[0].Mobs[0].TemplateName != "Beta" {
+		t.Fatalf("items filtered by mob = %+v, want item 1000 only on Beta", items)
+	}
+
+	mobs := catalog.ListMobDrops(Filter{ItemIndex: 1001})
+	if len(mobs) != 1 || mobs[0].TemplateName != "Alpha" || len(mobs[0].Items) != 1 {
+		t.Fatalf("mobs filtered by item index = %+v, want Alpha only", mobs)
+	}
+
+	mobs = catalog.ListMobDrops(Filter{ItemQuery: "ada"})
+	if len(mobs) != 2 {
+		t.Fatalf("mobs filtered by item query = %+v, want both mobs that drop Adaga", mobs)
+	}
+}
+
+func TestScanDecodesLatin1Names(t *testing.T) {
+	dir := t.TempDir()
+	writeItemList(t, dir,
+		[]byte{'1', '0', '0', '0', ',', 'P', 'o', 0xE7, 0xE3, 'o', ',', '0'},
+	)
+	writeMob(t, dir, "Dragao", []byte{'D', 'r', 'a', 'g', 0xE3, 'o'}, 12, map[int]int16{0: 1000})
+
+	catalog, err := Scan(dir, testLogger(), Options{})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	items := catalog.ListDropItems(Filter{})
+	if len(items) != 1 || items[0].ItemName != "Poção" || items[0].Mobs[0].MobName != "Dragão" {
+		t.Fatalf("items = %+v, want Latin-1 names decoded", items)
+	}
+}
+
+func TestLoadExclusions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ItensExceptions.txt")
+	if err := os.WriteFile(path, []byte("# comment\n1000,1002\n2000,1999\n\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadExclusions(path)
+	if err != nil {
+		t.Fatalf("LoadExclusions: %v", err)
+	}
+	want := []ExclusionRange{{From: 1000, To: 1002}, {From: 2000, To: 1999}}
+	if len(got) != len(want) {
+		t.Fatalf("ranges = %+v, want %+v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("ranges[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+
+	missing, err := LoadExclusions(filepath.Join(t.TempDir(), "missing.txt"))
+	if err != nil || len(missing) != 0 {
+		t.Fatalf("missing file = %+v, err %v, want empty nil", missing, err)
+	}
+}
+
+func TestScanMissingInputsError(t *testing.T) {
+	if _, err := Scan(t.TempDir(), testLogger(), Options{}); err == nil {
+		t.Fatal("expected error for content dir without ItemList.csv")
+	}
+}

--- a/webserver/internal/grpcsrv/npcadmin.go
+++ b/webserver/internal/grpcsrv/npcadmin.go
@@ -8,6 +8,7 @@ import (
 
 	webv1 "github.com/jeanluca/w2pp-openwyd/api/web/v1"
 	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+	"github.com/jeanluca/w2pp-openwyd/webserver/internal/droptool"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/itemcatalog"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/mapzones"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/npcadmin"
@@ -26,6 +27,8 @@ type NpcAdmin interface {
 	Delete(ctx context.Context, moderatorID, npcID int64) (npcadmin.Result, error)
 	ListMerchantTemplates(ctx context.Context, moderatorID int64) (npcadmin.Result, []npctemplates.Template, error)
 	ListItemCatalog(ctx context.Context, moderatorID int64) (npcadmin.Result, []itemcatalog.Entry, error)
+	ListDropItems(ctx context.Context, moderatorID int64, filter droptool.Filter) (npcadmin.Result, []droptool.ItemDropEntry, error)
+	ListMobDrops(ctx context.Context, moderatorID int64, filter droptool.Filter) (npcadmin.Result, []droptool.MobDropEntry, error)
 	ListItemPrices(ctx context.Context, moderatorID int64) (npcadmin.Result, []domain.ItemPriceOverride, error)
 	ListMapZones(ctx context.Context, moderatorID int64) (npcadmin.Result, []mapzones.Zone, error)
 }
@@ -159,6 +162,74 @@ func (s *NpcAdminServer) ListItemCatalog(ctx context.Context, req *webv1.ListIte
 		out = append(out, &webv1.ItemCatalogEntry{ItemIndex: it.Index, Name: it.Name})
 	}
 	return &webv1.ListItemCatalogResponse{Result: resultToProto(res), Items: out}, nil
+}
+
+// ListDropItems returns the item-centric DropTool report for the moderator
+// panel.
+func (s *NpcAdminServer) ListDropItems(ctx context.Context, req *webv1.ListDropItemsRequest) (*webv1.ListDropItemsResponse, error) {
+	res, items, err := s.admin.ListDropItems(ctx, req.GetModeratorId(), droptool.Filter{
+		ItemIndex:            req.GetItemIndex(),
+		ItemQuery:            req.GetItemQuery(),
+		MobQuery:             req.GetMobQuery(),
+		IncludeZeroDropItems: req.GetIncludeZeroDropItems(),
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list drop items: %v", err)
+	}
+	out := make([]*webv1.DropItemEntry, 0, len(items))
+	for _, item := range items {
+		out = append(out, dropItemEntryToProto(item))
+	}
+	return &webv1.ListDropItemsResponse{Result: resultToProto(res), Items: out}, nil
+}
+
+func dropItemEntryToProto(item droptool.ItemDropEntry) *webv1.DropItemEntry {
+	mobs := make([]*webv1.DropItemMob, 0, len(item.Mobs))
+	for _, mob := range item.Mobs {
+		mobs = append(mobs, &webv1.DropItemMob{
+			TemplateName: mob.TemplateName,
+			MobName:      mob.MobName,
+			MobLevel:     mob.MobLevel,
+			Slot:         mob.Slot,
+			RateDivisor:  mob.RateDivisor,
+		})
+	}
+	return &webv1.DropItemEntry{ItemIndex: item.ItemIndex, ItemName: item.ItemName, Mobs: mobs}
+}
+
+// ListMobDrops returns the mob-centric DropTool report for the moderator panel.
+func (s *NpcAdminServer) ListMobDrops(ctx context.Context, req *webv1.ListMobDropsRequest) (*webv1.ListMobDropsResponse, error) {
+	res, mobs, err := s.admin.ListMobDrops(ctx, req.GetModeratorId(), droptool.Filter{
+		MobQuery:  req.GetMobQuery(),
+		ItemIndex: req.GetItemIndex(),
+		ItemQuery: req.GetItemQuery(),
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list mob drops: %v", err)
+	}
+	out := make([]*webv1.MobDropEntry, 0, len(mobs))
+	for _, mob := range mobs {
+		out = append(out, mobDropEntryToProto(mob))
+	}
+	return &webv1.ListMobDropsResponse{Result: resultToProto(res), Mobs: out}, nil
+}
+
+func mobDropEntryToProto(mob droptool.MobDropEntry) *webv1.MobDropEntry {
+	items := make([]*webv1.MobDropItem, 0, len(mob.Items))
+	for _, item := range mob.Items {
+		items = append(items, &webv1.MobDropItem{
+			Slot:        item.Slot,
+			ItemIndex:   item.ItemIndex,
+			ItemName:    item.ItemName,
+			RateDivisor: item.RateDivisor,
+		})
+	}
+	return &webv1.MobDropEntry{
+		TemplateName: mob.TemplateName,
+		MobName:      mob.MobName,
+		MobLevel:     mob.MobLevel,
+		Items:        items,
+	}
 }
 
 // ListItemPrices returns every global item price override for the moderator

--- a/webserver/internal/grpcsrv/npcadmin_test.go
+++ b/webserver/internal/grpcsrv/npcadmin_test.go
@@ -7,6 +7,7 @@ import (
 
 	webv1 "github.com/jeanluca/w2pp-openwyd/api/web/v1"
 	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+	"github.com/jeanluca/w2pp-openwyd/webserver/internal/droptool"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/itemcatalog"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/mapzones"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/npcadmin"
@@ -25,6 +26,15 @@ type fakeNpcAdmin struct {
 	listItemsRes npcadmin.Result
 	listItems    []itemcatalog.Entry
 	listItemsErr error
+
+	listDropItemsRes npcadmin.Result
+	listDropItems    []droptool.ItemDropEntry
+	listDropItemsErr error
+	lastDropFilter   droptool.Filter
+
+	listMobDropsRes npcadmin.Result
+	listMobDrops    []droptool.MobDropEntry
+	listMobDropsErr error
 
 	listPricesRes npcadmin.Result
 	listPrices    []domain.ItemPriceOverride
@@ -66,6 +76,16 @@ func (f *fakeNpcAdmin) ListMerchantTemplates(_ context.Context, moderatorID int6
 func (f *fakeNpcAdmin) ListItemCatalog(_ context.Context, moderatorID int64) (npcadmin.Result, []itemcatalog.Entry, error) {
 	f.lastModeratorID = moderatorID
 	return f.listItemsRes, f.listItems, f.listItemsErr
+}
+func (f *fakeNpcAdmin) ListDropItems(_ context.Context, moderatorID int64, filter droptool.Filter) (npcadmin.Result, []droptool.ItemDropEntry, error) {
+	f.lastModeratorID = moderatorID
+	f.lastDropFilter = filter
+	return f.listDropItemsRes, f.listDropItems, f.listDropItemsErr
+}
+func (f *fakeNpcAdmin) ListMobDrops(_ context.Context, moderatorID int64, filter droptool.Filter) (npcadmin.Result, []droptool.MobDropEntry, error) {
+	f.lastModeratorID = moderatorID
+	f.lastDropFilter = filter
+	return f.listMobDropsRes, f.listMobDrops, f.listMobDropsErr
 }
 func (f *fakeNpcAdmin) ListItemPrices(_ context.Context, moderatorID int64) (npcadmin.Result, []domain.ItemPriceOverride, error) {
 	f.lastModeratorID = moderatorID
@@ -174,6 +194,135 @@ func TestListItemCatalogInfraError(t *testing.T) {
 	s := NewNpcAdmin(fake)
 
 	if _, err := s.ListItemCatalog(context.Background(), &webv1.ListItemCatalogRequest{}); err == nil {
+		t.Fatal("expected gRPC error on infra failure")
+	}
+}
+
+func TestListDropItemsMapping(t *testing.T) {
+	fake := &fakeNpcAdmin{
+		listDropItemsRes: npcadmin.OK,
+		listDropItems: []droptool.ItemDropEntry{{
+			ItemIndex: 1000,
+			ItemName:  "Adaga",
+			Mobs: []droptool.ItemDropMob{{
+				TemplateName: "Alpha",
+				MobName:      "Alpha",
+				MobLevel:     37,
+				Slot:         8,
+				RateDivisor:  4,
+			}},
+		}},
+	}
+	s := NewNpcAdmin(fake)
+
+	resp, err := s.ListDropItems(context.Background(), &webv1.ListDropItemsRequest{
+		ModeratorId:          7,
+		ItemIndex:            1000,
+		ItemQuery:            "ada",
+		MobQuery:             "alp",
+		IncludeZeroDropItems: true,
+	})
+	if err != nil {
+		t.Fatalf("ListDropItems: %v", err)
+	}
+	if fake.lastModeratorID != 7 {
+		t.Errorf("moderator id forwarded = %d, want 7", fake.lastModeratorID)
+	}
+	wantFilter := droptool.Filter{ItemIndex: 1000, ItemQuery: "ada", MobQuery: "alp", IncludeZeroDropItems: true}
+	if fake.lastDropFilter != wantFilter {
+		t.Errorf("filter = %+v, want %+v", fake.lastDropFilter, wantFilter)
+	}
+	if resp.GetResult() != webv1.AdminResult_ADMIN_RESULT_OK {
+		t.Fatalf("result = %v, want OK", resp.GetResult())
+	}
+	got := resp.GetItems()[0]
+	if got.GetItemIndex() != 1000 || got.GetItemName() != "Adaga" || got.GetMobs()[0].GetRateDivisor() != 4 {
+		t.Errorf("items[0] = %+v, want mapped drop item", got)
+	}
+}
+
+func TestListDropItemsForbidden(t *testing.T) {
+	fake := &fakeNpcAdmin{listDropItemsRes: npcadmin.Forbidden}
+	s := NewNpcAdmin(fake)
+
+	resp, err := s.ListDropItems(context.Background(), &webv1.ListDropItemsRequest{ModeratorId: 3})
+	if err != nil {
+		t.Fatalf("ListDropItems: %v", err)
+	}
+	if resp.GetResult() != webv1.AdminResult_ADMIN_RESULT_FORBIDDEN {
+		t.Errorf("result = %v, want FORBIDDEN", resp.GetResult())
+	}
+}
+
+func TestListDropItemsInfraError(t *testing.T) {
+	fake := &fakeNpcAdmin{listDropItemsErr: errors.New("scan failed")}
+	s := NewNpcAdmin(fake)
+
+	if _, err := s.ListDropItems(context.Background(), &webv1.ListDropItemsRequest{}); err == nil {
+		t.Fatal("expected gRPC error on infra failure")
+	}
+}
+
+func TestListMobDropsMapping(t *testing.T) {
+	fake := &fakeNpcAdmin{
+		listMobDropsRes: npcadmin.OK,
+		listMobDrops: []droptool.MobDropEntry{{
+			TemplateName: "Alpha",
+			MobName:      "Alpha",
+			MobLevel:     37,
+			Items: []droptool.MobDropItem{{
+				Slot:        8,
+				ItemIndex:   1000,
+				ItemName:    "Adaga",
+				RateDivisor: 4,
+			}},
+		}},
+	}
+	s := NewNpcAdmin(fake)
+
+	resp, err := s.ListMobDrops(context.Background(), &webv1.ListMobDropsRequest{
+		ModeratorId: 7,
+		MobQuery:    "alp",
+		ItemIndex:   1000,
+		ItemQuery:   "ada",
+	})
+	if err != nil {
+		t.Fatalf("ListMobDrops: %v", err)
+	}
+	if fake.lastModeratorID != 7 {
+		t.Errorf("moderator id forwarded = %d, want 7", fake.lastModeratorID)
+	}
+	wantFilter := droptool.Filter{MobQuery: "alp", ItemIndex: 1000, ItemQuery: "ada"}
+	if fake.lastDropFilter != wantFilter {
+		t.Errorf("filter = %+v, want %+v", fake.lastDropFilter, wantFilter)
+	}
+	if resp.GetResult() != webv1.AdminResult_ADMIN_RESULT_OK {
+		t.Fatalf("result = %v, want OK", resp.GetResult())
+	}
+	got := resp.GetMobs()[0]
+	if got.GetTemplateName() != "Alpha" || got.GetMobLevel() != 37 || got.GetItems()[0].GetItemName() != "Adaga" {
+		t.Errorf("mobs[0] = %+v, want mapped mob drops", got)
+	}
+}
+
+func TestListMobDropsForbidden(t *testing.T) {
+	fake := &fakeNpcAdmin{listMobDropsRes: npcadmin.Forbidden}
+	s := NewNpcAdmin(fake)
+
+	resp, err := s.ListMobDrops(context.Background(), &webv1.ListMobDropsRequest{ModeratorId: 3})
+	if err != nil {
+		t.Fatalf("ListMobDrops: %v", err)
+	}
+	if resp.GetResult() != webv1.AdminResult_ADMIN_RESULT_FORBIDDEN {
+		t.Errorf("result = %v, want FORBIDDEN", resp.GetResult())
+	}
+}
+
+func TestListMobDropsInfraError(t *testing.T) {
+	fake := &fakeNpcAdmin{listMobDropsErr: errors.New("scan failed")}
+	s := NewNpcAdmin(fake)
+
+	if _, err := s.ListMobDrops(context.Background(), &webv1.ListMobDropsRequest{}); err == nil {
 		t.Fatal("expected gRPC error on infra failure")
 	}
 }

--- a/webserver/internal/npcadmin/service.go
+++ b/webserver/internal/npcadmin/service.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jeanluca/w2pp-openwyd/internal/domain"
 	"github.com/jeanluca/w2pp-openwyd/internal/store"
+	"github.com/jeanluca/w2pp-openwyd/webserver/internal/droptool"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/itemcatalog"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/mapzones"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/npctemplates"
@@ -56,9 +57,10 @@ const (
 
 // Service implements the moderator NPC-editing operations.
 type Service struct {
-	store     Store
-	templates []npctemplates.Template
-	items     []itemcatalog.Entry
+	store       Store
+	templates   []npctemplates.Template
+	items       []itemcatalog.Entry
+	dropCatalog droptool.Catalog
 }
 
 // New builds the service over the given store.
@@ -75,6 +77,11 @@ func (s *Service) SetTemplates(templates []npctemplates.Template) { s.templates 
 // when -content/W2PP_CONTENT wasn't configured, in which case
 // ListItemCatalog returns an empty list rather than failing.
 func (s *Service) SetItems(items []itemcatalog.Entry) { s.items = items }
+
+// SetDropCatalog installs the DropTool-equivalent catalog ListDropItems and
+// ListMobDrops serve. Called once at boot after scanning the content tree; left
+// as a zero-value catalog when -content/W2PP_CONTENT wasn't configured.
+func (s *Service) SetDropCatalog(catalog droptool.Catalog) { s.dropCatalog = catalog }
 
 // List returns every NPC definition, after authorizing the caller.
 func (s *Service) List(ctx context.Context, moderatorID int64) (Result, []domain.NPCDefinition, error) {
@@ -108,6 +115,24 @@ func (s *Service) ListItemCatalog(ctx context.Context, moderatorID int64) (Resul
 		return r, nil, err
 	}
 	return OK, s.items, nil
+}
+
+// ListDropItems returns the item-centric DropTool report scanned from the
+// content tree at boot, after authorizing the caller.
+func (s *Service) ListDropItems(ctx context.Context, moderatorID int64, filter droptool.Filter) (Result, []droptool.ItemDropEntry, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, nil, err
+	}
+	return OK, s.dropCatalog.ListDropItems(filter), nil
+}
+
+// ListMobDrops returns the mob-centric DropTool report scanned from the content
+// tree at boot, after authorizing the caller.
+func (s *Service) ListMobDrops(ctx context.Context, moderatorID int64, filter droptool.Filter) (Result, []droptool.MobDropEntry, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, nil, err
+	}
+	return OK, s.dropCatalog.ListMobDrops(filter), nil
 }
 
 // ListMapZones returns the fixed map_id label table (mapzones.All), after

--- a/webserver/internal/npcadmin/service_test.go
+++ b/webserver/internal/npcadmin/service_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jeanluca/w2pp-openwyd/internal/domain"
 	"github.com/jeanluca/w2pp-openwyd/internal/store"
+	"github.com/jeanluca/w2pp-openwyd/webserver/internal/droptool"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/itemcatalog"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/mapzones"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/npctemplates"
@@ -290,6 +291,93 @@ func TestListItemCatalogEmptyWhenUnset(t *testing.T) {
 	}
 	if len(items) != 0 {
 		t.Errorf("items = %+v, want empty", items)
+	}
+}
+
+func TestListDropItems(t *testing.T) {
+	catalog := droptool.Catalog{
+		Items: []droptool.ItemEntry{{Index: 1000, Name: "Adaga"}},
+		Mobs:  []droptool.MobEntry{{TemplateName: "Alpha", DisplayName: "Alpha", Level: 37}},
+		Drops: []droptool.DropEntry{{
+			TemplateName: "Alpha",
+			MobName:      "Alpha",
+			MobLevel:     37,
+			Slot:         0,
+			ItemIndex:    1000,
+			ItemName:     "Adaga",
+			RateDivisor:  900,
+		}},
+	}
+
+	s := New(newFake())
+	s.SetDropCatalog(catalog)
+
+	got, items, err := s.ListDropItems(context.Background(), 1, droptool.Filter{ItemQuery: "ada"})
+	if err != nil {
+		t.Fatalf("ListDropItems: %v", err)
+	}
+	if got != OK {
+		t.Fatalf("result = %v, want OK", got)
+	}
+	if len(items) != 1 || items[0].ItemIndex != 1000 || len(items[0].Mobs) != 1 {
+		t.Fatalf("items = %+v, want one item drop entry", items)
+	}
+
+	if got, _, err := s.ListDropItems(context.Background(), 3, droptool.Filter{}); err != nil || got != Forbidden {
+		t.Errorf("player ListDropItems result = %v, err %v, want Forbidden, nil", got, err)
+	}
+}
+
+func TestListMobDrops(t *testing.T) {
+	catalog := droptool.Catalog{
+		Items: []droptool.ItemEntry{{Index: 1000, Name: "Adaga"}},
+		Mobs:  []droptool.MobEntry{{TemplateName: "Alpha", DisplayName: "Alpha", Level: 37}},
+		Drops: []droptool.DropEntry{{
+			TemplateName: "Alpha",
+			MobName:      "Alpha",
+			MobLevel:     37,
+			Slot:         0,
+			ItemIndex:    1000,
+			ItemName:     "Adaga",
+			RateDivisor:  900,
+		}},
+	}
+
+	s := New(newFake())
+	s.SetDropCatalog(catalog)
+
+	got, mobs, err := s.ListMobDrops(context.Background(), 1, droptool.Filter{MobQuery: "alp"})
+	if err != nil {
+		t.Fatalf("ListMobDrops: %v", err)
+	}
+	if got != OK {
+		t.Fatalf("result = %v, want OK", got)
+	}
+	if len(mobs) != 1 || mobs[0].TemplateName != "Alpha" || len(mobs[0].Items) != 1 {
+		t.Fatalf("mobs = %+v, want one mob drop entry", mobs)
+	}
+
+	if got, _, err := s.ListMobDrops(context.Background(), 3, droptool.Filter{}); err != nil || got != Forbidden {
+		t.Errorf("player ListMobDrops result = %v, err %v, want Forbidden, nil", got, err)
+	}
+}
+
+func TestDropCatalogEmptyWhenUnset(t *testing.T) {
+	s := New(newFake())
+	got, items, err := s.ListDropItems(context.Background(), 1, droptool.Filter{})
+	if err != nil || got != OK {
+		t.Fatalf("ListDropItems result = %v, err %v, want OK, nil", got, err)
+	}
+	if len(items) != 0 {
+		t.Errorf("items = %+v, want empty", items)
+	}
+
+	got, mobs, err := s.ListMobDrops(context.Background(), 1, droptool.Filter{})
+	if err != nil || got != OK {
+		t.Fatalf("ListMobDrops result = %v, err %v, want OK, nil", got, err)
+	}
+	if len(mobs) != 0 {
+		t.Errorf("mobs = %+v, want empty", mobs)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a read-only DropTool catalog scanner over Release/Common/ItemList.csv and Release/TMsrv/run/npc STRUCT_MOB templates
- expose item-centric and mob-centric drop reports through NpcAdminService gRPC endpoints
- document the Next.js portal integration contract and suggested BFF routes

Closes #166.

## Tests
- go test ./webserver/internal/droptool ./webserver/internal/npcadmin ./webserver/internal/grpcsrv ./webserver/cmd/webserver
- make test
- git diff --check