### PR TITLE
Fix baby mount summon spawn

### DIFF
--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -348,6 +348,9 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 		d.logCNFCharacterLogin("template", s, st, loginX, loginY, body)
 		w.SendTo(s, protocol.Header{Type: protocol.MsgCNFCharacterLogin, ID: protocol.IDScene}, body)
 		d.enterWorldView(w, s)
+		if e := w.Entity(s.Conn); e != nil {
+			d.refreshBabyMountSummon(w, s, e)
+		}
 		d.sendLoginAffects(w, s)
 		return
 	}
@@ -392,6 +395,9 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 	d.logCNFCharacterLogin("fallback", s, st, loginX, loginY, body)
 	w.SendTo(s, protocol.Header{Type: protocol.MsgCNFCharacterLogin, ID: protocol.IDScene}, body)
 	d.enterWorldView(w, s)
+	if e := w.Entity(s.Conn); e != nil {
+		d.refreshBabyMountSummon(w, s, e)
+	}
 	d.sendLoginAffects(w, s)
 }
 

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -524,6 +524,9 @@ func (d *Dispatcher) equipItem(w *world.World, s *world.Session, e *world.Entity
 	e.Carry[src], e.Equip[dst] = e.Equip[dst], e.Carry[src]
 	w.Send(s, protocol.MsgUseItem, payload) // echo result
 	d.refreshEquip(w, s, e)                 // update the rendered gear
+	if dst == mountEquipSlot {
+		d.refreshBabyMountSummon(w, s, e)
+	}
 }
 
 func (d *Dispatcher) useExpChest(w *world.World, s *world.Session, e *world.Entity, src int) {
@@ -1834,6 +1837,9 @@ func (d *Dispatcher) tradingItem(w *world.World, s *world.Session, _ protocol.He
 	// An equip/unequip changes the rendered gear: refresh the model everywhere.
 	if srcPlace == world.ItemPlaceEquip || dstPlace == world.ItemPlaceEquip {
 		d.refreshEquip(w, s, e)
+	}
+	if (srcPlace == world.ItemPlaceEquip && srcSlot == mountEquipSlot) || (dstPlace == world.ItemPlaceEquip && dstSlot == mountEquipSlot) {
+		d.refreshBabyMountSummon(w, s, e)
 	}
 }
 

--- a/tmserver/internal/handler/summon.go
+++ b/tmserver/internal/handler/summon.go
@@ -28,6 +28,18 @@ const affectSummonLife = 24
 // (Server.cpp:3193-3196). The 28..37 "permanent" mounts are out of scope.
 const summonLifeTicks = 20
 
+// Baby mounts (crias, item 2330..2359) are equipment-backed summons: while the
+// item is alive in Equip[14], MountProcess creates the corresponding BaseSummon
+// entry at sIndex-2320 and keeps it attached to the owner without a lifespan
+// affect (Server.cpp:4633-4676, GenerateSummon sItem branch).
+const (
+	babyMountLo        = 2330
+	babyMountHi        = 2360
+	babyMountSummonAdd = -2320
+	babyMountFaceLo    = 315
+	babyMountFaceHi    = 345
+)
+
 // summonFollowMax / summonTeleport / summonFollowMin shape the follow AI
 // (CMob.cpp:84-152): past 12 the pet warps to the owner, between 5 and 12 it
 // walks, at 4 or less it idles. summonLeash drops the pet's fight when the
@@ -119,10 +131,8 @@ func (d *Dispatcher) cellAvailable(w *world.World, x, y int16) bool {
 // caster, bound to it. Returns false when NOTHING was spawned (the cast then
 // refunds its mana, _MSG_Attack.cpp:830-834). Partial success is true.
 //
-// Not ported from the original: the party-wide mount face pre-scan (mount
-// recall path), and SendAddParty — the client's party frame doesn't list pets
-// yet; the summon still occupies a leader PartyList slot, which is what the
-// group-combat drag and the cleanup need.
+// The item-backed mount recall path uses refreshBabyMountSummon below; this
+// function stays on the spell/sItem==nil branch.
 func (d *Dispatcher) generateSummon(w *world.World, s *world.Session, e *world.Entity, summonID, count int) bool {
 	if count <= 0 || summonID < 0 || summonID >= len(d.summonMobs) || summonID >= len(summonBonus) || d.summonMobs[summonID] == nil {
 		return false
@@ -208,6 +218,110 @@ func (d *Dispatcher) generateSummon(w *world.World, s *world.Session, e *world.E
 		spawned++
 	}
 	return spawned > 0
+}
+
+func (d *Dispatcher) refreshBabyMountSummon(w *world.World, s *world.Session, e *world.Entity) {
+	d.removeBabyMountSummons(w, s.Conn, e)
+
+	mount := e.Equip[mountEquipSlot]
+	if !isBabyMount(mount) || mountHP(mount) <= 0 {
+		return
+	}
+	summonID := int(mount.Index) + babyMountSummonAdd
+	d.generateBabyMountSummon(w, s, e, summonID, mount)
+}
+
+func isBabyMount(it world.Item) bool {
+	return it.Index >= babyMountLo && it.Index < babyMountHi
+}
+
+func mountHP(it world.Item) int16 {
+	return int16(uint16(it.Effects[0].Effect) | uint16(it.Effects[0].Value)<<8)
+}
+
+func (d *Dispatcher) removeBabyMountSummons(w *world.World, ownerID int, owner *world.Entity) {
+	leaderID := owner.Leader
+	if leaderID == 0 {
+		leaderID = ownerID
+	}
+	leader := w.Entity(leaderID)
+	if leader == nil {
+		return
+	}
+	for _, memberID := range leader.PartyList {
+		if memberID < world.MaxUser {
+			continue
+		}
+		pet := w.Entity(memberID)
+		if pet == nil || pet.Summoner != ownerID {
+			continue
+		}
+		if pet.EquipVisual[0] >= babyMountFaceLo && pet.EquipVisual[0] < babyMountFaceHi {
+			w.DespawnMob(memberID, 3)
+		}
+	}
+}
+
+func (d *Dispatcher) generateBabyMountSummon(w *world.World, s *world.Session, e *world.Entity, summonID int, mount world.Item) bool {
+	if summonID < 0 || summonID >= len(d.summonMobs) || d.summonMobs[summonID] == nil {
+		return false
+	}
+	leaderID := e.Leader
+	if leaderID == 0 {
+		leaderID = s.Conn
+	}
+	leader := w.Entity(leaderID)
+	if leader == nil {
+		return false
+	}
+	slot := -1
+	for i := range leader.PartyList {
+		if leader.PartyList[i] == 0 {
+			slot = i
+			break
+		}
+	}
+	if slot < 0 {
+		return false
+	}
+	x, y, ok := d.freeCellNear(w, e.X, e.Y)
+	if !ok {
+		return false
+	}
+	id := w.SpawnMobAt(world.MobSpawn{Template: d.summonMobs[summonID], X: x, Y: y, RouteType: 5, GenIndex: -1})
+	if id < 0 {
+		return false
+	}
+	mob := w.Entity(id)
+	mob.Name = strings.ReplaceAll(mob.Name, "_", " ") + "^"
+	mob.Level = e.Level
+	if mob.Level > level.MaxLevel {
+		mob.Level = level.MaxLevel
+	}
+	mob.Clan = summonClan
+	mob.Leader = leaderID
+	mob.Summoner = s.Conn
+	mountSanc := int32(mount.Effects[1].Effect)
+	if mountSanc > 100 {
+		mountSanc = 100
+	}
+	mob.Damage += 6 * mountSanc
+	hp := int32(mountHP(mount))
+	if mob.MaxHP > 0 && hp > mob.MaxHP {
+		hp = mob.MaxHP
+	}
+	mob.HP = hp
+	leader.PartyList[slot] = id
+	d.sendAddParty(w, leaderID, leaderID, 0)
+	d.sendSummonPartySlot(w, leaderID, id, slot+1)
+
+	body := protocol.EncodeCreateMobBody(createMobFrom(mob, 3))
+	w.ForEachInView(id, func(vs *world.Session, _ *world.Entity) {
+		if w.MarkSeen(vs, id) {
+			w.SendTo(vs, protocol.Header{Type: protocol.MsgCreateMob, ID: protocol.IDScene}, body)
+		}
+	})
+	return true
 }
 
 func summonTemplateFace(template []byte) uint16 {

--- a/tmserver/internal/handler/summon_test.go
+++ b/tmserver/internal/handler/summon_test.go
@@ -138,6 +138,177 @@ func collectPets(t *testing.T, c net.Conn, timeout time.Duration) map[int][]byte
 	return pets
 }
 
+func babyMountItem(index int16, hp uint16) world.Item {
+	it := world.Item{Index: index}
+	putShort(&it.Effects[0], hp)
+	it.Effects[1] = world.Effect{Effect: 5, Value: 10} // mount sanc/life bytes
+	it.Effects[2] = world.Effect{Effect: 30, Value: 1} // feed/kill bytes
+	return it
+}
+
+func babyMountDB(carry, equip world.Item) *fakeDB {
+	db := newDB()
+	st := world.CharacterState{
+		Slot: 0, Name: "Hero", X: 5, Y: 5,
+		HP: 1000, MaxHP: 1000, Level: 50,
+	}
+	st.Carry[0] = carry
+	st.Equip[mountEquipSlot] = equip
+	db.loadResult = st
+	return db
+}
+
+func babyMountSummons() [][]byte {
+	mobs := make([][]byte, 40)
+	mob := summonTemplate("Porco")
+	binary.LittleEndian.PutUint16(mob[140:], 315) // Equip[0] face; 315+(2330-2330)
+	mobs[10] = mob                                // MountProcess: 2330 - 2320
+	return mobs
+}
+
+func startServerBabyMount(t *testing.T, db world.Persistence) (string, func(), *atomic.Uint32) {
+	return startServerSummonWith(t, db, nil, babyMountSummons(), nil, 0, 0)
+}
+
+func expectPetRemove(t *testing.T, c net.Conn, petID int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		h, _, ok := readMaybeHeaderRaw(t, c)
+		if !ok {
+			continue
+		}
+		if h.Type == protocol.MsgRemoveMob && int(h.ID) == petID {
+			return
+		}
+	}
+	t.Fatalf("no RemoveMob for baby mount pet %d", petID)
+}
+
+func TestBabyMountSpawnsOnEquip(t *testing.T) {
+	addr, stop, _ := startServerBabyMount(t, babyMountDB(babyMountItem(2330, 80), world.Item{}))
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	tradeItemFrame(t, c, world.ItemPlaceCarry, 0, world.ItemPlaceEquip, mountEquipSlot, 0)
+	expect(t, c, protocol.MsgTradingItem)
+	expect(t, c, protocol.MsgSendItem)
+	expect(t, c, protocol.MsgSendItem)
+	ue := expect(t, c, protocol.MsgUpdateEquip)
+	if got := le16(ue[mountEquipSlot*2:]); got != 2330 {
+		t.Fatalf("mount visual = %d, want baby mount item 2330", got)
+	}
+
+	pets := collectPets(t, c, time.Second)
+	if len(pets) != 1 {
+		t.Fatalf("baby mount pets = %d, want 1", len(pets))
+	}
+	for _, payload := range pets {
+		if name := cstr(payload[6:22]); name != "Porco^" {
+			t.Errorf("baby mount name = %q, want Porco^", name)
+		}
+		if face := le16(payload[22:24]); face != 315 {
+			t.Errorf("baby mount face = %d, want 315", face)
+		}
+		if createType := le16(payload[172:174]); createType&3 != 3 {
+			t.Errorf("baby mount CreateType = %#x, want summon appear bits", createType)
+		}
+		if hp := int32(le(payload[148:152])); hp != 80 {
+			t.Errorf("baby mount HP = %d, want item HP 80", hp)
+		}
+	}
+}
+
+func TestBabyMountDeadDoesNotSpawn(t *testing.T) {
+	addr, stop, _ := startServerBabyMount(t, babyMountDB(babyMountItem(2330, 0), world.Item{}))
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	tradeItemFrame(t, c, world.ItemPlaceCarry, 0, world.ItemPlaceEquip, mountEquipSlot, 0)
+	expect(t, c, protocol.MsgTradingItem)
+	expect(t, c, protocol.MsgSendItem)
+	expect(t, c, protocol.MsgSendItem)
+	expect(t, c, protocol.MsgUpdateEquip)
+
+	if pets := collectPets(t, c, 500*time.Millisecond); len(pets) != 0 {
+		t.Fatalf("dead baby mount spawned %d pet(s), want none", len(pets))
+	}
+}
+
+func TestBabyMountUnequipDespawnsPet(t *testing.T) {
+	addr, stop, _ := startServerBabyMount(t, babyMountDB(babyMountItem(2330, 80), world.Item{}))
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	tradeItemFrame(t, c, world.ItemPlaceCarry, 0, world.ItemPlaceEquip, mountEquipSlot, 0)
+	expect(t, c, protocol.MsgTradingItem)
+	expect(t, c, protocol.MsgSendItem)
+	expect(t, c, protocol.MsgSendItem)
+	expect(t, c, protocol.MsgUpdateEquip)
+	pets := collectPets(t, c, time.Second)
+	if len(pets) != 1 {
+		t.Fatalf("baby mount pets = %d, want 1", len(pets))
+	}
+	petID := 0
+	for id := range pets {
+		petID = id
+	}
+
+	tradeItemFrame(t, c, world.ItemPlaceEquip, mountEquipSlot, world.ItemPlaceCarry, 1, 0)
+	expect(t, c, protocol.MsgTradingItem)
+	expect(t, c, protocol.MsgSendItem)
+	expect(t, c, protocol.MsgSendItem)
+	expect(t, c, protocol.MsgUpdateEquip)
+	expectPetRemove(t, c, petID)
+}
+
+func TestBabyMountDoesNotExpireLikeSkillSummon(t *testing.T) {
+	addr, stop, _ := startServerBabyMount(t, babyMountDB(babyMountItem(2330, 80), world.Item{}))
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	tradeItemFrame(t, c, world.ItemPlaceCarry, 0, world.ItemPlaceEquip, mountEquipSlot, 0)
+	expect(t, c, protocol.MsgTradingItem)
+	expect(t, c, protocol.MsgSendItem)
+	expect(t, c, protocol.MsgSendItem)
+	expect(t, c, protocol.MsgUpdateEquip)
+	pets := collectPets(t, c, time.Second)
+	if len(pets) != 1 {
+		t.Fatalf("baby mount pets = %d, want 1", len(pets))
+	}
+	petID := 0
+	for id := range pets {
+		petID = id
+	}
+
+	deadline := time.Now().Add(2500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		h, _, ok := readMaybeHeaderRaw(t, c)
+		if !ok {
+			continue
+		}
+		if h.Type == protocol.MsgRemoveMob && int(h.ID) == petID {
+			t.Fatalf("baby mount pet %d expired; item-backed summons must not use Type-24 lifespan", petID)
+		}
+	}
+}
+
+func TestBabyMountSpawnsOnLogin(t *testing.T) {
+	addr, stop, _ := startServerBabyMount(t, babyMountDB(world.Item{}, babyMountItem(2330, 80)))
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	pets := collectPets(t, c, time.Second)
+	if len(pets) != 1 {
+		t.Fatalf("login baby mount pets = %d, want 1", len(pets))
+	}
+}
+
 // TestEvocationSpawnsScaledSummons is the happy path: Evocação 60 evokes two
 // Condors, each owner-scaled per pSummonBonus[0] — Damage 20 + Int·80% +
 // Evo·300% = 280, MaxHp 100 + Int·100% + Evo·400% = 440 — at the owner's level,

--- a/tmserver/internal/protocol/visual_test.go
+++ b/tmserver/internal/protocol/visual_test.go
@@ -34,3 +34,14 @@ func TestVisualEquipAncientGlow(t *testing.T) {
 		t.Errorf("anct = %#x, want 113", anct)
 	}
 }
+
+func TestVisualEquipBabyMount(t *testing.T) {
+	it := SelItem{Index: 2330}
+	visual, anct := VisualEquip(it, visualMountSlot)
+	if visual != 2330 {
+		t.Errorf("baby mount visual = %d, want 2330", visual)
+	}
+	if anct != 0 {
+		t.Errorf("baby mount anct = %#x, want 0", anct)
+	}
+}


### PR DESCRIPTION
## Summary
- port MountProcess-style spawning for baby mounts equipped in Equip[14]
- refresh baby mount pets on login, equip, unequip, and slot swaps
- cover baby mount visuals, spawn, despawn, dead mount, login, and non-expiring item-backed summon behavior

## Tests
- go test ./...
- make test

Closes #181