### PR TITLE
Fix autotrade shop visibility

### DIFF
--- a/tmserver/internal/handler/autotrade_test.go
+++ b/tmserver/internal/handler/autotrade_test.go
@@ -23,6 +23,30 @@ func autotradeDB(sellItem int16) *fakeDB {
 	return db
 }
 
+func autotradeViewDB(sellItem int16) *fakeDB {
+	db := newDB()
+	db.loads = map[int64]world.CharacterState{
+		7:  {Slot: 0, Name: "Seller", X: 2086, Y: 2093, HP: 1000, MaxHP: 1000, Coin: 1000},
+		11: {Slot: 0, Name: "Buyer", X: 2086, Y: 2130, HP: 1000, MaxHP: 1000, Coin: 1_000_000},
+	}
+	var cargo world.CargoState
+	cargo.Items[0] = world.Item{Index: sellItem}
+	db.accounts["tester"].cargo = cargo
+	return db
+}
+
+func createMobTradeFields(t *testing.T, payload []byte) (x, y int16, mobID int, title string) {
+	t.Helper()
+	if len(payload) != 240 {
+		t.Fatalf("CreateMobTrade body = %d bytes, want 240", len(payload))
+	}
+	x = int16(binary.LittleEndian.Uint16(payload[0:2]))
+	y = int16(binary.LittleEndian.Uint16(payload[2:4]))
+	mobID = int(binary.LittleEndian.Uint16(payload[4:6]))
+	title = cstr(payload[216:240])
+	return x, y, mobID, title
+}
+
 // openShopPayload builds a client MSG_SendAutoTrade selling Cargo[cargoPos] for
 // price in shop slot 0.
 func openShopPayload(title string, item int16, cargoPos int, price int32) []byte {
@@ -48,6 +72,37 @@ func reqBuyPayload(targetID, pos int, item int16, price, tax int32) []byte {
 		Item:     protocol.WireItem{Index: item},
 	}
 	return body.Encode()
+}
+
+func TestAutoTradeShopPoseWhenBuyerEntersView(t *testing.T) {
+	const sellItem = int16(1030)
+	const title = "Loja Longe"
+	addr, stop := startServerView(t, autotradeViewDB(sellItem), world.DefaultGridDim)
+	defer stop()
+	seller := enterWorldAs(t, addr, "tester") // conn 1, inside Armia at (2086,2093)
+	defer seller.Close()
+	buyer := enterWorldAs(t, addr, "tradeb") // conn 2, outside ViewRange at (2086,2130)
+	defer buyer.Close()
+	drainRaw(t, seller)
+	drainRaw(t, buyer)
+
+	send(t, seller, protocol.MsgSendAutoTrade, openShopPayload(title, sellItem, 0, 1000))
+	readUntil(t, seller, protocol.MsgSendAutoTrade)
+	if ty, _, ok := readMaybeRaw(t, buyer); ok {
+		t.Fatalf("out-of-view buyer got %#x after shop opened, want no shop pose yet", ty)
+	}
+
+	actionFrameXY(t, buyer, protocol.MsgAction, serverTime, 2086, 2130, 2086, 2100)
+	ty, payload, ok := readMaybeRaw(t, buyer)
+	if !ok || ty != protocol.MsgCreateMobTrade {
+		t.Fatalf("buyer entering view got %#x ok=%v, want CreateMobTrade", ty, ok)
+	}
+	if x, y, id, gotTitle := createMobTradeFields(t, payload); id != 1 || x != 2086 || y != 2093 || gotTitle != title {
+		t.Fatalf("shop pose = id %d at (%d,%d) title %q, want id 1 at (2086,2093) title %q", id, x, y, gotTitle, title)
+	}
+	if ty, _, ok = readMaybeRaw(t, buyer); !ok || ty != protocol.MsgPKInfo {
+		t.Fatalf("frame after shop pose = %#x ok=%v, want PKInfo", ty, ok)
+	}
 }
 
 func TestAutoTradeOpenBrowseBuy(t *testing.T) {

--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -465,8 +465,8 @@ func (d *Dispatcher) enterWorldView(w *world.World, s *world.Session) {
 		w.SendTo(vs, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(s.Conn)}, protocol.EncodeStandardParm(pkInfoParm(self)))
 		// (B) the newcomer sees each player already in view
 		w.MarkSeen(s, ve.ID)
-		w.SendTo(s, protocol.Header{Type: protocol.MsgCreateMob, ID: protocol.IDScene},
-			protocol.EncodeCreateMobBody(createMobFrom(ve, 0)))
+		ty, body := createMobViewPacket(w, ve, 0)
+		w.SendTo(s, protocol.Header{Type: ty, ID: protocol.IDScene}, body)
 		w.SendTo(s, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(ve.ID)}, protocol.EncodeStandardParm(pkInfoParm(ve)))
 	})
 	// (C) the newcomer sees the NPCs/monsters in view.
@@ -516,6 +516,21 @@ func createMobFrom(e *world.Entity, createType uint16) protocol.CreateMobData {
 		IsPlayer: world.IsPlayer(e.ID),
 		PKPoint:  playerPKPoint(e),
 	}
