### PR TITLE
Fix NPC legacy template resolution

### DIFF
--- a/dbserver/cmd/dbserver/main.go
+++ b/dbserver/cmd/dbserver/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/jeanluca/w2pp-openwyd/dbserver/internal/convert"
 	"github.com/jeanluca/w2pp-openwyd/dbserver/internal/grpcsrv"
 	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+	"github.com/jeanluca/w2pp-openwyd/internal/npctemplate"
 	"github.com/jeanluca/w2pp-openwyd/internal/savefmt"
 	"github.com/jeanluca/w2pp-openwyd/internal/secret"
 	"github.com/jeanluca/w2pp-openwyd/internal/secure"
@@ -133,36 +134,43 @@ func runImportNPCs(args []string, logger *slog.Logger) error {
 // buildNPCDefinitions parses NPCGener.txt and returns one domain.NPCDefinition
 // per MERCHANT spawn block (leader template Merchant != 0), with its shop stock
 // read from the template's Carry[]. The slug is stable across re-imports:
-// "<template>-<blockIndex>". A block whose leader template is missing or is not a
+// "<legacy-template>-<blockIndex>", while TemplateName is normalized to the
+// actual Linux file name. A block whose leader template is missing or is not a
 // merchant is skipped.
 func buildNPCDefinitions(contentDir string, logger *slog.Logger) ([]domain.NPCDefinition, error) {
 	blocks, err := parseNPCGener(filepath.Join(contentDir, "TMsrv", "run", "NPCGener.txt"))
 	if err != nil {
 		return nil, err
 	}
-	templates := make(map[string]*savefmt.Mob)
-	load := func(name string) *savefmt.Mob {
+	type loadedTemplate struct {
+		mob  *savefmt.Mob
+		name string
+	}
+	templates := make(map[string]loadedTemplate)
+	load := func(name string) loadedTemplate {
 		if name == "" {
-			return nil
+			return loadedTemplate{}
 		}
 		if m, seen := templates[name]; seen {
 			return m
 		}
-		var m *savefmt.Mob
-		if b, terr := os.ReadFile(filepath.Join(contentDir, "TMsrv", "run", "npc", name)); terr == nil {
+		var out loadedTemplate
+		if b, res, terr := npctemplate.Load(contentDir, name); terr == nil {
 			if mob, derr := savefmt.DecodeMob(b); derr == nil {
-				m = &mob
+				out.mob = &mob
+				out.name = res.Name
 			} else {
 				logger.Warn("npc template decode failed", "name", name, "err", derr)
 			}
 		}
-		templates[name] = m
-		return m
+		templates[name] = out
+		return out
 	}
 
 	var out []domain.NPCDefinition
 	for i, b := range blocks {
-		mob := load(b.leader)
+		tmpl := load(b.leader)
+		mob := tmpl.mob
 		// The shop flag the tmServer honours is CurrentScore.Merchant (STRUCT_MOB
 		// offset 104), NOT the top-level Mob.Merchant (offset 17) — read the same
 		// field here so importer and runtime agree on what is a merchant.
@@ -171,7 +179,7 @@ func buildNPCDefinitions(contentDir string, logger *slog.Logger) ([]domain.NPCDe
 		}
 		def := domain.NPCDefinition{
 			Slug:         fmt.Sprintf("%s-%d", b.leader, i),
-			TemplateName: b.leader,
+			TemplateName: tmpl.name,
 			DisplayName:  cString(mob.Name[:]),
 			Enabled:      true,
 			PosX:         int32(b.startX),

--- a/dbserver/cmd/dbserver/main_test.go
+++ b/dbserver/cmd/dbserver/main_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/savefmt"
+)
+
+func TestBuildNPCDefinitionsNormalizesLegacyTemplateNames(t *testing.T) {
+	dir := t.TempDir()
+	runDir := filepath.Join(dir, "TMsrv", "run")
+	npcDir := filepath.Join(runDir, "npc")
+	if err := os.MkdirAll(npcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const npcGener = `# [0]
+	Leader: Chefe_Treina.
+	StartX: 2234
+	StartY: 1566
+	RouteType: 0
+
+# [1]
+	Leader: Reiners
+	StartX: 2469
+	StartY: 1991
+	RouteType: 2
+`
+	if err := os.WriteFile(filepath.Join(runDir, "NPCGener.txt"), []byte(npcGener), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeDBNPCMob(t, npcDir, "Chefe_Treina", "Chefe_Treina.", 8)
+	writeDBNPCMob(t, npcDir, "reiners", "Reiners", 1)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	defs, err := buildNPCDefinitions(dir, logger)
+	if err != nil {
+		t.Fatalf("buildNPCDefinitions: %v", err)
+	}
+	if len(defs) != 2 {
+		t.Fatalf("got %d defs, want 2: %+v", len(defs), defs)
+	}
+	if defs[0].Slug != "Chefe_Treina.-0" || defs[0].TemplateName != "Chefe_Treina" ||
+		defs[0].DisplayName != "Chefe_Treina." || defs[0].Merchant != 8 {
+		t.Fatalf("def[0] = %+v, want normalized template with legacy slug/display name", defs[0])
+	}
+	if defs[1].Slug != "Reiners-1" || defs[1].TemplateName != "reiners" ||
+		defs[1].DisplayName != "Reiners" || defs[1].Merchant != 1 {
+		t.Fatalf("def[1] = %+v, want normalized lowercase template", defs[1])
+	}
+}
+
+func writeDBNPCMob(t *testing.T, dir, fileName, mobName string, merchant byte) {
+	t.Helper()
+	b := make([]byte, savefmt.MobSize)
+	copy(b[0:16], mobName)
+	b[104] = merchant // CurrentScore.Merchant
+	if err := os.WriteFile(filepath.Join(dir, fileName), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/migrations/0014_normalize_npc_template_names.down.sql
+++ b/internal/migrations/0014_normalize_npc_template_names.down.sql
@@ -1,0 +1,21 @@
+-- Restore the legacy spelling only for definitions whose slug still carries
+-- the original NPCGener.txt name.
+
+WITH changed AS (
+    UPDATE npc_definition
+    SET template_name = CASE
+        WHEN template_name = 'Cap.Explor' AND left(slug, length('Cap.Explor.-')) = 'Cap.Explor.-' THEN 'Cap.Explor.'
+        WHEN template_name = 'Diretor_Treina' AND left(slug, length('Diretor_Treina.-')) = 'Diretor_Treina.-' THEN 'Diretor_Treina.'
+        WHEN template_name = 'Chefe_Treina' AND left(slug, length('Chefe_Treina.-')) = 'Chefe_Treina.-' THEN 'Chefe_Treina.'
+        WHEN template_name = 'reiners' AND left(slug, length('Reiners-')) = 'Reiners-' THEN 'Reiners'
+        ELSE template_name
+    END
+    WHERE (template_name = 'Cap.Explor' AND left(slug, length('Cap.Explor.-')) = 'Cap.Explor.-')
+       OR (template_name = 'Diretor_Treina' AND left(slug, length('Diretor_Treina.-')) = 'Diretor_Treina.-')
+       OR (template_name = 'Chefe_Treina' AND left(slug, length('Chefe_Treina.-')) = 'Chefe_Treina.-')
+       OR (template_name = 'reiners' AND left(slug, length('Reiners-')) = 'Reiners-')
+    RETURNING 1
+)
+UPDATE npc_config_meta
+SET version = version + 1
+WHERE id = TRUE AND EXISTS (SELECT 1 FROM changed);

--- a/internal/migrations/0014_normalize_npc_template_names.up.sql
+++ b/internal/migrations/0014_normalize_npc_template_names.up.sql
@@ -1,0 +1,19 @@
+-- Normalize legacy NPC template names to the concrete Linux file names.
+-- NPCGener.txt keeps the old Windows-friendly spelling; the database stores the
+-- actual file name so the moderator UI and tmServer overlay agree.
+
+WITH changed AS (
+    UPDATE npc_definition
+    SET template_name = CASE template_name
+        WHEN 'Cap.Explor.' THEN 'Cap.Explor'
+        WHEN 'Diretor_Treina.' THEN 'Diretor_Treina'
+        WHEN 'Chefe_Treina.' THEN 'Chefe_Treina'
+        WHEN 'Reiners' THEN 'reiners'
+        ELSE template_name
+    END
+    WHERE template_name IN ('Cap.Explor.', 'Diretor_Treina.', 'Chefe_Treina.', 'Reiners')
+    RETURNING 1
+)
+UPDATE npc_config_meta
+SET version = version + 1
+WHERE id = TRUE AND EXISTS (SELECT 1 FROM changed);

--- a/internal/npctemplate/npctemplate.go
+++ b/internal/npctemplate/npctemplate.go
@@ -1,0 +1,102 @@
+// Package npctemplate resolves raw STRUCT_MOB template files from the legacy
+// Release/TMsrv/run/npc content tree.
+package npctemplate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/savefmt"
+)
+
+const (
+	// Size is sizeof(STRUCT_MOB), the raw NPC/mob template format.
+	Size = savefmt.MobSize
+)
+
+// Resolution identifies the concrete file selected for a requested template.
+type Resolution struct {
+	// Name is the actual file name under Release/TMsrv/run/npc.
+	Name string
+	// Path is the absolute or relative path used to read the file.
+	Path string
+}
+
+// Dir returns the NPC template directory for a Release/ content root.
+func Dir(contentDir string) string {
+	return filepath.Join(contentDir, "TMsrv", "run", "npc")
+}
+
+// Resolve maps a template name from legacy content/config to the actual file in
+// Release/TMsrv/run/npc. It first honors exact Linux file names, then falls back
+// to Windows-like matching for the original server data: case-insensitive, with
+// trailing dots ignored in path components.
+func Resolve(contentDir, name string) (Resolution, error) {
+	if name == "" {
+		return Resolution{}, fmt.Errorf("npctemplate: empty template name")
+	}
+	if filepath.Base(name) != name || strings.ContainsAny(name, `/\`) {
+		return Resolution{}, fmt.Errorf("npctemplate: invalid template name %q", name)
+	}
+	dir := Dir(contentDir)
+	exactPath := filepath.Join(dir, name)
+	if st, err := os.Stat(exactPath); err == nil {
+		if st.IsDir() {
+			return Resolution{}, fmt.Errorf("npctemplate: %s is a directory", exactPath)
+		}
+		return Resolution{Name: name, Path: exactPath}, nil
+	} else if !os.IsNotExist(err) {
+		return Resolution{}, fmt.Errorf("npctemplate: stat %s: %w", exactPath, err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return Resolution{}, fmt.Errorf("npctemplate: read %s: %w", dir, err)
+	}
+	want := canonicalName(name)
+	var matches []Resolution
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		entryName := entry.Name()
+		if canonicalName(entryName) == want {
+			matches = append(matches, Resolution{Name: entryName, Path: filepath.Join(dir, entryName)})
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return Resolution{}, fmt.Errorf("npctemplate: template %q not found in %s", name, dir)
+	case 1:
+		return matches[0], nil
+	default:
+		names := make([]string, len(matches))
+		for i, match := range matches {
+			names[i] = match.Name
+		}
+		return Resolution{}, fmt.Errorf("npctemplate: template %q is ambiguous in %s: %s", name, dir, strings.Join(names, ", "))
+	}
+}
+
+// Load reads a template resolved by Resolve and verifies it is one raw
+// STRUCT_MOB blob.
+func Load(contentDir, name string) ([]byte, Resolution, error) {
+	res, err := Resolve(contentDir, name)
+	if err != nil {
+		return nil, Resolution{}, err
+	}
+	b, err := os.ReadFile(res.Path)
+	if err != nil {
+		return nil, Resolution{}, fmt.Errorf("npctemplate: read %s: %w", res.Path, err)
+	}
+	if len(b) != Size {
+		return nil, Resolution{}, fmt.Errorf("npctemplate: npc %s = %d bytes, want %d", res.Name, len(b), Size)
+	}
+	return b, res, nil
+}
+
+func canonicalName(name string) string {
+	return strings.ToLower(strings.TrimRight(name, "."))
+}

--- a/internal/npctemplate/npctemplate_test.go
+++ b/internal/npctemplate/npctemplate_test.go
@@ -1,0 +1,93 @@
+package npctemplate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveExactName(t *testing.T) {
+	dir := makeNPCDir(t)
+	writeTemplate(t, dir, "Chefe_Treina.", Size)
+	writeTemplate(t, dir, "Chefe_Treina", Size)
+
+	res, err := Resolve(dir, "Chefe_Treina.")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Name != "Chefe_Treina." {
+		t.Fatalf("resolved %q, want exact file", res.Name)
+	}
+}
+
+func TestResolveTrimsLegacyTrailingDot(t *testing.T) {
+	dir := makeNPCDir(t)
+	writeTemplate(t, dir, "Chefe_Treina", Size)
+
+	res, err := Resolve(dir, "Chefe_Treina.")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Name != "Chefe_Treina" {
+		t.Fatalf("resolved %q, want Chefe_Treina", res.Name)
+	}
+}
+
+func TestResolveCaseInsensitive(t *testing.T) {
+	dir := makeNPCDir(t)
+	writeTemplate(t, dir, "reiners", Size)
+
+	res, err := Resolve(dir, "Reiners")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Name != "reiners" {
+		t.Fatalf("resolved %q, want reiners", res.Name)
+	}
+}
+
+func TestResolveAmbiguousLegacyName(t *testing.T) {
+	dir := makeNPCDir(t)
+	writeTemplate(t, dir, "Reiners", Size)
+	writeTemplate(t, dir, "reiners", Size)
+
+	if _, err := Resolve(dir, "REINERS"); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("Resolve ambiguous err = %v, want ambiguity", err)
+	}
+}
+
+func TestResolveRejectsPathTraversal(t *testing.T) {
+	dir := makeNPCDir(t)
+	for _, name := range []string{"../Chefe_Treina", `..\Chefe_Treina`, "npc/Chefe_Treina"} {
+		if _, err := Resolve(dir, name); err == nil || !strings.Contains(err.Error(), "invalid template name") {
+			t.Fatalf("Resolve(%q) err = %v, want invalid template name", name, err)
+		}
+	}
+}
+
+func TestLoadRejectsWrongSize(t *testing.T) {
+	dir := makeNPCDir(t)
+	writeTemplate(t, dir, "Broken", Size-1)
+
+	if _, _, err := Load(dir, "Broken"); err == nil || !strings.Contains(err.Error(), "want 816") {
+		t.Fatalf("Load err = %v, want size error", err)
+	}
+}
+
+func makeNPCDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "TMsrv", "run", "npc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func writeTemplate(t *testing.T, contentDir, name string, size int) {
+	t.Helper()
+	path := filepath.Join(contentDir, "TMsrv", "run", "npc", name)
+	if err := os.WriteFile(path, make([]byte, size), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/tmserver/cmd/tmserver/main_test.go
+++ b/tmserver/cmd/tmserver/main_test.go
@@ -79,6 +79,58 @@ func TestSpawnNPCsWarnsMissingTemplates(t *testing.T) {
 	}
 }
 
+func TestSpawnNPCsResolvesLegacyTemplateNames(t *testing.T) {
+	dir := t.TempDir()
+	runDir := filepath.Join(dir, "TMsrv", "run")
+	npcDir := filepath.Join(runDir, "npc")
+	if err := os.MkdirAll(npcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const npcGener = `# [0]
+	Leader: Chefe_Treina.
+	MinGroup: 0
+	MaxGroup: 0
+	MaxNumMob: 1
+	StartX: 10
+	StartY: 10
+
+# [1]
+	Leader: Reiners
+	MinGroup: 0
+	MaxGroup: 0
+	MaxNumMob: 1
+	StartX: 12
+	StartY: 12
+`
+	if err := os.WriteFile(filepath.Join(runDir, "NPCGener.txt"), []byte(npcGener), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(npcDir, "Chefe_Treina"), testMobTemplate("Chefe_Treina."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(npcDir, "reiners"), testMobTemplate("Reiners"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	w := world.New(world.Config{GridDim: 64}, logger, nil, nil)
+	spawnNPCs(w, dir, false, logger)
+
+	for i := 0; i < 2; i++ {
+		g := w.GeneratorAt(i)
+		if g == nil {
+			t.Fatalf("generator %d was not registered", i)
+		}
+		if g.CurrentNumMob != 1 {
+			t.Fatalf("generator %d CurrentNumMob = %d, want one spawned leader", i, g.CurrentNumMob)
+		}
+	}
+	if strings.Contains(logs.String(), "NPC templates missing") {
+		t.Fatalf("legacy aliases should not log missing templates:\n%s", logs.String())
+	}
+}
+
 func testMobTemplate(name string) []byte {
 	b := make([]byte, content.BaseMobSize)
 	copy(b[0:16], name)

--- a/tmserver/internal/content/npc.go
+++ b/tmserver/internal/content/npc.go
@@ -4,9 +4,10 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/npctemplate"
 )
 
 // NPCGenerator is one spawn block of NPCGener.txt (CNPCGene.cpp ParseString):
@@ -142,15 +143,13 @@ func LoadNPCGenerators(path string) ([]NPCGenerator, error) {
 }
 
 // LoadNPCTemplate reads one mob template (Release/TMsrv/run/npc/<name>), a raw
-// 816-byte STRUCT_MOB. Templates are cached by the caller (many generators share
-// a name).
+// 816-byte STRUCT_MOB. Legacy NPCGener names are resolved with Windows-like path
+// compatibility (case-insensitive, trailing dots ignored). Templates are cached
+// by the caller (many generators share a name).
 func LoadNPCTemplate(dir, name string) ([]byte, error) {
-	b, err := os.ReadFile(filepath.Join(dir, "TMsrv", "run", "npc", name))
+	b, _, err := npctemplate.Load(dir, name)
 	if err != nil {
 		return nil, err
-	}
-	if len(b) != BaseMobSize {
-		return nil, fmt.Errorf("content: npc %s = %d bytes, want %d", name, len(b), BaseMobSize)
 	}
 	return b, nil
 }


### PR DESCRIPTION
## Summary
- add shared NPC template resolver with Windows-like legacy matching for case and trailing dots
- normalize imported DB template_name values while keeping legacy slugs stable
- add migration for existing NPC definitions using legacy template names

## Validation
- make test
- go run ./dbserver/cmd/dbserver import-npcs -content Release

Closes #173