### PR TITLE
Port Classe A-E items and the Odin combine family

### DIFF
--- a/tmserver/cmd/tmserver/main.go
+++ b/tmserver/cmd/tmserver/main.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/jeanluca/w2pp-openwyd/internal/secure"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/binclient"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/combine"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/dbclient"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/handler"
@@ -132,6 +133,7 @@ func run(logger *slog.Logger) error {
 	var itemVolatiles, itemPos, itemUnique, itemGrades, itemExtra map[int]int
 	var itemRanges map[int]int16
 	var combineFamilies map[protocol.Type]handler.CombineFamily
+	var odinCatalog combine.Catalog
 	var spells *content.SkillData
 	var heights *content.Grid
 	var sancRate *content.SancRate
@@ -146,7 +148,8 @@ func run(logger *slog.Logger) error {
 		itemGrades = items.Grades()
 		itemExtra = items.Extras()
 		itemRanges = items.Ranges()
-		combineFamilies = handler.DefaultCombineFamilies(handler.NewCombineCatalog(items, c.comp))
+		odinCatalog = handler.NewCombineCatalog(items, c.comp)
+		combineFamilies = handler.DefaultCombineFamilies(odinCatalog)
 		spells = c.skills
 		heights = c.heights
 		sancRate = c.sanc
@@ -235,6 +238,7 @@ func run(logger *slog.Logger) error {
 		SancRate:        sancRate,
 		ExpEvents:       level.ExpEvents{DoubleMode: *doubleExp, NewbieEvent: *newbieEvent, KefraLive: *kefraLive},
 		CombineFamilies: combineFamilies,
+		OdinCatalog:     odinCatalog,
 		NpcConfig:       npcConfig,
 	})
 	w := world.New(world.Config{

--- a/tmserver/internal/combine/combine.go
+++ b/tmserver/internal/combine/combine.go
@@ -28,3 +28,24 @@ func Roll(r Rand, rate int) (value int, success bool) {
 	}
 	return v, v <= rate
 }
+
+// Odin roll constants (_MSG_CombineItemOdin.cpp:124-129): a distinct fold
+// from the base Roll — rand()%199, then values over 100 drop by 99. NOT the
+// same distribution as Roll's 115/-15 fold; the two must not be confused.
+const (
+	OdinRollModulo    = 199
+	OdinFlattenAbove  = 100
+	OdinFlattenAmount = 99
+)
+
+// RollOdin performs the Odin family's luck roll (_MSG_CombineItemOdin.cpp:125-129).
+// Unlike Roll, the caller compares the result against a recipe-specific rate
+// itself (each Odin branch computes its own threshold), so this only returns
+// the folded value.
+func RollOdin(r Rand) int {
+	v := r.Intn(OdinRollModulo)
+	if v > OdinFlattenAbove {
+		v -= OdinFlattenAmount
+	}
+	return v
+}

--- a/tmserver/internal/combine/match.go
+++ b/tmserver/internal/combine/match.go
@@ -25,6 +25,9 @@ type Catalog struct {
 	Extra      map[int]int
 	Effects    map[int][]content.BaseEffect
 	AnctChance [3]int
+	// Pos maps item index → nPos (equip-slot class), needed by MatchOdin's
+	// "+12+" recipe gate.
+	Pos map[int]int
 }
 
 // MatchAnct is the GetMatchCombine port (GetFunc.cpp:76). It returns the recipe

--- a/tmserver/internal/combine/odin.go
+++ b/tmserver/internal/combine/odin.go
@@ -1,0 +1,182 @@
+// Odin combine family (GetMatchCombineOdin, GetFunc.cpp:551; dispatched by
+// Exec_MSG_CombineItemOdin, _MSG_CombineItemOdin.cpp:132-722): 11 numbered
+// recipes plus a default "Composição de Sets" fallback keyed off an item's
+// catalog Extra field, the same "_selado" mechanism AnctResult already uses.
+package combine
+
+import (
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/refine"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// Odin recipe ids, matching GetMatchCombineOdin's return values. OdinNoMatch
+// is the function's DEFAULT return (no numbered pattern matched) — it is NOT
+// "invalid": Exec always attempts "Composição de Sets" for it.
+const (
+	OdinNoMatch          = 0 // "Composição de Sets" — the default fallback
+	OdinItemCelestial    = 1 // Exec's own comment for this branch is "Composição de armas"
+	OdinPlus12           = 2
+	OdinPistaDeRunas     = 3
+	OdinDestraveLv40     = 4
+	OdinPedraDaFuria     = 5
+	OdinSecretaAgua      = 6
+	OdinSecretaTerra     = 7
+	OdinSecretaSol       = 8
+	OdinSecretaVento     = 9
+	OdinSementeDeCristal = 10
+	OdinCapaCelestial    = 11
+)
+
+// blockedItem747 is already declared in match.go; reused here (Item[747]
+// blocks every Odin recipe the same way it blocks Anct).
+
+// maxItemListOdin mirrors handler.maxItemList — MAX_ITEMLIST is undocumented;
+// same UNVERIFIED placeholder used everywhere else in this fork.
+const maxItemListOdin = 30000
+
+// MatchOdin is the GetMatchCombineOdin port. items must have exactly 8
+// elements (protocol.MaxCombine / MAX_COMBINE, Basedef.h:173); a short slice
+// never matches. It returns the recipe id 0..11 — 0 means "no numbered
+// pattern matched", which the caller still routes to "Composição de Sets",
+// NOT to an invalid/no-op response.
+func MatchOdin(cat Catalog, items []world.Item) int {
+	for _, it := range items {
+		if int(it.Index) == blockedItem747 {
+			return OdinNoMatch
+		}
+	}
+	if len(items) < 8 {
+		return OdinNoMatch
+	}
+	for _, it := range items[:8] {
+		if it.Index < 0 || int(it.Index) >= maxItemListOdin {
+			return OdinNoMatch
+		}
+	}
+
+	idx := func(i int) int { return int(items[i].Index) }
+	lvl := func(i int) int { return refine.Level(items[i]) }
+	amt := func(i int) int { return refine.Amount(items[i]) }
+
+	switch {
+	case idx(0) == cat.Extra[idx(1)] && lvl(0) >= 9 && lvl(1) == 15 &&
+		(idx(2) == 542 || idx(2) == 772) &&
+		idx(3) == 5334 && idx(4) == 5335 && idx(5) == 5336 && idx(6) == 5337:
+		return OdinItemCelestial
+
+	case ((idx(0) == 413 && amt(0) >= 10 && idx(1) == 413 && amt(1) >= 10) || (idx(0) == 4043 && idx(1) == 4043)) &&
+		inRange(lvl(2), 10, 15) &&
+		isRuneOr3338(idx(3)) && isRuneOr3338(idx(4)) && isRuneOr3338(idx(5)) && isRuneOr3338(idx(6)) &&
+		isPlus12Pos(cat.Pos[idx(2)]):
+		return OdinPlus12
+
+	case idx(0) == 413 && idx(1) == 413 && idx(2) == 413 && idx(3) == 413 && idx(4) == 413 && idx(5) == 413 && idx(6) == 413:
+		return OdinPistaDeRunas
+
+	case idx(0) == 4127 && idx(1) == 4127 && idx(2) == 5135 && idx(3) == 5113 && idx(4) == 5129 && idx(5) == 5112 && idx(6) == 5110:
+		return OdinDestraveLv40
+
+	case idx(0) == 5125 && idx(1) == 5115 && idx(2) == 5111 && idx(3) == 5112 && idx(4) == 5120 && idx(5) == 5128 && idx(6) == 5119:
+		return OdinPedraDaFuria
+
+	case idx(0) == 5126 && idx(1) == 5127 && idx(2) == 5121 && idx(3) == 5114 && idx(4) == 5125 && idx(5) == 5111 && idx(6) == 5118:
+		return OdinSecretaAgua
+
+	case idx(0) == 5131 && idx(1) == 5113 && idx(2) == 5115 && idx(3) == 5116 && idx(4) == 5125 && idx(5) == 5112 && idx(6) == 5114:
+		return OdinSecretaTerra
+
+	case idx(0) == 5110 && idx(1) == 5124 && idx(2) == 5117 && idx(3) == 5129 && idx(4) == 5114 && idx(5) == 5125 && idx(6) == 5128:
+		return OdinSecretaSol
+
+	case idx(0) == 5122 && idx(1) == 5119 && idx(2) == 5132 && idx(3) == 5120 && idx(4) == 5130 && idx(5) == 5133 && idx(6) == 5123:
+		return OdinSecretaVento
+
+	case idx(0) == 421 && idx(1) == 422 && idx(2) == 423 && idx(3) == 424 && idx(4) == 425 && idx(5) == 426 && idx(6) == 427:
+		return OdinSementeDeCristal
+
+	case idx(0) == 4127 && idx(1) == 4127 && idx(2) == 5135 && idx(3) == 413 && idx(4) == 413 && idx(5) == 413 && idx(6) == 413:
+		return OdinCapaCelestial
+	}
+	return OdinNoMatch
+}
+
+// inRange reports whether lo < v <= hi (the "+12+" recipe's level window).
+func inRange(v, lo, hi int) bool { return v > lo && v <= hi }
+
+// isRuneOr3338 is the "+12+" recipe's per-slot ingredient gate: one of the
+// four elemental Secreta stones (5334-5337), or the neutral rune stone 3338.
+func isRuneOr3338(idx int) bool {
+	return (idx >= 5334 && idx <= 5337) || idx == 3338
+}
+
+// isPlus12Pos gates the "+12+" recipe to the equip slots it actually applies
+// to (g_pItemList[Item[2].sIndex].nPos == one of these).
+func isPlus12Pos(pos int) bool {
+	switch pos {
+	case 2, 4, 8, 16, 32, 64, 192, 128:
+		return true
+	}
+	return false
+}
+
+// g_pItemSancRate12 / g_pItemSancRate12Minus (Basedef.cpp:115-120): the
+// "+12+" recipe's rate bonuses (per rune stone present, and per the neutral
+// stone's own sanc level) and penalties (by the target's current level).
+var (
+	itemSancRate12      = [11]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 12, 15}
+	itemSancRate12Minus = [4]int{2, 3, 4, 5}
+)
+
+// Plus12Rate accumulates the "+12+" recipe's success rate
+// (_MSG_CombineItemOdin.cpp:257-322): a base rate, +itemSancRate12[0] per rune
+// stone (5334-5337) among the 8 slots, +itemSancRate12[1..9] keyed by stone
+// 3338's own level (0..9), a count of item 4043 ("protect") occurrences, and
+// finally a penalty from itemSancRate12Minus keyed by target's CURRENT level
+// (12/13/14/15 — 11 pays no penalty). items must be the same 8-slot input
+// MatchOdin saw; target is items[2], read before the level bump.
+func Plus12Rate(baseRate int, items []world.Item) (rate, protect int) {
+	rate = baseRate
+	for _, it := range items {
+		idx := int(it.Index)
+		if idx >= 5334 && idx <= 5337 {
+			rate += itemSancRate12[0]
+		}
+		if idx == 4043 {
+			protect++
+		}
+		if idx == 3338 {
+			if l := refine.Level(it); l >= 0 && l <= 9 {
+				rate += itemSancRate12[l+1]
+			}
+		}
+	}
+	switch refine.Level(items[2]) {
+	case 12:
+		rate -= itemSancRate12Minus[0]
+	case 13:
+		rate -= itemSancRate12Minus[1]
+	case 14:
+		rate -= itemSancRate12Minus[2]
+	case 15:
+		rate -= itemSancRate12Minus[3]
+	}
+	return rate, protect
+}
+
+// Plus12NewLevel is the "+12+" recipe's level ladder
+// (_MSG_CombineItemOdin.cpp:333-352): +11→12, +12→13, +13→14, +14→15. Any
+// other level (already excluded by the caller's level>10 && level<=15 gate,
+// but guarded here too) reports no bump.
+func Plus12NewLevel(level int) (int, bool) {
+	switch level {
+	case 11:
+		return 12, true
+	case 12:
+		return 13, true
+	case 13:
+		return 14, true
+	case 14:
+		return 15, true
+	}
+	return level, false
+}

--- a/tmserver/internal/combine/odin_test.go
+++ b/tmserver/internal/combine/odin_test.go
@@ -1,0 +1,204 @@
+package combine
+
+import (
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// items8 builds an 8-slot input from a list of sIndex values (0 = empty slot).
+func items8(idx ...int16) []world.Item {
+	var out [8]world.Item
+	for i, v := range idx {
+		if i >= 8 {
+			break
+		}
+		out[i] = world.Item{Index: v}
+	}
+	return out[:]
+}
+
+func TestMatchOdinRecipes(t *testing.T) {
+	cat := Catalog{
+		Extra: map[int]int{1902: 3626},
+		Pos:   map[int]int{3140: 4},
+	}
+	cases := []struct {
+		name  string
+		items []world.Item
+		want  int
+	}{
+		{
+			name:  "Pista de runas: 7x item 413",
+			items: items8(413, 413, 413, 413, 413, 413, 413),
+			want:  OdinPistaDeRunas,
+		},
+		{
+			name:  "Destrave Lv40",
+			items: items8(4127, 4127, 5135, 5113, 5129, 5112, 5110),
+			want:  OdinDestraveLv40,
+		},
+		{
+			name:  "Pedra da furia",
+			items: items8(5125, 5115, 5111, 5112, 5120, 5128, 5119),
+			want:  OdinPedraDaFuria,
+		},
+		{
+			name:  "Secreta da agua",
+			items: items8(5126, 5127, 5121, 5114, 5125, 5111, 5118),
+			want:  OdinSecretaAgua,
+		},
+		{
+			name:  "Secreta da terra",
+			items: items8(5131, 5113, 5115, 5116, 5125, 5112, 5114),
+			want:  OdinSecretaTerra,
+		},
+		{
+			name:  "Secreta do sol",
+			items: items8(5110, 5124, 5117, 5129, 5114, 5125, 5128),
+			want:  OdinSecretaSol,
+		},
+		{
+			name:  "Secreta do vento",
+			items: items8(5122, 5119, 5132, 5120, 5130, 5133, 5123),
+			want:  OdinSecretaVento,
+		},
+		{
+			name:  "Semente de cristal",
+			items: items8(421, 422, 423, 424, 425, 426, 427),
+			want:  OdinSementeDeCristal,
+		},
+		{
+			name:  "Capa celestial",
+			items: items8(4127, 4127, 5135, 413, 413, 413, 413),
+			want:  OdinCapaCelestial,
+		},
+		{
+			name:  "no match falls back to Composição de Sets (0)",
+			items: items8(1, 2, 3, 4, 5, 6, 7),
+			want:  OdinNoMatch,
+		},
+		{
+			name:  "Item 747 blocks any recipe",
+			items: items8(413, 413, 413, 413, 413, 413, 413, 747),
+			want:  OdinNoMatch,
+		},
+		{
+			name:  "too few slots never matches",
+			items: []world.Item{{Index: 413}},
+			want:  OdinNoMatch,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := MatchOdin(cat, c.items); got != c.want {
+				t.Errorf("MatchOdin() = %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+func TestMatchOdinItemCelestial(t *testing.T) {
+	cat := Catalog{Extra: map[int]int{2000: 3000}}
+	items := items8(3000, 2000, 542, 5334, 5335, 5336, 5337)
+	items[0].Effects[0] = world.Effect{Effect: efSanc, Value: 9}   // level 9
+	items[1].Effects[0] = world.Effect{Effect: efSanc, Value: 250} // level 15 (REF_15)
+
+	if got := MatchOdin(cat, items); got != OdinItemCelestial {
+		t.Fatalf("MatchOdin() = %d, want OdinItemCelestial", got)
+	}
+
+	// Dropping Item[0]'s sanc below 9 must break the match.
+	items[0].Effects[0] = world.Effect{Effect: efSanc, Value: 8}
+	if got := MatchOdin(cat, items); got == OdinItemCelestial {
+		t.Errorf("MatchOdin() matched Item-celestial with Item[0] sanc 8 < 9")
+	}
+}
+
+func TestMatchOdinPlus12(t *testing.T) {
+	cat := Catalog{Pos: map[int]int{3140: 4}}
+	items := items8(4043, 4043, 3140, 5334, 5335, 5336, 5337)
+	items[2].Effects[0] = world.Effect{Effect: efSanc, Value: 234} // level 11 (REF_11)
+
+	if got := MatchOdin(cat, items); got != OdinPlus12 {
+		t.Fatalf("MatchOdin() = %d, want OdinPlus12", got)
+	}
+
+	// Target at +10 falls outside the match's own (10,15] window. Level 15
+	// DOES still match here — GetMatchCombineOdin's own gate is level<=15;
+	// the level>=15 reject is a SEPARATE pre-check Exec applies after the
+	// match (_MSG_CombineItemOdin.cpp:74), not part of MatchOdin itself.
+	items[2].Effects[0] = world.Effect{Effect: efSanc, Value: 230} // level 10
+	if got := MatchOdin(cat, items); got == OdinPlus12 {
+		t.Errorf("MatchOdin() matched +12+ at level 10")
+	}
+
+	// A disallowed nPos (not in the {2,4,8,16,32,64,128,192} set) also breaks it.
+	items[2].Effects[0] = world.Effect{Effect: efSanc, Value: 234}
+	cat.Pos[3140] = 1
+	if got := MatchOdin(cat, items); got == OdinPlus12 {
+		t.Errorf("MatchOdin() matched +12+ with a disallowed nPos")
+	}
+}
+
+func TestPlus12Rate(t *testing.T) {
+	items := items8(4043, 4043, 3140, 5334, 5335, 3338, 5337)
+	items[5].Effects[0] = world.Effect{Effect: efSanc, Value: 3}   // stone 3338 at level 3
+	items[2].Effects[0] = world.Effect{Effect: efSanc, Value: 234} // target level 11 (no penalty)
+
+	rate, protect := Plus12Rate(100, items)
+	// +1 per rune (5334, 5335, 5337 = 3 runes) * itemSancRate12[0]=1, plus the
+	// 3338 stone's own level-3 bonus itemSancRate12[3+1]=5, no REF_12+ penalty.
+	want := 100 + 3*itemSancRate12[0] + itemSancRate12[3+1]
+	if rate != want {
+		t.Errorf("rate = %d, want %d", rate, want)
+	}
+	if protect != 2 {
+		t.Errorf("protect = %d, want 2 (two 4043 items)", protect)
+	}
+}
+
+func TestPlus12RateAppliesLevelPenalty(t *testing.T) {
+	items := items8(0, 0, 3140)
+	items[2].Effects[0] = world.Effect{Effect: efSanc, Value: 238} // level 12
+	rate, _ := Plus12Rate(100, items)
+	if want := 100 - itemSancRate12Minus[0]; rate != want {
+		t.Errorf("rate = %d, want %d", rate, want)
+	}
+}
+
+func TestPlus12NewLevel(t *testing.T) {
+	cases := []struct {
+		level  int
+		want   int
+		wantOK bool
+	}{
+		{11, 12, true}, {12, 13, true}, {13, 14, true}, {14, 15, true},
+		{10, 10, false}, {15, 15, false},
+	}
+	for _, c := range cases {
+		got, ok := Plus12NewLevel(c.level)
+		if got != c.want || ok != c.wantOK {
+			t.Errorf("Plus12NewLevel(%d) = (%d, %v), want (%d, %v)", c.level, got, ok, c.want, c.wantOK)
+		}
+	}
+}
+
+func TestRollOdin(t *testing.T) {
+	cases := []struct {
+		raw  int
+		want int
+	}{
+		{0, 0}, {100, 100}, {101, 2}, {198, 99},
+	}
+	for _, c := range cases {
+		got := RollOdin(constRand{c.raw})
+		if got != c.want {
+			t.Errorf("RollOdin() with raw %d = %d, want %d", c.raw, got, c.want)
+		}
+	}
+}
+
+type constRand struct{ v int }
+
+func (c constRand) Intn(int) int { return c.v }

--- a/tmserver/internal/handler/chat.go
+++ b/tmserver/internal/handler/chat.go
@@ -228,7 +228,19 @@ const (
 // celestial-system-plan.md. Re-running after the flag is already set is idempotent.
 func (d *Dispatcher) destravarCelestial(w *world.World, s *world.Session, ninety bool) {
 	e := w.Entity(s.Conn)
-	if e == nil || e.ClassMaster != classMasterCelestial {
+	if e == nil {
+		return
+	}
+	d.destravarCelestialFor(w, s, e, ninety)
+}
+
+// destravarCelestialFor is destravarCelestial's body with the entity passed
+// explicitly, so other callers that already have one (e.g. combineOdin's
+// Destrave Lv40 recipe) don't need it registered in the world's connection
+// table — the same split useItem/useClasseItem and combineItemOdin/combineOdin
+// already use.
+func (d *Dispatcher) destravarCelestialFor(w *world.World, s *world.Session, e *world.Entity, ninety bool) {
+	if e.ClassMaster != classMasterCelestial {
 		d.log.Debug("destravar: not a celestial", "conn", s.Conn, "ninety", ninety)
 		return
 	}

--- a/tmserver/internal/handler/classe.go
+++ b/tmserver/internal/handler/classe.go
@@ -1,0 +1,65 @@
+package handler
+
+import (
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/refine"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// Classe A-E item range (_MSG_UseItem.cpp:4989): 4016-4020 are the plain
+// tiers, 4021-4025 the "(P)" variant — both contiguous 5-item ranges mapping
+// to the same tier 1..5 (A..E), matched against the target's EF_ITEMLEVEL.
+const classeALo = 4016
+
+// classeTier maps a Classe item's sIndex to its tier 1..5 (A..E)
+// (_MSG_UseItem.cpp:4989). Only meaningful for items already classified as
+// volClasses by the catalog; callers don't need to range-check idx first —
+// same as the legacy, which computes this arithmetically with no bounds check.
+func classeTier(idx int16) int {
+	return int(idx-classeALo)%5 + 1
+}
+
+// useClasseItem is the Classe A-E path of _MSG_UseItem (Vol==190,
+// _MSG_UseItem.cpp:4958-5012): dragging a Classe item onto an equipped piece
+// of gear at the matching EF_ITEMLEVEL grade rerolls its sanc (capped at +6)
+// and its two bonus stats (SetItemBonus2). The Classe item is always consumed
+// on a successful match; a gate failure resyncs the dragged slot instead.
+//
+// Deviates from Source in exactly one place: the DestType gate below is
+// `!= Equip` here, not the literal `!m->DestType` (which rejects DestType==0
+// == ITEM_PLACE_EQUIP, i.e. every legitimate target — the feature could never
+// fire as literally written). Every analogous gate elsewhere in this same
+// file (_MSG_UseItem.cpp:3779,3901,3979,4057) uses the correct polarity;
+// reproduced as a corrected typo, not a literal port.
+func (d *Dispatcher) useClasseItem(w *world.World, s *world.Session, e *world.Entity, body protocol.MsgUseItemBody, src int) {
+	dst := d.itemSlot(w, s, e, int(body.DestType), int(body.DestPos))
+	if dst == nil || dst.Empty() {
+		return // no such target slot — the legacy just logs and drops the message
+	}
+
+	if int(body.DestType) != world.ItemPlaceEquip {
+		d.notify(w, s, NoticeOnlyToEquips)
+		d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
+		return
+	}
+
+	mobType := d.itemAbility(*dst, efMobType)
+	if itemSanc(*dst) >= 10 || (mobType != 0 && mobType != 2) {
+		// Source sends no notice on this gate — just resyncs the dragged slot.
+		d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
+		return
+	}
+
+	if d.itemAbility(*dst, efItemLevel) != classeTier(e.Carry[src].Index) {
+		d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
+		return
+	}
+
+	refine.ClasseBonus(dst, d.itemPos[int(dst.Index)], func(n int) int { return w.Rand().Intn(n) }, d.itemAbility)
+
+	d.sendSlot(w, s, int(body.DestType), int(body.DestPos), *dst)
+	d.log.Info("classe item bonus reroll", "conn", s.Conn, "item", dst.Index, "effects", dst.Effects)
+	consumeOneItem(&e.Carry[src])
+	// The Classe slot is deliberately NOT re-sent on success, mirroring
+	// refineSucceed: the client already removed the item it dragged.
+}

--- a/tmserver/internal/handler/classe_test.go
+++ b/tmserver/internal/handler/classe_test.go
@@ -1,0 +1,252 @@
+package handler
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/refine"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// Classe items and a matched set of tier-1 gear, one per covered nPos.
+const (
+	itemClasseA  = 4016 // tier 1
+	itemClasseE  = 4020 // tier 5
+	itemClasseAP = 4021 // tier 1, "(P)" variant
+
+	itemHelmT1   = 6001 // nPos 2
+	itemChestT1  = 6002 // nPos 4
+	itemGloveT1  = 6003 // nPos 16
+	itemBootT1   = 6004 // nPos 32
+	itemWeaponT1 = 6005 // nPos 1 (uncovered by SetItemBonus2)
+)
+
+func classeCatalog() (map[int]int, map[int][]content.BaseEffect) {
+	pos := map[int]int{
+		itemHelmT1: nPosHelmForTest, itemChestT1: 4, itemGloveT1: 16, itemBootT1: 32, itemWeaponT1: 1,
+	}
+	effects := map[int][]content.BaseEffect{
+		itemHelmT1:   {{Eff: efItemLevel, Val: 1}},
+		itemChestT1:  {{Eff: efItemLevel, Val: 1}},
+		itemGloveT1:  {{Eff: efItemLevel, Val: 1}},
+		itemBootT1:   {{Eff: efItemLevel, Val: 1}},
+		itemWeaponT1: {{Eff: efItemLevel, Val: 1}},
+	}
+	return pos, effects
+}
+
+// nPosHelmForTest avoids importing the unexported refine.nPosHelm constant.
+const nPosHelmForTest = 2
+
+type classeFixture struct {
+	d *Dispatcher
+	w *world.World
+	s *world.Session
+	e *world.Entity
+}
+
+func newClasseFixture(t *testing.T, pos map[int]int, effects map[int][]content.BaseEffect) *classeFixture {
+	t.Helper()
+	d := New(Config{
+		Log: slog.New(slog.DiscardHandler),
+		ItemVolatiles: map[int]int{
+			itemClasseA: volClasses, itemClasseE: volClasses, itemClasseAP: volClasses,
+		},
+		ItemPos:     pos,
+		ItemEffects: effects,
+	})
+	w := world.New(world.Config{GridDim: 16}, slog.New(slog.DiscardHandler), nil, nil)
+	return &classeFixture{
+		d: d, w: w,
+		s: &world.Session{Conn: 1, Mode: world.UserPlay},
+		e: &world.Entity{ID: 1, HP: 100},
+	}
+}
+
+// use drags the classe item in carry slot 0 onto the item in carry slot 1.
+func (f *classeFixture) use(classe int16) {
+	f.e.Carry[0] = world.Item{Index: classe}
+	body := protocol.MsgUseItemBody{
+		SourType: world.ItemPlaceCarry, SourPos: 0,
+		DestType: world.ItemPlaceEquip, DestPos: 1,
+	}
+	f.d.useClasseItem(f.w, f.s, f.e, body, 0)
+}
+
+func (f *classeFixture) target() world.Item { return f.e.Equip[1] }
+
+func TestClasseTier(t *testing.T) {
+	cases := []struct {
+		idx  int16
+		want int
+	}{
+		{4016, 1}, {4017, 2}, {4018, 3}, {4019, 4}, {4020, 5},
+		{4021, 1}, {4022, 2}, {4023, 3}, {4024, 4}, {4025, 5},
+	}
+	for _, c := range cases {
+		if got := classeTier(c.idx); got != c.want {
+			t.Errorf("classeTier(%d) = %d, want %d", c.idx, got, c.want)
+		}
+	}
+}
+
+func TestClasseBonusHelmRerollsSancAndEffects(t *testing.T) {
+	pos, effects := classeCatalog()
+	f := newClasseFixture(t, pos, effects)
+	f.e.Equip[1] = world.Item{Index: itemHelmT1}
+
+	f.use(itemClasseA)
+
+	if !f.e.Carry[0].Empty() {
+		t.Errorf("classe item not consumed: %+v", f.e.Carry[0])
+	}
+	got := f.target()
+	if got.Effects[0].Effect != efSanc {
+		t.Errorf("Effects[0] = %+v, want EF_SANC", got.Effects[0])
+	}
+	if refine.Level(got) > classeSancCapForTest {
+		t.Errorf("sanc level %d exceeds the +6 cap", refine.Level(got))
+	}
+	if got.Effects[1].Effect == 0 || got.Effects[2].Effect == 0 {
+		t.Errorf("bonus effects not set: %+v", got.Effects)
+	}
+}
+
+// classeSancCapForTest avoids importing the unexported refine.classeSancCap.
+const classeSancCapForTest = 6
+
+func TestClasseUncoveredSlotConsumesButDoesNothing(t *testing.T) {
+	pos, effects := classeCatalog()
+	f := newClasseFixture(t, pos, effects)
+	f.e.Equip[1] = world.Item{Index: itemWeaponT1}
+	before := f.target()
+
+	f.use(itemClasseA)
+
+	if !f.e.Carry[0].Empty() {
+		t.Errorf("classe item not consumed: %+v", f.e.Carry[0])
+	}
+	if got := f.target(); got != before {
+		t.Errorf("uncovered nPos was mutated: %+v -> %+v", before, got)
+	}
+}
+
+func TestClasseGates(t *testing.T) {
+	pos, effects := classeCatalog()
+	mobTypeGated := map[int][]content.BaseEffect{}
+	for k, v := range effects {
+		mobTypeGated[k] = v
+	}
+	mobTypeGated[itemChestT1] = append(append([]content.BaseEffect{}, effects[itemChestT1]...), content.BaseEffect{Eff: efMobType, Val: 1})
+
+	cases := []struct {
+		name     string
+		classe   int16
+		target   world.Item
+		effects  map[int][]content.BaseEffect
+		wantSame bool // target unchanged, item still consumed
+	}{
+		{
+			name:     "tier mismatch is rejected",
+			classe:   itemClasseE,                    // tier 5
+			target:   world.Item{Index: itemChestT1}, // catalog tier 1
+			effects:  effects,
+			wantSame: true,
+		},
+		{
+			name:     "sanc >= +10 is rejected",
+			classe:   itemClasseA,
+			target:   world.Item{Index: itemChestT1, Effects: [3]world.Effect{{Effect: efSanc, Value: 230}}}, // level 10
+			effects:  effects,
+			wantSame: true,
+		},
+		{
+			name:     "EF_MOBTYPE outside {0,2} is rejected",
+			classe:   itemClasseA,
+			target:   world.Item{Index: itemChestT1},
+			effects:  mobTypeGated,
+			wantSame: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			f := newClasseFixture(t, pos, c.effects)
+			f.e.Equip[1] = c.target
+			f.use(c.classe)
+			if got := f.target(); got != c.target {
+				t.Errorf("target mutated on a gate failure: %+v -> %+v", c.target, got)
+			}
+			// The dragged classe item resyncs to its carry slot either way; the
+			// handler never destroys it on a gate failure.
+			if f.e.Carry[0].Empty() {
+				t.Errorf("classe item unexpectedly consumed on a gate failure")
+			}
+		})
+	}
+}
+
+func TestClasseRejectsCarryDestination(t *testing.T) {
+	pos, effects := classeCatalog()
+	f := newClasseFixture(t, pos, effects)
+	f.e.Carry[1] = world.Item{Index: itemChestT1}
+	f.e.Carry[0] = world.Item{Index: itemClasseA}
+
+	body := protocol.MsgUseItemBody{
+		SourType: world.ItemPlaceCarry, SourPos: 0,
+		DestType: world.ItemPlaceCarry, DestPos: 1,
+	}
+	f.d.useClasseItem(f.w, f.s, f.e, body, 0)
+
+	if f.e.Carry[0].Empty() {
+		t.Error("classe item consumed despite a non-Equip destination")
+	}
+	if f.e.Carry[1].Index != itemChestT1 {
+		t.Errorf("carry target mutated: %+v", f.e.Carry[1])
+	}
+}
+
+func TestClasseBootDamageClamp(t *testing.T) {
+	pos, effects := classeCatalog()
+	// itemBootT1's catalog carries a base EF_DAMAGE so a rolled bonus can push
+	// the total over the 30 clamp ceiling (Server.cpp:2845-2861).
+	clamped := map[int][]content.BaseEffect{}
+	for k, v := range effects {
+		clamped[k] = v
+	}
+	clamped[itemBootT1] = append(append([]content.BaseEffect{}, effects[itemBootT1]...), content.BaseEffect{Eff: efDamage, Val: 20})
+
+	f := newClasseFixture(t, pos, clamped)
+	f.e.Equip[1] = world.Item{Index: itemBootT1}
+
+	f.use(itemClasseA)
+
+	got := f.target()
+	for _, ef := range got.Effects[1:] {
+		if ef.Effect != efDamage {
+			continue
+		}
+		total := f.d.itemAbility(got, efDamage)
+		if total > 30 {
+			t.Errorf("boot EF_DAMAGE ability = %d, want <= 30 after the clamp", total)
+		}
+	}
+}
+
+func TestClasseConsumesOneUnitFromStack(t *testing.T) {
+	pos, effects := classeCatalog()
+	f := newClasseFixture(t, pos, effects)
+	f.e.Equip[1] = world.Item{Index: itemChestT1}
+	f.e.Carry[0] = world.Item{Index: itemClasseA, Effects: [3]world.Effect{{Effect: efAmount, Value: 3}}}
+
+	body := protocol.MsgUseItemBody{
+		SourType: world.ItemPlaceCarry, SourPos: 0,
+		DestType: world.ItemPlaceEquip, DestPos: 1,
+	}
+	f.d.useClasseItem(f.w, f.s, f.e, body, 0)
+
+	if got := itemAmount(f.e.Carry[0]); got != 2 {
+		t.Errorf("amount = %d, want 2 after consuming one unit", got)
+	}
+}

--- a/tmserver/internal/handler/combine.go
+++ b/tmserver/internal/handler/combine.go
@@ -32,10 +32,13 @@ type CombineFamily struct {
 }
 
 // combineItemTypes are the Item[]-based combine variants sharing the engine.
+// MsgCombineItemOdin is NOT here — its recipes don't fit the generic
+// CombineFamily{Rate,Apply} shape, so it gets its own dedicated handler
+// (combine_odin.go) instead.
 var combineItemTypes = []protocol.Type{
 	protocol.MsgCombineItem, protocol.MsgCombineItemEhre, protocol.MsgCombineItemTiny,
 	protocol.MsgCombineItemShany, protocol.MsgCombineItemAilyn, protocol.MsgCombineItemAgatha,
-	protocol.MsgCombineItemOdin, protocol.MsgCombineItemLindy, protocol.MsgCombineItemAlquimia,
+	protocol.MsgCombineItemLindy, protocol.MsgCombineItemAlquimia,
 }
 
 // defaultCombineFamily is the UNVERIFIED placeholder used until the recipe/rate
@@ -63,6 +66,36 @@ func anctApply(items []world.Item) world.Item {
 	return result
 }
 
+// resolveComboInputs validates a combine packet's claimed inputs against the
+// live carry slots (bounds + sameItem anti-cheat) — the skeleton every
+// Item[]-based combine variant shares, generic and Odin alike. It returns the
+// items and their carry slots still indexed by ORIGINAL combine-message
+// position (zero Item/slot where the client left that position empty), plus
+// the list of active positions in ascending order. ok is false once the
+// caller has already sent a response (RemoveTrade or _NN_Wrong_Combination)
+// and must return immediately without consuming anything.
+func (d *Dispatcher) resolveComboInputs(w *world.World, s *world.Session, e *world.Entity, body protocol.MsgCombineItemBody) (items [protocol.MaxCombine]world.Item, slots [protocol.MaxCombine]int, active []int, ok bool) {
+	active = make([]int, 0, protocol.MaxCombine)
+	for i := 0; i < protocol.MaxCombine; i++ {
+		if body.Item[i].Index == 0 {
+			continue
+		}
+		pos := int(body.InvenPos[i])
+		if pos < 0 || pos >= world.MaxCarry {
+			d.removeTrade(w, s) // out of range → RemoveTrade (anti-cheat)
+			return items, slots, active, false
+		}
+		if !sameItem(body.Item[i], e.Carry[pos]) {
+			w.Send(s, protocol.MsgCombineComplete, parmPayload(combineInvalid)) // changed/removed
+			return items, slots, active, false
+		}
+		items[i] = e.Carry[pos]
+		slots[i] = pos
+		active = append(active, i)
+	}
+	return items, slots, active, true
+}
+
 // combineItem is the shared engine handler for the Item[]-based variants. It
 // follows the original ORDER exactly: validate recipe FIRST (invalid ⇒ inputs
 // kept), then consume inputs, then roll — so a failed roll still consumes the
@@ -85,23 +118,15 @@ func (d *Dispatcher) combineItem(w *world.World, s *world.Session, h protocol.He
 		return
 	}
 
-	var items []world.Item
-	var slots []int
-	for i := 0; i < protocol.MaxCombine; i++ {
-		if body.Item[i].Index == 0 {
-			continue
-		}
-		pos := int(body.InvenPos[i])
-		if pos < 0 || pos >= world.MaxCarry {
-			d.removeTrade(w, s) // out of range → RemoveTrade (anti-cheat)
-			return
-		}
-		if !sameItem(body.Item[i], e.Carry[pos]) {
-			w.Send(s, protocol.MsgCombineComplete, parmPayload(combineInvalid)) // changed/removed
-			return
-		}
-		items = append(items, e.Carry[pos])
-		slots = append(slots, pos)
+	byPos, slotByPos, active, ok := d.resolveComboInputs(w, s, e, body)
+	if !ok {
+		return
+	}
+	items := make([]world.Item, len(active))
+	slots := make([]int, len(active))
+	for i, pos := range active {
+		items[i] = byPos[pos]
+		slots[i] = slotByPos[pos]
 	}
 
 	rate := 0

--- a/tmserver/internal/handler/combine_catalog.go
+++ b/tmserver/internal/handler/combine_catalog.go
@@ -15,6 +15,7 @@ func NewCombineCatalog(items *content.ItemList, comp *content.CompRate) combine.
 		Extra:      items.Extras(),
 		Effects:    items.BaseEffects(),
 		AnctChance: comp.AnctChance(),
+		Pos:        items.Positions(),
 	}
 }
 

--- a/tmserver/internal/handler/combine_odin.go
+++ b/tmserver/internal/handler/combine_odin.go
@@ -1,0 +1,249 @@
+package handler
+
+import (
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/combine"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/refine"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// odinRate is g_pOdinRate[12] (Basedef.cpp:95-99), indexed by recipe id.
+var odinRate = [12]int{100, 35, 100, 40, 100, 100, 100, 100, 100, 100, 100, 100}
+
+// Odin recipe result item indices (_MSG_CombineItemOdin.cpp). The Capa
+// Celestial recipe targets the same cape slot as reinoCapeSlot (chat.go).
+const (
+	odinPistaDeRunasResult     = 5134
+	odinPedraDaFuriaResult     = 3020
+	odinSecretaBase            = 5334 // água=5334, terra=+1, sol=+2, vento=+3
+	odinSementeDeCristalResult = 4032
+)
+
+// combineItemOdin handles _MSG_CombineItemOdin (0x02D2): the 11-recipe Odin
+// family (Composição de Sets / de armas, the "+12+" +11→+15 refine tier,
+// Pista de runas, Destrave Lv40, Pedra da fúria, the 4 Secreta stones,
+// Semente de cristal, Capa celestial). This is a dedicated handler, not part
+// of the generic CombineFamily engine (combine.go): unlike Anct/Ehre/…, these
+// recipes don't share a "rate in, one result at slot 0" shape — results land
+// at varying slots, one recipe mutates equipped gear directly (Equip[15]),
+// and one sets a quest flag with no item at all.
+//
+// combine.MatchOdin returning combine.OdinNoMatch (0) is NOT "invalid" the
+// way a 0 rate is for every other combine family: GetMatchCombineOdin's
+// default return IS "Composição de Sets", a real (near-always-succeeding)
+// recipe keyed off Item[0]'s catalog Extra field — Exec always attempts it.
+// There is no "no recipe matched" rejection anywhere in the legacy handler.
+//
+// Two deliberate deviations from Source (issue #138 plan): the wall-clock
+// srand() reseeds sprinkled through _MSG_CombineItemOdin.cpp are dropped —
+// roll straight off w.Rand(), like every other combine/refine path; and the
+// "+12+" recipe's failure branch, byte-identical to its success branch in the
+// live (uncommented) code, is ported as it actually runs: it always succeeds
+// once the pre-checks below pass.
+func (d *Dispatcher) combineItemOdin(w *world.World, s *world.Session, _ protocol.Header, payload []byte) {
+	e := w.Entity(s.Conn)
+	if e == nil || e.HP <= 0 || s.Mode != world.UserPlay {
+		return
+	}
+	d.combineOdin(w, s, e, payload)
+}
+
+// combineOdin is combineItemOdin's body, split out (like useItem/useClasseItem)
+// so tests can drive it with an explicit entity instead of needing one
+// registered in the world's connection table.
+func (d *Dispatcher) combineOdin(w *world.World, s *world.Session, e *world.Entity, payload []byte) {
+	var body protocol.MsgCombineItemBody
+	if err := body.Decode(payload); err != nil {
+		return
+	}
+
+	items, slots, active, ok := d.resolveComboInputs(w, s, e, body)
+	if !ok {
+		return
+	}
+
+	id := combine.MatchOdin(d.odinCatalog, items[:])
+
+	// Recipe-specific pre-gates (_MSG_CombineItemOdin.cpp:48-90): fail here
+	// WITHOUT consuming anything, unlike every other outcome below. The two
+	// locals below carry a value each gate already had to compute on to its
+	// matching branch further down, instead of recomputing it there.
+	//
+	// Deviation from Source, not in the plan's three flagged ones but same
+	// spirit: id 0 (Composição de Sets, the catch-all "nothing else matched"
+	// default) is the one recipe whose pattern places no constraint on
+	// Item[1] at all. Source still blindly writes to Carry[m->InvenPos[1]]
+	// even when Item[1] was empty and its InvenPos never validated against
+	// anything the player actually offered — an arbitrary-slot-overwrite
+	// hazard this fork's single-owner/no-dup invariant (CLAUDE.md) can't
+	// allow. Require slot 1 to have been a real, validated input.
+	if (id == combine.OdinNoMatch || id == combine.OdinItemCelestial) && items[1].Empty() {
+		w.Send(s, protocol.MsgCombineComplete, parmPayload(combineInvalid))
+		return
+	}
+	var targetLevel, capeLevel int
+	switch id {
+	case combine.OdinPlus12:
+		targetLevel = refine.Level(items[2])
+		if odinSecretaUneven(items[:]) || targetLevel >= 15 || d.itemAbility(items[2], efMobType) == 3 {
+			w.Send(s, protocol.MsgCombineComplete, parmPayload(combineInvalid))
+			return
+		}
+	case combine.OdinDestraveLv40:
+		if e.Level != 39 || e.CelLv40 != 0 || e.ClassMaster != classMasterCelestial {
+			w.Send(s, protocol.MsgCombineComplete, parmPayload(combineInvalid))
+			return
+		}
+	case combine.OdinCapaCelestial:
+		capeLevel = itemSanc(e.Equip[reinoCapeSlot])
+		if e.ClassMaster == classMasterMortal || e.ClassMaster == classMasterArch || capeLevel >= 9 {
+			w.Send(s, protocol.MsgCombineComplete, parmPayload(combineInvalid))
+			return
+		}
+	}
+
+	// Consume every active input slot unconditionally — the ingredients are
+	// spent whether or not the recipe below ultimately produces anything
+	// (_MSG_CombineItemOdin.cpp:93-100), the same "spent either way" rule the
+	// dust refine and Anct combine already follow.
+	for _, i := range active {
+		e.Carry[slots[i]] = world.Item{}
+		w.Send(s, protocol.MsgSendItem, slotPayload(slots[i]))
+	}
+
+	roll := combine.RollOdin(w.Rand())
+
+	switch id {
+	case combine.OdinNoMatch, combine.OdinItemCelestial:
+		d.odinComposicao(w, s, e, items[0], items[1], slots[1], id, roll)
+	case combine.OdinPlus12:
+		d.odinPlus12(w, s, e, items[:], slots[2], targetLevel)
+	case combine.OdinPistaDeRunas:
+		d.odinFreshResult(w, s, e, slots[0], odinPistaDeRunasResult, roll, id)
+	case combine.OdinDestraveLv40:
+		d.odinDestraveLv40(w, s, e, roll)
+	case combine.OdinPedraDaFuria:
+		d.odinFreshResult(w, s, e, slots[0], odinPedraDaFuriaResult, roll, id)
+	case combine.OdinSecretaAgua, combine.OdinSecretaTerra, combine.OdinSecretaSol, combine.OdinSecretaVento:
+		d.odinFreshResult(w, s, e, slots[0], int16(odinSecretaBase+(id-combine.OdinSecretaAgua)), roll, id)
+	case combine.OdinSementeDeCristal:
+		d.odinFreshResult(w, s, e, slots[0], odinSementeDeCristalResult, roll, id)
+	case combine.OdinCapaCelestial:
+		d.odinCapaCelestial(w, s, e, roll, capeLevel)
+	}
+}
+
+// odinSecretaUneven is the "+12+" recipe's four-elemental-stone cross-check
+// (_MSG_CombineItemOdin.cpp:50-71): among the 8 slots, the four Secreta
+// stones (água/terra/sol/vento, 5334-5337) must be either all absent or all
+// present — one, two, or three present alone is rejected.
+func odinSecretaUneven(items []world.Item) bool {
+	var agua, terra, sol, vento bool
+	for _, it := range items {
+		switch it.Index {
+		case 5334:
+			agua = true
+		case 5335:
+			terra = true
+		case 5336:
+			sol = true
+		case 5337:
+			vento = true
+		}
+	}
+	some := agua || terra || sol || vento
+	all := agua && terra && sol && vento
+	return some && !all
+}
+
+// odinComposicao is id 0 ("Composição de Sets") and id 1 ("Composição de
+// armas") — the two share an identical shape in Source, differing only in
+// their success rate. On success, item[1] is relabeled to catalyst's Extra
+// and its sanc reset to 0; on failure item[1] is restored unchanged. Either
+// way item[0] (the catalyst/selado) stays consumed.
+func (d *Dispatcher) odinComposicao(w *world.World, s *world.Session, e *world.Entity, catalyst, base world.Item, baseSlot int, id, roll int) {
+	rate := odinRate[id] + w.Rand().Intn(5)
+	if roll > rate {
+		e.Carry[baseSlot] = base
+		w.Send(s, protocol.MsgSendItem, slotPayload(baseSlot))
+		w.Send(s, protocol.MsgCombineComplete, parmPayload(combineFailed))
+		return
+	}
+	result := base
+	if extra := d.odinCatalog.Extra[int(catalyst.Index)]; extra > 0 {
+		result.Index = int16(extra)
+	}
+	refine.Set(&result, 0, 0)
+	e.Carry[baseSlot] = result
+	w.Send(s, protocol.MsgSendItem, slotPayload(baseSlot))
+	w.Send(s, protocol.MsgCombineComplete, parmPayload(combineSuccess))
+}
+
+// odinPlus12 is id 2, the "+11→+15" refine tier. Per the issue #138 plan
+// (the live failure branch is a byte-identical copy of the success branch,
+// with the real rate-gated failure entirely commented out in Source), this
+// always succeeds once the caller's pre-gate has passed: the accumulated
+// rate is still computed and logged (useful for future economy tuning) but
+// does not gate the outcome. level is items[2]'s current refine level, already
+// computed by the caller's pre-gate.
+func (d *Dispatcher) odinPlus12(w *world.World, s *world.Session, e *world.Entity, items []world.Item, targetSlot, level int) {
+	rate, protect := combine.Plus12Rate(odinRate[combine.OdinPlus12], items)
+	newLevel, ok := combine.Plus12NewLevel(level)
+	if !ok {
+		newLevel = level
+	}
+	result := items[2]
+	refine.Set(&result, newLevel, refine.Gem(items[2]))
+	e.Carry[targetSlot] = result
+	w.Send(s, protocol.MsgSendItem, slotPayload(targetSlot))
+	w.Send(s, protocol.MsgCombineComplete, parmPayload(combineSuccess))
+	d.log.Info("odin +12+ refine", "conn", s.Conn, "from", level, "to", newLevel, "rate", rate, "protect", protect)
+}
+
+// odinFreshResult covers the recipes whose result is a bare item stamped
+// straight into an already-cleared slot (Pista de runas, Pedra da fúria, the
+// 4 Secreta stones, Semente de cristal): Source assigns only .sIndex onto the
+// slot the consume loop already zeroed, so — unlike odinComposicao/odinPlus12
+// — no prior effects/amount survive. On failure the slot is left empty; none
+// of these recipes restores anything (_MSG_CombineItemOdin.cpp:517-650).
+func (d *Dispatcher) odinFreshResult(w *world.World, s *world.Session, e *world.Entity, slot int, result int16, roll, id int) {
+	if roll > odinRate[id] {
+		w.Send(s, protocol.MsgCombineComplete, parmPayload(combineFailed))
+		return
+	}
+	e.Carry[slot] = world.Item{Index: result}
+	w.Send(s, protocol.MsgSendItem, slotPayload(slot))
+	w.Send(s, protocol.MsgCombineComplete, parmPayload(combineSuccess))
+}
+
+// odinDestraveLv40 is id 4: no item is produced, only the Celestial level-40
+// gate flips. Reuses destravarCelestial (chat.go), the same flag /destravar40
+// already sets — the caller's pre-gate already confirmed Level==39,
+// CelLv40==0 and ClassMaster==Celestial.
+func (d *Dispatcher) odinDestraveLv40(w *world.World, s *world.Session, e *world.Entity, roll int) {
+	if roll > odinRate[combine.OdinDestraveLv40] {
+		w.Send(s, protocol.MsgCombineComplete, parmPayload(combineFailed))
+		return
+	}
+	d.destravarCelestialFor(w, s, e, false) // sends its own MsgCombineComplete + persists
+}
+
+// odinCapaCelestial is id 11: no combine input slot is touched here (they
+// were already consumed above) — the equipped cape (Equip[15]) gets its sanc
+// bumped by one, bootstrapping a fresh EF_SANC pair first if it has none yet.
+// The caller's pre-gate already confirmed the class/cape-sanc requirements and
+// computed level, the cape's current refine level.
+func (d *Dispatcher) odinCapaCelestial(w *world.World, s *world.Session, e *world.Entity, roll, level int) {
+	if roll > odinRate[combine.OdinCapaCelestial] {
+		w.Send(s, protocol.MsgCombineComplete, parmPayload(combineFailed))
+		return
+	}
+	cape := &e.Equip[reinoCapeSlot]
+	if !refine.Bootstrap(cape) {
+		w.Send(s, protocol.MsgCombineComplete, parmPayload(combineFailed))
+		return
+	}
+	refine.Set(cape, level+1, 0)
+	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceEquip, reinoCapeSlot, itemToSel(*cape)))
+	w.Send(s, protocol.MsgCombineComplete, parmPayload(combineSuccess))
+}

--- a/tmserver/internal/handler/combine_odin_test.go
+++ b/tmserver/internal/handler/combine_odin_test.go
@@ -1,0 +1,303 @@
+package handler
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/combine"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// odinFixture wires a fresh Dispatcher/world per test — each gets the CRT
+// default seed (1), so the FIRST roll off w.Rand() is always the same,
+// empirically observed value (RollOdin() = 41; see the per-test comments
+// below for how that value plays out against each recipe's rate).
+type odinFixture struct {
+	d    *Dispatcher
+	w    *world.World
+	s    *world.Session
+	e    *world.Entity
+	body protocol.MsgCombineItemBody
+}
+
+func newOdinFixture(t *testing.T, cat combine.Catalog, effects map[int][]content.BaseEffect) *odinFixture {
+	t.Helper()
+	d := New(Config{
+		Log:         slog.New(slog.DiscardHandler),
+		OdinCatalog: cat,
+		ItemEffects: effects,
+	})
+	w := world.New(world.Config{GridDim: 16}, slog.New(slog.DiscardHandler), nil, nil)
+	return &odinFixture{
+		d: d, w: w,
+		s: &world.Session{Conn: 1, Mode: world.UserPlay},
+		e: &world.Entity{ID: 1, HP: 100},
+	}
+}
+
+// place puts it into carry slot i (== combine position i) and records it in
+// the wire body that send() will submit.
+func (f *odinFixture) place(i int, it world.Item) {
+	f.e.Carry[i] = it
+	f.body.Item[i] = wireFromItem(it)
+	f.body.InvenPos[i] = uint8(i)
+}
+
+// placeAll places idx[i] at combine position i for i in range, a shorthand
+// for recipes whose test cases only vary entity/equip state, not ingredients.
+func (f *odinFixture) placeAll(idx ...int16) {
+	for i, v := range idx {
+		f.place(i, world.Item{Index: v})
+	}
+}
+
+var (
+	destraveLv40Ingredients  = []int16{4127, 4127, 5135, 5113, 5129, 5112, 5110}
+	capaCelestialIngredients = []int16{4127, 4127, 5135, 413, 413, 413, 413}
+)
+
+func (f *odinFixture) send() {
+	f.d.combineOdin(f.w, f.s, f.e, f.body.Encode())
+}
+
+func TestCombineOdinComposicaoDeSetsSucceeds(t *testing.T) {
+	// No numbered recipe matches (id 0, Composição de Sets) — rate is
+	// 100+Intn(5), always >= the 0..100 roll range, so this always succeeds.
+	cat := combine.Catalog{Extra: map[int]int{1902: 3626}}
+	f := newOdinFixture(t, cat, nil)
+	f.place(0, world.Item{Index: 1902})
+	f.place(1, world.Item{Index: 800})
+	f.send()
+
+	if !f.e.Carry[0].Empty() {
+		t.Errorf("catalyst not consumed: %+v", f.e.Carry[0])
+	}
+	got := f.e.Carry[1]
+	if got.Index != 3626 {
+		t.Errorf("result index = %d, want 3626 (Extra[1902])", got.Index)
+	}
+	if itemSanc(got) != 0 {
+		t.Errorf("result sanc = %d, want 0", itemSanc(got))
+	}
+}
+
+func TestCombineOdinComposicaoDeArmasFailsOnFirstRoll(t *testing.T) {
+	// id 1 (Item celestial pattern → "Composição de armas" execution): rate
+	// 35+Intn(5). With a fresh seed-1 world the first roll is 41 and the
+	// bonus is 2 (rate 37), so 41 > 37 fails — the base item comes back
+	// unchanged, only the catalyst/stones are lost.
+	cat := combine.Catalog{Extra: map[int]int{2000: 3000}}
+	f := newOdinFixture(t, cat, nil)
+	f.place(0, world.Item{Index: 3000, Effects: [3]world.Effect{{Effect: efSanc, Value: 9}}})
+	f.place(1, world.Item{Index: 2000, Effects: [3]world.Effect{{Effect: efSanc, Value: 250}}}) // level 15
+	f.place(2, world.Item{Index: 542})
+	f.place(3, world.Item{Index: 5334})
+	f.place(4, world.Item{Index: 5335})
+	f.place(5, world.Item{Index: 5336})
+	f.place(6, world.Item{Index: 5337})
+	f.send()
+
+	if !f.e.Carry[0].Empty() {
+		t.Errorf("catalyst not consumed: %+v", f.e.Carry[0])
+	}
+	if got := f.e.Carry[1]; got.Index != 2000 {
+		t.Errorf("base item = %+v, want restored unchanged (Index 2000)", got)
+	}
+	for i := 2; i <= 6; i++ {
+		if !f.e.Carry[i].Empty() {
+			t.Errorf("stone slot %d not consumed: %+v", i, f.e.Carry[i])
+		}
+	}
+}
+
+func TestCombineOdinPlus12AlwaysSucceedsPostGate(t *testing.T) {
+	cat := combine.Catalog{Pos: map[int]int{3140: 4}}
+	f := newOdinFixture(t, cat, nil)
+	f.place(0, world.Item{Index: 4043})
+	f.place(1, world.Item{Index: 4043})
+	f.place(2, world.Item{Index: 3140, Effects: [3]world.Effect{{Effect: efSanc, Value: 234}}}) // level 11
+	f.place(3, world.Item{Index: 5334})
+	f.place(4, world.Item{Index: 5335})
+	f.place(5, world.Item{Index: 5336})
+	f.place(6, world.Item{Index: 5337})
+	f.send()
+
+	got := f.e.Carry[2]
+	if got.Index != 3140 {
+		t.Errorf("target index changed: %+v", got)
+	}
+	if lvl := itemSanc(got); lvl != 12 {
+		t.Errorf("level = %d, want 12 (11 -> 12)", lvl)
+	}
+}
+
+func TestCombineOdinPlus12RejectsLevelOutOfRange(t *testing.T) {
+	cat := combine.Catalog{Pos: map[int]int{3140: 4}}
+	f := newOdinFixture(t, cat, nil)
+	f.place(0, world.Item{Index: 4043})
+	f.place(1, world.Item{Index: 4043})
+	f.place(2, world.Item{Index: 3140, Effects: [3]world.Effect{{Effect: efSanc, Value: 250}}}) // level 15
+	f.place(3, world.Item{Index: 5334})
+	f.place(4, world.Item{Index: 5335})
+	f.place(5, world.Item{Index: 5336})
+	f.place(6, world.Item{Index: 5337})
+	f.send()
+
+	// The pre-gate rejects level >= 15 without consuming anything.
+	if f.e.Carry[2].Index != 3140 || itemSanc(f.e.Carry[2]) != 15 {
+		t.Errorf("target mutated on a pre-gate reject: %+v", f.e.Carry[2])
+	}
+	if f.e.Carry[0].Empty() {
+		t.Error("inputs consumed despite a pre-gate reject")
+	}
+}
+
+func TestCombineOdinPistaDeRunasFailsOnFirstRoll(t *testing.T) {
+	// rate 40, flat (no bonus roll); first roll from a fresh world is 41 > 40.
+	f := newOdinFixture(t, combine.Catalog{}, nil)
+	for i := 0; i < 7; i++ {
+		f.place(i, world.Item{Index: 413})
+	}
+	f.send()
+
+	if !f.e.Carry[0].Empty() {
+		t.Errorf("slot 0 = %+v, want empty (failed, no restore)", f.e.Carry[0])
+	}
+}
+
+func TestCombineOdinPedraDaFuriaSucceeds(t *testing.T) {
+	f := newOdinFixture(t, combine.Catalog{}, nil)
+	f.place(0, world.Item{Index: 5125})
+	f.place(1, world.Item{Index: 5115})
+	f.place(2, world.Item{Index: 5111})
+	f.place(3, world.Item{Index: 5112})
+	f.place(4, world.Item{Index: 5120})
+	f.place(5, world.Item{Index: 5128})
+	f.place(6, world.Item{Index: 5119})
+	f.send()
+
+	if got := f.e.Carry[0]; got.Index != odinPedraDaFuriaResult {
+		t.Errorf("result = %+v, want Index %d", got, odinPedraDaFuriaResult)
+	}
+	if !f.e.Carry[1].Empty() {
+		t.Errorf("slot 1 not consumed: %+v", f.e.Carry[1])
+	}
+}
+
+func TestCombineOdinSecretaVentoSucceeds(t *testing.T) {
+	f := newOdinFixture(t, combine.Catalog{}, nil)
+	f.place(0, world.Item{Index: 5122})
+	f.place(1, world.Item{Index: 5119})
+	f.place(2, world.Item{Index: 5132})
+	f.place(3, world.Item{Index: 5120})
+	f.place(4, world.Item{Index: 5130})
+	f.place(5, world.Item{Index: 5133})
+	f.place(6, world.Item{Index: 5123})
+	f.send()
+
+	want := int16(odinSecretaBase + 3) // vento = base+3
+	if got := f.e.Carry[0]; got.Index != want {
+		t.Errorf("result = %+v, want Index %d", got, want)
+	}
+}
+
+func TestCombineOdinSementeDeCristalSucceeds(t *testing.T) {
+	f := newOdinFixture(t, combine.Catalog{}, nil)
+	f.place(0, world.Item{Index: 421})
+	f.place(1, world.Item{Index: 422})
+	f.place(2, world.Item{Index: 423})
+	f.place(3, world.Item{Index: 424})
+	f.place(4, world.Item{Index: 425})
+	f.place(5, world.Item{Index: 426})
+	f.place(6, world.Item{Index: 427})
+	f.send()
+
+	if got := f.e.Carry[0]; got.Index != odinSementeDeCristalResult {
+		t.Errorf("result = %+v, want Index %d", got, odinSementeDeCristalResult)
+	}
+}
+
+func TestCombineOdinDestraveLv40Succeeds(t *testing.T) {
+	f := newOdinFixture(t, combine.Catalog{}, nil)
+	f.e.Level = 39
+	f.e.ClassMaster = classMasterCelestial
+	f.placeAll(destraveLv40Ingredients...)
+	f.send()
+
+	if f.e.CelLv40 == 0 {
+		t.Error("CelLv40 not set on success")
+	}
+}
+
+func TestCombineOdinDestraveLv40RejectsWrongLevel(t *testing.T) {
+	f := newOdinFixture(t, combine.Catalog{}, nil)
+	f.e.Level = 38 // not 39
+	f.e.ClassMaster = classMasterCelestial
+	f.placeAll(destraveLv40Ingredients...)
+	f.send()
+
+	if f.e.CelLv40 != 0 {
+		t.Error("CelLv40 set despite failing the level gate")
+	}
+	if f.e.Carry[0].Empty() {
+		t.Error("inputs consumed despite a pre-gate reject")
+	}
+}
+
+func TestCombineOdinCapaCelestialBumpsSanc(t *testing.T) {
+	f := newOdinFixture(t, combine.Catalog{}, nil)
+	f.e.ClassMaster = classMasterCelestial
+	f.e.Equip[15] = world.Item{Index: 550}
+	f.placeAll(capaCelestialIngredients...)
+	f.send()
+
+	if lvl := itemSanc(f.e.Equip[15]); lvl != 1 {
+		t.Errorf("cape sanc = %d, want 1", lvl)
+	}
+}
+
+func TestCombineOdinCapaCelestialRejectsMortal(t *testing.T) {
+	f := newOdinFixture(t, combine.Catalog{}, nil)
+	f.e.ClassMaster = classMasterMortal
+	f.e.Equip[15] = world.Item{Index: 550}
+	f.placeAll(capaCelestialIngredients...)
+	f.send()
+
+	if got := itemSanc(f.e.Equip[15]); got != 0 {
+		t.Errorf("cape sanc = %d, want 0 (Mortal rejected)", got)
+	}
+	if f.e.Carry[0].Empty() {
+		t.Error("inputs consumed despite a pre-gate reject")
+	}
+}
+
+func TestCombineOdinNoMatchWithEmptySlot1IsRejected(t *testing.T) {
+	// Item[1] absent (unvalidated InvenPos) must not fall through to
+	// Composição de Sets writing onto some other, unrelated carry slot.
+	cat := combine.Catalog{Extra: map[int]int{999: 111}}
+	f := newOdinFixture(t, cat, nil)
+	f.e.Carry[3] = world.Item{Index: 5000} // an unrelated item sitting in carry slot 3
+	f.place(0, world.Item{Index: 999})
+	f.send()
+
+	if got := f.e.Carry[3]; got.Index != 5000 {
+		t.Errorf("unrelated slot 3 mutated: %+v", got)
+	}
+	if f.e.Carry[0].Empty() {
+		t.Error("catalyst consumed despite the missing-slot-1 guard")
+	}
+}
+
+func TestCombineOdinAntiCheatRejectsChangedItem(t *testing.T) {
+	f := newOdinFixture(t, combine.Catalog{}, nil)
+	f.e.Carry[0] = world.Item{Index: 999} // differs from what the body claims
+	f.body.Item[0] = protocol.WireItem{Index: 413}
+	f.body.InvenPos[0] = 0
+	f.send()
+
+	if f.e.Carry[0].Index != 999 {
+		t.Errorf("carry mutated despite anti-cheat mismatch: %+v", f.e.Carry[0])
+	}
+}

--- a/tmserver/internal/handler/dispatch.go
+++ b/tmserver/internal/handler/dispatch.go
@@ -15,6 +15,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/combine"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/level"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/npccfg"
@@ -34,6 +35,12 @@ type Config struct {
 	// CombineFamilies overrides the per-Type combine recipe/rate logic. When nil,
 	// UNVERIFIED placeholders are installed (every recipe reports "no match").
 	CombineFamilies map[protocol.Type]CombineFamily
+
+	// OdinCatalog is the item metadata combineItemOdin needs (MatchOdin's Extra
+	// lookup, Plus12's nPos gate). NewCombineCatalog builds it the same way
+	// DefaultCombineFamilies does. When zero, every Odin recipe still matches by
+	// sIndex, but Composição de Sets/armas can't resolve a result item.
+	OdinCatalog combine.Catalog
 
 	// BaseMobs are the per-class STRUCT_MOB templates (class index → raw 816 bytes,
 	// content.LoadBaseMobs). Used to render a character on entering the world with
@@ -116,6 +123,7 @@ type Dispatcher struct {
 	routes          map[protocol.Type]handlerFunc
 	fails           map[string]int // wrong-password count per account (CheckFailAccount)
 	combineFamilies map[protocol.Type]CombineFamily
+	odinCatalog     combine.Catalog
 	baseMobs        map[int][]byte               // per-class STRUCT_MOB templates
 	summonMobs      [][]byte                     // BM evocation templates (summon id → STRUCT_MOB)
 	vineMob         []byte                       // Sephira Muro de Espinhos template
@@ -185,6 +193,7 @@ func New(cfg Config) *Dispatcher {
 		routes:          make(map[protocol.Type]handlerFunc),
 		fails:           make(map[string]int),
 		combineFamilies: cfg.CombineFamilies,
+		odinCatalog:     cfg.OdinCatalog,
 		baseMobs:        cfg.BaseMobs,
 		summonMobs:      cfg.SummonMobs,
 		vineMob:         cfg.VineMob,
@@ -277,6 +286,7 @@ func New(cfg Config) *Dispatcher {
 		d.routes[ty] = d.combineItem
 	}
 	d.routes[protocol.MsgCombineItemExtracao] = d.combineExtracao
+	d.routes[protocol.MsgCombineItemOdin] = d.combineItemOdin
 	// Batch 7 — party & guild.
 	d.routes[protocol.MsgSendReqParty] = d.sendReqParty
 	d.routes[protocol.MsgAcceptParty] = d.acceptParty

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -277,7 +277,6 @@ const (
 	volWaterMLo, volWaterMHi = 21, 30   // Pergaminho da Água (M), _MSG_UseItem.cpp:1726
 	volWaterNLo, volWaterNHi = 131, 140 // Pergaminho da Água (N), _MSG_UseItem.cpp:1920
 	volWaterALo, volWaterAHi = 161, 170 // Pergaminho da Água (A), _MSG_UseItem.cpp:2025
-	volClasses               = 190      // Classes A-E, _MSG_UseItem.cpp:4959
 
 	// itemSeloDoGuerreiro and itemPedraMisteriosa carry no EF_VOLATILE in the
 	// catalog (BASE_GetItemAbility falls back to 0), so the legacy — and this
@@ -285,6 +284,14 @@ const (
 	itemSeloDoGuerreiro = 4146
 	itemPedraMisteriosa = 4148
 )
+
+// volClasses (Classes A-E, _MSG_UseItem.cpp:4959) is handled by useClasseItem
+// (classe.go), NOT rejectUnimplementedConsumable: unlike the water scrolls
+// above, its logic — the #pragma region Classe block, SetItemBonus2
+// (Server.cpp:2719-2861), and the four g_pBonusValue2..5 tables
+// (Basedef.cpp:353-529) — is fully present in Source/. The issue #135 fix
+// lumped it in with the genuinely-missing cases by mistake.
+const volClasses = 190
 
 // potionDelay is the minimum ms between potion uses (_MSG_UseItem.cpp:105-115).
 // The original defaults to 100 and exposes it to the runtime config (Server.cpp:647,
@@ -366,10 +373,11 @@ func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header
 		d.useChocolateDoAmor(w, s, e, src)
 	case vol == volCoracaoDoce:
 		d.useCoracaoDoce(w, s, e, src)
+	case vol == volClasses:
+		d.useClasseItem(w, s, e, body, src)
 	case vol >= volWaterMLo && vol <= volWaterMHi,
 		vol >= volWaterNLo && vol <= volWaterNHi,
-		vol >= volWaterALo && vol <= volWaterAHi,
-		vol == volClasses:
+		vol >= volWaterALo && vol <= volWaterAHi:
 		// issue #135: real behavior needs data absent from Source/ (see the const
 		// block above) — reject honestly instead of no-op'ing, so the client never
 		// shows a consumption the next slot resync would revert.
@@ -429,11 +437,10 @@ func (d *Dispatcher) useQuest256Ticket(w *world.World, s *world.Session, e *worl
 
 // rejectUnimplementedConsumable answers _MSG_UseItem for a consumable whose real
 // effect this fork can't implement with parity (issue #135: the water-scroll
-// dungeon coordinates, the Celestial-class swap, and the item-bonus reroll all
-// depend on data/algorithms that don't exist anywhere in the available Source/
-// tree). Unlike a silent no-op, this tells the client plainly that nothing
-// happened and re-syncs the slot, so it never shows a phantom consumption that a
-// later move/trade would "revert".
+// dungeon coordinates depend on data/algorithms that don't exist anywhere in
+// the available Source/ tree). Unlike a silent no-op, this tells the client
+// plainly that nothing happened and re-syncs the slot, so it never shows a
+// phantom consumption that a later move/trade would "revert".
 func (d *Dispatcher) rejectUnimplementedConsumable(w *world.World, s *world.Session, e *world.Entity, src int) {
 	d.notify(w, s, NoticeCantUseHere)
 	d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])

--- a/tmserver/internal/protocol/messages.go
+++ b/tmserver/internal/protocol/messages.go
@@ -647,11 +647,11 @@ func EncodeStandardParm3(parm1, parm2, parm3 int32) []byte {
 	return b
 }
 
-// MaxCombine is the number of input slots in a combine packet.
-//
-// UNVERIFIED: MAX_COMBINE is not documented; placeholder (game-rules.md §3 /
-// _MSG_CombineItem.cpp). The base Anct uses Item[0] (base) and Item[1] (jewel).
-const MaxCombine = 6
+// MaxCombine is the number of input slots in a combine packet: MAX_COMBINE
+// (Basedef.h:173). The base Anct recipe only uses Item[0]/Item[1], but the
+// Odin family's "+12+" recipe (GetMatchCombineOdin, GetFunc.cpp:551) reads up
+// to Item[6] — 7 of the 8 slots — so the full size is required for parity.
+const MaxCombine = 8
 
 // MsgCombineItemBody — MSG_CombineItem (C→S, 0x03A6 and the Item[]-based
 // variants), game-rules.md §3.1. An input i is active when Item[i].Index != 0;

--- a/tmserver/internal/protocol/messages_test.go
+++ b/tmserver/internal/protocol/messages_test.go
@@ -57,6 +57,31 @@ func TestAccountLoginRoundTrip(t *testing.T) {
 	}
 }
 
+// TestMsgCombineItemBodyRoundTrip locks in MaxCombine=8 (MAX_COMBINE,
+// Basedef.h:173): the Odin "+12+" recipe needs all 7 of Item[0..6], one more
+// than the base Anct recipe ever used.
+func TestMsgCombineItemBodyRoundTrip(t *testing.T) {
+	if MaxCombine != 8 {
+		t.Fatalf("MaxCombine = %d, want 8 (Basedef.h:173 MAX_COMBINE)", MaxCombine)
+	}
+	var in MsgCombineItemBody
+	for i := 0; i < MaxCombine; i++ {
+		in.Item[i] = WireItem{Index: int16(1000 + i)}
+		in.InvenPos[i] = uint8(i)
+	}
+	b := in.Encode()
+	if len(b) != MsgCombineItemBodySize {
+		t.Fatalf("Encode length = %d, want %d", len(b), MsgCombineItemBodySize)
+	}
+	var out MsgCombineItemBody
+	if err := out.Decode(b); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if out != in {
+		t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", out, in)
+	}
+}
+
 func TestMessageBodyShortInput(t *testing.T) {
 	var m MsgActionBody
 	if err := m.Decode(make([]byte, MsgActionBodySize-1)); err == nil {

--- a/tmserver/internal/refine/amount.go
+++ b/tmserver/internal/refine/amount.go
@@ -1,0 +1,19 @@
+package refine
+
+import "github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+
+// efAmount is EF_AMOUNT (ItemEffect.h): a stack size, when an item carries
+// one. Shared by the handler and combine packages, which both already depend
+// on refine for the sanc encoding.
+const efAmount = 61
+
+// Amount returns an item's stack size (BASE_GetItemAmount), or 1 for an item
+// with no EF_AMOUNT pair.
+func Amount(it world.Item) int {
+	for _, ef := range it.Effects {
+		if ef.Effect == efAmount {
+			return int(ef.Value)
+		}
+	}
+	return 1
+}

--- a/tmserver/internal/refine/classebonus.go
+++ b/tmserver/internal/refine/classebonus.go
@@ -1,0 +1,152 @@
+package refine
+
+import "github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+
+// bonusValue3/2/4/5 are g_pBonusValue3/2/4/5 (Basedef.cpp:432/467/396/353):
+// SetItemBonus2's reroll pools, one per equip slot class. Each row is
+// {effect1, value1, effect2, value2}.
+var (
+	bonusValue3 = [25][4]int{ // Elmo (nPos 2)
+		{4, 60, 26, 18}, {4, 60, 26, 15}, {4, 60, 26, 12},
+		{4, 50, 26, 18}, {4, 50, 26, 15}, {4, 50, 26, 12},
+		{4, 40, 26, 18}, {4, 40, 26, 15}, {4, 40, 26, 12},
+		{4, 30, 26, 18}, {4, 30, 26, 15}, {4, 30, 26, 12},
+		{4, 60, 60, 12}, {4, 60, 60, 10}, {4, 60, 60, 8}, {4, 60, 60, 6},
+		{4, 50, 60, 12}, {4, 50, 60, 10}, {4, 50, 60, 8}, {4, 50, 60, 6},
+		{4, 40, 60, 12}, {4, 40, 60, 10}, {4, 40, 60, 8}, {4, 40, 60, 6}, {4, 40, 60, 4},
+	}
+
+	bonusValue2 = [48][4]int{ // Peito/Calça (nPos 4|8)
+		{2, 30, 3, 30}, {2, 30, 3, 25}, {2, 30, 3, 20}, {2, 30, 3, 10},
+		{2, 24, 3, 30}, {2, 24, 3, 25}, {2, 24, 3, 20}, {2, 24, 3, 15},
+		{2, 18, 3, 30}, {2, 18, 3, 25}, {2, 18, 3, 20}, {2, 18, 3, 15},
+		{2, 30, 71, 50}, {2, 30, 71, 60}, {2, 30, 71, 70},
+		{2, 24, 71, 50}, {2, 24, 71, 60}, {2, 24, 71, 70},
+		{2, 18, 71, 50}, {2, 18, 71, 60}, {2, 18, 71, 70},
+		{60, 10, 3, 30}, {60, 10, 3, 25}, {60, 10, 3, 20}, {60, 10, 3, 15}, {60, 10, 3, 10},
+		{60, 8, 3, 30}, {60, 8, 3, 25}, {60, 8, 3, 20}, {60, 8, 3, 15}, {60, 8, 3, 10},
+		{60, 6, 3, 30}, {60, 6, 3, 25}, {60, 6, 3, 20}, {60, 6, 3, 15}, {60, 6, 3, 10},
+		{60, 10, 71, 50}, {60, 10, 71, 60}, {60, 10, 71, 70},
+		{60, 8, 71, 50}, {60, 8, 71, 60}, {60, 8, 71, 70},
+		{60, 6, 71, 50}, {60, 6, 71, 60}, {60, 6, 71, 70},
+		{60, 4, 71, 50}, {60, 4, 71, 60}, {60, 4, 71, 70},
+	}
+
+	bonusValue4 = [30][4]int{ // Luva (nPos 16)
+		{2, 30, 72, 30}, {2, 30, 72, 25}, {2, 30, 72, 20}, {2, 30, 72, 15}, {2, 30, 72, 10},
+		{2, 24, 72, 30}, {2, 24, 72, 25}, {2, 24, 72, 20}, {2, 24, 72, 15}, {2, 24, 72, 10},
+		{2, 18, 72, 30}, {2, 18, 72, 25}, {2, 18, 72, 20}, {2, 18, 72, 15}, {2, 18, 72, 10},
+		{60, 10, 72, 30}, {60, 10, 72, 25}, {60, 10, 72, 20}, {60, 10, 72, 15},
+		{60, 8, 72, 30}, {60, 8, 72, 25}, {60, 8, 72, 20}, {60, 8, 72, 15},
+		{60, 6, 72, 30}, {60, 6, 72, 25}, {60, 6, 72, 20}, {60, 6, 72, 15},
+	}
+
+	bonusValue5 = [30][4]int{ // Bota (nPos 32)
+		{2, 30, 74, 18}, {2, 30, 74, 15}, {2, 30, 74, 12},
+		{2, 24, 74, 18}, {2, 24, 74, 15}, {2, 24, 74, 12},
+		{2, 18, 74, 18}, {2, 18, 74, 15}, {2, 18, 74, 12},
+		{2, 12, 74, 18}, {2, 12, 74, 15}, {2, 12, 74, 12},
+		{2, 6, 74, 18}, {2, 6, 74, 15}, {2, 6, 74, 12},
+		{2, 30, 60, 10}, {2, 30, 60, 8}, {2, 30, 60, 6},
+		{2, 24, 60, 10}, {2, 24, 60, 8}, {2, 24, 60, 6},
+		{2, 18, 60, 10}, {2, 18, 60, 8}, {2, 18, 60, 6},
+		{2, 12, 60, 10}, {2, 12, 60, 8}, {2, 12, 60, 6},
+		{2, 6, 60, 10}, {2, 6, 60, 8}, {2, 6, 60, 6},
+	}
+)
+
+// classeSancCap is the +6 ceiling SetItemBonus2 puts on the sanc it bumps
+// (Server.cpp:2727-2739 and its three siblings) — distinct from the dust
+// path's own caps, and never lowered, only raised toward it.
+const classeSancCap = 6
+
+// efDamageBonus is EF_DAMAGE (ItemEffect.h:4), reused here for the boot-only
+// clamp below.
+const efDamageBonus = 2
+
+// classeSancEffect is EF_SANC (ItemEffect.h:100). Kept local (rather than
+// exported from this package) because SetItemBonus2 checks slot 0
+// specifically, not the general readSlot/writeSlot scan the dust path uses.
+const classeSancEffect = efSanc
+
+// nPos equip-slot classes SetItemBonus2 rerolls (Basedef.h:1162+). Any other
+// nPos (weapons, accessories, …) is left completely untouched — the legacy
+// function simply has no `if` branch for them.
+const (
+	nPosHelm      = 2
+	nPosChest     = 4
+	nPosLegs      = 8
+	nPosGlove     = 16
+	nPosBoot      = 32
+	bootDamageCap = 30
+)
+
+// ClasseBonus rerolls dest's sanc (capped at +6) and its two bonus effects,
+// selected by dest's equip slot nPos (SetItemBonus2, Server.cpp:2719-2861).
+// roll(n) must behave like rand()%n; itemAbility must sum an item's catalog +
+// instance effects for a given id (BASE_GetItemAbility), needed only for the
+// boot damage clamp. Reports whether nPos was one of the four covered slots —
+// the caller does not need to branch on it (an uncovered item is left
+// unchanged, matching the legacy exactly), but tests find it useful.
+func ClasseBonus(dest *world.Item, nPos int, roll func(int) int, itemAbility func(world.Item, uint8) int) bool {
+	var table [][4]int
+	switch nPos {
+	case nPosHelm:
+		table = bonusValue3[:]
+	case nPosChest, nPosLegs:
+		table = bonusValue2[:]
+	case nPosGlove:
+		table = bonusValue4[:]
+	case nPosBoot:
+		table = bonusValue5[:]
+	default:
+		return false
+	}
+
+	if dest.Effects[0].Effect == classeSancEffect {
+		lvl := Level(*dest)
+		if lvl < classeSancCap {
+			lvl += roll(2)
+			if lvl >= classeSancCap {
+				lvl = classeSancCap
+			}
+			Set(dest, lvl, 0)
+		}
+	} else {
+		dest.Effects[0] = world.Effect{Effect: classeSancEffect, Value: uint8(roll(2))}
+	}
+
+	row := table[roll(len(table))]
+	dest.Effects[1] = world.Effect{Effect: uint8(row[0]), Value: uint8(row[1])}
+	dest.Effects[2] = world.Effect{Effect: uint8(row[2]), Value: uint8(row[3])}
+
+	if nPos == nPosBoot {
+		clampBootDamage(dest, itemAbility)
+	}
+	return true
+}
+
+// clampBootDamage ports the boot-only EF_DAMAGE ceiling (Server.cpp:2845-2861):
+// a freshly-rolled EF_DAMAGE bonus is trimmed so the item's total damage
+// ability (catalog + instance, read AFTER the roll above) never exceeds 30.
+func clampBootDamage(dest *world.Item, itemAbility func(world.Item, uint8) int) {
+	for i := 1; i <= 2; i++ {
+		if dest.Effects[i].Effect != efDamageBonus {
+			continue
+		}
+		ability := itemAbility(*dest, efDamageBonus)
+		if ability <= bootDamageCap {
+			continue
+		}
+		over := ability - bootDamageCap
+		v := int(dest.Effects[i].Value)
+		if v < over {
+			over = v
+		}
+		v -= over
+		if v < 0 {
+			v = 0
+		}
+		dest.Effects[i].Value = uint8(v)
+	}
+}


### PR DESCRIPTION
## Summary
- Ports the Classe A-E gear stat-reroll consumables (items 4016-4025): `SetItemBonus2` and its four bonus tables were previously assumed missing from `Source/` (issue #135) and hard-rejected; they're fully present, so this wires them up via a new `refine.ClasseBonus` + `useClasseItem` handler. Fixes one legacy typo along the way (an inverted `DestType` equip-gate check that would have made the feature reject every legitimate target).
- Ports the Odin combine family: 11 recipes (Composição de Sets/armas, the +11→+15 "+12+" refine tier, Pista de runas, Destrave Lv40, Pedra da fúria, the 4 Secreta stones, Semente de cristal, Capa celestial) via a new dedicated `combineItemOdin`/`combineOdin` handler, since their result shapes don't fit the existing generic `CombineFamily{Rate,Apply}` engine.
- Bumps `protocol.MaxCombine` from an unverified placeholder of 6 to 8, matching the legacy `MAX_COMBINE` — the "+12+" recipe needs 7 of the 8 input slots.
- Closes a real item-corruption gap found while porting: Source's "Composição de Sets" fallback would blindly write to an unvalidated inventory slot when its `Item[1]` was left empty; this port requires that slot to be a real, validated input instead.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `govulncheck ./...`
- [x] `go test -race ./...` (includes new coverage for every Classe A-E gate/roll path and all 11 Odin recipes)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>