### PR TITLE
Implement Pergaminho do Retorno

### DIFF
--- a/docs/migration/handlers/_MSG_UseItem.md
+++ b/docs/migration/handlers/_MSG_UseItem.md
@@ -18,6 +18,8 @@
 - Equipar: move item `CARRY → EQUIP[slot]`, recalcula score (`BASE_GetCurrentScore`), valida
   requisitos (level/str/int/dex/con) do `STRUCT_ITEMLIST`.
 - Consumir (poção/scroll): aplica efeito/affect, decrementa stack.
+- Pergaminho do Retorno (`EF_VOLATILE=11`): chama recall para o spawn da última cidade e
+  decrementa stack.
 - Refinar: ajusta `sanc`/efeitos do item (ver tabelas `SancRate.txt`, Fase 4 §3.3).
 - Teleporte por scroll: usa `WarpID`/`GridX/Y`.
 

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -240,6 +240,7 @@ func (d *Dispatcher) splitItem(w *world.World, s *world.Session, _ protocol.Head
 const (
 	volHpMpPotion   = 1
 	volFairyDust    = 7
+	volRecallScroll = 11 // Pergaminho do Retorno: recalls to the last-city spawn
 	volGemaEstelar  = 12 // Gema Estelar: records the warp save-point
 	volPortalScroll = 13 // Pergaminho de Portal: teleports to the save-point
 	volVigor        = 58
@@ -302,8 +303,9 @@ const potionDelay = 100
 
 // useItem handles _MSG_UseItem (0x0373), handlers/_MSG_UseItem.md. The action is
 // classified by the source item's EF_VOLATILE value (BASE_GetItemAbility, captura §B):
-// 0 = equip (CARRY → EQUIP); 12/13 = Gema Estelar/Portal (warp save-point, issue #140);
-// 64-66 = Poção Divina; other consumables are UNVERIFIED and not handled yet.
+// 0 = equip (CARRY → EQUIP); 11 = Retorno (recall); 12/13 = Gema Estelar/Portal
+// (warp save-point, issue #140); 64-66 = Poção Divina; other consumables are
+// UNVERIFIED and not handled yet.
 // Drag-and-drop between slots is a different message (tradingItem).
 func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header, payload []byte) {
 	e := w.Entity(s.Conn)
@@ -347,6 +349,8 @@ func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header
 		d.refineItem(w, s, e, body, src, vol)
 	case vol == volHpMpPotion:
 		d.useHealPotion(w, s, e, src)
+	case vol == volRecallScroll:
+		d.useRecallScroll(w, s, e, src)
 	case vol == volGemaEstelar:
 		d.useGemaEstelar(w, s, e, src)
 	case vol == volPortalScroll:
@@ -574,6 +578,14 @@ func (d *Dispatcher) useFairyDust(w *world.World, s *world.Session, e *world.Ent
 // tickets (Gema Estelar, Portal, and the two Pesadelo entry scrolls).
 func inPesadelo(x, y int16) bool {
 	return (x/128 == 9 && y/128 == 1) || (x/128 == 8 && y/128 == 2)
+}
+
+// useRecallScroll consumes a Pergaminho do Retorno (EF_VOLATILE 11): the legacy
+// handler calls DoRecall(conn) and then decrements the item (_MSG_UseItem.cpp:1344).
+func (d *Dispatcher) useRecallScroll(w *world.World, s *world.Session, e *world.Entity, src int) {
+	consumeOneItem(&e.Carry[src])
+	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
+	d.recall(w, s, e)
 }
 
 // useGemaEstelar consumes a Gema Estelar (EF_VOLATILE 12): records the player's

--- a/tmserver/internal/handler/item_test.go
+++ b/tmserver/internal/handler/item_test.go
@@ -2115,10 +2115,90 @@ func startServerClockVolGrid(t *testing.T, persist world.Persistence, vols map[i
 	}
 }
 
+func recallScrollDB(lastCity int16, hp, mp int32, carry ...world.Item) *fakeDB {
+	db := newDB()
+	st := world.CharacterState{
+		Slot: 0, Name: "Hero", X: 5, Y: 5, LastCity: lastCity,
+		HP: hp, MaxHP: 1000, MP: mp, MaxMP: 500,
+	}
+	for i, it := range carry {
+		if i >= len(st.Carry) {
+			break
+		}
+		st.Carry[i] = it
+	}
+	db.loadResult = st
+	return db
+}
+
 func useItemFrame(t *testing.T, c net.Conn, slot int) {
 	t.Helper()
 	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: int32(slot)}
 	send(t, c, protocol.MsgUseItem, body.Encode())
+}
+
+// TestUseRecallScrollConsumesAndRecalls ports _MSG_UseItem.cpp's "Retorno" block:
+// EF_VOLATILE 11 calls DoRecall and consumes one Pergaminho_Retorno.
+func TestUseRecallScrollConsumesAndRecalls(t *testing.T) {
+	const recall = 410
+	db := recallScrollDB(2, 321, 123, world.Item{Index: recall})
+	addr, stop := startServerClockVolGrid(t, db, map[int]int{recall: volRecallScroll}, 2600)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	useItemFrame(t, c, 0)
+	item := expect(t, c, protocol.MsgSendItem)
+	if got := le16(item[4:6]); got != 0 {
+		t.Errorf("recall slot = %d, want empty after use", got)
+	}
+	action := expectAction(t, c)
+	if action.PosX != 5 || action.PosY != 5 || action.Effect != 1 {
+		t.Errorf("recall action origin/effect = (%d,%d)/%d, want (5,5)/1", action.PosX, action.PosY, action.Effect)
+	}
+	if city := world.Village(action.TargetX, action.TargetY); city != 2 {
+		t.Fatalf("recall target = (%d,%d) in city %d, want last city 2", action.TargetX, action.TargetY, city)
+	}
+	if ty, _, ok := readMaybe(t, c); ok && ty == protocol.MsgSetHpMp {
+		t.Fatal("recall scroll sent SetHpMp, want no HP/MP bar mutation")
+	}
+
+	send(t, c, protocol.MsgCharacterLogout, nil)
+	expect(t, c, protocol.MsgCNFCharacterLogout)
+	save, n := db.lastSavedChar()
+	if n == 0 {
+		t.Fatal("character was not saved on logout")
+	}
+	if save.HP != 321 || save.MP != 123 {
+		t.Fatalf("saved HP/MP = %d/%d, want unchanged 321/123", save.HP, save.MP)
+	}
+	if _, ok := savedItemAt(save.Carry, 0); ok {
+		t.Fatal("saved carry slot 0 still has recall scroll, want consumed")
+	}
+}
+
+// TestUseRecallScrollStack decrements EF_AMOUNT on the 10x return scroll and still
+// recalls to the character's last-city spawn.
+func TestUseRecallScrollStack(t *testing.T) {
+	const recall10x = 411
+	db := recallScrollDB(1, 1000, 500, world.Item{Index: recall10x, Effects: [3]world.Effect{{Effect: efAmount, Value: 10}}})
+	addr, stop := startServerClockVolGrid(t, db, map[int]int{recall10x: volRecallScroll}, 2700)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	useItemFrame(t, c, 0)
+	item := expect(t, c, protocol.MsgSendItem)
+	if got := le16(item[4:6]); got != recall10x {
+		t.Fatalf("carry slot 0 item = %d, want stacked recall scroll", got)
+	}
+	if item[6] != efAmount || item[7] != 9 {
+		t.Errorf("effect0 = %d.%d, want %d.9", item[6], item[7], efAmount)
+	}
+	action := expectAction(t, c)
+	if city := world.Village(action.TargetX, action.TargetY); city != 1 {
+		t.Fatalf("recall target = (%d,%d) in city %d, want last city 1", action.TargetX, action.TargetY, city)
+	}
 }
 
 // TestUseGemaEstelarThenPortalRoundTrip: saving at the current position, then


### PR DESCRIPTION
## Summary
- handle `EF_VOLATILE == 11` return scrolls in `_MSG_UseItem`
- consume/decrement the scroll and reuse the existing recall path
- document the return scroll behavior in the UseItem migration notes

## Tests
- `go test -run 'TestUseRecallScroll|TestUsePortalScroll|TestUseGemaEstelar' ./tmserver/internal/handler`\n- `go test ./tmserver/internal/handler`\n\nCloses #178