### PR TITLE
Agrupa stacks de itens

### DIFF
--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -169,6 +169,8 @@ func isSplittable(index int16) bool {
 	return index >= 2390 && index <= 2419
 }
 
+const maxStackAmount = 120
+
 // setItemAmount writes n into the item's EF_AMOUNT effect slot (mirrors
 // BASE_SetItemAmount): reuse an existing EF_AMOUNT effect, else claim the first
 // empty effect slot. It is the inverse of itemAmount/consumeOneItem.
@@ -186,6 +188,76 @@ func setItemAmount(it *world.Item, n int) {
 			return
 		}
 	}
+}
+
+func tryMergeItemStacks(src, dst *world.Item) bool {
+	if !sameStackClass(*src, *dst) {
+		return false
+	}
+	srcAmount := itemAmount(*src)
+	dstAmount := itemAmount(*dst)
+	if srcAmount <= 0 || dstAmount <= 0 {
+		return true
+	}
+	if dstAmount >= maxStackAmount {
+		return true
+	}
+	if !canWriteItemAmount(*dst) {
+		return true
+	}
+	move := srcAmount
+	if space := maxStackAmount - dstAmount; move > space {
+		move = space
+	}
+	if move < srcAmount && !canWriteItemAmount(*src) {
+		return true
+	}
+	setItemAmount(dst, dstAmount+move)
+	if move == srcAmount {
+		*src = world.Item{}
+		return true
+	}
+	setItemAmount(src, srcAmount-move)
+	return true
+}
+
+func sameStackClass(a, b world.Item) bool {
+	if a.Empty() || b.Empty() || a.Index != b.Index || !isSplittable(a.Index) || a.ExpiresAt != b.ExpiresAt {
+		return false
+	}
+	ae, an := nonAmountEffects(a)
+	be, bn := nonAmountEffects(b)
+	if an != bn {
+		return false
+	}
+	for i := 0; i < an; i++ {
+		if ae[i] != be[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func canWriteItemAmount(it world.Item) bool {
+	for _, ef := range it.Effects {
+		if ef.Effect == 0 || ef.Effect == efAmount {
+			return true
+		}
+	}
+	return false
+}
+
+func nonAmountEffects(it world.Item) ([3]world.Effect, int) {
+	var out [3]world.Effect
+	n := 0
+	for _, ef := range it.Effects {
+		if ef.Effect == 0 || ef.Effect == efAmount {
+			continue
+		}
+		out[n] = ef
+		n++
+	}
+	return out, n
 }
 
 // splitItem handles _MSG_SplitItem (0x02E5, Basedef.h:2381): peel Num units off the
@@ -211,7 +283,7 @@ func (d *Dispatcher) splitItem(w *world.World, s *world.Session, _ protocol.Head
 	if slot < 0 || slot >= world.MaxCarry-4 {
 		return
 	}
-	if num <= 0 || num >= 120 {
+	if num <= 0 || num >= maxStackAmount {
 		return
 	}
 	src := &e.Carry[slot]
@@ -1801,6 +1873,9 @@ func (d *Dispatcher) tradingItem(w *world.World, s *world.Session, _ protocol.He
 	if src == nil || dst == nil {
 		return
 	}
+	if srcPlace == dstPlace && srcSlot == dstSlot {
+		return
+	}
 	if src.Empty() && dst.Empty() {
 		return // nothing to move
 	}
@@ -1812,7 +1887,12 @@ func (d *Dispatcher) tradingItem(w *world.World, s *world.Session, _ protocol.He
 		d.notify(w, s, NoticeReqNotMet)
 		return
 	}
-	// UNVERIFIED: amount-stacking (arrows/potions) is not yet applied.
+	if srcPlace == world.ItemPlaceCarry && dstPlace == world.ItemPlaceCarry && tryMergeItemStacks(src, dst) {
+		w.Send(s, protocol.MsgTradingItem, payload) // echo the move
+		w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(srcPlace, srcSlot, itemToSel(*src)))
+		w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(dstPlace, dstSlot, itemToSel(*dst)))
+		return
+	}
 	*src, *dst = *dst, *src
 	w.Send(s, protocol.MsgTradingItem, payload) // echo the move
 	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(srcPlace, srcSlot, itemToSel(*src)))

--- a/tmserver/internal/handler/itemops_test.go
+++ b/tmserver/internal/handler/itemops_test.go
@@ -129,6 +129,106 @@ func TestSplitItemNoFreeSlot(t *testing.T) {
 	}
 }
 
+func TestTradingItemMergeStacksFull(t *testing.T) {
+	addr, stop, _ := startServerClock(t, carryDB(amountItem(2400, 5), amountItem(2400, 10)))
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	tradeItemFrame(t, c, world.ItemPlaceCarry, 0, world.ItemPlaceCarry, 1, 0)
+	expect(t, c, protocol.MsgTradingItem)
+	_, srcSlot, srcIdx, _ := sendItemSlotAmount(expect(t, c, protocol.MsgSendItem))
+	_, dstSlot, dstIdx, dstAmt := sendItemSlotAmount(expect(t, c, protocol.MsgSendItem))
+
+	if srcSlot != 0 || srcIdx != 0 {
+		t.Errorf("source after full merge slot=%d idx=%d, want slot 0 cleared", srcSlot, srcIdx)
+	}
+	if dstSlot != 1 || dstIdx != 2400 || dstAmt != 15 {
+		t.Errorf("dest after full merge slot=%d idx=%d amt=%d, want slot 1 idx 2400 amt 15", dstSlot, dstIdx, dstAmt)
+	}
+}
+
+func TestTradingItemMergeStacksCapsAt120(t *testing.T) {
+	addr, stop, _ := startServerClock(t, carryDB(amountItem(2400, 50), amountItem(2400, 90)))
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	tradeItemFrame(t, c, world.ItemPlaceCarry, 0, world.ItemPlaceCarry, 1, 0)
+	expect(t, c, protocol.MsgTradingItem)
+	_, srcSlot, srcIdx, srcAmt := sendItemSlotAmount(expect(t, c, protocol.MsgSendItem))
+	_, dstSlot, dstIdx, dstAmt := sendItemSlotAmount(expect(t, c, protocol.MsgSendItem))
+
+	if srcSlot != 0 || srcIdx != 2400 || srcAmt != 20 {
+		t.Errorf("source after capped merge slot=%d idx=%d amt=%d, want slot 0 idx 2400 amt 20", srcSlot, srcIdx, srcAmt)
+	}
+	if dstSlot != 1 || dstIdx != 2400 || dstAmt != 120 {
+		t.Errorf("dest after capped merge slot=%d idx=%d amt=%d, want slot 1 idx 2400 amt 120", dstSlot, dstIdx, dstAmt)
+	}
+}
+
+func TestTradingItemMergeStacksFullDestinationNoSwap(t *testing.T) {
+	addr, stop, _ := startServerClock(t, carryDB(amountItem(2400, 5), amountItem(2400, 120)))
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	tradeItemFrame(t, c, world.ItemPlaceCarry, 0, world.ItemPlaceCarry, 1, 0)
+	expect(t, c, protocol.MsgTradingItem)
+	_, srcSlot, srcIdx, srcAmt := sendItemSlotAmount(expect(t, c, protocol.MsgSendItem))
+	_, dstSlot, dstIdx, dstAmt := sendItemSlotAmount(expect(t, c, protocol.MsgSendItem))
+
+	if srcSlot != 0 || srcIdx != 2400 || srcAmt != 5 {
+		t.Errorf("source with full destination slot=%d idx=%d amt=%d, want unchanged slot 0 idx 2400 amt 5", srcSlot, srcIdx, srcAmt)
+	}
+	if dstSlot != 1 || dstIdx != 2400 || dstAmt != 120 {
+		t.Errorf("full destination slot=%d idx=%d amt=%d, want unchanged slot 1 idx 2400 amt 120", dstSlot, dstIdx, dstAmt)
+	}
+}
+
+func TestTradingItemMergeStacksFallsBackToSwap(t *testing.T) {
+	tests := []struct {
+		name string
+		src  world.Item
+		dst  world.Item
+	}{
+		{"different index", amountItem(2400, 5), amountItem(2401, 10)},
+		{"non splittable", amountItem(1100, 5), amountItem(1100, 10)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			addr, stop, _ := startServerClock(t, carryDB(tc.src, tc.dst))
+			defer stop()
+			c := enterWorld(t, addr)
+			defer c.Close()
+
+			tradeItemFrame(t, c, world.ItemPlaceCarry, 0, world.ItemPlaceCarry, 1, 0)
+			expect(t, c, protocol.MsgTradingItem)
+			_, srcSlot, srcIdx, srcAmt := sendItemSlotAmount(expect(t, c, protocol.MsgSendItem))
+			_, dstSlot, dstIdx, dstAmt := sendItemSlotAmount(expect(t, c, protocol.MsgSendItem))
+
+			if srcSlot != 0 || srcIdx != int(tc.dst.Index) || srcAmt != itemAmount(tc.dst) {
+				t.Errorf("source after fallback slot=%d idx=%d amt=%d, want slot 0 idx %d amt %d", srcSlot, srcIdx, srcAmt, tc.dst.Index, itemAmount(tc.dst))
+			}
+			if dstSlot != 1 || dstIdx != int(tc.src.Index) || dstAmt != itemAmount(tc.src) {
+				t.Errorf("dest after fallback slot=%d idx=%d amt=%d, want slot 1 idx %d amt %d", dstSlot, dstIdx, dstAmt, tc.src.Index, itemAmount(tc.src))
+			}
+		})
+	}
+}
+
+func TestTradingItemSameSlotNoop(t *testing.T) {
+	addr, stop, _ := startServerClock(t, carryDB(amountItem(2400, 10)))
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	tradeItemFrame(t, c, world.ItemPlaceCarry, 0, world.ItemPlaceCarry, 0, 0)
+	if ty, _, ok := readMaybe(t, c); ok {
+		t.Errorf("same-slot move produced %#x, want silence", ty)
+	}
+}
+
 func TestIsSplittable(t *testing.T) {
 	for _, idx := range []int16{412, 413, 414, 416, 419, 420, 2390, 2400, 2419} {
 		if !isSplittable(idx) {


### PR DESCRIPTION
## Summary
- Agrupa stacks compatíveis ao arrastar um item de carry sobre outro
- Limita o destino a 120 unidades e mantém overflow na origem
- Mantém swap normal para itens não empilháveis, classes diferentes, equip/cargo e casos inválidos

Closes #186

## Tests
- go test ./tmserver/internal/handler
- make test