### PR TITLE
Fix character selection equipment preview

### DIFF
--- a/api/db/v1/db.pb.go
+++ b/api/db/v1/db.pb.go
@@ -369,15 +369,18 @@ type CharacterSummary struct {
 	Exp     int64                  `protobuf:"varint,5,opt,name=exp,proto3" json:"exp,omitempty"`
 	GuildId uint32                 `protobuf:"varint,6,opt,name=guild_id,json=guildId,proto3" json:"guild_id,omitempty"`
 	// Score preview shown on the character-selection screen (STRUCT_SELCHAR).
-	Coin          int32 `protobuf:"varint,7,opt,name=coin,proto3" json:"coin,omitempty"`
-	MaxHp         int32 `protobuf:"varint,8,opt,name=max_hp,json=maxHp,proto3" json:"max_hp,omitempty"`
-	Hp            int32 `protobuf:"varint,9,opt,name=hp,proto3" json:"hp,omitempty"`
-	MaxMp         int32 `protobuf:"varint,10,opt,name=max_mp,json=maxMp,proto3" json:"max_mp,omitempty"`
-	Mp            int32 `protobuf:"varint,11,opt,name=mp,proto3" json:"mp,omitempty"`
-	Str           int32 `protobuf:"varint,12,opt,name=str,proto3" json:"str,omitempty"`
-	Int           int32 `protobuf:"varint,13,opt,name=int,proto3" json:"int,omitempty"`
-	Dex           int32 `protobuf:"varint,14,opt,name=dex,proto3" json:"dex,omitempty"`
-	Con           int32 `protobuf:"varint,15,opt,name=con,proto3" json:"con,omitempty"`
+	Coin  int32 `protobuf:"varint,7,opt,name=coin,proto3" json:"coin,omitempty"`
+	MaxHp int32 `protobuf:"varint,8,opt,name=max_hp,json=maxHp,proto3" json:"max_hp,omitempty"`
+	Hp    int32 `protobuf:"varint,9,opt,name=hp,proto3" json:"hp,omitempty"`
+	MaxMp int32 `protobuf:"varint,10,opt,name=max_mp,json=maxMp,proto3" json:"max_mp,omitempty"`
+	Mp    int32 `protobuf:"varint,11,opt,name=mp,proto3" json:"mp,omitempty"`
+	Str   int32 `protobuf:"varint,12,opt,name=str,proto3" json:"str,omitempty"`
+	Int   int32 `protobuf:"varint,13,opt,name=int,proto3" json:"int,omitempty"`
+	Dex   int32 `protobuf:"varint,14,opt,name=dex,proto3" json:"dex,omitempty"`
+	Con   int32 `protobuf:"varint,15,opt,name=con,proto3" json:"con,omitempty"`
+	// Equipped items shown on the character-selection model. Empty slots are
+	// omitted; tmServer falls back to the class BaseMob only when none are present.
+	Equip         []*Item `protobuf:"bytes,16,rep,name=equip,proto3" json:"equip,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -515,6 +518,13 @@ func (x *CharacterSummary) GetCon() int32 {
 		return x.Con
 	}
 	return 0
+}
+
+func (x *CharacterSummary) GetEquip() []*Item {
+	if x != nil {
+		return x.Equip
+	}
+	return nil
 }
 
 type ListCharactersResponse struct {
@@ -4592,7 +4602,7 @@ const file_api_db_v1_db_proto_rawDesc = "" +
 	"\x04role\x18\x03 \x01(\tR\x04role\"6\n" +
 	"\x15ListCharactersRequest\x12\x1d\n" +
 	"\n" +
-	"account_id\x18\x01 \x01(\x03R\taccountId\"\xbd\x02\n" +
+	"account_id\x18\x01 \x01(\x03R\taccountId\"\xe0\x02\n" +
 	"\x10CharacterSummary\x12\x12\n" +
 	"\x04slot\x18\x01 \x01(\x05R\x04slot\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
@@ -4609,7 +4619,8 @@ const file_api_db_v1_db_proto_rawDesc = "" +
 	"\x03str\x18\f \x01(\x05R\x03str\x12\x10\n" +
 	"\x03int\x18\r \x01(\x05R\x03int\x12\x10\n" +
 	"\x03dex\x18\x0e \x01(\x05R\x03dex\x12\x10\n" +
-	"\x03con\x18\x0f \x01(\x05R\x03con\"Q\n" +
+	"\x03con\x18\x0f \x01(\x05R\x03con\x12!\n" +
+	"\x05equip\x18\x10 \x03(\v2\v.db.v1.ItemR\x05equip\"Q\n" +
 	"\x16ListCharactersResponse\x127\n" +
 	"\n" +
 	"characters\x18\x01 \x03(\v2\x17.db.v1.CharacterSummaryR\n" +
@@ -5064,99 +5075,100 @@ var file_api_db_v1_db_proto_goTypes = []any{
 }
 var file_api_db_v1_db_proto_depIdxs = []int32{
 	0,  // 0: db.v1.AccountLoginResponse.result:type_name -> db.v1.LoginResult
-	6,  // 1: db.v1.ListCharactersResponse.characters:type_name -> db.v1.CharacterSummary
-	10, // 2: db.v1.Character.equip:type_name -> db.v1.Item
-	10, // 3: db.v1.Character.carry:type_name -> db.v1.Item
-	11, // 4: db.v1.Character.affects:type_name -> db.v1.Affect
-	9,  // 5: db.v1.LoadCharacterResponse.character:type_name -> db.v1.Character
-	9,  // 6: db.v1.SaveCharacterRequest.character:type_name -> db.v1.Character
-	1,  // 7: db.v1.VerifyPinResponse.result:type_name -> db.v1.PinResult
-	10, // 8: db.v1.LoadCargoResponse.items:type_name -> db.v1.Item
-	10, // 9: db.v1.SaveCargoRequest.items:type_name -> db.v1.Item
-	10, // 10: db.v1.Delivery.item:type_name -> db.v1.Item
-	29, // 11: db.v1.ListPendingDeliveriesResponse.deliveries:type_name -> db.v1.Delivery
-	10, // 12: db.v1.SaveCargoWithDeliveriesRequest.items:type_name -> db.v1.Item
-	2,  // 13: db.v1.GuildRelation.kind:type_name -> db.v1.GuildRelationKind
-	37, // 14: db.v1.CreateGuildResponse.guild:type_name -> db.v1.Guild
-	2,  // 15: db.v1.SetGuildRelationRequest.kind:type_name -> db.v1.GuildRelationKind
-	37, // 16: db.v1.ListGuildsResponse.guilds:type_name -> db.v1.Guild
-	38, // 17: db.v1.ListGuildRelationsResponse.relations:type_name -> db.v1.GuildRelation
-	53, // 18: db.v1.LoadGuildZonesResponse.zones:type_name -> db.v1.GuildZone
-	53, // 19: db.v1.SaveGuildZoneRequest.zone:type_name -> db.v1.GuildZone
-	58, // 20: db.v1.LoadGuildTowerStateResponse.state:type_name -> db.v1.GuildTowerState
-	58, // 21: db.v1.SaveGuildTowerStateRequest.state:type_name -> db.v1.GuildTowerState
-	63, // 22: db.v1.LoadCastleQuestStateResponse.state:type_name -> db.v1.CastleQuestState
-	63, // 23: db.v1.SaveCastleQuestStateRequest.state:type_name -> db.v1.CastleQuestState
-	73, // 24: db.v1.ListNpcDefinitionsResponse.definitions:type_name -> db.v1.NpcDefinition
-	74, // 25: db.v1.ListNpcDefinitionsResponse.price_overrides:type_name -> db.v1.ItemPrice
-	72, // 26: db.v1.NpcDefinition.shop:type_name -> db.v1.NpcShopItem
-	3,  // 27: db.v1.AccountService.AccountLogin:input_type -> db.v1.AccountLoginRequest
-	5,  // 28: db.v1.AccountService.ListCharacters:input_type -> db.v1.ListCharactersRequest
-	8,  // 29: db.v1.AccountService.LoadCharacter:input_type -> db.v1.LoadCharacterRequest
-	13, // 30: db.v1.AccountService.SaveCharacter:input_type -> db.v1.SaveCharacterRequest
-	15, // 31: db.v1.AccountService.CreateCharacter:input_type -> db.v1.CreateCharacterRequest
-	17, // 32: db.v1.AccountService.CreateArchCharacter:input_type -> db.v1.CreateArchCharacterRequest
-	19, // 33: db.v1.AccountService.DeleteCharacter:input_type -> db.v1.DeleteCharacterRequest
-	21, // 34: db.v1.AccountService.SetPin:input_type -> db.v1.SetPinRequest
-	23, // 35: db.v1.AccountService.VerifyPin:input_type -> db.v1.VerifyPinRequest
-	25, // 36: db.v1.AccountService.LoadCargo:input_type -> db.v1.LoadCargoRequest
-	27, // 37: db.v1.AccountService.SaveCargo:input_type -> db.v1.SaveCargoRequest
-	30, // 38: db.v1.AccountService.ListPendingDeliveries:input_type -> db.v1.ListPendingDeliveriesRequest
-	32, // 39: db.v1.AccountService.SaveCargoWithDeliveries:input_type -> db.v1.SaveCargoWithDeliveriesRequest
-	33, // 40: db.v1.AccountService.SetAccountBlocked:input_type -> db.v1.SetAccountBlockedRequest
-	35, // 41: db.v1.AccountService.RecordDuelResult:input_type -> db.v1.RecordDuelResultRequest
-	39, // 42: db.v1.AccountService.CreateGuild:input_type -> db.v1.CreateGuildRequest
-	41, // 43: db.v1.AccountService.SetGuildMember:input_type -> db.v1.SetGuildMemberRequest
-	43, // 44: db.v1.AccountService.LeaveGuild:input_type -> db.v1.LeaveGuildRequest
-	44, // 45: db.v1.AccountService.PromoteGuildMember:input_type -> db.v1.PromoteGuildMemberRequest
-	46, // 46: db.v1.AccountService.TransferGuildLeader:input_type -> db.v1.TransferGuildLeaderRequest
-	47, // 47: db.v1.AccountService.SetGuildRelation:input_type -> db.v1.SetGuildRelationRequest
-	49, // 48: db.v1.AccountService.ListGuilds:input_type -> db.v1.ListGuildsRequest
-	51, // 49: db.v1.AccountService.ListGuildRelations:input_type -> db.v1.ListGuildRelationsRequest
-	54, // 50: db.v1.AccountService.LoadGuildZones:input_type -> db.v1.LoadGuildZonesRequest
-	56, // 51: db.v1.AccountService.SaveGuildZone:input_type -> db.v1.SaveGuildZoneRequest
-	59, // 52: db.v1.AccountService.LoadGuildTowerState:input_type -> db.v1.LoadGuildTowerStateRequest
-	61, // 53: db.v1.AccountService.SaveGuildTowerState:input_type -> db.v1.SaveGuildTowerStateRequest
-	64, // 54: db.v1.AccountService.LoadCastleQuestState:input_type -> db.v1.LoadCastleQuestStateRequest
-	66, // 55: db.v1.AccountService.SaveCastleQuestState:input_type -> db.v1.SaveCastleQuestStateRequest
-	68, // 56: db.v1.NpcConfigService.NpcConfigVersion:input_type -> db.v1.NpcConfigVersionRequest
-	70, // 57: db.v1.NpcConfigService.ListNpcDefinitions:input_type -> db.v1.ListNpcDefinitionsRequest
-	4,  // 58: db.v1.AccountService.AccountLogin:output_type -> db.v1.AccountLoginResponse
-	7,  // 59: db.v1.AccountService.ListCharacters:output_type -> db.v1.ListCharactersResponse
-	12, // 60: db.v1.AccountService.LoadCharacter:output_type -> db.v1.LoadCharacterResponse
-	14, // 61: db.v1.AccountService.SaveCharacter:output_type -> db.v1.SaveCharacterResponse
-	16, // 62: db.v1.AccountService.CreateCharacter:output_type -> db.v1.CreateCharacterResponse
-	18, // 63: db.v1.AccountService.CreateArchCharacter:output_type -> db.v1.CreateArchCharacterResponse
-	20, // 64: db.v1.AccountService.DeleteCharacter:output_type -> db.v1.DeleteCharacterResponse
-	22, // 65: db.v1.AccountService.SetPin:output_type -> db.v1.SetPinResponse
-	24, // 66: db.v1.AccountService.VerifyPin:output_type -> db.v1.VerifyPinResponse
-	26, // 67: db.v1.AccountService.LoadCargo:output_type -> db.v1.LoadCargoResponse
-	28, // 68: db.v1.AccountService.SaveCargo:output_type -> db.v1.SaveCargoResponse
-	31, // 69: db.v1.AccountService.ListPendingDeliveries:output_type -> db.v1.ListPendingDeliveriesResponse
-	28, // 70: db.v1.AccountService.SaveCargoWithDeliveries:output_type -> db.v1.SaveCargoResponse
-	34, // 71: db.v1.AccountService.SetAccountBlocked:output_type -> db.v1.SetAccountBlockedResponse
-	36, // 72: db.v1.AccountService.RecordDuelResult:output_type -> db.v1.RecordDuelResultResponse
-	40, // 73: db.v1.AccountService.CreateGuild:output_type -> db.v1.CreateGuildResponse
-	42, // 74: db.v1.AccountService.SetGuildMember:output_type -> db.v1.SetGuildMemberResponse
-	42, // 75: db.v1.AccountService.LeaveGuild:output_type -> db.v1.SetGuildMemberResponse
-	45, // 76: db.v1.AccountService.PromoteGuildMember:output_type -> db.v1.PromoteGuildMemberResponse
-	42, // 77: db.v1.AccountService.TransferGuildLeader:output_type -> db.v1.SetGuildMemberResponse
-	48, // 78: db.v1.AccountService.SetGuildRelation:output_type -> db.v1.SetGuildRelationResponse
-	50, // 79: db.v1.AccountService.ListGuilds:output_type -> db.v1.ListGuildsResponse
-	52, // 80: db.v1.AccountService.ListGuildRelations:output_type -> db.v1.ListGuildRelationsResponse
-	55, // 81: db.v1.AccountService.LoadGuildZones:output_type -> db.v1.LoadGuildZonesResponse
-	57, // 82: db.v1.AccountService.SaveGuildZone:output_type -> db.v1.SaveGuildZoneResponse
-	60, // 83: db.v1.AccountService.LoadGuildTowerState:output_type -> db.v1.LoadGuildTowerStateResponse
-	62, // 84: db.v1.AccountService.SaveGuildTowerState:output_type -> db.v1.SaveGuildTowerStateResponse
-	65, // 85: db.v1.AccountService.LoadCastleQuestState:output_type -> db.v1.LoadCastleQuestStateResponse
-	67, // 86: db.v1.AccountService.SaveCastleQuestState:output_type -> db.v1.SaveCastleQuestStateResponse
-	69, // 87: db.v1.NpcConfigService.NpcConfigVersion:output_type -> db.v1.NpcConfigVersionResponse
-	71, // 88: db.v1.NpcConfigService.ListNpcDefinitions:output_type -> db.v1.ListNpcDefinitionsResponse
-	58, // [58:89] is the sub-list for method output_type
-	27, // [27:58] is the sub-list for method input_type
-	27, // [27:27] is the sub-list for extension type_name
-	27, // [27:27] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	10, // 1: db.v1.CharacterSummary.equip:type_name -> db.v1.Item
+	6,  // 2: db.v1.ListCharactersResponse.characters:type_name -> db.v1.CharacterSummary
+	10, // 3: db.v1.Character.equip:type_name -> db.v1.Item
+	10, // 4: db.v1.Character.carry:type_name -> db.v1.Item
+	11, // 5: db.v1.Character.affects:type_name -> db.v1.Affect
+	9,  // 6: db.v1.LoadCharacterResponse.character:type_name -> db.v1.Character
+	9,  // 7: db.v1.SaveCharacterRequest.character:type_name -> db.v1.Character
+	1,  // 8: db.v1.VerifyPinResponse.result:type_name -> db.v1.PinResult
+	10, // 9: db.v1.LoadCargoResponse.items:type_name -> db.v1.Item
+	10, // 10: db.v1.SaveCargoRequest.items:type_name -> db.v1.Item
+	10, // 11: db.v1.Delivery.item:type_name -> db.v1.Item
+	29, // 12: db.v1.ListPendingDeliveriesResponse.deliveries:type_name -> db.v1.Delivery
+	10, // 13: db.v1.SaveCargoWithDeliveriesRequest.items:type_name -> db.v1.Item
+	2,  // 14: db.v1.GuildRelation.kind:type_name -> db.v1.GuildRelationKind
+	37, // 15: db.v1.CreateGuildResponse.guild:type_name -> db.v1.Guild
+	2,  // 16: db.v1.SetGuildRelationRequest.kind:type_name -> db.v1.GuildRelationKind
+	37, // 17: db.v1.ListGuildsResponse.guilds:type_name -> db.v1.Guild
+	38, // 18: db.v1.ListGuildRelationsResponse.relations:type_name -> db.v1.GuildRelation
+	53, // 19: db.v1.LoadGuildZonesResponse.zones:type_name -> db.v1.GuildZone
+	53, // 20: db.v1.SaveGuildZoneRequest.zone:type_name -> db.v1.GuildZone
+	58, // 21: db.v1.LoadGuildTowerStateResponse.state:type_name -> db.v1.GuildTowerState
+	58, // 22: db.v1.SaveGuildTowerStateRequest.state:type_name -> db.v1.GuildTowerState
+	63, // 23: db.v1.LoadCastleQuestStateResponse.state:type_name -> db.v1.CastleQuestState
+	63, // 24: db.v1.SaveCastleQuestStateRequest.state:type_name -> db.v1.CastleQuestState
+	73, // 25: db.v1.ListNpcDefinitionsResponse.definitions:type_name -> db.v1.NpcDefinition
+	74, // 26: db.v1.ListNpcDefinitionsResponse.price_overrides:type_name -> db.v1.ItemPrice
+	72, // 27: db.v1.NpcDefinition.shop:type_name -> db.v1.NpcShopItem
+	3,  // 28: db.v1.AccountService.AccountLogin:input_type -> db.v1.AccountLoginRequest
+	5,  // 29: db.v1.AccountService.ListCharacters:input_type -> db.v1.ListCharactersRequest
+	8,  // 30: db.v1.AccountService.LoadCharacter:input_type -> db.v1.LoadCharacterRequest
+	13, // 31: db.v1.AccountService.SaveCharacter:input_type -> db.v1.SaveCharacterRequest
+	15, // 32: db.v1.AccountService.CreateCharacter:input_type -> db.v1.CreateCharacterRequest
+	17, // 33: db.v1.AccountService.CreateArchCharacter:input_type -> db.v1.CreateArchCharacterRequest
+	19, // 34: db.v1.AccountService.DeleteCharacter:input_type -> db.v1.DeleteCharacterRequest
+	21, // 35: db.v1.AccountService.SetPin:input_type -> db.v1.SetPinRequest
+	23, // 36: db.v1.AccountService.VerifyPin:input_type -> db.v1.VerifyPinRequest
+	25, // 37: db.v1.AccountService.LoadCargo:input_type -> db.v1.LoadCargoRequest
+	27, // 38: db.v1.AccountService.SaveCargo:input_type -> db.v1.SaveCargoRequest
+	30, // 39: db.v1.AccountService.ListPendingDeliveries:input_type -> db.v1.ListPendingDeliveriesRequest
+	32, // 40: db.v1.AccountService.SaveCargoWithDeliveries:input_type -> db.v1.SaveCargoWithDeliveriesRequest
+	33, // 41: db.v1.AccountService.SetAccountBlocked:input_type -> db.v1.SetAccountBlockedRequest
+	35, // 42: db.v1.AccountService.RecordDuelResult:input_type -> db.v1.RecordDuelResultRequest
+	39, // 43: db.v1.AccountService.CreateGuild:input_type -> db.v1.CreateGuildRequest
+	41, // 44: db.v1.AccountService.SetGuildMember:input_type -> db.v1.SetGuildMemberRequest
+	43, // 45: db.v1.AccountService.LeaveGuild:input_type -> db.v1.LeaveGuildRequest
+	44, // 46: db.v1.AccountService.PromoteGuildMember:input_type -> db.v1.PromoteGuildMemberRequest
+	46, // 47: db.v1.AccountService.TransferGuildLeader:input_type -> db.v1.TransferGuildLeaderRequest
+	47, // 48: db.v1.AccountService.SetGuildRelation:input_type -> db.v1.SetGuildRelationRequest
+	49, // 49: db.v1.AccountService.ListGuilds:input_type -> db.v1.ListGuildsRequest
+	51, // 50: db.v1.AccountService.ListGuildRelations:input_type -> db.v1.ListGuildRelationsRequest
+	54, // 51: db.v1.AccountService.LoadGuildZones:input_type -> db.v1.LoadGuildZonesRequest
+	56, // 52: db.v1.AccountService.SaveGuildZone:input_type -> db.v1.SaveGuildZoneRequest
+	59, // 53: db.v1.AccountService.LoadGuildTowerState:input_type -> db.v1.LoadGuildTowerStateRequest
+	61, // 54: db.v1.AccountService.SaveGuildTowerState:input_type -> db.v1.SaveGuildTowerStateRequest
+	64, // 55: db.v1.AccountService.LoadCastleQuestState:input_type -> db.v1.LoadCastleQuestStateRequest
+	66, // 56: db.v1.AccountService.SaveCastleQuestState:input_type -> db.v1.SaveCastleQuestStateRequest
+	68, // 57: db.v1.NpcConfigService.NpcConfigVersion:input_type -> db.v1.NpcConfigVersionRequest
+	70, // 58: db.v1.NpcConfigService.ListNpcDefinitions:input_type -> db.v1.ListNpcDefinitionsRequest
+	4,  // 59: db.v1.AccountService.AccountLogin:output_type -> db.v1.AccountLoginResponse
+	7,  // 60: db.v1.AccountService.ListCharacters:output_type -> db.v1.ListCharactersResponse
+	12, // 61: db.v1.AccountService.LoadCharacter:output_type -> db.v1.LoadCharacterResponse
+	14, // 62: db.v1.AccountService.SaveCharacter:output_type -> db.v1.SaveCharacterResponse
+	16, // 63: db.v1.AccountService.CreateCharacter:output_type -> db.v1.CreateCharacterResponse
+	18, // 64: db.v1.AccountService.CreateArchCharacter:output_type -> db.v1.CreateArchCharacterResponse
+	20, // 65: db.v1.AccountService.DeleteCharacter:output_type -> db.v1.DeleteCharacterResponse
+	22, // 66: db.v1.AccountService.SetPin:output_type -> db.v1.SetPinResponse
+	24, // 67: db.v1.AccountService.VerifyPin:output_type -> db.v1.VerifyPinResponse
+	26, // 68: db.v1.AccountService.LoadCargo:output_type -> db.v1.LoadCargoResponse
+	28, // 69: db.v1.AccountService.SaveCargo:output_type -> db.v1.SaveCargoResponse
+	31, // 70: db.v1.AccountService.ListPendingDeliveries:output_type -> db.v1.ListPendingDeliveriesResponse
+	28, // 71: db.v1.AccountService.SaveCargoWithDeliveries:output_type -> db.v1.SaveCargoResponse
+	34, // 72: db.v1.AccountService.SetAccountBlocked:output_type -> db.v1.SetAccountBlockedResponse
+	36, // 73: db.v1.AccountService.RecordDuelResult:output_type -> db.v1.RecordDuelResultResponse
+	40, // 74: db.v1.AccountService.CreateGuild:output_type -> db.v1.CreateGuildResponse
+	42, // 75: db.v1.AccountService.SetGuildMember:output_type -> db.v1.SetGuildMemberResponse
+	42, // 76: db.v1.AccountService.LeaveGuild:output_type -> db.v1.SetGuildMemberResponse
+	45, // 77: db.v1.AccountService.PromoteGuildMember:output_type -> db.v1.PromoteGuildMemberResponse
+	42, // 78: db.v1.AccountService.TransferGuildLeader:output_type -> db.v1.SetGuildMemberResponse
+	48, // 79: db.v1.AccountService.SetGuildRelation:output_type -> db.v1.SetGuildRelationResponse
+	50, // 80: db.v1.AccountService.ListGuilds:output_type -> db.v1.ListGuildsResponse
+	52, // 81: db.v1.AccountService.ListGuildRelations:output_type -> db.v1.ListGuildRelationsResponse
+	55, // 82: db.v1.AccountService.LoadGuildZones:output_type -> db.v1.LoadGuildZonesResponse
+	57, // 83: db.v1.AccountService.SaveGuildZone:output_type -> db.v1.SaveGuildZoneResponse
+	60, // 84: db.v1.AccountService.LoadGuildTowerState:output_type -> db.v1.LoadGuildTowerStateResponse
+	62, // 85: db.v1.AccountService.SaveGuildTowerState:output_type -> db.v1.SaveGuildTowerStateResponse
+	65, // 86: db.v1.AccountService.LoadCastleQuestState:output_type -> db.v1.LoadCastleQuestStateResponse
+	67, // 87: db.v1.AccountService.SaveCastleQuestState:output_type -> db.v1.SaveCastleQuestStateResponse
+	69, // 88: db.v1.NpcConfigService.NpcConfigVersion:output_type -> db.v1.NpcConfigVersionResponse
+	71, // 89: db.v1.NpcConfigService.ListNpcDefinitions:output_type -> db.v1.ListNpcDefinitionsResponse
+	59, // [59:90] is the sub-list for method output_type
+	28, // [28:59] is the sub-list for method input_type
+	28, // [28:28] is the sub-list for extension type_name
+	28, // [28:28] is the sub-list for extension extendee
+	0,  // [0:28] is the sub-list for field type_name
 }
 
 func init() { file_api_db_v1_db_proto_init() }

--- a/api/db/v1/db.proto
+++ b/api/db/v1/db.proto
@@ -123,6 +123,9 @@ message CharacterSummary {
   int32 int = 13;
   int32 dex = 14;
   int32 con = 15;
+  // Equipped items shown on the character-selection model. Empty slots are
+  // omitted; tmServer falls back to the class BaseMob only when none are present.
+  repeated Item equip = 16;
 }
 
 message ListCharactersResponse { repeated CharacterSummary characters = 1; }

--- a/dbserver/internal/grpcsrv/server.go
+++ b/dbserver/internal/grpcsrv/server.go
@@ -118,6 +118,7 @@ func (s *Server) ListCharacters(ctx context.Context, req *dbv1.ListCharactersReq
 			Int:     int32(ch.Int),
 			Dex:     int32(ch.Dex),
 			Con:     int32(ch.Con),
+			Equip:   itemsToProto(ch.Equip),
 		})
 	}
 	return &dbv1.ListCharactersResponse{Characters: out}, nil

--- a/dbserver/internal/grpcsrv/server_test.go
+++ b/dbserver/internal/grpcsrv/server_test.go
@@ -413,7 +413,8 @@ func TestListCharacters(t *testing.T) {
 	fs := &fakeStore{
 		chars: map[int64][]domain.Character{
 			1: {
-				{Slot: 0, Name: "a", Class: 1, Level: 5, Exp: 10, GuildID: 7},
+				{Slot: 0, Name: "a", Class: 1, Level: 5, Exp: 10, GuildID: 7,
+					Equip: []domain.Item{{Slot: 1, Index: 1100, Eff1: 1, EffV1: 9}}},
 				{Slot: 1, Name: "b", Class: 2, Level: 6},
 			},
 		},
@@ -425,6 +426,9 @@ func TestListCharacters(t *testing.T) {
 	got := resp.GetCharacters()
 	if len(got) != 2 || got[0].GetName() != "a" || got[0].GetGuildId() != 7 || got[1].GetName() != "b" {
 		t.Fatalf("unexpected summaries: %+v", got)
+	}
+	if eq := got[0].GetEquip(); len(eq) != 1 || eq[0].GetSlot() != 1 || eq[0].GetIndex() != 1100 || eq[0].GetEffv1() != 9 {
+		t.Fatalf("equipment not mapped: %+v", got[0].GetEquip())
 	}
 }
 

--- a/internal/store/store_live.go
+++ b/internal/store/store_live.go
@@ -108,10 +108,10 @@ func (s *Store) SetBlockedByName(ctx context.Context, name string, blocked bool)
 }
 
 // ListCharacters returns the character-selection projection (slot, name, class,
-// level, exp, guild) for an account, ordered by slot.
+// score preview and equipped gear) for an account, ordered by slot.
 func (s *Store) ListCharacters(ctx context.Context, accountID int64) ([]domain.Character, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT slot, name, class, guild_id, level, exp, coin,
+		`SELECT id, slot, name, class, guild_id, level, exp, coin,
 		        max_hp, hp, max_mp, mp, str, int, dex, con
 		   FROM character WHERE account_id = $1 ORDER BY slot`, accountID)
 	if err != nil {
@@ -119,17 +119,29 @@ func (s *Store) ListCharacters(ctx context.Context, accountID int64) ([]domain.C
 	}
 	defer rows.Close()
 
+	var charIDs []int64
 	var out []domain.Character
 	for rows.Next() {
+		var charID int64
 		var ch domain.Character
-		if err := rows.Scan(&ch.Slot, &ch.Name, &ch.Class, &ch.GuildID, &ch.Level, &ch.Exp, &ch.Coin,
+		if err := rows.Scan(&charID, &ch.Slot, &ch.Name, &ch.Class, &ch.GuildID, &ch.Level, &ch.Exp, &ch.Coin,
 			&ch.MaxHp, &ch.Hp, &ch.MaxMp, &ch.Mp, &ch.Str, &ch.Int, &ch.Dex, &ch.Con); err != nil {
 			return nil, fmt.Errorf("store: scan character summary: %w", err)
 		}
+		charIDs = append(charIDs, charID)
 		out = append(out, ch)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("store: list characters: %w", err)
+	}
+	rows.Close()
+
+	for i, charID := range charIDs {
+		equip, err := s.loadItems(ctx, charID, "char_equip")
+		if err != nil {
+			return nil, fmt.Errorf("store: list character equipment: %w", err)
+		}
+		out[i].Equip = equip
 	}
 	return out, nil
 }

--- a/internal/store/store_live_integration_test.go
+++ b/internal/store/store_live_integration_test.go
@@ -52,13 +52,17 @@ func TestLiveQueries(t *testing.T) {
 		t.Fatalf("AccountByName(ghost) = %v, want ErrNotFound", err)
 	}
 
-	// ListCharacters — the summary now carries the select-screen score preview.
+	// ListCharacters — the summary now carries the select-screen score preview
+	// and the persisted equipment used by the character-selection model.
 	list, err := s.ListCharacters(ctx, accID)
 	if err != nil || len(list) != 1 || list[0].Name != "Warrior" {
 		t.Fatalf("ListCharacters: %+v err=%v", list, err)
 	}
 	if c0 := list[0]; c0.Level != 40 || c0.Coin != 1000 || c0.MaxHp != 800 || c0.Str != 50 {
 		t.Fatalf("ListCharacters score preview: %+v", c0)
+	}
+	if c0 := list[0]; len(c0.Equip) != 1 || c0.Equip[0].Slot != 0 || c0.Equip[0].Index != 1100 || c0.Equip[0].EffV1 != 9 {
+		t.Fatalf("ListCharacters equipment preview: %+v", c0.Equip)
 	}
 
 	// LoadCharacter (with items + affects)

--- a/tmserver/internal/dbclient/client.go
+++ b/tmserver/internal/dbclient/client.go
@@ -75,7 +75,7 @@ func (c *Client) ListCharacters(ctx context.Context, accountID int64) ([]world.C
 	}
 	out := make([]world.CharSummary, 0, len(list.GetCharacters()))
 	for _, ch := range list.GetCharacters() {
-		out = append(out, world.CharSummary{
+		summary := world.CharSummary{
 			Slot:    int(ch.GetSlot()),
 			Name:    ch.GetName(),
 			Class:   int(ch.GetClass()),
@@ -91,7 +91,15 @@ func (c *Client) ListCharacters(ctx context.Context, accountID int64) ([]world.C
 			Int:     int16(ch.GetInt()),
 			Dex:     int16(ch.GetDex()),
 			Con:     int16(ch.GetCon()),
-		})
+		}
+		for _, it := range ch.GetEquip() {
+			slot := int(it.GetSlot())
+			if slot < 0 || slot >= world.MaxEquip {
+				continue
+			}
+			summary.Equip[slot] = itemFromProto(it)
+		}
+		out = append(out, summary)
 	}
 	return out, nil
 }

--- a/tmserver/internal/dbclient/client_test.go
+++ b/tmserver/internal/dbclient/client_test.go
@@ -147,7 +147,8 @@ func TestAccountLoginMapping(t *testing.T) {
 	api := &fakeAPI{
 		loginResp: &dbv1.AccountLoginResponse{Result: dbv1.LoginResult_LOGIN_RESULT_OK, AccountId: 1},
 		listResp: &dbv1.ListCharactersResponse{Characters: []*dbv1.CharacterSummary{
-			{Slot: 0, Name: "hero", Class: 2, Level: 10, GuildId: 5, Coin: 12345, MaxHp: 800, Hp: 750, Str: 60},
+			{Slot: 0, Name: "hero", Class: 2, Level: 10, GuildId: 5, Coin: 12345, MaxHp: 800, Hp: 750, Str: 60,
+				Equip: []*dbv1.Item{{Slot: 1, Index: 1100, Eff1: 1, Effv1: 9}}},
 		}},
 		cargoResp: &dbv1.LoadCargoResponse{CargoCoin: 4200, Items: []*dbv1.Item{
 			{Slot: 2, Index: 999, Eff1: 1, Effv1: 7},
@@ -166,6 +167,9 @@ func TestAccountLoginMapping(t *testing.T) {
 	// The select-screen score preview (gold, HP, attributes) is carried too.
 	if c0 := out.Characters[0]; c0.Coin != 12345 || c0.MaxHp != 800 || c0.Hp != 750 || c0.Str != 60 {
 		t.Fatalf("character score not mapped: %+v", c0)
+	}
+	if c0 := out.Characters[0]; c0.Equip[1].Index != 1100 || c0.Equip[1].Effects[0].Value != 9 {
+		t.Fatalf("character equip not mapped: %+v", c0.Equip[1])
 	}
 	// Cargo is fetched in the same login round-trip and mapped positionally.
 	if out.Cargo.AccountID != 1 || out.Cargo.Coin != 4200 || out.Cargo.Items[2].Index != 999 {

--- a/tmserver/internal/handler/handler_test.go
+++ b/tmserver/internal/handler/handler_test.go
@@ -543,6 +543,46 @@ func TestLoginOK(t *testing.T) {
 	}
 }
 
+func TestLoginSelectionUsesPersistedEquip(t *testing.T) {
+	db := newDB()
+	db.accounts["tester"].chars[0].Equip[1] = world.Item{
+		Index:   4321,
+		Effects: [3]world.Effect{{Effect: 1, Value: 9}},
+	}
+
+	addr, stop := startServer(t, db)
+	defer stop()
+	c := dial(t, addr)
+	defer c.Close()
+
+	send(t, c, protocol.MsgAccountLogin, loginBody("Tester", "secret", protocol.AppVersion))
+	ty, payload := read(t, c)
+	if ty != protocol.MsgCNFAccountLogin {
+		t.Fatalf("response = %#x, want CNFAccountLogin", ty)
+	}
+	const equip1Off = 20 + 272 + 8 // sel@20 + Equip[0][1] @272 + one STRUCT_ITEM
+	if got := binary.LittleEndian.Uint16(payload[equip1Off : equip1Off+2]); got != 4321 {
+		t.Fatalf("slot-0 equip[1] = %d, want persisted item 4321", got)
+	}
+	if got := payload[equip1Off+3]; got != 9 {
+		t.Fatalf("slot-0 equip[1] EffV1 = %d, want 9", got)
+	}
+}
+
+func TestSelCharsFromFallsBackToBaseMobEquip(t *testing.T) {
+	tmpl := make([]byte, content.BaseMobSize)
+	binary.LittleEndian.PutUint16(tmpl[140+8:140+10], 2222)
+	d := &Dispatcher{baseMobs: map[int][]byte{1: tmpl}}
+
+	chars := d.selCharsFrom([]world.CharSummary{{Slot: 0, Name: "fresh", Class: 1}})
+	if len(chars) != 1 {
+		t.Fatalf("sel chars = %d, want 1", len(chars))
+	}
+	if got := chars[0].Equip[1].Index; got != 2222 {
+		t.Fatalf("fallback equip[1] = %d, want BaseMob item 2222", got)
+	}
+}
+
 func TestLoginSendsCargo(t *testing.T) {
 	db := newDB()
 	cargo := world.CargoState{Coin: 777}

--- a/tmserver/internal/handler/login.go
+++ b/tmserver/internal/handler/login.go
@@ -144,9 +144,13 @@ func (d *Dispatcher) selCharsFrom(chars []world.CharSummary) []protocol.SelChar 
 			MaxHp: c.MaxHp, Hp: c.Hp, MaxMp: c.MaxMp, Mp: c.Mp,
 			Str: c.Str, Int: c.Int, Dex: c.Dex, Con: c.Con,
 		}
-		// Preview the character's class with its starter equipment from the class
-		// BaseMob template (B4: otherwise the client draws the default TK model).
-		if tmpl, ok := d.baseMobs[c.Class]; ok && len(tmpl) == content.BaseMobSize {
+		// Preview the saved gear. Empty equipment falls back to the class BaseMob so
+		// fresh characters still render with the right class model on the select screen.
+		if !equipEmpty(c.Equip) {
+			for i := range c.Equip {
+				sc.Equip[i] = itemToSel(c.Equip[i])
+			}
+		} else if tmpl, ok := d.baseMobs[c.Class]; ok && len(tmpl) == content.BaseMobSize {
 			sc.Equip = protocol.MobEquip(tmpl)
 		}
 		out = append(out, sc)

--- a/tmserver/internal/world/persistence.go
+++ b/tmserver/internal/world/persistence.go
@@ -54,6 +54,7 @@ type CharSummary struct {
 	Int     int16
 	Dex     int16
 	Con     int16
+	Equip   [MaxEquip]Item
 }
 
 // LoginOutcome is the result of an account-login attempt. On success it also


### PR DESCRIPTION
## Summary
- include persisted equipped items in the dbServer character selection summary
- map selection equipment through tmServer dbclient and STRUCT_SELCHAR encoding
- keep BaseMob starter gear fallback for fresh characters with empty equipment

Fixes #172

## Tests
- go test ./...
- make test