### PR TITLE
Fix party creation

### DIFF
--- a/tmserver/internal/handler/misc.go
+++ b/tmserver/internal/handler/misc.go
@@ -427,12 +427,8 @@ func (d *Dispatcher) amuMistico(w *world.World, s *world.Session, e *world.Entit
 	if confirm == 0 {
 		return
 	}
-	// e.Leader == s.Conn is this codebase's "I am the party leader" idiom
-	// (acceptParty sets a forming leader's own Leader to its own conn,
-	// party.go:84-91) — solo (Leader==0) and followers (Leader==otherConn)
-	// both fail this, matching the legacy "Leader must be 0 AND partycont>0"
-	// pair (a leader is only ever recorded this way once a real member joined).
-	if e.Leader != s.Conn {
+	// Legacy party leaders keep Leader==0; the non-solo proof is PartyList.
+	if e.Leader != 0 || partyMemberCount(e) == 0 {
 		d.notify(w, s, NoticeReqNotMet)
 		return
 	}

--- a/tmserver/internal/handler/party.go
+++ b/tmserver/internal/handler/party.go
@@ -37,20 +37,24 @@ func (d *Dispatcher) sendReqParty(w *world.World, s *world.Session, _ protocol.H
 	if int(body.PartyID) != s.Conn { // PartyID must be the inviter
 		return
 	}
-	if e.Leader != 0 && e.Leader != s.Conn { // already a member elsewhere
+	if e.Leader != 0 { // already a member elsewhere
 		return
 	}
-	target := int(body.Target)
+	target := int(body.Unk)
+	if target == 0 && body.Target != 0 {
+		target = int(body.Target)
+	}
 	other := w.Session(target)
 	te := w.Entity(target)
 	if target <= 0 || target >= world.MaxUser || other == nil || other.Mode != world.UserPlay || te == nil {
 		return
 	}
-	if te.Leader != 0 || !partyLevelOK(e, te) { // target already partied / level gate
+	if isInParty(te) || !partyLevelOK(e, te) { // target already partied / level gate
 		return
 	}
 	te.LastReqParty = s.Conn // anti-forge gate for AcceptParty
-	w.SendTo(other, protocol.Header{Type: protocol.MsgSendReqParty, ID: uint16(s.Conn)}, payload)
+	out := d.reqPartyBody(e, s.Conn)
+	w.SendTo(other, protocol.Header{Type: protocol.MsgSendReqParty, ID: protocol.IDScene}, out.Encode())
 }
 
 // acceptParty handles _MSG_AcceptParty (0x03AB): join the inviter's party. The
@@ -77,61 +81,79 @@ func (d *Dispatcher) acceptParty(w *world.World, s *world.Session, _ protocol.He
 	if leaderSess == nil || leaderSess.Mode != world.UserPlay || le == nil {
 		return
 	}
-	if e.Leader != 0 || (le.Leader != 0 && le.Leader != leaderConn) || !partyLevelOK(le, e) {
+	if cstr(body.MobName[:]) != le.Name {
 		return
 	}
-
-	if le.Leader == 0 { // form the party, leader takes the first slot
-		le.Leader = leaderConn
-		addMember(le, leaderConn)
+	if isInParty(e) || le.Leader != 0 || !partyLevelOK(le, e) {
+		return
 	}
-	if !addMember(le, s.Conn) {
+	slot, ok := addMember(le, s.Conn)
+	if !ok {
 		return // party full
 	}
 	e.Leader = leaderConn
 	e.LastReqParty = 0
-
-	// Sync the (new) party list to every member.
-	for _, m := range le.PartyList {
-		if m == 0 {
-			continue
-		}
-		if ms := w.Session(m); ms != nil {
-			w.SendTo(ms, protocol.Header{Type: protocol.MsgAcceptParty, ID: uint16(s.Conn)}, payload)
-		}
-	}
+	d.syncAcceptedParty(w, leaderConn, s.Conn, slot+1)
 }
 
-// removeParty handles _MSG_RemoveParty (0x037E): leave (member) or dissolve
-// (leader). Parm is the target; out of range or self means "me".
-func (d *Dispatcher) removeParty(w *world.World, s *world.Session, _ protocol.Header, _ []byte) {
+// removeParty handles _MSG_RemoveParty (0x037E): members leave, leaders can
+// kick a member, and a leader leaving promotes the next member when possible.
+// Parm is the target; out of range or self means "me".
+func (d *Dispatcher) removeParty(w *world.World, s *world.Session, _ protocol.Header, payload []byte) {
 	e := w.Entity(s.Conn)
-	if e == nil || e.Leader == 0 {
+	if e == nil {
 		return
 	}
-	if e.Leader == s.Conn {
-		d.dissolveParty(w, s.Conn) // leader leaves → dissolve
-	} else {
-		d.leaveParty(w, s.Conn)
+	target := s.Conn
+	if parm, ok := protocol.StandardParm(payload); ok && parm > 0 && int(parm) < world.MaxUser {
+		target = int(parm)
 	}
+	if target != s.Conn && !hasMember(e, target) {
+		target = s.Conn
+	}
+	if e.Leader != 0 {
+		d.leaveParty(w, s.Conn)
+		return
+	}
+	if target == s.Conn {
+		d.leaderLeaveParty(w, s.Conn)
+		return
+	}
+	d.kickPartyMember(w, s.Conn, target)
 }
 
-func (d *Dispatcher) dissolveParty(w *world.World, leaderConn int) {
+func (d *Dispatcher) reqPartyBody(e *world.Entity, partyID int) protocol.MsgSendReqPartyBody {
+	body := protocol.MsgSendReqPartyBody{
+		Class:    e.Class,
+		PartyPos: 0,
+		Level:    uint16(clampPartyWire(e.Level)),
+		MaxHP:    uint16(partyHPWire(effectiveMaxHP(e))),
+		HP:       uint16(partyHPWire(e.HP)),
+		PartyID:  int16(partyID),
+	}
+	copy(body.MobName[:], e.Name)
+	return body
+}
+
+func (d *Dispatcher) syncAcceptedParty(w *world.World, leaderConn, newMember, newMemberPartyPos int) {
 	le := w.Entity(leaderConn)
 	if le == nil {
 		return
 	}
-	for _, m := range le.PartyList {
-		if m == 0 {
+	if partyMemberCount(le) == 1 {
+		d.sendAddParty(w, leaderConn, leaderConn, 0)
+		d.sendAddParty(w, newMember, newMember, newMemberPartyPos)
+	}
+	d.sendAddParty(w, newMember, leaderConn, 0)
+	d.sendAddParty(w, leaderConn, newMember, newMemberPartyPos)
+	for j, memberID := range le.PartyList {
+		if memberID == 0 {
 			continue
 		}
-		if me := w.Entity(m); me != nil {
-			me.Leader = 0
-			me.PartyList = [world.MaxParty]int{}
+		if memberID != newMember {
+			d.sendAddParty(w, newMember, memberID, newMemberPartyPos)
 		}
-		if ms := w.Session(m); ms != nil {
-			w.SendTo(ms, protocol.Header{Type: protocol.MsgRemoveParty, ID: uint16(leaderConn)}, nil)
-		}
+		d.sendAddParty(w, memberID, newMember, j+1)
 	}
 }
 
@@ -143,35 +165,98 @@ func (d *Dispatcher) leaveParty(w *world.World, conn int) {
 	leaderConn := e.Leader
 	e.Leader = 0
 	e.PartyList = [world.MaxParty]int{}
+	d.sendRemoveParty(w, conn, 0)
 	if le := w.Entity(leaderConn); le != nil {
 		removeMember(le, conn)
 		for _, m := range le.PartyList {
 			if m == 0 {
 				continue
 			}
-			if ms := w.Session(m); ms != nil {
-				w.SendTo(ms, protocol.Header{Type: protocol.MsgRemoveParty, ID: uint16(conn)}, nil)
-			}
+			d.sendRemoveParty(w, m, conn)
 		}
-	}
-	if ms := w.Session(conn); ms != nil {
-		w.SendTo(ms, protocol.Header{Type: protocol.MsgRemoveParty, ID: uint16(conn)}, nil)
+		d.sendRemoveParty(w, leaderConn, conn)
 	}
 }
 
-// addMember puts conn in the leader's first free party slot (idempotent),
-// returning false if the party is full.
-func addMember(leader *world.Entity, conn int) bool {
+func (d *Dispatcher) kickPartyMember(w *world.World, leaderConn, conn int) {
+	e := w.Entity(conn)
+	le := w.Entity(leaderConn)
+	if e == nil || le == nil || e.Leader != leaderConn {
+		return
+	}
+	e.Leader = 0
+	e.PartyList = [world.MaxParty]int{}
+	removeMember(le, conn)
+	d.sendRemoveParty(w, conn, 0)
+	d.sendRemoveParty(w, leaderConn, conn)
+	for _, m := range le.PartyList {
+		if m != 0 {
+			d.sendRemoveParty(w, m, conn)
+		}
+	}
+}
+
+func (d *Dispatcher) leaderLeaveParty(w *world.World, leaderConn int) {
+	le := w.Entity(leaderConn)
+	if le == nil {
+		return
+	}
+	members := partyMembers(le)
+	le.PartyList = [world.MaxParty]int{}
+	for _, memberID := range members {
+		if me := w.Entity(memberID); me != nil && me.Leader == leaderConn {
+			me.Leader = 0
+			me.PartyList = [world.MaxParty]int{}
+		}
+		d.sendRemoveParty(w, memberID, 0)
+	}
+	d.sendRemoveParty(w, leaderConn, 0)
+	if len(members) == 0 {
+		return
+	}
+	newLeader := members[0]
+	nle := w.Entity(newLeader)
+	if nle == nil {
+		return
+	}
+	nle.Leader = 0
+	nle.PartyList = [world.MaxParty]int{}
+	for _, memberID := range members[1:] {
+		me := w.Entity(memberID)
+		if me == nil {
+			continue
+		}
+		slot, ok := addMember(nle, memberID)
+		if !ok {
+			return
+		}
+		me.Leader = newLeader
+		d.syncAcceptedParty(w, newLeader, memberID, slot+1)
+	}
+}
+
+func (d *Dispatcher) sendRemoveParty(w *world.World, conn, connExit int) {
+	if conn <= 0 || conn >= world.MaxUser {
+		return
+	}
+	if ms := w.Session(conn); ms != nil && ms.Mode == world.UserPlay {
+		body := protocol.MsgRemovePartyBody{LeaderConn: int16(connExit)}
+		w.SendTo(ms, protocol.Header{Type: protocol.MsgRemoveParty, ID: protocol.IDScene}, body.Encode())
+	}
+}
+
+// addMember puts conn in the leader's first free party slot (idempotent).
+func addMember(leader *world.Entity, conn int) (int, bool) {
 	for i := range leader.PartyList {
 		if leader.PartyList[i] == conn {
-			return true
+			return i, true
 		}
 		if leader.PartyList[i] == 0 {
 			leader.PartyList[i] = conn
-			return true
+			return i, true
 		}
 	}
-	return false
+	return -1, false
 }
 
 func removeMember(leader *world.Entity, conn int) {
@@ -180,6 +265,39 @@ func removeMember(leader *world.Entity, conn int) {
 			leader.PartyList[i] = 0
 		}
 	}
+}
+
+func hasMember(leader *world.Entity, conn int) bool {
+	for _, memberID := range leader.PartyList {
+		if memberID == conn {
+			return true
+		}
+	}
+	return false
+}
+
+func partyMemberCount(leader *world.Entity) int {
+	n := 0
+	for _, memberID := range leader.PartyList {
+		if memberID != 0 {
+			n++
+		}
+	}
+	return n
+}
+
+func partyMembers(leader *world.Entity) []int {
+	members := make([]int, 0, world.MaxParty)
+	for _, memberID := range leader.PartyList {
+		if memberID > 0 && memberID < world.MaxUser {
+			members = append(members, memberID)
+		}
+	}
+	return members
+}
+
+func isInParty(e *world.Entity) bool {
+	return e.Leader != 0 || partyMemberCount(e) != 0
 }
 
 func (d *Dispatcher) sendAddParty(w *world.World, recipientID, entryID, partyPos int) {

--- a/tmserver/internal/handler/party_test.go
+++ b/tmserver/internal/handler/party_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
@@ -10,10 +11,11 @@ import (
 
 func partyDB() *fakeDB {
 	db := newDB()
-	mk := func() world.CharacterState {
-		return world.CharacterState{Slot: 0, Name: "Hero", X: 5, Y: 5, HP: 1000, MaxHP: 1000, Level: 50}
+	mk := func(name string) world.CharacterState {
+		return world.CharacterState{Slot: 0, Name: name, X: 5, Y: 5, HP: 1000, MaxHP: 1000, Level: 50}
 	}
-	db.loads = map[int64]world.CharacterState{7: mk(), 11: mk()}
+	db.accounts["third"] = &fakeAccount{id: 13, pass: "secret", chars: []world.CharSummary{{Slot: 0, Name: "HeroC", Class: 1, Level: 50}}}
+	db.loads = map[int64]world.CharacterState{7: mk("Hero"), 11: mk("HeroB"), 13: mk("HeroC")}
 	return db
 }
 
@@ -28,14 +30,57 @@ func guildDB() *fakeDB {
 
 func reqPartyFrame(t *testing.T, c net.Conn, partyID, target int) {
 	t.Helper()
-	body := protocol.MsgSendReqPartyBody{PartyID: int32(partyID), Target: int32(target)}
+	body := protocol.MsgSendReqPartyBody{PartyID: int16(partyID), Unk: int32(target)}
 	send(t, c, protocol.MsgSendReqParty, body.Encode())
 }
 
-func acceptPartyFrame(t *testing.T, c net.Conn, leaderID int) {
+func acceptPartyFrame(t *testing.T, c net.Conn, leaderID int, leaderName string) {
 	t.Helper()
-	body := protocol.MsgAcceptPartyBody{LeaderID: int32(leaderID)}
+	body := protocol.MsgAcceptPartyBody{LeaderID: int16(leaderID)}
+	copy(body.MobName[:], leaderName)
 	send(t, c, protocol.MsgAcceptParty, body.Encode())
+}
+
+func removePartyFrame(t *testing.T, c net.Conn, target int) {
+	t.Helper()
+	send(t, c, protocol.MsgRemoveParty, protocol.EncodeStandardParm(int32(target)))
+}
+
+func expectPartyFrame(t *testing.T, c net.Conn, want protocol.Type) []byte {
+	t.Helper()
+	ty, payload, ok := readMaybe(t, c)
+	if !ok || ty != want {
+		t.Fatalf("got %#x ok=%v, want %#x", ty, ok, want)
+	}
+	return payload
+}
+
+func expectCNFAddParty(t *testing.T, c net.Conn) protocol.MsgCNFAddPartyBody {
+	t.Helper()
+	payload := expectPartyFrame(t, c, protocol.MsgCNFAddParty)
+	if len(payload) != protocol.MsgCNFAddPartyBodySize {
+		t.Fatalf("CNFAddParty payload = %d, want %d", len(payload), protocol.MsgCNFAddPartyBodySize)
+	}
+	return protocol.MsgCNFAddPartyBody{
+		LeaderConn: protocolLe16(payload[0:2]),
+		PartyID:    protocolLe16(payload[8:10]),
+		Target:     protocolLe16(payload[26:28]),
+	}
+}
+
+func expectRemoveParty(t *testing.T, c net.Conn, connExit uint16) {
+	t.Helper()
+	payload := expectPartyFrame(t, c, protocol.MsgRemoveParty)
+	if len(payload) != protocol.MsgRemovePartyBodySize {
+		t.Fatalf("RemoveParty payload = %d, want %d", len(payload), protocol.MsgRemovePartyBodySize)
+	}
+	if got := protocolLe16(payload[0:2]); got != connExit {
+		t.Fatalf("RemoveParty Leaderconn = %d, want %d", got, connExit)
+	}
+}
+
+func protocolLe16(b []byte) uint16 {
+	return uint16(b[0]) | uint16(b[1])<<8
 }
 
 func TestPartyInviteAndAccept(t *testing.T) {
@@ -47,17 +92,23 @@ func TestPartyInviteAndAccept(t *testing.T) {
 	defer b.Close()
 
 	reqPartyFrame(t, a, 1, 2)
-	if ty, _, ok := readMaybe(t, b); !ok || ty != protocol.MsgSendReqParty {
-		t.Fatalf("invitee got %#x ok=%v, want SendReqParty", ty, ok)
+	payload := expectPartyFrame(t, b, protocol.MsgSendReqParty)
+	var invite protocol.MsgSendReqPartyBody
+	if err := invite.Decode(payload); err != nil {
+		t.Fatal(err)
+	}
+	if invite.PartyID != 1 || strings.TrimRight(string(invite.MobName[:]), "\x00") != "Hero" {
+		t.Fatalf("invite payload = %+v, want leader party/name", invite)
 	}
 
-	acceptPartyFrame(t, b, 1)
-	// Both members receive the party-list sync.
-	if ty, _, ok := readMaybe(t, a); !ok || ty != protocol.MsgAcceptParty {
-		t.Errorf("leader got %#x ok=%v, want AcceptParty sync", ty, ok)
+	acceptPartyFrame(t, b, 1, "Hero")
+	leaderSlot := expectCNFAddParty(t, a)
+	if leaderSlot.LeaderConn != 1 || leaderSlot.PartyID != 1 {
+		t.Fatalf("leader first CNFAddParty = %+v, want leader slot", leaderSlot)
 	}
-	if ty, _, ok := readMaybe(t, b); !ok || ty != protocol.MsgAcceptParty {
-		t.Errorf("invitee got %#x ok=%v, want AcceptParty sync", ty, ok)
+	memberSlot := expectCNFAddParty(t, b)
+	if memberSlot.PartyID != 2 || memberSlot.Target != 52428 {
+		t.Fatalf("invitee first CNFAddParty = %+v, want member slot", memberSlot)
 	}
 }
 
@@ -71,12 +122,97 @@ func TestPartyAcceptWithoutInvite(t *testing.T) {
 	defer b.Close()
 
 	// B accepts a party it was never invited to → rejected, no sync.
-	acceptPartyFrame(t, b, 1)
+	acceptPartyFrame(t, b, 1, "Hero")
 	if ty, _, ok := readMaybe(t, b); ok {
 		t.Errorf("forged accept produced %#x; should be rejected (PARTYHACK)", ty)
 	}
 	if ty, _, ok := readMaybe(t, a); ok {
 		t.Errorf("leader received %#x for a forged accept; should be none", ty)
+	}
+}
+
+func TestPartyAddMemberFull(t *testing.T) {
+	leader := &world.Entity{}
+	for i := range leader.PartyList {
+		leader.PartyList[i] = i + 1
+	}
+	if _, ok := addMember(leader, 99); ok {
+		t.Fatal("addMember succeeded for a full party")
+	}
+	if hasMember(leader, 99) {
+		t.Fatal("full party mutated with the rejected member")
+	}
+}
+
+func TestPartyMemberLeave(t *testing.T) {
+	addr, stop, _ := startServerClock(t, partyDB())
+	defer stop()
+	a := enterWorldAs(t, addr, "tester")
+	defer a.Close()
+	b := enterWorldAs(t, addr, "tradeb")
+	defer b.Close()
+
+	reqPartyFrame(t, a, 1, 2)
+	expectPartyFrame(t, b, protocol.MsgSendReqParty)
+	acceptPartyFrame(t, b, 1, "Hero")
+	drainRaw(t, a)
+	drainRaw(t, b)
+
+	removePartyFrame(t, b, 2)
+	expectRemoveParty(t, b, 0)
+	expectRemoveParty(t, a, 2)
+}
+
+func TestPartyLeaderKicksMember(t *testing.T) {
+	addr, stop, _ := startServerClock(t, partyDB())
+	defer stop()
+	a := enterWorldAs(t, addr, "tester")
+	defer a.Close()
+	b := enterWorldAs(t, addr, "tradeb")
+	defer b.Close()
+
+	reqPartyFrame(t, a, 1, 2)
+	expectPartyFrame(t, b, protocol.MsgSendReqParty)
+	acceptPartyFrame(t, b, 1, "Hero")
+	drainRaw(t, a)
+	drainRaw(t, b)
+
+	removePartyFrame(t, a, 2)
+	expectRemoveParty(t, b, 0)
+	expectRemoveParty(t, a, 2)
+}
+
+func TestPartyLeaderLeavePromotesNextMember(t *testing.T) {
+	addr, stop, _ := startServerClock(t, partyDB())
+	defer stop()
+	a := enterWorldAs(t, addr, "tester")
+	defer a.Close()
+	b := enterWorldAs(t, addr, "tradeb")
+	defer b.Close()
+	c := enterWorldAs(t, addr, "third")
+	defer c.Close()
+
+	reqPartyFrame(t, a, 1, 2)
+	expectPartyFrame(t, b, protocol.MsgSendReqParty)
+	acceptPartyFrame(t, b, 1, "Hero")
+	drainRaw(t, a)
+	drainRaw(t, b)
+	reqPartyFrame(t, a, 1, 3)
+	expectPartyFrame(t, c, protocol.MsgSendReqParty)
+	acceptPartyFrame(t, c, 1, "Hero")
+	drainRaw(t, a)
+	drainRaw(t, b)
+	drainRaw(t, c)
+
+	removePartyFrame(t, a, 1)
+	expectRemoveParty(t, a, 0)
+	expectRemoveParty(t, b, 0)
+	expectRemoveParty(t, c, 0)
+	if slot := expectCNFAddParty(t, b); slot.LeaderConn != 2 || slot.PartyID != 2 {
+		t.Fatalf("promoted member first sync = %+v, want new leader slot", slot)
+	}
+	if slot := expectCNFAddParty(t, c); slot.PartyID != 3 {
+		t.Fatalf("remaining member first sync = %+v, want own slot", slot)
 	}
 }
 

--- a/tmserver/internal/handler/quest_test.go
+++ b/tmserver/internal/handler/quest_test.go
@@ -328,9 +328,11 @@ func TestAmuMisticoCompletesForPartyLeader(t *testing.T) {
 	if ty, _, ok := readMaybe(t, c2); !ok || ty != protocol.MsgSendReqParty {
 		t.Fatalf("invitee got %#x ok=%v, want SendReqParty", ty, ok)
 	}
-	acceptPartyFrame(t, c2, 1)
-	expect(t, c, protocol.MsgAcceptParty)
-	expect(t, c2, protocol.MsgAcceptParty)
+	acceptPartyFrame(t, c2, 1, "Hero")
+	expect(t, c, protocol.MsgCNFAddParty)
+	expect(t, c2, protocol.MsgCNFAddParty)
+	drainRaw(t, c)
+	drainRaw(t, c2)
 
 	send(t, c, protocol.MsgQuest, protocol.EncodeStandardParm2(int32(npcID), 1))
 	if ty, _, ok := readMaybe(t, c); ok {

--- a/tmserver/internal/protocol/messages.go
+++ b/tmserver/internal/protocol/messages.go
@@ -497,44 +497,61 @@ func (m *MsgWhisperBody) Encode() []byte {
 	return b
 }
 
-// MsgSendReqPartyBody — MSG_SendReqParty (C→S, 0x037F): PartyID is the leader
-// (the sender), Target is the invited player (lote2-party-guilda-guerra.md).
-//
-// UNVERIFIED: exact field offsets not in §3.5; best-effort layout.
+// MsgSendReqPartyBody is MSG_SendReqParty (C↔S, 0x037F): PartyID is the leader
+// and Unk carries the invited player on the client request. This struct is
+// outside the legacy pack(1) blocks, so the int field keeps the MSVC x86 padding
+// after MobName (Basedef.h:2261-2279).
 type MsgSendReqPartyBody struct {
-	PartyID int32
-	Target  int32
-	MobName [16]byte
+	Class    uint8
+	PartyPos uint8
+	Level    uint16
+	MaxHP    uint16
+	HP       uint16
+	PartyID  int16
+	MobName  [16]byte
+	Unk      int32
+	Target   int16
 }
 
 // MsgSendReqPartyBodySize is the body length.
-const MsgSendReqPartyBodySize = 24
+const MsgSendReqPartyBodySize = 36
 
 // Decode parses an MSG_SendReqParty body.
 func (m *MsgSendReqPartyBody) Decode(b []byte) error {
 	if len(b) < MsgSendReqPartyBodySize {
 		return fmt.Errorf("protocol: MsgSendReqPartyBody.Decode: have %d, need %d", len(b), MsgSendReqPartyBodySize)
 	}
-	m.PartyID = int32(le.Uint32(b[0:4]))
-	m.Target = int32(le.Uint32(b[4:8]))
-	copy(m.MobName[:], b[8:24])
+	m.Class = b[0]
+	m.PartyPos = b[1]
+	m.Level = le.Uint16(b[2:4])
+	m.MaxHP = le.Uint16(b[4:6])
+	m.HP = le.Uint16(b[6:8])
+	m.PartyID = int16(le.Uint16(b[8:10]))
+	copy(m.MobName[:], b[10:26])
+	m.Unk = int32(le.Uint32(b[28:32]))
+	m.Target = int16(le.Uint16(b[32:34]))
 	return nil
 }
 
 // Encode writes the MSG_SendReqParty body into a new slice.
 func (m *MsgSendReqPartyBody) Encode() []byte {
 	b := make([]byte, MsgSendReqPartyBodySize)
-	le.PutUint32(b[0:4], uint32(m.PartyID))
-	le.PutUint32(b[4:8], uint32(m.Target))
-	copy(b[8:24], m.MobName[:])
+	b[0] = m.Class
+	b[1] = m.PartyPos
+	le.PutUint16(b[2:4], m.Level)
+	le.PutUint16(b[4:6], m.MaxHP)
+	le.PutUint16(b[6:8], m.HP)
+	le.PutUint16(b[8:10], uint16(m.PartyID))
+	copy(b[10:26], m.MobName[:])
+	le.PutUint32(b[28:32], uint32(m.Unk))
+	le.PutUint16(b[32:34], uint16(m.Target))
 	return b
 }
 
-// MsgAcceptPartyBody — MSG_AcceptParty (C→S, 0x03AB): LeaderID is who invited me.
-//
-// UNVERIFIED: exact field offsets not in §3.5; best-effort layout.
+// MsgAcceptPartyBody is MSG_AcceptParty (C↔S, 0x03AB): LeaderID is who invited
+// me. The natural-alignment tail padding keeps sizeof(MSG_AcceptParty)==32.
 type MsgAcceptPartyBody struct {
-	LeaderID int32
+	LeaderID int16
 	MobName  [16]byte
 }
 
@@ -546,16 +563,35 @@ func (m *MsgAcceptPartyBody) Decode(b []byte) error {
 	if len(b) < MsgAcceptPartyBodySize {
 		return fmt.Errorf("protocol: MsgAcceptPartyBody.Decode: have %d, need %d", len(b), MsgAcceptPartyBodySize)
 	}
-	m.LeaderID = int32(le.Uint32(b[0:4]))
-	copy(m.MobName[:], b[4:20])
+	m.LeaderID = int16(le.Uint16(b[0:2]))
+	copy(m.MobName[:], b[2:18])
 	return nil
 }
 
 // Encode writes the MSG_AcceptParty body into a new slice.
 func (m *MsgAcceptPartyBody) Encode() []byte {
 	b := make([]byte, MsgAcceptPartyBodySize)
-	le.PutUint32(b[0:4], uint32(m.LeaderID))
-	copy(b[4:20], m.MobName[:])
+	le.PutUint16(b[0:2], uint16(m.LeaderID))
+	copy(b[2:18], m.MobName[:])
+	return b
+}
+
+// MsgRemovePartyBody is MSG_RemoveParty (S→C, 0x037E), sent by legacy
+// SendRemoveParty. LeaderConn is 0 when clearing the recipient's whole party UI,
+// or the conn that left/was kicked when notifying remaining members.
+type MsgRemovePartyBody struct {
+	LeaderConn int16
+	Unk        int16
+}
+
+// MsgRemovePartyBodySize is sizeof(MSG_RemoveParty) minus the common header.
+const MsgRemovePartyBodySize = 4
+
+// Encode writes the MSG_RemoveParty body into a new slice.
+func (m *MsgRemovePartyBody) Encode() []byte {
+	b := make([]byte, MsgRemovePartyBodySize)
+	le.PutUint16(b[0:2], uint16(m.LeaderConn))
+	le.PutUint16(b[2:4], uint16(m.Unk))
 	return b
 }
 

--- a/tmserver/internal/protocol/messages_test.go
+++ b/tmserver/internal/protocol/messages_test.go
@@ -19,6 +19,9 @@ func TestMessageBodySizes(t *testing.T) {
 		{"DeleteCharacter", MsgDeleteCharacterBodySize, 44},
 		{"CharacterLogin", MsgCharacterLoginBodySize, 20},
 		{"Action", MsgActionBodySize, 52},
+		{"SendReqParty", MsgSendReqPartyBodySize, 48},
+		{"AcceptParty", MsgAcceptPartyBodySize, 32},
+		{"RemoveParty", MsgRemovePartyBodySize, 16},
 		{"CNFAddParty", MsgCNFAddPartyBodySize, 40},
 	}
 	for _, tt := range tests {
@@ -95,6 +98,61 @@ func TestSimpleBodyRoundTrips(t *testing.T) {
 		}
 		if out != in {
 			t.Errorf("got %+v want %+v", out, in)
+		}
+	})
+}
+
+func TestPartyBodyLayouts(t *testing.T) {
+	t.Run("SendReqParty", func(t *testing.T) {
+		in := MsgSendReqPartyBody{Class: 3, PartyPos: 0, Level: 50, MaxHP: 1000, HP: 900, PartyID: 1, Unk: 2, Target: 7}
+		copy(in.MobName[:], "Leader")
+		b := in.Encode()
+		if len(b) != MsgSendReqPartyBodySize {
+			t.Fatalf("SendReqParty body = %d, want %d", len(b), MsgSendReqPartyBodySize)
+		}
+		if b[0] != 3 || le.Uint16(b[8:10]) != 1 || le.Uint32(b[28:32]) != 2 || le.Uint16(b[32:34]) != 7 {
+			t.Fatalf("SendReqParty offsets not encoded as legacy layout: %v", b)
+		}
+		if got := strings.TrimRight(string(b[10:26]), "\x00"); got != "Leader" {
+			t.Fatalf("MobName = %q, want Leader", got)
+		}
+		var out MsgSendReqPartyBody
+		if err := out.Decode(b); err != nil {
+			t.Fatal(err)
+		}
+		if out != in {
+			t.Fatalf("round-trip got %+v want %+v", out, in)
+		}
+	})
+	t.Run("AcceptParty", func(t *testing.T) {
+		in := MsgAcceptPartyBody{LeaderID: 1}
+		copy(in.MobName[:], "Leader")
+		b := in.Encode()
+		if len(b) != MsgAcceptPartyBodySize {
+			t.Fatalf("AcceptParty body = %d, want %d", len(b), MsgAcceptPartyBodySize)
+		}
+		if le.Uint16(b[0:2]) != 1 {
+			t.Fatalf("LeaderID offset = %d, want 1", le.Uint16(b[0:2]))
+		}
+		if got := strings.TrimRight(string(b[2:18]), "\x00"); got != "Leader" {
+			t.Fatalf("MobName = %q, want Leader", got)
+		}
+		var out MsgAcceptPartyBody
+		if err := out.Decode(b); err != nil {
+			t.Fatal(err)
+		}
+		if out != in {
+			t.Fatalf("round-trip got %+v want %+v", out, in)
+		}
+	})
+	t.Run("RemoveParty", func(t *testing.T) {
+		in := MsgRemovePartyBody{LeaderConn: 2}
+		b := in.Encode()
+		if len(b) != MsgRemovePartyBodySize {
+			t.Fatalf("RemoveParty body = %d, want %d", len(b), MsgRemovePartyBodySize)
+		}
+		if le.Uint16(b[0:2]) != 2 || le.Uint16(b[2:4]) != 0 {
+			t.Fatalf("RemoveParty offsets not encoded as legacy layout: %v", b)
 		}
 	})
 }

--- a/tmserver/internal/world/session.go
+++ b/tmserver/internal/world/session.go
@@ -338,8 +338,9 @@ type Entity struct {
 	EquipVisual [16]uint16 // visual item codes for MSG_CreateMob/UpdateEquip
 	EquipAnct   [16]uint8  // refine/ancient glow overlay bytes paired with EquipVisual
 
-	// Party state (lote2-party-guilda-guerra.md). Leader is the leader's conn
-	// (0 = solo); LastReqParty is who last invited this entity (anti-forge gate).
+	// Party state (lote2-party-guilda-guerra.md). Members point Leader at the
+	// leader conn; leaders keep Leader=0 and own the PartyList. LastReqParty is
+	// who last invited this entity (anti-forge gate).
 	Leader       int
 	LastReqParty int
 


### PR DESCRIPTION
## Summary
- decode legacy party invite/accept/remove packet layouts
- send legacy-compatible party invite, add-party sync, and remove-party frames
- support member leave, leader kick, and leader-leave promotion

Closes #184.

## Tests
- go test ./...
- make test