+}
+
+// createMobViewPacket mirrors legacy SendCreateMob: a player with an open
+// personal shop must be revealed with MSG_CreateMobTrade, not the normal avatar
+// packet, so clients that enter view after the shop opened still see the stall.
+func createMobViewPacket(w *world.World, e *world.Entity, createType uint16) (protocol.Type, []byte) {
+	data := createMobFrom(e, createType)
+	if world.IsPlayer(e.ID) {
+		s := w.Session(e.ID)
+		if s != nil && s.Mode == world.UserPlay && s.TradeMode == 1 && s.AutoTrade != nil {
+			data.Con = 0 // GetCreateMobTrade parity: shop pose hides the Con field.
+			return protocol.MsgCreateMobTrade, protocol.EncodeCreateMobTradeBody(data, nil, s.AutoTrade.Title)
+		}
+	}
+	return protocol.MsgCreateMob, protocol.EncodeCreateMobBody(data)
 }
 
 // playerPKPoint is pkPoint(e) for a player, or 0 for a mob (mobs never carry PK

--- a/tmserver/internal/handler/movement.go
+++ b/tmserver/internal/handler/movement.go
@@ -271,10 +271,10 @@ func (d *Dispatcher) doTeleport(w *world.World, s *world.Session, x, y int16) {
 // noViewMob handles _MSG_NoViewMob (0x0369): the client asks to re-sync one
 // entity's visibility (Parm = target id). Port of _MSG_NoViewMob.cpp: a live
 // target within GetInView range (±NoViewRange, looser than the multicast
-// window) gets a full CreateMob snapshot + PKInfo; anything else — empty slot,
-// player not in play, or out of range — gets a RemoveMob. The nil-payload
-// CreateMob this used to send made the client rebuild the avatar from a
-// truncated body: the multiplayer "snap-back" bug.
+// window) gets a full CreateMob/CreateMobTrade snapshot + PKInfo; anything else
+// — empty slot, player not in play, or out of range — gets a RemoveMob. The
+// nil-payload CreateMob this used to send made the client rebuild the avatar
+// from a truncated body: the multiplayer "snap-back" bug.
 func (d *Dispatcher) noViewMob(w *world.World, s *world.Session, _ protocol.Header, payload []byte) {
 	if s.Mode != world.UserPlay {
 		return
@@ -293,8 +293,8 @@ func (d *Dispatcher) noViewMob(w *world.World, s *world.Session, _ protocol.Head
 	}
 	if inPlay && self != nil && chebyshev(self.X, self.Y, target.X, target.Y) <= world.NoViewRange {
 		w.MarkSeen(s, id)
-		w.SendTo(s, protocol.Header{Type: protocol.MsgCreateMob, ID: protocol.IDScene},
-			protocol.EncodeCreateMobBody(createMobFrom(target, 1)))
+		ty, body := createMobViewPacket(w, target, 1)
+		w.SendTo(s, protocol.Header{Type: ty, ID: protocol.IDScene}, body)
 		if id < world.MaxUser {
 			// PKInfo travels only about players (SendPKInfo, SendFunc.cpp:1869).
 			w.SendTo(s, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(id)}, protocol.EncodeStandardParm(pkInfoParm(target)))

--- a/tmserver/internal/handler/view.go
+++ b/tmserver/internal/handler/view.go
@@ -39,6 +39,7 @@ func (d *Dispatcher) moveMulticast(w *world.World, moverID int, oldX, oldY int16
 	if moverID < world.MaxUser {
 		moverSess = w.Session(moverID)
 	}
+	var moverCreateType protocol.Type
 	var moverBody []byte // lazily encoded once, only if someone gains sight
 
 	w.ForEachPlaying(moverID, func(s *world.Session, e *world.Entity) {
@@ -62,15 +63,15 @@ func (d *Dispatcher) moveMulticast(w *world.World, moverID int, oldX, oldY int16
 			}
 		case inNew:
 			if moverBody == nil {
-				moverBody = protocol.EncodeCreateMobBody(createMobFrom(mover, 0))
+				moverCreateType, moverBody = createMobViewPacket(w, mover, 0)
 			}
 			w.MarkSeen(s, moverID)
-			w.SendTo(s, protocol.Header{Type: protocol.MsgCreateMob, ID: protocol.IDScene}, moverBody)
+			w.SendTo(s, protocol.Header{Type: moverCreateType, ID: protocol.IDScene}, moverBody)
 			if moverSess != nil {
 				w.SendTo(s, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(moverID)}, protocol.EncodeStandardParm(pkInfoParm(mover)))
 				w.MarkSeen(moverSess, e.ID)
-				w.SendTo(moverSess, protocol.Header{Type: protocol.MsgCreateMob, ID: protocol.IDScene},
-					protocol.EncodeCreateMobBody(createMobFrom(e, 0)))
+				ty, body := createMobViewPacket(w, e, 0)
+				w.SendTo(moverSess, protocol.Header{Type: ty, ID: protocol.IDScene}, body)
 				w.SendTo(moverSess, protocol.Header{Type: protocol.MsgPKInfo, ID: uint16(e.ID)}, protocol.EncodeStandardParm(pkInfoParm(e)))
 			}
 			if payload != nil {


### PR DESCRIPTION
## Summary
- reveal players with open personal shops using MSG_CreateMobTrade when they enter another player's view
- reuse the same create-packet selection for login-time reveal and NoViewMob resync
- add regression coverage for issue #174 where the buyer walks into range after the shop opens

## Tests
- go test ./tmserver/internal/handler -run 'TestAutoTrade|TestMoveView|TestPlayersCrossingViewOnMovement|TestNoViewMobRanges'\n- go test ./tmserver/internal/protocol\n- go test ./tmserver/internal/handler\n\nCloses #174