### PR TITLE
Implement Bolsa do Andarilho carry unlock

### DIFF
--- a/tmserver/internal/handler/autotrade.go
+++ b/tmserver/internal/handler/autotrade.go
@@ -294,10 +294,10 @@ func (d *Dispatcher) closeAutoTrade(w *world.World, s *world.Session) {
 	w.BroadcastInView(s.Conn, protocol.MsgCreateMob, body)
 }
 
-// firstFreeTradeSlot returns the first empty Carry slot in the tradeable region
-// [0, MaxCarry-4) (_MSG_ReqBuy.cpp:105), or -1 if it is full.
+// firstFreeTradeSlot returns the first empty Carry slot in the currently unlocked
+// tradeable region, or -1 if it is full.
 func firstFreeTradeSlot(e *world.Entity) int {
-	for i := 0; i < maxTradeSlot; i++ {
+	for i := 0; i < activeCarryLimit(e); i++ {
 		if e.Carry[i].Empty() {
 			return i
 		}

--- a/tmserver/internal/handler/carry.go
+++ b/tmserver/internal/handler/carry.go
@@ -1,0 +1,118 @@
+package handler
+
+import (
+	"time"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+const (
+	itemWandererBag = 3467
+
+	baseCarrySlots      = 30
+	wandererBagSlots    = 15
+	maxUnlockedCarry    = 60
+	wandererBagSlot1    = 60
+	wandererBagSlot2    = 61
+	wandererBagDuration = 30 * 24 * time.Hour
+)
+
+func activeCarryLimit(e *world.Entity) int {
+	if e == nil {
+		return 0
+	}
+	return carryLimit(e.Carry[:])
+}
+
+func carryLimit(items []world.Item) int {
+	limit := baseCarrySlots
+	if len(items) > wandererBagSlot1 && items[wandererBagSlot1].Index == itemWandererBag {
+		limit += wandererBagSlots
+	}
+	if len(items) > wandererBagSlot2 && items[wandererBagSlot2].Index == itemWandererBag {
+		limit += wandererBagSlots
+	}
+	if limit > maxUnlockedCarry {
+		return maxUnlockedCarry
+	}
+	return limit
+}
+
+func carrySlotAccessible(e *world.Entity, slot int) bool {
+	return slot >= 0 && slot < activeCarryLimit(e)
+}
+
+func firstEmptyCarrySlot(items []world.Item, limit int) int {
+	if limit > len(items) {
+		limit = len(items)
+	}
+	for i := 0; i < limit; i++ {
+		if items[i].Empty() {
+			return i
+		}
+	}
+	return -1
+}
+
+func firstEmptyAccessibleCarry(e *world.Entity) int {
+	return firstEmptyCarrySlot(e.Carry[:], activeCarryLimit(e))
+}
+
+func freeAccessibleCarry(e *world.Entity) int {
+	limit := activeCarryLimit(e)
+	n := 0
+	for i := 0; i < limit; i++ {
+		if e.Carry[i].Empty() {
+			n++
+		}
+	}
+	return n
+}
+
+func (d *Dispatcher) sendCarry(w *world.World, s *world.Session, e *world.Entity) {
+	var carry [world.MaxCarry]protocol.SelItem
+	for i := range e.Carry {
+		carry[i] = itemToSel(e.Carry[i])
+	}
+	w.Send(s, protocol.MsgUpdateCarry, protocol.EncodeUpdateCarryBody(carry, e.Coin))
+}
+
+func (d *Dispatcher) useWandererBag(w *world.World, s *world.Session, e *world.Entity, src int) {
+	if e.Carry[wandererBagSlot1].Index == itemWandererBag && e.Carry[wandererBagSlot2].Index == itemWandererBag {
+		d.notify(w, s, NoticeMaxBag)
+		return
+	}
+
+	marker := wandererBagSlot1
+	if e.Carry[marker].Index == itemWandererBag {
+		marker = wandererBagSlot2
+	}
+	e.Carry[marker] = world.Item{
+		Index:     itemWandererBag,
+		ExpiresAt: time.Now().Add(wandererBagDuration).Unix(),
+	}
+	consumeOneItem(&e.Carry[src])
+
+	d.sendSlot(w, s, world.ItemPlaceCarry, marker, e.Carry[marker])
+	d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
+	d.sendScore(w, s, e)
+	d.sendEtc(w, s, e)
+	d.sendCarry(w, s, e)
+}
+
+func (d *Dispatcher) expireWandererBags(w *world.World, s *world.Session, e *world.Entity, now int64) {
+	changed := false
+	for _, slot := range []int{wandererBagSlot1, wandererBagSlot2} {
+		it := e.Carry[slot]
+		if it.Index != itemWandererBag || it.ExpiresAt == 0 || now < it.ExpiresAt {
+			continue
+		}
+		e.Carry[slot] = world.Item{}
+		d.sendSlot(w, s, world.ItemPlaceCarry, slot, e.Carry[slot])
+		changed = true
+	}
+	if changed {
+		d.sendCarry(w, s, e)
+	}
+}

--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -698,12 +698,7 @@ func (d *Dispatcher) grantStarterCarry(carry *[world.MaxCarry]world.Item, class 
 
 // firstEmptyCarry returns the index of the first empty inventory slot, or -1.
 func firstEmptyCarry(carry *[world.MaxCarry]world.Item) int {
-	for i := range carry {
-		if carry[i].Empty() {
-			return i
-		}
-	}
-	return -1
+	return firstEmptyCarrySlot(carry[:], carryLimit(carry[:]))
 }
 
 // validCharName approximates BASE_CheckValidString.

--- a/tmserver/internal/handler/chat.go
+++ b/tmserver/internal/handler/chat.go
@@ -277,12 +277,11 @@ func (d *Dispatcher) arcana(w *world.World, s *world.Session) {
 // SendItem update. If the inventory is full the grant is dropped (logged) — the flag
 // change still stands, matching the legacy PutItem best-effort behavior.
 func (d *Dispatcher) grantCarry(w *world.World, s *world.Session, e *world.Entity, index int16) {
-	for i := range e.Carry {
-		if e.Carry[i].Empty() {
-			e.Carry[i] = world.Item{Index: index}
-			w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, i, itemToSel(e.Carry[i])))
-			return
-		}
+	i := firstEmptyAccessibleCarry(e)
+	if i >= 0 {
+		e.Carry[i] = world.Item{Index: index}
+		w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, i, itemToSel(e.Carry[i])))
+		return
 	}
 	d.log.Info("grantCarry: inventory full", "conn", s.Conn, "index", index)
 }

--- a/tmserver/internal/handler/combine.go
+++ b/tmserver/internal/handler/combine.go
@@ -92,7 +92,7 @@ func (d *Dispatcher) combineItem(w *world.World, s *world.Session, h protocol.He
 			continue
 		}
 		pos := int(body.InvenPos[i])
-		if pos < 0 || pos >= world.MaxCarry {
+		if !carrySlotAccessible(e, pos) {
 			d.removeTrade(w, s) // out of range → RemoveTrade (anti-cheat)
 			return
 		}
@@ -143,7 +143,7 @@ func (d *Dispatcher) combineExtracao(w *world.World, s *world.Session, _ protoco
 		return
 	}
 	slot := int(p2)
-	if slot < 0 || slot >= world.MaxCarry {
+	if !carrySlotAccessible(e, slot) {
 		return
 	}
 	it := e.Carry[slot]
@@ -160,7 +160,7 @@ func (d *Dispatcher) combineExtracao(w *world.World, s *world.Session, _ protoco
 		return
 	}
 	catalyst := -1
-	for i := range e.Carry {
+	for i := 0; i < activeCarryLimit(e); i++ {
 		if e.Carry[i].Index == 1774 {
 			catalyst = i
 			break

--- a/tmserver/internal/handler/gate.go
+++ b/tmserver/internal/handler/gate.go
@@ -84,7 +84,7 @@ func itemKeyID(it world.Item) int {
 // carryKeySlot returns the first carry slot holding an item whose EF_KEYID matches
 // key, or -1. Loop-only (reads Entity.Carry directly).
 func carryKeySlot(e *world.Entity, key int) int {
-	for i := range e.Carry {
+	for i := 0; i < activeCarryLimit(e); i++ {
 		if !e.Carry[i].Empty() && itemKeyID(e.Carry[i]) == key {
 			return i
 		}

--- a/tmserver/internal/handler/gm.go
+++ b/tmserver/internal/handler/gm.go
@@ -182,11 +182,12 @@ func (d *Dispatcher) gmItem(w *world.World, s *world.Session, rest string) {
 	if e == nil {
 		return
 	}
-	slot := w.AddToCarry(e, world.Item{Index: int16(id)})
+	slot := firstEmptyAccessibleCarry(e)
 	if slot < 0 {
 		d.notify(w, s, NoticeNoEmptySlot)
 		return
 	}
+	e.Carry[slot] = world.Item{Index: int16(id)}
 	w.Send(s, protocol.MsgCNFGetItem, slotPayload(slot))
 	d.log.Info("gm item", "account", s.AccountName, "item", id, "slot", slot)
 }

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -55,7 +55,7 @@ func (d *Dispatcher) dropItem(w *world.World, s *world.Session, _ protocol.Heade
 		return // can't drop equipped directly; only CARRY in this batch
 	}
 	slot := int(body.SourPos)
-	if slot < 0 || slot >= world.MaxCarry {
+	if !carrySlotAccessible(e, slot) {
 		return
 	}
 	item := e.Carry[slot]
@@ -116,10 +116,11 @@ func (d *Dispatcher) getItem(w *world.World, s *world.Session, _ protocol.Header
 		return // special restriction
 	}
 
-	slot := w.AddToCarry(e, gi.Item)
-	if slot < 0 {
-		return // inventory full → leave on floor
+	slot := int(body.DestPos)
+	if !carrySlotAccessible(e, slot) || !e.Carry[slot].Empty() {
+		return // inventory full/locked/occupied → leave on floor
 	}
+	e.Carry[slot] = gi.Item
 	w.RemoveGroundItem(id) // atomic claim point
 	w.Send(s, protocol.MsgCNFGetItem, slotPayload(slot))
 }
@@ -146,7 +147,7 @@ func (d *Dispatcher) deleteItem(w *world.World, s *world.Session, _ protocol.Hea
 		return
 	}
 	slot := int(body.Slot)
-	if slot < 0 || slot >= world.MaxCarry-4 { // last 4 carry cells reserved
+	if !carrySlotAccessible(e, slot) {
 		return
 	}
 	if e.Carry[slot].Empty() {
@@ -208,7 +209,7 @@ func (d *Dispatcher) splitItem(w *world.World, s *world.Session, _ protocol.Head
 	}
 	slot := int(body.Slot)
 	num := int(body.Num)
-	if slot < 0 || slot >= world.MaxCarry-4 {
+	if !carrySlotAccessible(e, slot) {
 		return
 	}
 	if num <= 0 || num >= 120 {
@@ -224,10 +225,11 @@ func (d *Dispatcher) splitItem(w *world.World, s *world.Session, _ protocol.Head
 	}
 	nItem := *src
 	setItemAmount(&nItem, num)
-	dst := w.AddToCarry(e, nItem)
+	dst := firstEmptyAccessibleCarry(e)
 	if dst < 0 {
 		return // no free cell — leave the stack whole
 	}
+	e.Carry[dst] = nItem
 	setItemAmount(src, amount-num)
 	d.sendSlot(w, s, world.ItemPlaceCarry, dst, e.Carry[dst])
 	d.sendSlot(w, s, world.ItemPlaceCarry, slot, *src)
@@ -309,7 +311,11 @@ func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header
 		return // consumed/equipped items come from the inventory
 	}
 	src := int(body.SourPos)
-	if src < 0 || src >= world.MaxCarry || e.Carry[src].Empty() {
+	if !carrySlotAccessible(e, src) || e.Carry[src].Empty() {
+		return
+	}
+	if e.Carry[src].Index == itemWandererBag {
+		d.useWandererBag(w, s, e, src)
 		return
 	}
 	if d.useQuest256Ticket(w, s, e, src) {
@@ -1854,8 +1860,8 @@ func (d *Dispatcher) shiftWeaponToRightHand(w *world.World, s *world.Session, e 
 
 // itemSlot returns a pointer to the live item slot for a place/slot pair, or nil
 // if the place is unknown or the slot is out of bounds. Carry moves are bounded by
-// MaxCarry-4 (the last 4 slots are reserved, as in _MSG_TradingItem.cpp). The
-// cargo slot is nil unless the account's warehouse is loaded.
+// the currently unlocked Carry range. The cargo slot is nil unless the account's
+// warehouse is loaded.
 func (d *Dispatcher) itemSlot(w *world.World, s *world.Session, e *world.Entity, place, slot int) *world.Item {
 	switch place {
 	case world.ItemPlaceEquip:
@@ -1864,7 +1870,7 @@ func (d *Dispatcher) itemSlot(w *world.World, s *world.Session, e *world.Entity,
 		}
 		return &e.Equip[slot]
 	case world.ItemPlaceCarry:
-		if slot < 0 || slot >= world.MaxCarry-4 {
+		if !carrySlotAccessible(e, slot) {
 			return nil
 		}
 		return &e.Carry[slot]

--- a/tmserver/internal/handler/misc.go
+++ b/tmserver/internal/handler/misc.go
@@ -456,7 +456,8 @@ const (
 // A 697 counts as 1 unit, a 4131 as 10. The legacy case never checks confirm.
 func (d *Dispatcher) blackOracle(w *world.World, s *world.Session, e *world.Entity) {
 	soulSlot := -1
-	for i := 0; i < len(e.Carry)-1; i++ {
+	limit := activeCarryLimit(e)
+	for i := 0; i < limit-1; i++ {
 		if e.Carry[i].Index == soulItem1 && e.Carry[i+1].Index == soulItem2 {
 			soulSlot = i
 			break
@@ -467,7 +468,8 @@ func (d *Dispatcher) blackOracle(w *world.World, s *world.Session, e *world.Enti
 		return
 	}
 	units := 0
-	for _, it := range e.Carry {
+	for i := 0; i < limit; i++ {
+		it := e.Carry[i]
 		switch it.Index {
 		case sapphireUnit1:
 			units++
@@ -480,7 +482,7 @@ func (d *Dispatcher) blackOracle(w *world.World, s *world.Session, e *world.Enti
 		return
 	}
 	remaining := blackOracleCost
-	for i := range e.Carry {
+	for i := 0; i < limit; i++ {
 		if remaining <= 0 {
 			break
 		}
@@ -523,10 +525,12 @@ func (d *Dispatcher) compSephi(w *world.World, s *world.Session, e, npc *world.E
 		return
 	}
 	const pedraCount = 8
+	limit := activeCarryLimit(e)
 	slots := make([]int, 0, pedraCount)
 	for j := 0; j < pedraCount; j++ {
 		found := -1
-		for i, it := range e.Carry {
+		for i := 0; i < limit; i++ {
+			it := e.Carry[i]
 			if it.Index == int16(1744+j) {
 				found = i
 				break
@@ -671,7 +675,7 @@ func (d *Dispatcher) perzenExchange(w *world.World, s *world.Session, npc *world
 		return
 	}
 	slot := -1
-	for i := range e.Carry {
+	for i := 0; i < activeCarryLimit(e); i++ {
 		if e.Carry[i].Index == input {
 			slot = i
 			break

--- a/tmserver/internal/handler/mobai.go
+++ b/tmserver/internal/handler/mobai.go
@@ -444,6 +444,7 @@ func (d *Dispatcher) regenPlayers(w *world.World) {
 		if e.HP <= 0 {
 			return
 		}
+		d.expireWandererBags(w, s, e, now)
 		// Expire the Divine buff when its wall-clock deadline passes (captura §B): drop
 		// the affect and push the (now lower) score + buff snapshot.
 		if e.DivineEnd > 0 && now >= e.DivineEnd && e.HasAffect(world.AffectDivine) {

--- a/tmserver/internal/handler/notice.go
+++ b/tmserver/internal/handler/notice.go
@@ -48,6 +48,7 @@ const (
 	NoticeIncuWaitMore   // _NN_Incu_Wait_More (261): the egg's incubation timer
 
 	NoticeNoEmptySlot // _NN_NoEmptySlot
+	NoticeMaxBag      // _NN_MAX_BAG: both Bolsa do Andarilho slots are already active
 
 	NoticeNoKey // _NN_No_Key: a locked gate needs a key the player doesn't hold
 

--- a/tmserver/internal/handler/shop.go
+++ b/tmserver/internal/handler/shop.go
@@ -64,7 +64,7 @@ func (d *Dispatcher) buy(w *world.World, s *world.Session, _ protocol.Header, pa
 	if npc == nil || npc.Merchant == 0 || e == nil {
 		return
 	}
-	if npcPos < 0 || npcPos >= world.MaxCarry || myPos < 0 || myPos >= world.MaxCarry {
+	if npcPos < 0 || npcPos >= world.MaxCarry || !carrySlotAccessible(e, myPos) {
 		return
 	}
 	item := npc.Carry[npcPos]
@@ -129,7 +129,7 @@ func (d *Dispatcher) sell(w *world.World, s *world.Session, _ protocol.Header, p
 	if npc == nil || npc.Merchant == 0 || e == nil || myType != 1 {
 		return // only inventory (Carry) sell supported this pass
 	}
-	if myPos < 0 || myPos >= world.MaxCarry || e.Carry[myPos].Index == 0 {
+	if !carrySlotAccessible(e, myPos) || e.Carry[myPos].Index == 0 {
 		return
 	}
 	price := d.itemPrices[int(e.Carry[myPos].Index)]

--- a/tmserver/internal/handler/trade.go
+++ b/tmserver/internal/handler/trade.go
@@ -7,8 +7,9 @@ import (
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
 )
 
-// maxTradeSlot bounds an offered InvenPos: [0, MAX_CARRY-4) (lote2-trade-autotrade.md).
-const maxTradeSlot = world.MaxCarry - 4
+// maxTradeSlot is the absolute upper bound for normal player carry slots. The
+// per-character active limit may be lower when Bolsa do Andarilho is inactive.
+const maxTradeSlot = maxUnlockedCarry
 
 // trade handles _MSG_Trade (0x0383): validate the offer and confirm; when BOTH
 // sides have confirmed a matching trade, perform the atomic swap. Any validation
@@ -43,7 +44,7 @@ func (d *Dispatcher) trade(w *world.World, s *world.Session, _ protocol.Header, 
 			continue
 		}
 		pos := int(body.InvenPos[i])
-		if pos < 0 || pos >= maxTradeSlot || !sameItem(body.Item[i], e.Carry[pos]) {
+		if pos < 0 || pos >= maxTradeSlot || !carrySlotAccessible(e, pos) || !sameItem(body.Item[i], e.Carry[pos]) {
 			d.removeTrade(w, s) // bounds or item changed during confirm
 			return
 		}
@@ -73,6 +74,10 @@ func (d *Dispatcher) executeSwap(w *world.World, a, b *world.Session) {
 		d.removeTrade(w, a)
 		return
 	}
+	if !tradeSlotsAccessible(ea, a.Trade.Slots) || !tradeSlotsAccessible(eb, b.Trade.Slots) {
+		d.removeTrade(w, a)
+		return
+	}
 
 	aItems := takeItems(ea, a.Trade.Slots)
 	bItems := takeItems(eb, b.Trade.Slots)
@@ -83,10 +88,14 @@ func (d *Dispatcher) executeSwap(w *world.World, a, b *world.Session) {
 		return
 	}
 	for _, it := range aItems {
-		w.AddToCarry(eb, it)
+		if dst := firstEmptyAccessibleCarry(eb); dst >= 0 {
+			eb.Carry[dst] = it
+		}
 	}
 	for _, it := range bItems {
-		w.AddToCarry(ea, it)
+		if dst := firstEmptyAccessibleCarry(ea); dst >= 0 {
+			ea.Carry[dst] = it
+		}
 	}
 	ea.Coin += b.Trade.Money - a.Trade.Money
 	eb.Coin += a.Trade.Money - b.Trade.Money
@@ -156,13 +165,16 @@ func sameItem(wi protocol.WireItem, it world.Item) bool {
 }
 
 func freeCarry(e *world.Entity) int {
-	n := 0
-	for i := range e.Carry {
-		if e.Carry[i].Empty() {
-			n++
+	return freeAccessibleCarry(e)
+}
+
+func tradeSlotsAccessible(e *world.Entity, slots []int) bool {
+	for _, sl := range slots {
+		if sl < 0 || sl >= maxTradeSlot || !carrySlotAccessible(e, sl) || e.Carry[sl].Empty() {
+			return false
 		}
 	}
-	return n
+	return true
 }
 
 // takeItems removes the items at the given carry slots, returning them aligned to

--- a/tmserver/internal/handler/trade_test.go
+++ b/tmserver/internal/handler/trade_test.go
@@ -72,6 +72,32 @@ func firstResultIndex(t *testing.T, payload []byte) int16 {
 	return int16(binary.LittleEndian.Uint16(payload[1:3]))
 }
 
+func TestTradeSlotsAccessibleRequiresUnlockedCarry(t *testing.T) {
+	e := &world.Entity{}
+	e.Carry[44] = world.Item{Index: 1100}
+	e.Carry[45] = world.Item{Index: 2200}
+
+	if tradeSlotsAccessible(e, []int{44}) {
+		t.Fatal("slot 44 was tradeable without a Wanderer Bag marker")
+	}
+
+	e.Carry[wandererBagSlot1] = world.Item{Index: itemWandererBag}
+	if !tradeSlotsAccessible(e, []int{44}) {
+		t.Fatal("slot 44 was not tradeable with one active Wanderer Bag marker")
+	}
+	if tradeSlotsAccessible(e, []int{45}) {
+		t.Fatal("slot 45 was tradeable with only one active Wanderer Bag marker")
+	}
+
+	e.Carry[wandererBagSlot2] = world.Item{Index: itemWandererBag}
+	if !tradeSlotsAccessible(e, []int{45}) {
+		t.Fatal("slot 45 was not tradeable with two active Wanderer Bag markers")
+	}
+	if tradeSlotsAccessible(e, []int{wandererBagSlot1}) {
+		t.Fatal("marker slot 60 must never be tradeable")
+	}
+}
+
 func TestTradeAtomicSwap(t *testing.T) {
 	addr, stop, _ := startServerClock(t, tradeDB())
 	defer stop()

--- a/tmserver/internal/handler/wanderer_bag_test.go
+++ b/tmserver/internal/handler/wanderer_bag_test.go
@@ -1,0 +1,150 @@
+package handler
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+func wandererBagDB(carry map[int]world.Item) *fakeDB {
+	db := newDB()
+	st := world.CharacterState{Slot: 0, Name: "Hero", X: 5, Y: 5, HP: 1000, MaxHP: 1000}
+	for slot, it := range carry {
+		st.Carry[slot] = it
+	}
+	db.loadResult = st
+	return db
+}
+
+func useCarryItem(t *testing.T, c net.Conn, slot int) {
+	t.Helper()
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: int32(slot)}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+}
+
+func updateCarryIndex(payload []byte, slot int) uint16 {
+	return le16(payload[slot*protocol.ItemSize : slot*protocol.ItemSize+2])
+}
+
+func TestWandererBagUnlocksFirstExtraPage(t *testing.T) {
+	db := wandererBagDB(map[int]world.Item{
+		0: {Index: itemWandererBag},
+		1: {Index: 1100},
+	})
+	addr, stop, _ := startServerClock(t, db)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	tradeItemFrame(t, c, world.ItemPlaceCarry, 1, world.ItemPlaceCarry, 30, 0)
+	if ty, _, ok := readMaybe(t, c); ok {
+		t.Fatalf("move into locked slot 30 produced %#x, want silence", ty)
+	}
+
+	useCarryItem(t, c, 0)
+	carry := expect(t, c, protocol.MsgUpdateCarry)
+	if got := updateCarryIndex(carry, wandererBagSlot1); got != itemWandererBag {
+		t.Fatalf("marker slot 60 = %d, want Bolsa do Andarilho", got)
+	}
+	if got := updateCarryIndex(carry, 0); got != 0 {
+		t.Fatalf("source slot 0 = %d, want consumed", got)
+	}
+
+	tradeItemFrame(t, c, world.ItemPlaceCarry, 1, world.ItemPlaceCarry, 30, 0)
+	expect(t, c, protocol.MsgTradingItem)
+	expect(t, c, protocol.MsgSendItem)
+	dst := expect(t, c, protocol.MsgSendItem)
+	if got := le16(dst[2:4]); got != 30 {
+		t.Fatalf("move destination slot = %d, want 30", got)
+	}
+	if got := le16(dst[4:6]); got != 1100 {
+		t.Fatalf("moved item = %d, want 1100", got)
+	}
+}
+
+func TestWandererBagSecondUseAndMaxBag(t *testing.T) {
+	db := wandererBagDB(map[int]world.Item{
+		0: amountItem(itemWandererBag, 3),
+		1: {Index: 1100},
+	})
+	addr, stop, _ := startServerClock(t, db)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	useCarryItem(t, c, 0)
+	expect(t, c, protocol.MsgUpdateCarry)
+
+	tradeItemFrame(t, c, world.ItemPlaceCarry, 1, world.ItemPlaceCarry, 45, 0)
+	if ty, _, ok := readMaybe(t, c); ok {
+		t.Fatalf("move into locked slot 45 with one bag produced %#x, want silence", ty)
+	}
+
+	useCarryItem(t, c, 0)
+	carry := expect(t, c, protocol.MsgUpdateCarry)
+	if got := updateCarryIndex(carry, wandererBagSlot2); got != itemWandererBag {
+		t.Fatalf("marker slot 61 = %d, want Bolsa do Andarilho", got)
+	}
+
+	tradeItemFrame(t, c, world.ItemPlaceCarry, 1, world.ItemPlaceCarry, 45, 0)
+	expect(t, c, protocol.MsgTradingItem)
+	expect(t, c, protocol.MsgSendItem)
+	expect(t, c, protocol.MsgSendItem)
+
+	useCarryItem(t, c, 0)
+	if ty, p, ok := readMaybe(t, c); !ok || ty != protocol.MsgMessageBoxOk || noticeCode(t, p) != NoticeMaxBag {
+		t.Fatalf("third bag use got %#x ok=%v, want max-bag notice", ty, ok)
+	}
+	if ty, _, ok := readMaybe(t, c); ok {
+		t.Fatalf("max-bag use produced extra frame %#x", ty)
+	}
+
+	send(t, c, protocol.MsgCharacterLogout, nil)
+	expect(t, c, protocol.MsgCNFCharacterLogout)
+	save, n := db.lastSavedChar()
+	if n == 0 {
+		t.Fatal("character was not saved on logout")
+	}
+	carry0, ok := savedItemAt(save.Carry, 0)
+	if !ok || carry0.Index != itemWandererBag || carry0.Eff1 != efAmount || carry0.EffV1 != 1 {
+		t.Fatalf("saved source bag = %+v ok=%v, want one remaining stack unit", carry0, ok)
+	}
+	for _, slot := range []int{wandererBagSlot1, wandererBagSlot2} {
+		marker, ok := savedItemAt(save.Carry, slot)
+		if !ok || marker.Index != itemWandererBag || marker.ExpiresAt <= time.Now().Unix() {
+			t.Fatalf("saved marker slot %d = %+v ok=%v, want active timed bag", slot, marker, ok)
+		}
+	}
+}
+
+func TestExpiredWandererBagMarkerDropsOnLogin(t *testing.T) {
+	db := wandererBagDB(map[int]world.Item{
+		30:               {Index: 1100},
+		wandererBagSlot1: {Index: itemWandererBag, ExpiresAt: time.Now().Unix() - 1},
+	})
+	addr, stop, _ := startServerClock(t, db)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	tradeItemFrame(t, c, world.ItemPlaceCarry, 30, world.ItemPlaceCarry, 0, 0)
+	if ty, _, ok := readMaybe(t, c); ok {
+		t.Fatalf("expired bag still allowed slot 30 move, got %#x", ty)
+	}
+
+	send(t, c, protocol.MsgCharacterLogout, nil)
+	expect(t, c, protocol.MsgCNFCharacterLogout)
+	save, n := db.lastSavedChar()
+	if n == 0 {
+		t.Fatal("character was not saved on logout")
+	}
+	if marker, ok := savedItemAt(save.Carry, wandererBagSlot1); ok {
+		t.Fatalf("expired marker was saved: %+v", marker)
+	}
+	if item, ok := savedItemAt(save.Carry, 30); !ok || item.Index != 1100 {
+		t.Fatalf("inaccessible item slot 30 = %+v ok=%v, want preserved", item, ok)
+	}
+}

--- a/tmserver/internal/protocol/carry.go
+++ b/tmserver/internal/protocol/carry.go
@@ -1,0 +1,15 @@
+package protocol
+
+const updateCarrySize = HeaderSize + 64*ItemSize + 4
+
+// EncodeUpdateCarryBody builds MSG_UpdateCarry: the full Carry[64] snapshot plus
+// carried gold. The legacy sends this after Bolsa do Andarilho changes so the
+// client recalculates which inventory pages are available.
+func EncodeUpdateCarryBody(carry [64]SelItem, coin int32) []byte {
+	b := make([]byte, updateCarrySize-HeaderSize)
+	for i := 0; i < 64; i++ {
+		writeSelItem(b[i*ItemSize:], carry[i])
+	}
+	le.PutUint32(b[64*ItemSize:], uint32(coin))
+	return b
+}

--- a/tmserver/internal/protocol/createmob_test.go
+++ b/tmserver/internal/protocol/createmob_test.go
@@ -77,6 +77,27 @@ func TestRemoveMobBodyLayout(t *testing.T) {
 	}
 }
 
+func TestUpdateCarryBodyLayout(t *testing.T) {
+	var carry [64]SelItem
+	carry[0] = SelItem{Index: 3467}
+	carry[61] = SelItem{Index: 1100}
+	b := EncodeUpdateCarryBody(carry, 12345)
+
+	if len(b) != updateCarrySize-HeaderSize { // 528 - 12 = 516
+		t.Fatalf("UpdateCarry body = %d, want %d", len(b), updateCarrySize-HeaderSize)
+	}
+	if got := binary.LittleEndian.Uint16(b[0:2]); got != 3467 {
+		t.Errorf("carry[0] = %d, want 3467", got)
+	}
+	off := 61 * ItemSize
+	if got := binary.LittleEndian.Uint16(b[off : off+2]); got != 1100 {
+		t.Errorf("carry[61] = %d, want 1100", got)
+	}
+	if got := int32(binary.LittleEndian.Uint32(b[64*ItemSize:])); got != 12345 {
+		t.Errorf("coin = %d, want 12345", got)
+	}
+}
+
 func TestShopListBodyLayout(t *testing.T) {
 	var list [maxShopList]SelItem
 	list[0] = SelItem{Index: 831}

--- a/tmserver/internal/protocol/types.go
+++ b/tmserver/internal/protocol/types.go
@@ -128,6 +128,7 @@ const (
 	MsgPKInfo             Type = 0x0166 // 358  S→C PK/war state of a player (MSG_STANDARDPARM, Basedef.h:1954)
 	MsgPKMode             Type = 0x0399 // 921  C→S PlayerKiller toggle (K key; MSG_STANDARDPARM, Basedef.h:2164)
 	MsgSendItem           Type = 0x0182 // 386  update one slot
+	MsgUpdateCarry        Type = 0x0185 // 389  S→C full Carry[64] + Coin snapshot
 	MsgAccountSecureFail  Type = 0x0FDF // 4063 S→C PIN rejected (_MSG_AccountSecureFail)
 	MsgCNFAddParty        Type = 0x037D // 893  S→C party-list slot sync (MSG_CNFAddParty)
 	MsgUpdateEquip        Type = 0x036B // 875  S→C refresh visible equipment (_MSG_UpdateEquip, Basedef.h:2094)

--- a/tmserver/internal/protocol/types_test.go
+++ b/tmserver/internal/protocol/types_test.go
@@ -95,6 +95,7 @@ func TestMessageTypeValues(t *testing.T) {
 		{"_MSG_PKInfo (Basedef.h:1954)", MsgPKInfo, 102 | flagGame2Client},
 		{"_MSG_PKMode (Basedef.h:2164)", MsgPKMode, 153 | flagGame2Client | flagClient2Game},
 		{"_MSG_SendItem (Basedef.h:2036)", MsgSendItem, 130 | flagGame2Client},
+		{"_MSG_UpdateCarry (Basedef.h:1813)", MsgUpdateCarry, 133 | flagGame2Client},
 		{"_MSG_CNFAddParty (Basedef.h:2246)", MsgCNFAddParty, 125 | flagGame2Client | flagClient2Game},
 		{"_MSG_UpdateEquip (Basedef.h:2094)", MsgUpdateEquip, 107 | flagGame2Client | flagClient2Game},
 		{"_MSG_REQShopList (Basedef.h:2153)", MsgREQShopList, 123 | flagClient2Game},


### PR DESCRIPTION
Summary
- Add Bolsa do Andarilho consumption with 30-day marker slots 60/61 and active carry limits of 30/45/60 slots.
- Gate inventory, shop, trade, autotrade, quest, combine, GM, and key flows to the currently unlocked carry range.
- Add MSG_UpdateCarry encoding and regression tests for unlocks, max-bag notice, expiry, persistence, packet layout, and trade validation.

Tests
- go test ./tmserver/internal/handler -run 'TestWandererBag|TestTradeSlotsAccessible|TestTradeAtomicSwap|TestTradeCancel|TestTradeDup'\n- make test\n- make build\n\nCloses #180