### PR TITLE
Add portal-managed world events

### DIFF
--- a/api/db/v1/db.pb.go
+++ b/api/db/v1/db.pb.go
@@ -4586,6 +4586,386 @@ func (x *ItemPrice) GetPrice() int64 {
 	return 0
 }
 
+type WorldEventConfigVersionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorldEventConfigVersionRequest) Reset() {
+	*x = WorldEventConfigVersionRequest{}
+	mi := &file_api_db_v1_db_proto_msgTypes[72]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorldEventConfigVersionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorldEventConfigVersionRequest) ProtoMessage() {}
+
+func (x *WorldEventConfigVersionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_db_v1_db_proto_msgTypes[72]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorldEventConfigVersionRequest.ProtoReflect.Descriptor instead.
+func (*WorldEventConfigVersionRequest) Descriptor() ([]byte, []int) {
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{72}
+}
+
+type WorldEventConfigVersionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Version       int64                  `protobuf:"varint,1,opt,name=version,proto3" json:"version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorldEventConfigVersionResponse) Reset() {
+	*x = WorldEventConfigVersionResponse{}
+	mi := &file_api_db_v1_db_proto_msgTypes[73]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorldEventConfigVersionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorldEventConfigVersionResponse) ProtoMessage() {}
+
+func (x *WorldEventConfigVersionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_db_v1_db_proto_msgTypes[73]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorldEventConfigVersionResponse.ProtoReflect.Descriptor instead.
+func (*WorldEventConfigVersionResponse) Descriptor() ([]byte, []int) {
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{73}
+}
+
+func (x *WorldEventConfigVersionResponse) GetVersion() int64 {
+	if x != nil {
+		return x.Version
+	}
+	return 0
+}
+
+type GetWorldEventConfigRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetWorldEventConfigRequest) Reset() {
+	*x = GetWorldEventConfigRequest{}
+	mi := &file_api_db_v1_db_proto_msgTypes[74]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetWorldEventConfigRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetWorldEventConfigRequest) ProtoMessage() {}
+
+func (x *GetWorldEventConfigRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_db_v1_db_proto_msgTypes[74]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetWorldEventConfigRequest.ProtoReflect.Descriptor instead.
+func (*GetWorldEventConfigRequest) Descriptor() ([]byte, []int) {
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{74}
+}
+
+type GetWorldEventConfigResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Version       int64                  `protobuf:"varint,1,opt,name=version,proto3" json:"version,omitempty"`
+	Config        *WorldEventConfig      `protobuf:"bytes,2,opt,name=config,proto3" json:"config,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetWorldEventConfigResponse) Reset() {
+	*x = GetWorldEventConfigResponse{}
+	mi := &file_api_db_v1_db_proto_msgTypes[75]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetWorldEventConfigResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetWorldEventConfigResponse) ProtoMessage() {}
+
+func (x *GetWorldEventConfigResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_db_v1_db_proto_msgTypes[75]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetWorldEventConfigResponse.ProtoReflect.Descriptor instead.
+func (*GetWorldEventConfigResponse) Descriptor() ([]byte, []int) {
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{75}
+}
+
+func (x *GetWorldEventConfigResponse) GetVersion() int64 {
+	if x != nil {
+		return x.Version
+	}
+	return 0
+}
+
+func (x *GetWorldEventConfigResponse) GetConfig() *WorldEventConfig {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
+type UpdateWorldEventProgressRequest struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	ExpectedVersion int64                  `protobuf:"varint,1,opt,name=expected_version,json=expectedVersion,proto3" json:"expected_version,omitempty"`
+	CurrentIndex    int32                  `protobuf:"varint,2,opt,name=current_index,json=currentIndex,proto3" json:"current_index,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *UpdateWorldEventProgressRequest) Reset() {
+	*x = UpdateWorldEventProgressRequest{}
+	mi := &file_api_db_v1_db_proto_msgTypes[76]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateWorldEventProgressRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateWorldEventProgressRequest) ProtoMessage() {}
+
+func (x *UpdateWorldEventProgressRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_db_v1_db_proto_msgTypes[76]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateWorldEventProgressRequest.ProtoReflect.Descriptor instead.
+func (*UpdateWorldEventProgressRequest) Descriptor() ([]byte, []int) {
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{76}
+}
+
+func (x *UpdateWorldEventProgressRequest) GetExpectedVersion() int64 {
+	if x != nil {
+		return x.ExpectedVersion
+	}
+	return 0
+}
+
+func (x *UpdateWorldEventProgressRequest) GetCurrentIndex() int32 {
+	if x != nil {
+		return x.CurrentIndex
+	}
+	return 0
+}
+
+type UpdateWorldEventProgressResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Applied       bool                   `protobuf:"varint,1,opt,name=applied,proto3" json:"applied,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateWorldEventProgressResponse) Reset() {
+	*x = UpdateWorldEventProgressResponse{}
+	mi := &file_api_db_v1_db_proto_msgTypes[77]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateWorldEventProgressResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateWorldEventProgressResponse) ProtoMessage() {}
+
+func (x *UpdateWorldEventProgressResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_db_v1_db_proto_msgTypes[77]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateWorldEventProgressResponse.ProtoReflect.Descriptor instead.
+func (*UpdateWorldEventProgressResponse) Descriptor() ([]byte, []int) {
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{77}
+}
+
+func (x *UpdateWorldEventProgressResponse) GetApplied() bool {
+	if x != nil {
+		return x.Applied
+	}
+	return false
+}
+
+type WorldEventConfig struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	Enabled            bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	ItemIndex          int32                  `protobuf:"varint,2,opt,name=item_index,json=itemIndex,proto3" json:"item_index,omitempty"`
+	Rate               int32                  `protobuf:"varint,3,opt,name=rate,proto3" json:"rate,omitempty"`
+	StartIndex         int32                  `protobuf:"varint,4,opt,name=start_index,json=startIndex,proto3" json:"start_index,omitempty"`
+	CurrentIndex       int32                  `protobuf:"varint,5,opt,name=current_index,json=currentIndex,proto3" json:"current_index,omitempty"`
+	EndIndex           int32                  `protobuf:"varint,6,opt,name=end_index,json=endIndex,proto3" json:"end_index,omitempty"`
+	Indexed            bool                   `protobuf:"varint,7,opt,name=indexed,proto3" json:"indexed,omitempty"`
+	NoticeEnabled      bool                   `protobuf:"varint,8,opt,name=notice_enabled,json=noticeEnabled,proto3" json:"notice_enabled,omitempty"`
+	DoubleExpEnabled   bool                   `protobuf:"varint,9,opt,name=double_exp_enabled,json=doubleExpEnabled,proto3" json:"double_exp_enabled,omitempty"`
+	NewbieEventEnabled bool                   `protobuf:"varint,10,opt,name=newbie_event_enabled,json=newbieEventEnabled,proto3" json:"newbie_event_enabled,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *WorldEventConfig) Reset() {
+	*x = WorldEventConfig{}
+	mi := &file_api_db_v1_db_proto_msgTypes[78]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorldEventConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorldEventConfig) ProtoMessage() {}
+
+func (x *WorldEventConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_api_db_v1_db_proto_msgTypes[78]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorldEventConfig.ProtoReflect.Descriptor instead.
+func (*WorldEventConfig) Descriptor() ([]byte, []int) {
+	return file_api_db_v1_db_proto_rawDescGZIP(), []int{78}
+}
+
+func (x *WorldEventConfig) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *WorldEventConfig) GetItemIndex() int32 {
+	if x != nil {
+		return x.ItemIndex
+	}
+	return 0
+}
+
+func (x *WorldEventConfig) GetRate() int32 {
+	if x != nil {
+		return x.Rate
+	}
+	return 0
+}
+
+func (x *WorldEventConfig) GetStartIndex() int32 {
+	if x != nil {
+		return x.StartIndex
+	}
+	return 0
+}
+
+func (x *WorldEventConfig) GetCurrentIndex() int32 {
+	if x != nil {
+		return x.CurrentIndex
+	}
+	return 0
+}
+
+func (x *WorldEventConfig) GetEndIndex() int32 {
+	if x != nil {
+		return x.EndIndex
+	}
+	return 0
+}
+
+func (x *WorldEventConfig) GetIndexed() bool {
+	if x != nil {
+		return x.Indexed
+	}
+	return false
+}
+
+func (x *WorldEventConfig) GetNoticeEnabled() bool {
+	if x != nil {
+		return x.NoticeEnabled
+	}
+	return false
+}
+
+func (x *WorldEventConfig) GetDoubleExpEnabled() bool {
+	if x != nil {
+		return x.DoubleExpEnabled
+	}
+	return false
+}
+
+func (x *WorldEventConfig) GetNewbieEventEnabled() bool {
+	if x != nil {
+		return x.NewbieEventEnabled
+	}
+	return false
+}
+
 var File_api_db_v1_db_proto protoreflect.FileDescriptor
 
 const file_api_db_v1_db_proto_rawDesc = "" +
@@ -4928,7 +5308,33 @@ const file_api_db_v1_db_proto_rawDesc = "" +
 	"\tItemPrice\x12\x1d\n" +
 	"\n" +
 	"item_index\x18\x01 \x01(\x05R\titemIndex\x12\x14\n" +
-	"\x05price\x18\x02 \x01(\x03R\x05price*\xb8\x01\n" +
+	"\x05price\x18\x02 \x01(\x03R\x05price\" \n" +
+	"\x1eWorldEventConfigVersionRequest\";\n" +
+	"\x1fWorldEventConfigVersionResponse\x12\x18\n" +
+	"\aversion\x18\x01 \x01(\x03R\aversion\"\x1c\n" +
+	"\x1aGetWorldEventConfigRequest\"h\n" +
+	"\x1bGetWorldEventConfigResponse\x12\x18\n" +
+	"\aversion\x18\x01 \x01(\x03R\aversion\x12/\n" +
+	"\x06config\x18\x02 \x01(\v2\x17.db.v1.WorldEventConfigR\x06config\"q\n" +
+	"\x1fUpdateWorldEventProgressRequest\x12)\n" +
+	"\x10expected_version\x18\x01 \x01(\x03R\x0fexpectedVersion\x12#\n" +
+	"\rcurrent_index\x18\x02 \x01(\x05R\fcurrentIndex\"<\n" +
+	" UpdateWorldEventProgressResponse\x12\x18\n" +
+	"\aapplied\x18\x01 \x01(\bR\aapplied\"\xe3\x02\n" +
+	"\x10WorldEventConfig\x12\x18\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x1d\n" +
+	"\n" +
+	"item_index\x18\x02 \x01(\x05R\titemIndex\x12\x12\n" +
+	"\x04rate\x18\x03 \x01(\x05R\x04rate\x12\x1f\n" +
+	"\vstart_index\x18\x04 \x01(\x05R\n" +
+	"startIndex\x12#\n" +
+	"\rcurrent_index\x18\x05 \x01(\x05R\fcurrentIndex\x12\x1b\n" +
+	"\tend_index\x18\x06 \x01(\x05R\bendIndex\x12\x18\n" +
+	"\aindexed\x18\a \x01(\bR\aindexed\x12%\n" +
+	"\x0enotice_enabled\x18\b \x01(\bR\rnoticeEnabled\x12,\n" +
+	"\x12double_exp_enabled\x18\t \x01(\bR\x10doubleExpEnabled\x120\n" +
+	"\x14newbie_event_enabled\x18\n" +
+	" \x01(\bR\x12newbieEventEnabled*\xb8\x01\n" +
 	"\vLoginResult\x12\x1c\n" +
 	"\x18LOGIN_RESULT_UNSPECIFIED\x10\x00\x12\x13\n" +
 	"\x0fLOGIN_RESULT_OK\x10\x01\x12\x1b\n" +
@@ -4980,7 +5386,11 @@ const file_api_db_v1_db_proto_rawDesc = "" +
 	"\x14SaveCastleQuestState\x12\".db.v1.SaveCastleQuestStateRequest\x1a#.db.v1.SaveCastleQuestStateResponse2\xc2\x01\n" +
 	"\x10NpcConfigService\x12S\n" +
 	"\x10NpcConfigVersion\x12\x1e.db.v1.NpcConfigVersionRequest\x1a\x1f.db.v1.NpcConfigVersionResponse\x12Y\n" +
-	"\x12ListNpcDefinitions\x12 .db.v1.ListNpcDefinitionsRequest\x1a!.db.v1.ListNpcDefinitionsResponseB1Z/github.com/jeanluca/w2pp-openwyd/api/db/v1;dbv1b\x06proto3"
+	"\x12ListNpcDefinitions\x12 .db.v1.ListNpcDefinitionsRequest\x1a!.db.v1.ListNpcDefinitionsResponse2\xce\x02\n" +
+	"\x17WorldEventConfigService\x12h\n" +
+	"\x17WorldEventConfigVersion\x12%.db.v1.WorldEventConfigVersionRequest\x1a&.db.v1.WorldEventConfigVersionResponse\x12\\\n" +
+	"\x13GetWorldEventConfig\x12!.db.v1.GetWorldEventConfigRequest\x1a\".db.v1.GetWorldEventConfigResponse\x12k\n" +
+	"\x18UpdateWorldEventProgress\x12&.db.v1.UpdateWorldEventProgressRequest\x1a'.db.v1.UpdateWorldEventProgressResponseB1Z/github.com/jeanluca/w2pp-openwyd/api/db/v1;dbv1b\x06proto3"
 
 var (
 	file_api_db_v1_db_proto_rawDescOnce sync.Once
@@ -4995,83 +5405,90 @@ func file_api_db_v1_db_proto_rawDescGZIP() []byte {
 }
 
 var file_api_db_v1_db_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_api_db_v1_db_proto_msgTypes = make([]protoimpl.MessageInfo, 72)
+var file_api_db_v1_db_proto_msgTypes = make([]protoimpl.MessageInfo, 79)
 var file_api_db_v1_db_proto_goTypes = []any{
-	(LoginResult)(0),                       // 0: db.v1.LoginResult
-	(PinResult)(0),                         // 1: db.v1.PinResult
-	(GuildRelationKind)(0),                 // 2: db.v1.GuildRelationKind
-	(*AccountLoginRequest)(nil),            // 3: db.v1.AccountLoginRequest
-	(*AccountLoginResponse)(nil),           // 4: db.v1.AccountLoginResponse
-	(*ListCharactersRequest)(nil),          // 5: db.v1.ListCharactersRequest
-	(*CharacterSummary)(nil),               // 6: db.v1.CharacterSummary
-	(*ListCharactersResponse)(nil),         // 7: db.v1.ListCharactersResponse
-	(*LoadCharacterRequest)(nil),           // 8: db.v1.LoadCharacterRequest
-	(*Character)(nil),                      // 9: db.v1.Character
-	(*Item)(nil),                           // 10: db.v1.Item
-	(*Affect)(nil),                         // 11: db.v1.Affect
-	(*LoadCharacterResponse)(nil),          // 12: db.v1.LoadCharacterResponse
-	(*SaveCharacterRequest)(nil),           // 13: db.v1.SaveCharacterRequest
-	(*SaveCharacterResponse)(nil),          // 14: db.v1.SaveCharacterResponse
-	(*CreateCharacterRequest)(nil),         // 15: db.v1.CreateCharacterRequest
-	(*CreateCharacterResponse)(nil),        // 16: db.v1.CreateCharacterResponse
-	(*CreateArchCharacterRequest)(nil),     // 17: db.v1.CreateArchCharacterRequest
-	(*CreateArchCharacterResponse)(nil),    // 18: db.v1.CreateArchCharacterResponse
-	(*DeleteCharacterRequest)(nil),         // 19: db.v1.DeleteCharacterRequest
-	(*DeleteCharacterResponse)(nil),        // 20: db.v1.DeleteCharacterResponse
-	(*SetPinRequest)(nil),                  // 21: db.v1.SetPinRequest
-	(*SetPinResponse)(nil),                 // 22: db.v1.SetPinResponse
-	(*VerifyPinRequest)(nil),               // 23: db.v1.VerifyPinRequest
-	(*VerifyPinResponse)(nil),              // 24: db.v1.VerifyPinResponse
-	(*LoadCargoRequest)(nil),               // 25: db.v1.LoadCargoRequest
-	(*LoadCargoResponse)(nil),              // 26: db.v1.LoadCargoResponse
-	(*SaveCargoRequest)(nil),               // 27: db.v1.SaveCargoRequest
-	(*SaveCargoResponse)(nil),              // 28: db.v1.SaveCargoResponse
-	(*Delivery)(nil),                       // 29: db.v1.Delivery
-	(*ListPendingDeliveriesRequest)(nil),   // 30: db.v1.ListPendingDeliveriesRequest
-	(*ListPendingDeliveriesResponse)(nil),  // 31: db.v1.ListPendingDeliveriesResponse
-	(*SaveCargoWithDeliveriesRequest)(nil), // 32: db.v1.SaveCargoWithDeliveriesRequest
-	(*SetAccountBlockedRequest)(nil),       // 33: db.v1.SetAccountBlockedRequest
-	(*SetAccountBlockedResponse)(nil),      // 34: db.v1.SetAccountBlockedResponse
-	(*RecordDuelResultRequest)(nil),        // 35: db.v1.RecordDuelResultRequest
-	(*RecordDuelResultResponse)(nil),       // 36: db.v1.RecordDuelResultResponse
-	(*Guild)(nil),                          // 37: db.v1.Guild
-	(*GuildRelation)(nil),                  // 38: db.v1.GuildRelation
-	(*CreateGuildRequest)(nil),             // 39: db.v1.CreateGuildRequest
-	(*CreateGuildResponse)(nil),            // 40: db.v1.CreateGuildResponse
-	(*SetGuildMemberRequest)(nil),          // 41: db.v1.SetGuildMemberRequest
-	(*SetGuildMemberResponse)(nil),         // 42: db.v1.SetGuildMemberResponse
-	(*LeaveGuildRequest)(nil),              // 43: db.v1.LeaveGuildRequest
-	(*PromoteGuildMemberRequest)(nil),      // 44: db.v1.PromoteGuildMemberRequest
-	(*PromoteGuildMemberResponse)(nil),     // 45: db.v1.PromoteGuildMemberResponse
-	(*TransferGuildLeaderRequest)(nil),     // 46: db.v1.TransferGuildLeaderRequest
-	(*SetGuildRelationRequest)(nil),        // 47: db.v1.SetGuildRelationRequest
-	(*SetGuildRelationResponse)(nil),       // 48: db.v1.SetGuildRelationResponse
-	(*ListGuildsRequest)(nil),              // 49: db.v1.ListGuildsRequest
-	(*ListGuildsResponse)(nil),             // 50: db.v1.ListGuildsResponse
-	(*ListGuildRelationsRequest)(nil),      // 51: db.v1.ListGuildRelationsRequest
-	(*ListGuildRelationsResponse)(nil),     // 52: db.v1.ListGuildRelationsResponse
-	(*GuildZone)(nil),                      // 53: db.v1.GuildZone
-	(*LoadGuildZonesRequest)(nil),          // 54: db.v1.LoadGuildZonesRequest
-	(*LoadGuildZonesResponse)(nil),         // 55: db.v1.LoadGuildZonesResponse
-	(*SaveGuildZoneRequest)(nil),           // 56: db.v1.SaveGuildZoneRequest
-	(*SaveGuildZoneResponse)(nil),          // 57: db.v1.SaveGuildZoneResponse
-	(*GuildTowerState)(nil),                // 58: db.v1.GuildTowerState
-	(*LoadGuildTowerStateRequest)(nil),     // 59: db.v1.LoadGuildTowerStateRequest
-	(*LoadGuildTowerStateResponse)(nil),    // 60: db.v1.LoadGuildTowerStateResponse
-	(*SaveGuildTowerStateRequest)(nil),     // 61: db.v1.SaveGuildTowerStateRequest
-	(*SaveGuildTowerStateResponse)(nil),    // 62: db.v1.SaveGuildTowerStateResponse
-	(*CastleQuestState)(nil),               // 63: db.v1.CastleQuestState
-	(*LoadCastleQuestStateRequest)(nil),    // 64: db.v1.LoadCastleQuestStateRequest
-	(*LoadCastleQuestStateResponse)(nil),   // 65: db.v1.LoadCastleQuestStateResponse
-	(*SaveCastleQuestStateRequest)(nil),    // 66: db.v1.SaveCastleQuestStateRequest
-	(*SaveCastleQuestStateResponse)(nil),   // 67: db.v1.SaveCastleQuestStateResponse
-	(*NpcConfigVersionRequest)(nil),        // 68: db.v1.NpcConfigVersionRequest
-	(*NpcConfigVersionResponse)(nil),       // 69: db.v1.NpcConfigVersionResponse
-	(*ListNpcDefinitionsRequest)(nil),      // 70: db.v1.ListNpcDefinitionsRequest
-	(*ListNpcDefinitionsResponse)(nil),     // 71: db.v1.ListNpcDefinitionsResponse
-	(*NpcShopItem)(nil),                    // 72: db.v1.NpcShopItem
-	(*NpcDefinition)(nil),                  // 73: db.v1.NpcDefinition
-	(*ItemPrice)(nil),                      // 74: db.v1.ItemPrice
+	(LoginResult)(0),                         // 0: db.v1.LoginResult
+	(PinResult)(0),                           // 1: db.v1.PinResult
+	(GuildRelationKind)(0),                   // 2: db.v1.GuildRelationKind
+	(*AccountLoginRequest)(nil),              // 3: db.v1.AccountLoginRequest
+	(*AccountLoginResponse)(nil),             // 4: db.v1.AccountLoginResponse
+	(*ListCharactersRequest)(nil),            // 5: db.v1.ListCharactersRequest
+	(*CharacterSummary)(nil),                 // 6: db.v1.CharacterSummary
+	(*ListCharactersResponse)(nil),           // 7: db.v1.ListCharactersResponse
+	(*LoadCharacterRequest)(nil),             // 8: db.v1.LoadCharacterRequest
+	(*Character)(nil),                        // 9: db.v1.Character
+	(*Item)(nil),                             // 10: db.v1.Item
+	(*Affect)(nil),                           // 11: db.v1.Affect
+	(*LoadCharacterResponse)(nil),            // 12: db.v1.LoadCharacterResponse
+	(*SaveCharacterRequest)(nil),             // 13: db.v1.SaveCharacterRequest
+	(*SaveCharacterResponse)(nil),            // 14: db.v1.SaveCharacterResponse
+	(*CreateCharacterRequest)(nil),           // 15: db.v1.CreateCharacterRequest
+	(*CreateCharacterResponse)(nil),          // 16: db.v1.CreateCharacterResponse
+	(*CreateArchCharacterRequest)(nil),       // 17: db.v1.CreateArchCharacterRequest
+	(*CreateArchCharacterResponse)(nil),      // 18: db.v1.CreateArchCharacterResponse
+	(*DeleteCharacterRequest)(nil),           // 19: db.v1.DeleteCharacterRequest
+	(*DeleteCharacterResponse)(nil),          // 20: db.v1.DeleteCharacterResponse
+	(*SetPinRequest)(nil),                    // 21: db.v1.SetPinRequest
+	(*SetPinResponse)(nil),                   // 22: db.v1.SetPinResponse
+	(*VerifyPinRequest)(nil),                 // 23: db.v1.VerifyPinRequest
+	(*VerifyPinResponse)(nil),                // 24: db.v1.VerifyPinResponse
+	(*LoadCargoRequest)(nil),                 // 25: db.v1.LoadCargoRequest
+	(*LoadCargoResponse)(nil),                // 26: db.v1.LoadCargoResponse
+	(*SaveCargoRequest)(nil),                 // 27: db.v1.SaveCargoRequest
+	(*SaveCargoResponse)(nil),                // 28: db.v1.SaveCargoResponse
+	(*Delivery)(nil),                         // 29: db.v1.Delivery
+	(*ListPendingDeliveriesRequest)(nil),     // 30: db.v1.ListPendingDeliveriesRequest
+	(*ListPendingDeliveriesResponse)(nil),    // 31: db.v1.ListPendingDeliveriesResponse
+	(*SaveCargoWithDeliveriesRequest)(nil),   // 32: db.v1.SaveCargoWithDeliveriesRequest
+	(*SetAccountBlockedRequest)(nil),         // 33: db.v1.SetAccountBlockedRequest
+	(*SetAccountBlockedResponse)(nil),        // 34: db.v1.SetAccountBlockedResponse
+	(*RecordDuelResultRequest)(nil),          // 35: db.v1.RecordDuelResultRequest
+	(*RecordDuelResultResponse)(nil),         // 36: db.v1.RecordDuelResultResponse
+	(*Guild)(nil),                            // 37: db.v1.Guild
+	(*GuildRelation)(nil),                    // 38: db.v1.GuildRelation
+	(*CreateGuildRequest)(nil),               // 39: db.v1.CreateGuildRequest
+	(*CreateGuildResponse)(nil),              // 40: db.v1.CreateGuildResponse
+	(*SetGuildMemberRequest)(nil),            // 41: db.v1.SetGuildMemberRequest
+	(*SetGuildMemberResponse)(nil),           // 42: db.v1.SetGuildMemberResponse
+	(*LeaveGuildRequest)(nil),                // 43: db.v1.LeaveGuildRequest
+	(*PromoteGuildMemberRequest)(nil),        // 44: db.v1.PromoteGuildMemberRequest
+	(*PromoteGuildMemberResponse)(nil),       // 45: db.v1.PromoteGuildMemberResponse
+	(*TransferGuildLeaderRequest)(nil),       // 46: db.v1.TransferGuildLeaderRequest
+	(*SetGuildRelationRequest)(nil),          // 47: db.v1.SetGuildRelationRequest
+	(*SetGuildRelationResponse)(nil),         // 48: db.v1.SetGuildRelationResponse
+	(*ListGuildsRequest)(nil),                // 49: db.v1.ListGuildsRequest
+	(*ListGuildsResponse)(nil),               // 50: db.v1.ListGuildsResponse
+	(*ListGuildRelationsRequest)(nil),        // 51: db.v1.ListGuildRelationsRequest
+	(*ListGuildRelationsResponse)(nil),       // 52: db.v1.ListGuildRelationsResponse
+	(*GuildZone)(nil),                        // 53: db.v1.GuildZone
+	(*LoadGuildZonesRequest)(nil),            // 54: db.v1.LoadGuildZonesRequest
+	(*LoadGuildZonesResponse)(nil),           // 55: db.v1.LoadGuildZonesResponse
+	(*SaveGuildZoneRequest)(nil),             // 56: db.v1.SaveGuildZoneRequest
+	(*SaveGuildZoneResponse)(nil),            // 57: db.v1.SaveGuildZoneResponse
+	(*GuildTowerState)(nil),                  // 58: db.v1.GuildTowerState
+	(*LoadGuildTowerStateRequest)(nil),       // 59: db.v1.LoadGuildTowerStateRequest
+	(*LoadGuildTowerStateResponse)(nil),      // 60: db.v1.LoadGuildTowerStateResponse
+	(*SaveGuildTowerStateRequest)(nil),       // 61: db.v1.SaveGuildTowerStateRequest
+	(*SaveGuildTowerStateResponse)(nil),      // 62: db.v1.SaveGuildTowerStateResponse
+	(*CastleQuestState)(nil),                 // 63: db.v1.CastleQuestState
+	(*LoadCastleQuestStateRequest)(nil),      // 64: db.v1.LoadCastleQuestStateRequest
+	(*LoadCastleQuestStateResponse)(nil),     // 65: db.v1.LoadCastleQuestStateResponse
+	(*SaveCastleQuestStateRequest)(nil),      // 66: db.v1.SaveCastleQuestStateRequest
+	(*SaveCastleQuestStateResponse)(nil),     // 67: db.v1.SaveCastleQuestStateResponse
+	(*NpcConfigVersionRequest)(nil),          // 68: db.v1.NpcConfigVersionRequest
+	(*NpcConfigVersionResponse)(nil),         // 69: db.v1.NpcConfigVersionResponse
+	(*ListNpcDefinitionsRequest)(nil),        // 70: db.v1.ListNpcDefinitionsRequest
+	(*ListNpcDefinitionsResponse)(nil),       // 71: db.v1.ListNpcDefinitionsResponse
+	(*NpcShopItem)(nil),                      // 72: db.v1.NpcShopItem
+	(*NpcDefinition)(nil),                    // 73: db.v1.NpcDefinition
+	(*ItemPrice)(nil),                        // 74: db.v1.ItemPrice
+	(*WorldEventConfigVersionRequest)(nil),   // 75: db.v1.WorldEventConfigVersionRequest
+	(*WorldEventConfigVersionResponse)(nil),  // 76: db.v1.WorldEventConfigVersionResponse
+	(*GetWorldEventConfigRequest)(nil),       // 77: db.v1.GetWorldEventConfigRequest
+	(*GetWorldEventConfigResponse)(nil),      // 78: db.v1.GetWorldEventConfigResponse
+	(*UpdateWorldEventProgressRequest)(nil),  // 79: db.v1.UpdateWorldEventProgressRequest
+	(*UpdateWorldEventProgressResponse)(nil), // 80: db.v1.UpdateWorldEventProgressResponse
+	(*WorldEventConfig)(nil),                 // 81: db.v1.WorldEventConfig
 }
 var file_api_db_v1_db_proto_depIdxs = []int32{
 	0,  // 0: db.v1.AccountLoginResponse.result:type_name -> db.v1.LoginResult
@@ -5102,73 +5519,80 @@ var file_api_db_v1_db_proto_depIdxs = []int32{
 	73, // 25: db.v1.ListNpcDefinitionsResponse.definitions:type_name -> db.v1.NpcDefinition
 	74, // 26: db.v1.ListNpcDefinitionsResponse.price_overrides:type_name -> db.v1.ItemPrice
 	72, // 27: db.v1.NpcDefinition.shop:type_name -> db.v1.NpcShopItem
-	3,  // 28: db.v1.AccountService.AccountLogin:input_type -> db.v1.AccountLoginRequest
-	5,  // 29: db.v1.AccountService.ListCharacters:input_type -> db.v1.ListCharactersRequest
-	8,  // 30: db.v1.AccountService.LoadCharacter:input_type -> db.v1.LoadCharacterRequest
-	13, // 31: db.v1.AccountService.SaveCharacter:input_type -> db.v1.SaveCharacterRequest
-	15, // 32: db.v1.AccountService.CreateCharacter:input_type -> db.v1.CreateCharacterRequest
-	17, // 33: db.v1.AccountService.CreateArchCharacter:input_type -> db.v1.CreateArchCharacterRequest
-	19, // 34: db.v1.AccountService.DeleteCharacter:input_type -> db.v1.DeleteCharacterRequest
-	21, // 35: db.v1.AccountService.SetPin:input_type -> db.v1.SetPinRequest
-	23, // 36: db.v1.AccountService.VerifyPin:input_type -> db.v1.VerifyPinRequest
-	25, // 37: db.v1.AccountService.LoadCargo:input_type -> db.v1.LoadCargoRequest
-	27, // 38: db.v1.AccountService.SaveCargo:input_type -> db.v1.SaveCargoRequest
-	30, // 39: db.v1.AccountService.ListPendingDeliveries:input_type -> db.v1.ListPendingDeliveriesRequest
-	32, // 40: db.v1.AccountService.SaveCargoWithDeliveries:input_type -> db.v1.SaveCargoWithDeliveriesRequest
-	33, // 41: db.v1.AccountService.SetAccountBlocked:input_type -> db.v1.SetAccountBlockedRequest
-	35, // 42: db.v1.AccountService.RecordDuelResult:input_type -> db.v1.RecordDuelResultRequest
-	39, // 43: db.v1.AccountService.CreateGuild:input_type -> db.v1.CreateGuildRequest
-	41, // 44: db.v1.AccountService.SetGuildMember:input_type -> db.v1.SetGuildMemberRequest
-	43, // 45: db.v1.AccountService.LeaveGuild:input_type -> db.v1.LeaveGuildRequest
-	44, // 46: db.v1.AccountService.PromoteGuildMember:input_type -> db.v1.PromoteGuildMemberRequest
-	46, // 47: db.v1.AccountService.TransferGuildLeader:input_type -> db.v1.TransferGuildLeaderRequest
-	47, // 48: db.v1.AccountService.SetGuildRelation:input_type -> db.v1.SetGuildRelationRequest
-	49, // 49: db.v1.AccountService.ListGuilds:input_type -> db.v1.ListGuildsRequest
-	51, // 50: db.v1.AccountService.ListGuildRelations:input_type -> db.v1.ListGuildRelationsRequest
-	54, // 51: db.v1.AccountService.LoadGuildZones:input_type -> db.v1.LoadGuildZonesRequest
-	56, // 52: db.v1.AccountService.SaveGuildZone:input_type -> db.v1.SaveGuildZoneRequest
-	59, // 53: db.v1.AccountService.LoadGuildTowerState:input_type -> db.v1.LoadGuildTowerStateRequest
-	61, // 54: db.v1.AccountService.SaveGuildTowerState:input_type -> db.v1.SaveGuildTowerStateRequest
-	64, // 55: db.v1.AccountService.LoadCastleQuestState:input_type -> db.v1.LoadCastleQuestStateRequest
-	66, // 56: db.v1.AccountService.SaveCastleQuestState:input_type -> db.v1.SaveCastleQuestStateRequest
-	68, // 57: db.v1.NpcConfigService.NpcConfigVersion:input_type -> db.v1.NpcConfigVersionRequest
-	70, // 58: db.v1.NpcConfigService.ListNpcDefinitions:input_type -> db.v1.ListNpcDefinitionsRequest
-	4,  // 59: db.v1.AccountService.AccountLogin:output_type -> db.v1.AccountLoginResponse
-	7,  // 60: db.v1.AccountService.ListCharacters:output_type -> db.v1.ListCharactersResponse
-	12, // 61: db.v1.AccountService.LoadCharacter:output_type -> db.v1.LoadCharacterResponse
-	14, // 62: db.v1.AccountService.SaveCharacter:output_type -> db.v1.SaveCharacterResponse
-	16, // 63: db.v1.AccountService.CreateCharacter:output_type -> db.v1.CreateCharacterResponse
-	18, // 64: db.v1.AccountService.CreateArchCharacter:output_type -> db.v1.CreateArchCharacterResponse
-	20, // 65: db.v1.AccountService.DeleteCharacter:output_type -> db.v1.DeleteCharacterResponse
-	22, // 66: db.v1.AccountService.SetPin:output_type -> db.v1.SetPinResponse
-	24, // 67: db.v1.AccountService.VerifyPin:output_type -> db.v1.VerifyPinResponse
-	26, // 68: db.v1.AccountService.LoadCargo:output_type -> db.v1.LoadCargoResponse
-	28, // 69: db.v1.AccountService.SaveCargo:output_type -> db.v1.SaveCargoResponse
-	31, // 70: db.v1.AccountService.ListPendingDeliveries:output_type -> db.v1.ListPendingDeliveriesResponse
-	28, // 71: db.v1.AccountService.SaveCargoWithDeliveries:output_type -> db.v1.SaveCargoResponse
-	34, // 72: db.v1.AccountService.SetAccountBlocked:output_type -> db.v1.SetAccountBlockedResponse
-	36, // 73: db.v1.AccountService.RecordDuelResult:output_type -> db.v1.RecordDuelResultResponse
-	40, // 74: db.v1.AccountService.CreateGuild:output_type -> db.v1.CreateGuildResponse
-	42, // 75: db.v1.AccountService.SetGuildMember:output_type -> db.v1.SetGuildMemberResponse
-	42, // 76: db.v1.AccountService.LeaveGuild:output_type -> db.v1.SetGuildMemberResponse
-	45, // 77: db.v1.AccountService.PromoteGuildMember:output_type -> db.v1.PromoteGuildMemberResponse
-	42, // 78: db.v1.AccountService.TransferGuildLeader:output_type -> db.v1.SetGuildMemberResponse
-	48, // 79: db.v1.AccountService.SetGuildRelation:output_type -> db.v1.SetGuildRelationResponse
-	50, // 80: db.v1.AccountService.ListGuilds:output_type -> db.v1.ListGuildsResponse
-	52, // 81: db.v1.AccountService.ListGuildRelations:output_type -> db.v1.ListGuildRelationsResponse
-	55, // 82: db.v1.AccountService.LoadGuildZones:output_type -> db.v1.LoadGuildZonesResponse
-	57, // 83: db.v1.AccountService.SaveGuildZone:output_type -> db.v1.SaveGuildZoneResponse
-	60, // 84: db.v1.AccountService.LoadGuildTowerState:output_type -> db.v1.LoadGuildTowerStateResponse
-	62, // 85: db.v1.AccountService.SaveGuildTowerState:output_type -> db.v1.SaveGuildTowerStateResponse
-	65, // 86: db.v1.AccountService.LoadCastleQuestState:output_type -> db.v1.LoadCastleQuestStateResponse
-	67, // 87: db.v1.AccountService.SaveCastleQuestState:output_type -> db.v1.SaveCastleQuestStateResponse
-	69, // 88: db.v1.NpcConfigService.NpcConfigVersion:output_type -> db.v1.NpcConfigVersionResponse
-	71, // 89: db.v1.NpcConfigService.ListNpcDefinitions:output_type -> db.v1.ListNpcDefinitionsResponse
-	59, // [59:90] is the sub-list for method output_type
-	28, // [28:59] is the sub-list for method input_type
-	28, // [28:28] is the sub-list for extension type_name
-	28, // [28:28] is the sub-list for extension extendee
-	0,  // [0:28] is the sub-list for field type_name
+	81, // 28: db.v1.GetWorldEventConfigResponse.config:type_name -> db.v1.WorldEventConfig
+	3,  // 29: db.v1.AccountService.AccountLogin:input_type -> db.v1.AccountLoginRequest
+	5,  // 30: db.v1.AccountService.ListCharacters:input_type -> db.v1.ListCharactersRequest
+	8,  // 31: db.v1.AccountService.LoadCharacter:input_type -> db.v1.LoadCharacterRequest
+	13, // 32: db.v1.AccountService.SaveCharacter:input_type -> db.v1.SaveCharacterRequest
+	15, // 33: db.v1.AccountService.CreateCharacter:input_type -> db.v1.CreateCharacterRequest
+	17, // 34: db.v1.AccountService.CreateArchCharacter:input_type -> db.v1.CreateArchCharacterRequest
+	19, // 35: db.v1.AccountService.DeleteCharacter:input_type -> db.v1.DeleteCharacterRequest
+	21, // 36: db.v1.AccountService.SetPin:input_type -> db.v1.SetPinRequest
+	23, // 37: db.v1.AccountService.VerifyPin:input_type -> db.v1.VerifyPinRequest
+	25, // 38: db.v1.AccountService.LoadCargo:input_type -> db.v1.LoadCargoRequest
+	27, // 39: db.v1.AccountService.SaveCargo:input_type -> db.v1.SaveCargoRequest
+	30, // 40: db.v1.AccountService.ListPendingDeliveries:input_type -> db.v1.ListPendingDeliveriesRequest
+	32, // 41: db.v1.AccountService.SaveCargoWithDeliveries:input_type -> db.v1.SaveCargoWithDeliveriesRequest
+	33, // 42: db.v1.AccountService.SetAccountBlocked:input_type -> db.v1.SetAccountBlockedRequest
+	35, // 43: db.v1.AccountService.RecordDuelResult:input_type -> db.v1.RecordDuelResultRequest
+	39, // 44: db.v1.AccountService.CreateGuild:input_type -> db.v1.CreateGuildRequest
+	41, // 45: db.v1.AccountService.SetGuildMember:input_type -> db.v1.SetGuildMemberRequest
+	43, // 46: db.v1.AccountService.LeaveGuild:input_type -> db.v1.LeaveGuildRequest
+	44, // 47: db.v1.AccountService.PromoteGuildMember:input_type -> db.v1.PromoteGuildMemberRequest
+	46, // 48: db.v1.AccountService.TransferGuildLeader:input_type -> db.v1.TransferGuildLeaderRequest
+	47, // 49: db.v1.AccountService.SetGuildRelation:input_type -> db.v1.SetGuildRelationRequest
+	49, // 50: db.v1.AccountService.ListGuilds:input_type -> db.v1.ListGuildsRequest
+	51, // 51: db.v1.AccountService.ListGuildRelations:input_type -> db.v1.ListGuildRelationsRequest
+	54, // 52: db.v1.AccountService.LoadGuildZones:input_type -> db.v1.LoadGuildZonesRequest
+	56, // 53: db.v1.AccountService.SaveGuildZone:input_type -> db.v1.SaveGuildZoneRequest
+	59, // 54: db.v1.AccountService.LoadGuildTowerState:input_type -> db.v1.LoadGuildTowerStateRequest
+	61, // 55: db.v1.AccountService.SaveGuildTowerState:input_type -> db.v1.SaveGuildTowerStateRequest
+	64, // 56: db.v1.AccountService.LoadCastleQuestState:input_type -> db.v1.LoadCastleQuestStateRequest
+	66, // 57: db.v1.AccountService.SaveCastleQuestState:input_type -> db.v1.SaveCastleQuestStateRequest
+	68, // 58: db.v1.NpcConfigService.NpcConfigVersion:input_type -> db.v1.NpcConfigVersionRequest
+	70, // 59: db.v1.NpcConfigService.ListNpcDefinitions:input_type -> db.v1.ListNpcDefinitionsRequest
+	75, // 60: db.v1.WorldEventConfigService.WorldEventConfigVersion:input_type -> db.v1.WorldEventConfigVersionRequest
+	77, // 61: db.v1.WorldEventConfigService.GetWorldEventConfig:input_type -> db.v1.GetWorldEventConfigRequest
+	79, // 62: db.v1.WorldEventConfigService.UpdateWorldEventProgress:input_type -> db.v1.UpdateWorldEventProgressRequest
+	4,  // 63: db.v1.AccountService.AccountLogin:output_type -> db.v1.AccountLoginResponse
+	7,  // 64: db.v1.AccountService.ListCharacters:output_type -> db.v1.ListCharactersResponse
+	12, // 65: db.v1.AccountService.LoadCharacter:output_type -> db.v1.LoadCharacterResponse
+	14, // 66: db.v1.AccountService.SaveCharacter:output_type -> db.v1.SaveCharacterResponse
+	16, // 67: db.v1.AccountService.CreateCharacter:output_type -> db.v1.CreateCharacterResponse
+	18, // 68: db.v1.AccountService.CreateArchCharacter:output_type -> db.v1.CreateArchCharacterResponse
+	20, // 69: db.v1.AccountService.DeleteCharacter:output_type -> db.v1.DeleteCharacterResponse
+	22, // 70: db.v1.AccountService.SetPin:output_type -> db.v1.SetPinResponse
+	24, // 71: db.v1.AccountService.VerifyPin:output_type -> db.v1.VerifyPinResponse
+	26, // 72: db.v1.AccountService.LoadCargo:output_type -> db.v1.LoadCargoResponse
+	28, // 73: db.v1.AccountService.SaveCargo:output_type -> db.v1.SaveCargoResponse
+	31, // 74: db.v1.AccountService.ListPendingDeliveries:output_type -> db.v1.ListPendingDeliveriesResponse
+	28, // 75: db.v1.AccountService.SaveCargoWithDeliveries:output_type -> db.v1.SaveCargoResponse
+	34, // 76: db.v1.AccountService.SetAccountBlocked:output_type -> db.v1.SetAccountBlockedResponse
+	36, // 77: db.v1.AccountService.RecordDuelResult:output_type -> db.v1.RecordDuelResultResponse
+	40, // 78: db.v1.AccountService.CreateGuild:output_type -> db.v1.CreateGuildResponse
+	42, // 79: db.v1.AccountService.SetGuildMember:output_type -> db.v1.SetGuildMemberResponse
+	42, // 80: db.v1.AccountService.LeaveGuild:output_type -> db.v1.SetGuildMemberResponse
+	45, // 81: db.v1.AccountService.PromoteGuildMember:output_type -> db.v1.PromoteGuildMemberResponse
+	42, // 82: db.v1.AccountService.TransferGuildLeader:output_type -> db.v1.SetGuildMemberResponse
+	48, // 83: db.v1.AccountService.SetGuildRelation:output_type -> db.v1.SetGuildRelationResponse
+	50, // 84: db.v1.AccountService.ListGuilds:output_type -> db.v1.ListGuildsResponse
+	52, // 85: db.v1.AccountService.ListGuildRelations:output_type -> db.v1.ListGuildRelationsResponse
+	55, // 86: db.v1.AccountService.LoadGuildZones:output_type -> db.v1.LoadGuildZonesResponse
+	57, // 87: db.v1.AccountService.SaveGuildZone:output_type -> db.v1.SaveGuildZoneResponse
+	60, // 88: db.v1.AccountService.LoadGuildTowerState:output_type -> db.v1.LoadGuildTowerStateResponse
+	62, // 89: db.v1.AccountService.SaveGuildTowerState:output_type -> db.v1.SaveGuildTowerStateResponse
+	65, // 90: db.v1.AccountService.LoadCastleQuestState:output_type -> db.v1.LoadCastleQuestStateResponse
+	67, // 91: db.v1.AccountService.SaveCastleQuestState:output_type -> db.v1.SaveCastleQuestStateResponse
+	69, // 92: db.v1.NpcConfigService.NpcConfigVersion:output_type -> db.v1.NpcConfigVersionResponse
+	71, // 93: db.v1.NpcConfigService.ListNpcDefinitions:output_type -> db.v1.ListNpcDefinitionsResponse
+	76, // 94: db.v1.WorldEventConfigService.WorldEventConfigVersion:output_type -> db.v1.WorldEventConfigVersionResponse
+	78, // 95: db.v1.WorldEventConfigService.GetWorldEventConfig:output_type -> db.v1.GetWorldEventConfigResponse
+	80, // 96: db.v1.WorldEventConfigService.UpdateWorldEventProgress:output_type -> db.v1.UpdateWorldEventProgressResponse
+	63, // [63:97] is the sub-list for method output_type
+	29, // [29:63] is the sub-list for method input_type
+	29, // [29:29] is the sub-list for extension type_name
+	29, // [29:29] is the sub-list for extension extendee
+	0,  // [0:29] is the sub-list for field type_name
 }
 
 func init() { file_api_db_v1_db_proto_init() }
@@ -5182,9 +5606,9 @@ func file_api_db_v1_db_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_db_v1_db_proto_rawDesc), len(file_api_db_v1_db_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   72,
+			NumMessages:   79,
 			NumExtensions: 0,
-			NumServices:   2,
+			NumServices:   3,
 		},
 		GoTypes:           file_api_db_v1_db_proto_goTypes,
 		DependencyIndexes: file_api_db_v1_db_proto_depIdxs,

--- a/api/db/v1/db.proto
+++ b/api/db/v1/db.proto
@@ -484,3 +484,46 @@ message ItemPrice {
   int32 item_index = 1;
   int64 price = 2;
 }
+
+// WorldEventConfigService serves portal-managed global world events to tmServer
+// (issue #116). tmServer reads the config and writes only the event-progress
+// counter; all moderator edits go through the web-api.
+service WorldEventConfigService {
+  // WorldEventConfigVersion returns the monotonic moderator config version.
+  rpc WorldEventConfigVersion(WorldEventConfigVersionRequest) returns (WorldEventConfigVersionResponse);
+  // GetWorldEventConfig returns the full global event snapshot.
+  rpc GetWorldEventConfig(GetWorldEventConfigRequest) returns (GetWorldEventConfigResponse);
+  // UpdateWorldEventProgress persists tmServer's current_index without bumping
+  // the config version. expected_version rejects stale tmServer snapshots.
+  rpc UpdateWorldEventProgress(UpdateWorldEventProgressRequest) returns (UpdateWorldEventProgressResponse);
+}
+
+message WorldEventConfigVersionRequest {}
+message WorldEventConfigVersionResponse { int64 version = 1; }
+
+message GetWorldEventConfigRequest {}
+message GetWorldEventConfigResponse {
+  int64 version = 1;
+  WorldEventConfig config = 2;
+}
+
+message UpdateWorldEventProgressRequest {
+  int64 expected_version = 1;
+  int32 current_index = 2;
+}
+message UpdateWorldEventProgressResponse {
+  bool applied = 1;
+}
+
+message WorldEventConfig {
+  bool enabled = 1;
+  int32 item_index = 2;
+  int32 rate = 3;
+  int32 start_index = 4;
+  int32 current_index = 5;
+  int32 end_index = 6;
+  bool indexed = 7;
+  bool notice_enabled = 8;
+  bool double_exp_enabled = 9;
+  bool newbie_event_enabled = 10;
+}

--- a/api/db/v1/db_grpc.pb.go
+++ b/api/db/v1/db_grpc.pb.go
@@ -1419,3 +1419,198 @@ var NpcConfigService_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "api/db/v1/db.proto",
 }
+
+const (
+	WorldEventConfigService_WorldEventConfigVersion_FullMethodName  = "/db.v1.WorldEventConfigService/WorldEventConfigVersion"
+	WorldEventConfigService_GetWorldEventConfig_FullMethodName      = "/db.v1.WorldEventConfigService/GetWorldEventConfig"
+	WorldEventConfigService_UpdateWorldEventProgress_FullMethodName = "/db.v1.WorldEventConfigService/UpdateWorldEventProgress"
+)
+
+// WorldEventConfigServiceClient is the client API for WorldEventConfigService service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// WorldEventConfigService serves portal-managed global world events to tmServer
+// (issue #116). tmServer reads the config and writes only the event-progress
+// counter; all moderator edits go through the web-api.
+type WorldEventConfigServiceClient interface {
+	// WorldEventConfigVersion returns the monotonic moderator config version.
+	WorldEventConfigVersion(ctx context.Context, in *WorldEventConfigVersionRequest, opts ...grpc.CallOption) (*WorldEventConfigVersionResponse, error)
+	// GetWorldEventConfig returns the full global event snapshot.
+	GetWorldEventConfig(ctx context.Context, in *GetWorldEventConfigRequest, opts ...grpc.CallOption) (*GetWorldEventConfigResponse, error)
+	// UpdateWorldEventProgress persists tmServer's current_index without bumping
+	// the config version. expected_version rejects stale tmServer snapshots.
+	UpdateWorldEventProgress(ctx context.Context, in *UpdateWorldEventProgressRequest, opts ...grpc.CallOption) (*UpdateWorldEventProgressResponse, error)
+}
+
+type worldEventConfigServiceClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewWorldEventConfigServiceClient(cc grpc.ClientConnInterface) WorldEventConfigServiceClient {
+	return &worldEventConfigServiceClient{cc}
+}
+
+func (c *worldEventConfigServiceClient) WorldEventConfigVersion(ctx context.Context, in *WorldEventConfigVersionRequest, opts ...grpc.CallOption) (*WorldEventConfigVersionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(WorldEventConfigVersionResponse)
+	err := c.cc.Invoke(ctx, WorldEventConfigService_WorldEventConfigVersion_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *worldEventConfigServiceClient) GetWorldEventConfig(ctx context.Context, in *GetWorldEventConfigRequest, opts ...grpc.CallOption) (*GetWorldEventConfigResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetWorldEventConfigResponse)
+	err := c.cc.Invoke(ctx, WorldEventConfigService_GetWorldEventConfig_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *worldEventConfigServiceClient) UpdateWorldEventProgress(ctx context.Context, in *UpdateWorldEventProgressRequest, opts ...grpc.CallOption) (*UpdateWorldEventProgressResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UpdateWorldEventProgressResponse)
+	err := c.cc.Invoke(ctx, WorldEventConfigService_UpdateWorldEventProgress_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// WorldEventConfigServiceServer is the server API for WorldEventConfigService service.
+// All implementations must embed UnimplementedWorldEventConfigServiceServer
+// for forward compatibility.
+//
+// WorldEventConfigService serves portal-managed global world events to tmServer
+// (issue #116). tmServer reads the config and writes only the event-progress
+// counter; all moderator edits go through the web-api.
+type WorldEventConfigServiceServer interface {
+	// WorldEventConfigVersion returns the monotonic moderator config version.
+	WorldEventConfigVersion(context.Context, *WorldEventConfigVersionRequest) (*WorldEventConfigVersionResponse, error)
+	// GetWorldEventConfig returns the full global event snapshot.
+	GetWorldEventConfig(context.Context, *GetWorldEventConfigRequest) (*GetWorldEventConfigResponse, error)
+	// UpdateWorldEventProgress persists tmServer's current_index without bumping
+	// the config version. expected_version rejects stale tmServer snapshots.
+	UpdateWorldEventProgress(context.Context, *UpdateWorldEventProgressRequest) (*UpdateWorldEventProgressResponse, error)
+	mustEmbedUnimplementedWorldEventConfigServiceServer()
+}
+
+// UnimplementedWorldEventConfigServiceServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedWorldEventConfigServiceServer struct{}
+
+func (UnimplementedWorldEventConfigServiceServer) WorldEventConfigVersion(context.Context, *WorldEventConfigVersionRequest) (*WorldEventConfigVersionResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method WorldEventConfigVersion not implemented")
+}
+func (UnimplementedWorldEventConfigServiceServer) GetWorldEventConfig(context.Context, *GetWorldEventConfigRequest) (*GetWorldEventConfigResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetWorldEventConfig not implemented")
+}
+func (UnimplementedWorldEventConfigServiceServer) UpdateWorldEventProgress(context.Context, *UpdateWorldEventProgressRequest) (*UpdateWorldEventProgressResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method UpdateWorldEventProgress not implemented")
+}
+func (UnimplementedWorldEventConfigServiceServer) mustEmbedUnimplementedWorldEventConfigServiceServer() {
+}
+func (UnimplementedWorldEventConfigServiceServer) testEmbeddedByValue() {}
+
+// UnsafeWorldEventConfigServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to WorldEventConfigServiceServer will
+// result in compilation errors.
+type UnsafeWorldEventConfigServiceServer interface {
+	mustEmbedUnimplementedWorldEventConfigServiceServer()
+}
+
+func RegisterWorldEventConfigServiceServer(s grpc.ServiceRegistrar, srv WorldEventConfigServiceServer) {
+	// If the following call panics, it indicates UnimplementedWorldEventConfigServiceServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&WorldEventConfigService_ServiceDesc, srv)
+}
+
+func _WorldEventConfigService_WorldEventConfigVersion_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(WorldEventConfigVersionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WorldEventConfigServiceServer).WorldEventConfigVersion(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WorldEventConfigService_WorldEventConfigVersion_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WorldEventConfigServiceServer).WorldEventConfigVersion(ctx, req.(*WorldEventConfigVersionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _WorldEventConfigService_GetWorldEventConfig_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetWorldEventConfigRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WorldEventConfigServiceServer).GetWorldEventConfig(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WorldEventConfigService_GetWorldEventConfig_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WorldEventConfigServiceServer).GetWorldEventConfig(ctx, req.(*GetWorldEventConfigRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _WorldEventConfigService_UpdateWorldEventProgress_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateWorldEventProgressRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WorldEventConfigServiceServer).UpdateWorldEventProgress(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WorldEventConfigService_UpdateWorldEventProgress_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WorldEventConfigServiceServer).UpdateWorldEventProgress(ctx, req.(*UpdateWorldEventProgressRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// WorldEventConfigService_ServiceDesc is the grpc.ServiceDesc for WorldEventConfigService service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var WorldEventConfigService_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "db.v1.WorldEventConfigService",
+	HandlerType: (*WorldEventConfigServiceServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "WorldEventConfigVersion",
+			Handler:    _WorldEventConfigService_WorldEventConfigVersion_Handler,
+		},
+		{
+			MethodName: "GetWorldEventConfig",
+			Handler:    _WorldEventConfigService_GetWorldEventConfig_Handler,
+		},
+		{
+			MethodName: "UpdateWorldEventProgress",
+			Handler:    _WorldEventConfigService_UpdateWorldEventProgress_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "api/db/v1/db.proto",
+}

--- a/api/web/v1/web.pb.go
+++ b/api/web/v1/web.pb.go
@@ -5259,6 +5259,278 @@ func (x *DeleteRewardItemRequest) GetItemId() int64 {
 	return 0
 }
 
+type WorldEventConfig struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	Enabled            bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	ItemIndex          int32                  `protobuf:"varint,2,opt,name=item_index,json=itemIndex,proto3" json:"item_index,omitempty"`
+	Rate               int32                  `protobuf:"varint,3,opt,name=rate,proto3" json:"rate,omitempty"`
+	StartIndex         int32                  `protobuf:"varint,4,opt,name=start_index,json=startIndex,proto3" json:"start_index,omitempty"`
+	CurrentIndex       int32                  `protobuf:"varint,5,opt,name=current_index,json=currentIndex,proto3" json:"current_index,omitempty"`
+	EndIndex           int32                  `protobuf:"varint,6,opt,name=end_index,json=endIndex,proto3" json:"end_index,omitempty"`
+	Indexed            bool                   `protobuf:"varint,7,opt,name=indexed,proto3" json:"indexed,omitempty"`
+	NoticeEnabled      bool                   `protobuf:"varint,8,opt,name=notice_enabled,json=noticeEnabled,proto3" json:"notice_enabled,omitempty"`
+	DoubleExpEnabled   bool                   `protobuf:"varint,9,opt,name=double_exp_enabled,json=doubleExpEnabled,proto3" json:"double_exp_enabled,omitempty"`
+	NewbieEventEnabled bool                   `protobuf:"varint,10,opt,name=newbie_event_enabled,json=newbieEventEnabled,proto3" json:"newbie_event_enabled,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *WorldEventConfig) Reset() {
+	*x = WorldEventConfig{}
+	mi := &file_api_web_v1_web_proto_msgTypes[77]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorldEventConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorldEventConfig) ProtoMessage() {}
+
+func (x *WorldEventConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[77]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorldEventConfig.ProtoReflect.Descriptor instead.
+func (*WorldEventConfig) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{77}
+}
+
+func (x *WorldEventConfig) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *WorldEventConfig) GetItemIndex() int32 {
+	if x != nil {
+		return x.ItemIndex
+	}
+	return 0
+}
+
+func (x *WorldEventConfig) GetRate() int32 {
+	if x != nil {
+		return x.Rate
+	}
+	return 0
+}
+
+func (x *WorldEventConfig) GetStartIndex() int32 {
+	if x != nil {
+		return x.StartIndex
+	}
+	return 0
+}
+
+func (x *WorldEventConfig) GetCurrentIndex() int32 {
+	if x != nil {
+		return x.CurrentIndex
+	}
+	return 0
+}
+
+func (x *WorldEventConfig) GetEndIndex() int32 {
+	if x != nil {
+		return x.EndIndex
+	}
+	return 0
+}
+
+func (x *WorldEventConfig) GetIndexed() bool {
+	if x != nil {
+		return x.Indexed
+	}
+	return false
+}
+
+func (x *WorldEventConfig) GetNoticeEnabled() bool {
+	if x != nil {
+		return x.NoticeEnabled
+	}
+	return false
+}
+
+func (x *WorldEventConfig) GetDoubleExpEnabled() bool {
+	if x != nil {
+		return x.DoubleExpEnabled
+	}
+	return false
+}
+
+func (x *WorldEventConfig) GetNewbieEventEnabled() bool {
+	if x != nil {
+		return x.NewbieEventEnabled
+	}
+	return false
+}
+
+type GetWorldEventConfigRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId   int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetWorldEventConfigRequest) Reset() {
+	*x = GetWorldEventConfigRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[78]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetWorldEventConfigRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetWorldEventConfigRequest) ProtoMessage() {}
+
+func (x *GetWorldEventConfigRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[78]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetWorldEventConfigRequest.ProtoReflect.Descriptor instead.
+func (*GetWorldEventConfigRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{78}
+}
+
+func (x *GetWorldEventConfigRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+type GetWorldEventConfigResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Result        AdminResult            `protobuf:"varint,1,opt,name=result,proto3,enum=web.v1.AdminResult" json:"result,omitempty"`
+	Version       int64                  `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
+	Config        *WorldEventConfig      `protobuf:"bytes,3,opt,name=config,proto3" json:"config,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetWorldEventConfigResponse) Reset() {
+	*x = GetWorldEventConfigResponse{}
+	mi := &file_api_web_v1_web_proto_msgTypes[79]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetWorldEventConfigResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetWorldEventConfigResponse) ProtoMessage() {}
+
+func (x *GetWorldEventConfigResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[79]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetWorldEventConfigResponse.ProtoReflect.Descriptor instead.
+func (*GetWorldEventConfigResponse) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{79}
+}
+
+func (x *GetWorldEventConfigResponse) GetResult() AdminResult {
+	if x != nil {
+		return x.Result
+	}
+	return AdminResult_ADMIN_RESULT_UNSPECIFIED
+}
+
+func (x *GetWorldEventConfigResponse) GetVersion() int64 {
+	if x != nil {
+		return x.Version
+	}
+	return 0
+}
+
+func (x *GetWorldEventConfigResponse) GetConfig() *WorldEventConfig {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
+type SetWorldEventConfigRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId   int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	Config        *WorldEventConfig      `protobuf:"bytes,2,opt,name=config,proto3" json:"config,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetWorldEventConfigRequest) Reset() {
+	*x = SetWorldEventConfigRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[80]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetWorldEventConfigRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetWorldEventConfigRequest) ProtoMessage() {}
+
+func (x *SetWorldEventConfigRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[80]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetWorldEventConfigRequest.ProtoReflect.Descriptor instead.
+func (*SetWorldEventConfigRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{80}
+}
+
+func (x *SetWorldEventConfigRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+func (x *SetWorldEventConfigRequest) GetConfig() *WorldEventConfig {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
 type ListRewardsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -5267,7 +5539,7 @@ type ListRewardsRequest struct {
 
 func (x *ListRewardsRequest) Reset() {
 	*x = ListRewardsRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[77]
+	mi := &file_api_web_v1_web_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5279,7 +5551,7 @@ func (x *ListRewardsRequest) String() string {
 func (*ListRewardsRequest) ProtoMessage() {}
 
 func (x *ListRewardsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[77]
+	mi := &file_api_web_v1_web_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5292,7 +5564,7 @@ func (x *ListRewardsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRewardsRequest.ProtoReflect.Descriptor instead.
 func (*ListRewardsRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{77}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{81}
 }
 
 type ListRewardsResponse struct {
@@ -5304,7 +5576,7 @@ type ListRewardsResponse struct {
 
 func (x *ListRewardsResponse) Reset() {
 	*x = ListRewardsResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[78]
+	mi := &file_api_web_v1_web_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5316,7 +5588,7 @@ func (x *ListRewardsResponse) String() string {
 func (*ListRewardsResponse) ProtoMessage() {}
 
 func (x *ListRewardsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[78]
+	mi := &file_api_web_v1_web_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5329,7 +5601,7 @@ func (x *ListRewardsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRewardsResponse.ProtoReflect.Descriptor instead.
 func (*ListRewardsResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{78}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *ListRewardsResponse) GetItems() []*DailyRewardItem {
@@ -5348,7 +5620,7 @@ type GetClaimStatusRequest struct {
 
 func (x *GetClaimStatusRequest) Reset() {
 	*x = GetClaimStatusRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[79]
+	mi := &file_api_web_v1_web_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5360,7 +5632,7 @@ func (x *GetClaimStatusRequest) String() string {
 func (*GetClaimStatusRequest) ProtoMessage() {}
 
 func (x *GetClaimStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[79]
+	mi := &file_api_web_v1_web_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5373,7 +5645,7 @@ func (x *GetClaimStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetClaimStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetClaimStatusRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{79}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *GetClaimStatusRequest) GetAccountId() int64 {
@@ -5394,7 +5666,7 @@ type GetClaimStatusResponse struct {
 
 func (x *GetClaimStatusResponse) Reset() {
 	*x = GetClaimStatusResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[80]
+	mi := &file_api_web_v1_web_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5406,7 +5678,7 @@ func (x *GetClaimStatusResponse) String() string {
 func (*GetClaimStatusResponse) ProtoMessage() {}
 
 func (x *GetClaimStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[80]
+	mi := &file_api_web_v1_web_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5419,7 +5691,7 @@ func (x *GetClaimStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetClaimStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetClaimStatusResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{80}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *GetClaimStatusResponse) GetClaimedToday() bool {
@@ -5453,7 +5725,7 @@ type ClaimRequest struct {
 
 func (x *ClaimRequest) Reset() {
 	*x = ClaimRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[81]
+	mi := &file_api_web_v1_web_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5465,7 +5737,7 @@ func (x *ClaimRequest) String() string {
 func (*ClaimRequest) ProtoMessage() {}
 
 func (x *ClaimRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[81]
+	mi := &file_api_web_v1_web_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5478,7 +5750,7 @@ func (x *ClaimRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClaimRequest.ProtoReflect.Descriptor instead.
 func (*ClaimRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{81}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *ClaimRequest) GetAccountId() int64 {
@@ -5504,7 +5776,7 @@ type ClaimResponse struct {
 
 func (x *ClaimResponse) Reset() {
 	*x = ClaimResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[82]
+	mi := &file_api_web_v1_web_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5516,7 +5788,7 @@ func (x *ClaimResponse) String() string {
 func (*ClaimResponse) ProtoMessage() {}
 
 func (x *ClaimResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[82]
+	mi := &file_api_web_v1_web_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5529,7 +5801,7 @@ func (x *ClaimResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClaimResponse.ProtoReflect.Descriptor instead.
 func (*ClaimResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{82}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *ClaimResponse) GetResult() ClaimResult {
@@ -5548,7 +5820,7 @@ type GetPayerProfileRequest struct {
 
 func (x *GetPayerProfileRequest) Reset() {
 	*x = GetPayerProfileRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[83]
+	mi := &file_api_web_v1_web_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5560,7 +5832,7 @@ func (x *GetPayerProfileRequest) String() string {
 func (*GetPayerProfileRequest) ProtoMessage() {}
 
 func (x *GetPayerProfileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[83]
+	mi := &file_api_web_v1_web_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5573,7 +5845,7 @@ func (x *GetPayerProfileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPayerProfileRequest.ProtoReflect.Descriptor instead.
 func (*GetPayerProfileRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{83}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *GetPayerProfileRequest) GetAccountId() int64 {
@@ -5594,7 +5866,7 @@ type GetPayerProfileResponse struct {
 
 func (x *GetPayerProfileResponse) Reset() {
 	*x = GetPayerProfileResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[84]
+	mi := &file_api_web_v1_web_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5606,7 +5878,7 @@ func (x *GetPayerProfileResponse) String() string {
 func (*GetPayerProfileResponse) ProtoMessage() {}
 
 func (x *GetPayerProfileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[84]
+	mi := &file_api_web_v1_web_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5619,7 +5891,7 @@ func (x *GetPayerProfileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPayerProfileResponse.ProtoReflect.Descriptor instead.
 func (*GetPayerProfileResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{84}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *GetPayerProfileResponse) GetFound() bool {
@@ -5654,7 +5926,7 @@ type SavePayerProfileRequest struct {
 
 func (x *SavePayerProfileRequest) Reset() {
 	*x = SavePayerProfileRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[85]
+	mi := &file_api_web_v1_web_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5666,7 +5938,7 @@ func (x *SavePayerProfileRequest) String() string {
 func (*SavePayerProfileRequest) ProtoMessage() {}
 
 func (x *SavePayerProfileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[85]
+	mi := &file_api_web_v1_web_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5679,7 +5951,7 @@ func (x *SavePayerProfileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SavePayerProfileRequest.ProtoReflect.Descriptor instead.
 func (*SavePayerProfileRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{85}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *SavePayerProfileRequest) GetAccountId() int64 {
@@ -5712,7 +5984,7 @@ type SavePayerProfileResponse struct {
 
 func (x *SavePayerProfileResponse) Reset() {
 	*x = SavePayerProfileResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[86]
+	mi := &file_api_web_v1_web_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5724,7 +5996,7 @@ func (x *SavePayerProfileResponse) String() string {
 func (*SavePayerProfileResponse) ProtoMessage() {}
 
 func (x *SavePayerProfileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[86]
+	mi := &file_api_web_v1_web_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5737,7 +6009,7 @@ func (x *SavePayerProfileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SavePayerProfileResponse.ProtoReflect.Descriptor instead.
 func (*SavePayerProfileResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{86}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *SavePayerProfileResponse) GetResult() AdminResult {
@@ -5760,7 +6032,7 @@ type CreateTopupOrderRequest struct {
 
 func (x *CreateTopupOrderRequest) Reset() {
 	*x = CreateTopupOrderRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[87]
+	mi := &file_api_web_v1_web_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5772,7 +6044,7 @@ func (x *CreateTopupOrderRequest) String() string {
 func (*CreateTopupOrderRequest) ProtoMessage() {}
 
 func (x *CreateTopupOrderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[87]
+	mi := &file_api_web_v1_web_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5785,7 +6057,7 @@ func (x *CreateTopupOrderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTopupOrderRequest.ProtoReflect.Descriptor instead.
 func (*CreateTopupOrderRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{87}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *CreateTopupOrderRequest) GetAccountId() int64 {
@@ -5833,7 +6105,7 @@ type CreateTopupOrderResponse struct {
 
 func (x *CreateTopupOrderResponse) Reset() {
 	*x = CreateTopupOrderResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[88]
+	mi := &file_api_web_v1_web_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5845,7 +6117,7 @@ func (x *CreateTopupOrderResponse) String() string {
 func (*CreateTopupOrderResponse) ProtoMessage() {}
 
 func (x *CreateTopupOrderResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[88]
+	mi := &file_api_web_v1_web_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5858,7 +6130,7 @@ func (x *CreateTopupOrderResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTopupOrderResponse.ProtoReflect.Descriptor instead.
 func (*CreateTopupOrderResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{88}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *CreateTopupOrderResponse) GetResult() AdminResult {
@@ -5884,7 +6156,7 @@ type ConfirmTopupOrderRequest struct {
 
 func (x *ConfirmTopupOrderRequest) Reset() {
 	*x = ConfirmTopupOrderRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[89]
+	mi := &file_api_web_v1_web_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5896,7 +6168,7 @@ func (x *ConfirmTopupOrderRequest) String() string {
 func (*ConfirmTopupOrderRequest) ProtoMessage() {}
 
 func (x *ConfirmTopupOrderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[89]
+	mi := &file_api_web_v1_web_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5909,7 +6181,7 @@ func (x *ConfirmTopupOrderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfirmTopupOrderRequest.ProtoReflect.Descriptor instead.
 func (*ConfirmTopupOrderRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{89}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *ConfirmTopupOrderRequest) GetExternalReference() string {
@@ -5929,7 +6201,7 @@ type ConfirmTopupOrderResponse struct {
 
 func (x *ConfirmTopupOrderResponse) Reset() {
 	*x = ConfirmTopupOrderResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[90]
+	mi := &file_api_web_v1_web_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5941,7 +6213,7 @@ func (x *ConfirmTopupOrderResponse) String() string {
 func (*ConfirmTopupOrderResponse) ProtoMessage() {}
 
 func (x *ConfirmTopupOrderResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[90]
+	mi := &file_api_web_v1_web_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5954,7 +6226,7 @@ func (x *ConfirmTopupOrderResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfirmTopupOrderResponse.ProtoReflect.Descriptor instead.
 func (*ConfirmTopupOrderResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{90}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *ConfirmTopupOrderResponse) GetResult() TopupResult {
@@ -5981,7 +6253,7 @@ type GetTopupOrderRequest struct {
 
 func (x *GetTopupOrderRequest) Reset() {
 	*x = GetTopupOrderRequest{}
-	mi := &file_api_web_v1_web_proto_msgTypes[91]
+	mi := &file_api_web_v1_web_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5993,7 +6265,7 @@ func (x *GetTopupOrderRequest) String() string {
 func (*GetTopupOrderRequest) ProtoMessage() {}
 
 func (x *GetTopupOrderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[91]
+	mi := &file_api_web_v1_web_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6006,7 +6278,7 @@ func (x *GetTopupOrderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTopupOrderRequest.ProtoReflect.Descriptor instead.
 func (*GetTopupOrderRequest) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{91}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *GetTopupOrderRequest) GetExternalReference() string {
@@ -6034,7 +6306,7 @@ type GetTopupOrderResponse struct {
 
 func (x *GetTopupOrderResponse) Reset() {
 	*x = GetTopupOrderResponse{}
-	mi := &file_api_web_v1_web_proto_msgTypes[92]
+	mi := &file_api_web_v1_web_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6046,7 +6318,7 @@ func (x *GetTopupOrderResponse) String() string {
 func (*GetTopupOrderResponse) ProtoMessage() {}
 
 func (x *GetTopupOrderResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_web_v1_web_proto_msgTypes[92]
+	mi := &file_api_web_v1_web_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6059,7 +6331,7 @@ func (x *GetTopupOrderResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTopupOrderResponse.ProtoReflect.Descriptor instead.
 func (*GetTopupOrderResponse) Descriptor() ([]byte, []int) {
-	return file_api_web_v1_web_proto_rawDescGZIP(), []int{92}
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *GetTopupOrderResponse) GetStatus() TopupStatus {
@@ -6449,7 +6721,30 @@ const file_api_web_v1_web_proto_rawDesc = "" +
 	"\aenabled\x18\x03 \x01(\bR\aenabled\"U\n" +
 	"\x17DeleteRewardItemRequest\x12!\n" +
 	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\x12\x17\n" +
-	"\aitem_id\x18\x02 \x01(\x03R\x06itemId\"\x14\n" +
+	"\aitem_id\x18\x02 \x01(\x03R\x06itemId\"\xe3\x02\n" +
+	"\x10WorldEventConfig\x12\x18\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x1d\n" +
+	"\n" +
+	"item_index\x18\x02 \x01(\x05R\titemIndex\x12\x12\n" +
+	"\x04rate\x18\x03 \x01(\x05R\x04rate\x12\x1f\n" +
+	"\vstart_index\x18\x04 \x01(\x05R\n" +
+	"startIndex\x12#\n" +
+	"\rcurrent_index\x18\x05 \x01(\x05R\fcurrentIndex\x12\x1b\n" +
+	"\tend_index\x18\x06 \x01(\x05R\bendIndex\x12\x18\n" +
+	"\aindexed\x18\a \x01(\bR\aindexed\x12%\n" +
+	"\x0enotice_enabled\x18\b \x01(\bR\rnoticeEnabled\x12,\n" +
+	"\x12double_exp_enabled\x18\t \x01(\bR\x10doubleExpEnabled\x120\n" +
+	"\x14newbie_event_enabled\x18\n" +
+	" \x01(\bR\x12newbieEventEnabled\"?\n" +
+	"\x1aGetWorldEventConfigRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\"\x96\x01\n" +
+	"\x1bGetWorldEventConfigResponse\x12+\n" +
+	"\x06result\x18\x01 \x01(\x0e2\x13.web.v1.AdminResultR\x06result\x12\x18\n" +
+	"\aversion\x18\x02 \x01(\x03R\aversion\x120\n" +
+	"\x06config\x18\x03 \x01(\v2\x18.web.v1.WorldEventConfigR\x06config\"q\n" +
+	"\x1aSetWorldEventConfigRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\x120\n" +
+	"\x06config\x18\x02 \x01(\v2\x18.web.v1.WorldEventConfigR\x06config\"\x14\n" +
 	"\x12ListRewardsRequest\"D\n" +
 	"\x13ListRewardsResponse\x12-\n" +
 	"\x05items\x18\x01 \x03(\v2\x17.web.v1.DailyRewardItemR\x05items\"6\n" +
@@ -6589,7 +6884,10 @@ const file_api_web_v1_web_proto_rawDesc = "" +
 	"\x0fListRewardItems\x12\x1e.web.v1.ListRewardItemsRequest\x1a\x1f.web.v1.ListRewardItemsResponse\x12U\n" +
 	"\x10UpsertRewardItem\x12\x1f.web.v1.UpsertRewardItemRequest\x1a .web.v1.UpsertRewardItemResponse\x12M\n" +
 	"\x14SetRewardItemEnabled\x12#.web.v1.SetRewardItemEnabledRequest\x1a\x10.web.v1.AdminAck\x12E\n" +
-	"\x10DeleteRewardItem\x12\x1f.web.v1.DeleteRewardItemRequest\x1a\x10.web.v1.AdminAck2\xe3\x01\n" +
+	"\x10DeleteRewardItem\x12\x1f.web.v1.DeleteRewardItemRequest\x1a\x10.web.v1.AdminAck2\xc5\x01\n" +
+	"\x16WorldEventAdminService\x12^\n" +
+	"\x13GetWorldEventConfig\x12\".web.v1.GetWorldEventConfigRequest\x1a#.web.v1.GetWorldEventConfigResponse\x12K\n" +
+	"\x13SetWorldEventConfig\x12\".web.v1.SetWorldEventConfigRequest\x1a\x10.web.v1.AdminAck2\xe3\x01\n" +
 	"\x12DailyRewardService\x12F\n" +
 	"\vListRewards\x12\x1a.web.v1.ListRewardsRequest\x1a\x1b.web.v1.ListRewardsResponse\x12O\n" +
 	"\x0eGetClaimStatus\x12\x1d.web.v1.GetClaimStatusRequest\x1a\x1e.web.v1.GetClaimStatusResponse\x124\n" +
@@ -6614,7 +6912,7 @@ func file_api_web_v1_web_proto_rawDescGZIP() []byte {
 }
 
 var file_api_web_v1_web_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_api_web_v1_web_proto_msgTypes = make([]protoimpl.MessageInfo, 93)
+var file_api_web_v1_web_proto_msgTypes = make([]protoimpl.MessageInfo, 97)
 var file_api_web_v1_web_proto_goTypes = []any{
 	(CreateResult)(0),                     // 0: web.v1.CreateResult
 	(AdminResult)(0),                      // 1: web.v1.AdminResult
@@ -6701,22 +6999,26 @@ var file_api_web_v1_web_proto_goTypes = []any{
 	(*UpsertRewardItemResponse)(nil),      // 82: web.v1.UpsertRewardItemResponse
 	(*SetRewardItemEnabledRequest)(nil),   // 83: web.v1.SetRewardItemEnabledRequest
 	(*DeleteRewardItemRequest)(nil),       // 84: web.v1.DeleteRewardItemRequest
-	(*ListRewardsRequest)(nil),            // 85: web.v1.ListRewardsRequest
-	(*ListRewardsResponse)(nil),           // 86: web.v1.ListRewardsResponse
-	(*GetClaimStatusRequest)(nil),         // 87: web.v1.GetClaimStatusRequest
-	(*GetClaimStatusResponse)(nil),        // 88: web.v1.GetClaimStatusResponse
-	(*ClaimRequest)(nil),                  // 89: web.v1.ClaimRequest
-	(*ClaimResponse)(nil),                 // 90: web.v1.ClaimResponse
-	(*GetPayerProfileRequest)(nil),        // 91: web.v1.GetPayerProfileRequest
-	(*GetPayerProfileResponse)(nil),       // 92: web.v1.GetPayerProfileResponse
-	(*SavePayerProfileRequest)(nil),       // 93: web.v1.SavePayerProfileRequest
-	(*SavePayerProfileResponse)(nil),      // 94: web.v1.SavePayerProfileResponse
-	(*CreateTopupOrderRequest)(nil),       // 95: web.v1.CreateTopupOrderRequest
-	(*CreateTopupOrderResponse)(nil),      // 96: web.v1.CreateTopupOrderResponse
-	(*ConfirmTopupOrderRequest)(nil),      // 97: web.v1.ConfirmTopupOrderRequest
-	(*ConfirmTopupOrderResponse)(nil),     // 98: web.v1.ConfirmTopupOrderResponse
-	(*GetTopupOrderRequest)(nil),          // 99: web.v1.GetTopupOrderRequest
-	(*GetTopupOrderResponse)(nil),         // 100: web.v1.GetTopupOrderResponse
+	(*WorldEventConfig)(nil),              // 85: web.v1.WorldEventConfig
+	(*GetWorldEventConfigRequest)(nil),    // 86: web.v1.GetWorldEventConfigRequest
+	(*GetWorldEventConfigResponse)(nil),   // 87: web.v1.GetWorldEventConfigResponse
+	(*SetWorldEventConfigRequest)(nil),    // 88: web.v1.SetWorldEventConfigRequest
+	(*ListRewardsRequest)(nil),            // 89: web.v1.ListRewardsRequest
+	(*ListRewardsResponse)(nil),           // 90: web.v1.ListRewardsResponse
+	(*GetClaimStatusRequest)(nil),         // 91: web.v1.GetClaimStatusRequest
+	(*GetClaimStatusResponse)(nil),        // 92: web.v1.GetClaimStatusResponse
+	(*ClaimRequest)(nil),                  // 93: web.v1.ClaimRequest
+	(*ClaimResponse)(nil),                 // 94: web.v1.ClaimResponse
+	(*GetPayerProfileRequest)(nil),        // 95: web.v1.GetPayerProfileRequest
+	(*GetPayerProfileResponse)(nil),       // 96: web.v1.GetPayerProfileResponse
+	(*SavePayerProfileRequest)(nil),       // 97: web.v1.SavePayerProfileRequest
+	(*SavePayerProfileResponse)(nil),      // 98: web.v1.SavePayerProfileResponse
+	(*CreateTopupOrderRequest)(nil),       // 99: web.v1.CreateTopupOrderRequest
+	(*CreateTopupOrderResponse)(nil),      // 100: web.v1.CreateTopupOrderResponse
+	(*ConfirmTopupOrderRequest)(nil),      // 101: web.v1.ConfirmTopupOrderRequest
+	(*ConfirmTopupOrderResponse)(nil),     // 102: web.v1.ConfirmTopupOrderResponse
+	(*GetTopupOrderRequest)(nil),          // 103: web.v1.GetTopupOrderRequest
+	(*GetTopupOrderResponse)(nil),         // 104: web.v1.GetTopupOrderResponse
 }
 var file_api_web_v1_web_proto_depIdxs = []int32{
 	0,   // 0: web.v1.CreateAccountResponse.result:type_name -> web.v1.CreateResult
@@ -6766,98 +7068,105 @@ var file_api_web_v1_web_proto_depIdxs = []int32{
 	78,  // 44: web.v1.ListRewardItemsResponse.items:type_name -> web.v1.DailyRewardItem
 	78,  // 45: web.v1.UpsertRewardItemRequest.item:type_name -> web.v1.DailyRewardItem
 	1,   // 46: web.v1.UpsertRewardItemResponse.result:type_name -> web.v1.AdminResult
-	78,  // 47: web.v1.ListRewardsResponse.items:type_name -> web.v1.DailyRewardItem
-	4,   // 48: web.v1.ClaimResponse.result:type_name -> web.v1.ClaimResult
-	1,   // 49: web.v1.SavePayerProfileResponse.result:type_name -> web.v1.AdminResult
-	5,   // 50: web.v1.CreateTopupOrderRequest.payment_method:type_name -> web.v1.PaymentMethod
-	1,   // 51: web.v1.CreateTopupOrderResponse.result:type_name -> web.v1.AdminResult
-	6,   // 52: web.v1.ConfirmTopupOrderResponse.result:type_name -> web.v1.TopupResult
-	7,   // 53: web.v1.GetTopupOrderResponse.status:type_name -> web.v1.TopupStatus
-	8,   // 54: web.v1.AccountWebService.CreateAccount:input_type -> web.v1.CreateAccountRequest
-	10,  // 55: web.v1.AccountWebService.VerifyCredentials:input_type -> web.v1.VerifyCredentialsRequest
-	12,  // 56: web.v1.RankingWebService.ListExpRanking:input_type -> web.v1.ListExpRankingRequest
-	15,  // 57: web.v1.RankingWebService.ListDuelRanking:input_type -> web.v1.ListDuelRankingRequest
-	18,  // 58: web.v1.CharacterWebService.ListMyCharacters:input_type -> web.v1.ListMyCharactersRequest
-	24,  // 59: web.v1.NpcAdminService.ListNpcs:input_type -> web.v1.ListNpcsRequest
-	26,  // 60: web.v1.NpcAdminService.GetNpc:input_type -> web.v1.GetNpcRequest
-	28,  // 61: web.v1.NpcAdminService.UpsertNpc:input_type -> web.v1.UpsertNpcRequest
-	30,  // 62: web.v1.NpcAdminService.SetNpcVisibility:input_type -> web.v1.SetNpcVisibilityRequest
-	31,  // 63: web.v1.NpcAdminService.SetNpcShop:input_type -> web.v1.SetNpcShopRequest
-	32,  // 64: web.v1.NpcAdminService.SetItemPrice:input_type -> web.v1.SetItemPriceRequest
-	33,  // 65: web.v1.NpcAdminService.DeleteNpc:input_type -> web.v1.DeleteNpcRequest
-	35,  // 66: web.v1.NpcAdminService.ListMerchantTemplates:input_type -> web.v1.ListMerchantTemplatesRequest
-	38,  // 67: web.v1.NpcAdminService.ListItemCatalog:input_type -> web.v1.ListItemCatalogRequest
-	42,  // 68: web.v1.NpcAdminService.ListDropItems:input_type -> web.v1.ListDropItemsRequest
-	46,  // 69: web.v1.NpcAdminService.ListMobDrops:input_type -> web.v1.ListMobDropsRequest
-	49,  // 70: web.v1.NpcAdminService.ListItemPrices:input_type -> web.v1.ListItemPricesRequest
-	52,  // 71: web.v1.NpcAdminService.ListMapZones:input_type -> web.v1.ListMapZonesRequest
-	54,  // 72: web.v1.AttributeMapAdminService.GetAttributeMapInfo:input_type -> web.v1.GetAttributeMapInfoRequest
-	61,  // 73: web.v1.AttributeMapAdminService.TransformAttributeMap:input_type -> web.v1.TransformAttributeMapRequest
-	64,  // 74: web.v1.DonateAdminService.ListShopItems:input_type -> web.v1.ListShopItemsRequest
-	66,  // 75: web.v1.DonateAdminService.UpsertShopItem:input_type -> web.v1.UpsertShopItemRequest
-	68,  // 76: web.v1.DonateAdminService.SetShopItemEnabled:input_type -> web.v1.SetShopItemEnabledRequest
-	69,  // 77: web.v1.DonateAdminService.DeleteShopItem:input_type -> web.v1.DeleteShopItemRequest
-	70,  // 78: web.v1.DonateAdminService.CreditDonateBalance:input_type -> web.v1.CreditDonateBalanceRequest
-	72,  // 79: web.v1.DonateShopService.ListShopItems:input_type -> web.v1.ListStoreItemsRequest
-	74,  // 80: web.v1.DonateShopService.GetBalance:input_type -> web.v1.GetBalanceRequest
-	76,  // 81: web.v1.DonateShopService.Buy:input_type -> web.v1.BuyRequest
-	79,  // 82: web.v1.DailyRewardAdminService.ListRewardItems:input_type -> web.v1.ListRewardItemsRequest
-	81,  // 83: web.v1.DailyRewardAdminService.UpsertRewardItem:input_type -> web.v1.UpsertRewardItemRequest
-	83,  // 84: web.v1.DailyRewardAdminService.SetRewardItemEnabled:input_type -> web.v1.SetRewardItemEnabledRequest
-	84,  // 85: web.v1.DailyRewardAdminService.DeleteRewardItem:input_type -> web.v1.DeleteRewardItemRequest
-	85,  // 86: web.v1.DailyRewardService.ListRewards:input_type -> web.v1.ListRewardsRequest
-	87,  // 87: web.v1.DailyRewardService.GetClaimStatus:input_type -> web.v1.GetClaimStatusRequest
-	89,  // 88: web.v1.DailyRewardService.Claim:input_type -> web.v1.ClaimRequest
-	91,  // 89: web.v1.DonateTopupService.GetPayerProfile:input_type -> web.v1.GetPayerProfileRequest
-	93,  // 90: web.v1.DonateTopupService.SavePayerProfile:input_type -> web.v1.SavePayerProfileRequest
-	95,  // 91: web.v1.DonateTopupService.CreateTopupOrder:input_type -> web.v1.CreateTopupOrderRequest
-	97,  // 92: web.v1.DonateTopupService.ConfirmTopupOrder:input_type -> web.v1.ConfirmTopupOrderRequest
-	99,  // 93: web.v1.DonateTopupService.GetTopupOrder:input_type -> web.v1.GetTopupOrderRequest
-	9,   // 94: web.v1.AccountWebService.CreateAccount:output_type -> web.v1.CreateAccountResponse
-	11,  // 95: web.v1.AccountWebService.VerifyCredentials:output_type -> web.v1.VerifyCredentialsResponse
-	14,  // 96: web.v1.RankingWebService.ListExpRanking:output_type -> web.v1.ListExpRankingResponse
-	17,  // 97: web.v1.RankingWebService.ListDuelRanking:output_type -> web.v1.ListDuelRankingResponse
-	20,  // 98: web.v1.CharacterWebService.ListMyCharacters:output_type -> web.v1.ListMyCharactersResponse
-	25,  // 99: web.v1.NpcAdminService.ListNpcs:output_type -> web.v1.ListNpcsResponse
-	27,  // 100: web.v1.NpcAdminService.GetNpc:output_type -> web.v1.GetNpcResponse
-	29,  // 101: web.v1.NpcAdminService.UpsertNpc:output_type -> web.v1.UpsertNpcResponse
-	21,  // 102: web.v1.NpcAdminService.SetNpcVisibility:output_type -> web.v1.AdminAck
-	21,  // 103: web.v1.NpcAdminService.SetNpcShop:output_type -> web.v1.AdminAck
-	21,  // 104: web.v1.NpcAdminService.SetItemPrice:output_type -> web.v1.AdminAck
-	21,  // 105: web.v1.NpcAdminService.DeleteNpc:output_type -> web.v1.AdminAck
-	36,  // 106: web.v1.NpcAdminService.ListMerchantTemplates:output_type -> web.v1.ListMerchantTemplatesResponse
-	39,  // 107: web.v1.NpcAdminService.ListItemCatalog:output_type -> web.v1.ListItemCatalogResponse
-	43,  // 108: web.v1.NpcAdminService.ListDropItems:output_type -> web.v1.ListDropItemsResponse
-	47,  // 109: web.v1.NpcAdminService.ListMobDrops:output_type -> web.v1.ListMobDropsResponse
-	50,  // 110: web.v1.NpcAdminService.ListItemPrices:output_type -> web.v1.ListItemPricesResponse
-	53,  // 111: web.v1.NpcAdminService.ListMapZones:output_type -> web.v1.ListMapZonesResponse
-	55,  // 112: web.v1.AttributeMapAdminService.GetAttributeMapInfo:output_type -> web.v1.GetAttributeMapInfoResponse
-	62,  // 113: web.v1.AttributeMapAdminService.TransformAttributeMap:output_type -> web.v1.TransformAttributeMapResponse
-	65,  // 114: web.v1.DonateAdminService.ListShopItems:output_type -> web.v1.ListShopItemsResponse
-	67,  // 115: web.v1.DonateAdminService.UpsertShopItem:output_type -> web.v1.UpsertShopItemResponse
-	21,  // 116: web.v1.DonateAdminService.SetShopItemEnabled:output_type -> web.v1.AdminAck
-	21,  // 117: web.v1.DonateAdminService.DeleteShopItem:output_type -> web.v1.AdminAck
-	71,  // 118: web.v1.DonateAdminService.CreditDonateBalance:output_type -> web.v1.CreditDonateBalanceResponse
-	73,  // 119: web.v1.DonateShopService.ListShopItems:output_type -> web.v1.ListStoreItemsResponse
-	75,  // 120: web.v1.DonateShopService.GetBalance:output_type -> web.v1.GetBalanceResponse
-	77,  // 121: web.v1.DonateShopService.Buy:output_type -> web.v1.BuyResponse
-	80,  // 122: web.v1.DailyRewardAdminService.ListRewardItems:output_type -> web.v1.ListRewardItemsResponse
-	82,  // 123: web.v1.DailyRewardAdminService.UpsertRewardItem:output_type -> web.v1.UpsertRewardItemResponse
-	21,  // 124: web.v1.DailyRewardAdminService.SetRewardItemEnabled:output_type -> web.v1.AdminAck
-	21,  // 125: web.v1.DailyRewardAdminService.DeleteRewardItem:output_type -> web.v1.AdminAck
-	86,  // 126: web.v1.DailyRewardService.ListRewards:output_type -> web.v1.ListRewardsResponse
-	88,  // 127: web.v1.DailyRewardService.GetClaimStatus:output_type -> web.v1.GetClaimStatusResponse
-	90,  // 128: web.v1.DailyRewardService.Claim:output_type -> web.v1.ClaimResponse
-	92,  // 129: web.v1.DonateTopupService.GetPayerProfile:output_type -> web.v1.GetPayerProfileResponse
-	94,  // 130: web.v1.DonateTopupService.SavePayerProfile:output_type -> web.v1.SavePayerProfileResponse
-	96,  // 131: web.v1.DonateTopupService.CreateTopupOrder:output_type -> web.v1.CreateTopupOrderResponse
-	98,  // 132: web.v1.DonateTopupService.ConfirmTopupOrder:output_type -> web.v1.ConfirmTopupOrderResponse
-	100, // 133: web.v1.DonateTopupService.GetTopupOrder:output_type -> web.v1.GetTopupOrderResponse
-	94,  // [94:134] is the sub-list for method output_type
-	54,  // [54:94] is the sub-list for method input_type
-	54,  // [54:54] is the sub-list for extension type_name
-	54,  // [54:54] is the sub-list for extension extendee
-	0,   // [0:54] is the sub-list for field type_name
+	1,   // 47: web.v1.GetWorldEventConfigResponse.result:type_name -> web.v1.AdminResult
+	85,  // 48: web.v1.GetWorldEventConfigResponse.config:type_name -> web.v1.WorldEventConfig
+	85,  // 49: web.v1.SetWorldEventConfigRequest.config:type_name -> web.v1.WorldEventConfig
+	78,  // 50: web.v1.ListRewardsResponse.items:type_name -> web.v1.DailyRewardItem
+	4,   // 51: web.v1.ClaimResponse.result:type_name -> web.v1.ClaimResult
+	1,   // 52: web.v1.SavePayerProfileResponse.result:type_name -> web.v1.AdminResult
+	5,   // 53: web.v1.CreateTopupOrderRequest.payment_method:type_name -> web.v1.PaymentMethod
+	1,   // 54: web.v1.CreateTopupOrderResponse.result:type_name -> web.v1.AdminResult
+	6,   // 55: web.v1.ConfirmTopupOrderResponse.result:type_name -> web.v1.TopupResult
+	7,   // 56: web.v1.GetTopupOrderResponse.status:type_name -> web.v1.TopupStatus
+	8,   // 57: web.v1.AccountWebService.CreateAccount:input_type -> web.v1.CreateAccountRequest
+	10,  // 58: web.v1.AccountWebService.VerifyCredentials:input_type -> web.v1.VerifyCredentialsRequest
+	12,  // 59: web.v1.RankingWebService.ListExpRanking:input_type -> web.v1.ListExpRankingRequest
+	15,  // 60: web.v1.RankingWebService.ListDuelRanking:input_type -> web.v1.ListDuelRankingRequest
+	18,  // 61: web.v1.CharacterWebService.ListMyCharacters:input_type -> web.v1.ListMyCharactersRequest
+	24,  // 62: web.v1.NpcAdminService.ListNpcs:input_type -> web.v1.ListNpcsRequest
+	26,  // 63: web.v1.NpcAdminService.GetNpc:input_type -> web.v1.GetNpcRequest
+	28,  // 64: web.v1.NpcAdminService.UpsertNpc:input_type -> web.v1.UpsertNpcRequest
+	30,  // 65: web.v1.NpcAdminService.SetNpcVisibility:input_type -> web.v1.SetNpcVisibilityRequest
+	31,  // 66: web.v1.NpcAdminService.SetNpcShop:input_type -> web.v1.SetNpcShopRequest
+	32,  // 67: web.v1.NpcAdminService.SetItemPrice:input_type -> web.v1.SetItemPriceRequest
+	33,  // 68: web.v1.NpcAdminService.DeleteNpc:input_type -> web.v1.DeleteNpcRequest
+	35,  // 69: web.v1.NpcAdminService.ListMerchantTemplates:input_type -> web.v1.ListMerchantTemplatesRequest
+	38,  // 70: web.v1.NpcAdminService.ListItemCatalog:input_type -> web.v1.ListItemCatalogRequest
+	42,  // 71: web.v1.NpcAdminService.ListDropItems:input_type -> web.v1.ListDropItemsRequest
+	46,  // 72: web.v1.NpcAdminService.ListMobDrops:input_type -> web.v1.ListMobDropsRequest
+	49,  // 73: web.v1.NpcAdminService.ListItemPrices:input_type -> web.v1.ListItemPricesRequest
+	52,  // 74: web.v1.NpcAdminService.ListMapZones:input_type -> web.v1.ListMapZonesRequest
+	54,  // 75: web.v1.AttributeMapAdminService.GetAttributeMapInfo:input_type -> web.v1.GetAttributeMapInfoRequest
+	61,  // 76: web.v1.AttributeMapAdminService.TransformAttributeMap:input_type -> web.v1.TransformAttributeMapRequest
+	64,  // 77: web.v1.DonateAdminService.ListShopItems:input_type -> web.v1.ListShopItemsRequest
+	66,  // 78: web.v1.DonateAdminService.UpsertShopItem:input_type -> web.v1.UpsertShopItemRequest
+	68,  // 79: web.v1.DonateAdminService.SetShopItemEnabled:input_type -> web.v1.SetShopItemEnabledRequest
+	69,  // 80: web.v1.DonateAdminService.DeleteShopItem:input_type -> web.v1.DeleteShopItemRequest
+	70,  // 81: web.v1.DonateAdminService.CreditDonateBalance:input_type -> web.v1.CreditDonateBalanceRequest
+	72,  // 82: web.v1.DonateShopService.ListShopItems:input_type -> web.v1.ListStoreItemsRequest
+	74,  // 83: web.v1.DonateShopService.GetBalance:input_type -> web.v1.GetBalanceRequest
+	76,  // 84: web.v1.DonateShopService.Buy:input_type -> web.v1.BuyRequest
+	79,  // 85: web.v1.DailyRewardAdminService.ListRewardItems:input_type -> web.v1.ListRewardItemsRequest
+	81,  // 86: web.v1.DailyRewardAdminService.UpsertRewardItem:input_type -> web.v1.UpsertRewardItemRequest
+	83,  // 87: web.v1.DailyRewardAdminService.SetRewardItemEnabled:input_type -> web.v1.SetRewardItemEnabledRequest
+	84,  // 88: web.v1.DailyRewardAdminService.DeleteRewardItem:input_type -> web.v1.DeleteRewardItemRequest
+	86,  // 89: web.v1.WorldEventAdminService.GetWorldEventConfig:input_type -> web.v1.GetWorldEventConfigRequest
+	88,  // 90: web.v1.WorldEventAdminService.SetWorldEventConfig:input_type -> web.v1.SetWorldEventConfigRequest
+	89,  // 91: web.v1.DailyRewardService.ListRewards:input_type -> web.v1.ListRewardsRequest
+	91,  // 92: web.v1.DailyRewardService.GetClaimStatus:input_type -> web.v1.GetClaimStatusRequest
+	93,  // 93: web.v1.DailyRewardService.Claim:input_type -> web.v1.ClaimRequest
+	95,  // 94: web.v1.DonateTopupService.GetPayerProfile:input_type -> web.v1.GetPayerProfileRequest
+	97,  // 95: web.v1.DonateTopupService.SavePayerProfile:input_type -> web.v1.SavePayerProfileRequest
+	99,  // 96: web.v1.DonateTopupService.CreateTopupOrder:input_type -> web.v1.CreateTopupOrderRequest
+	101, // 97: web.v1.DonateTopupService.ConfirmTopupOrder:input_type -> web.v1.ConfirmTopupOrderRequest
+	103, // 98: web.v1.DonateTopupService.GetTopupOrder:input_type -> web.v1.GetTopupOrderRequest
+	9,   // 99: web.v1.AccountWebService.CreateAccount:output_type -> web.v1.CreateAccountResponse
+	11,  // 100: web.v1.AccountWebService.VerifyCredentials:output_type -> web.v1.VerifyCredentialsResponse
+	14,  // 101: web.v1.RankingWebService.ListExpRanking:output_type -> web.v1.ListExpRankingResponse
+	17,  // 102: web.v1.RankingWebService.ListDuelRanking:output_type -> web.v1.ListDuelRankingResponse
+	20,  // 103: web.v1.CharacterWebService.ListMyCharacters:output_type -> web.v1.ListMyCharactersResponse
+	25,  // 104: web.v1.NpcAdminService.ListNpcs:output_type -> web.v1.ListNpcsResponse
+	27,  // 105: web.v1.NpcAdminService.GetNpc:output_type -> web.v1.GetNpcResponse
+	29,  // 106: web.v1.NpcAdminService.UpsertNpc:output_type -> web.v1.UpsertNpcResponse
+	21,  // 107: web.v1.NpcAdminService.SetNpcVisibility:output_type -> web.v1.AdminAck
+	21,  // 108: web.v1.NpcAdminService.SetNpcShop:output_type -> web.v1.AdminAck
+	21,  // 109: web.v1.NpcAdminService.SetItemPrice:output_type -> web.v1.AdminAck
+	21,  // 110: web.v1.NpcAdminService.DeleteNpc:output_type -> web.v1.AdminAck
+	36,  // 111: web.v1.NpcAdminService.ListMerchantTemplates:output_type -> web.v1.ListMerchantTemplatesResponse
+	39,  // 112: web.v1.NpcAdminService.ListItemCatalog:output_type -> web.v1.ListItemCatalogResponse
+	43,  // 113: web.v1.NpcAdminService.ListDropItems:output_type -> web.v1.ListDropItemsResponse
+	47,  // 114: web.v1.NpcAdminService.ListMobDrops:output_type -> web.v1.ListMobDropsResponse
+	50,  // 115: web.v1.NpcAdminService.ListItemPrices:output_type -> web.v1.ListItemPricesResponse
+	53,  // 116: web.v1.NpcAdminService.ListMapZones:output_type -> web.v1.ListMapZonesResponse
+	55,  // 117: web.v1.AttributeMapAdminService.GetAttributeMapInfo:output_type -> web.v1.GetAttributeMapInfoResponse
+	62,  // 118: web.v1.AttributeMapAdminService.TransformAttributeMap:output_type -> web.v1.TransformAttributeMapResponse
+	65,  // 119: web.v1.DonateAdminService.ListShopItems:output_type -> web.v1.ListShopItemsResponse
+	67,  // 120: web.v1.DonateAdminService.UpsertShopItem:output_type -> web.v1.UpsertShopItemResponse
+	21,  // 121: web.v1.DonateAdminService.SetShopItemEnabled:output_type -> web.v1.AdminAck
+	21,  // 122: web.v1.DonateAdminService.DeleteShopItem:output_type -> web.v1.AdminAck
+	71,  // 123: web.v1.DonateAdminService.CreditDonateBalance:output_type -> web.v1.CreditDonateBalanceResponse
+	73,  // 124: web.v1.DonateShopService.ListShopItems:output_type -> web.v1.ListStoreItemsResponse
+	75,  // 125: web.v1.DonateShopService.GetBalance:output_type -> web.v1.GetBalanceResponse
+	77,  // 126: web.v1.DonateShopService.Buy:output_type -> web.v1.BuyResponse
+	80,  // 127: web.v1.DailyRewardAdminService.ListRewardItems:output_type -> web.v1.ListRewardItemsResponse
+	82,  // 128: web.v1.DailyRewardAdminService.UpsertRewardItem:output_type -> web.v1.UpsertRewardItemResponse
+	21,  // 129: web.v1.DailyRewardAdminService.SetRewardItemEnabled:output_type -> web.v1.AdminAck
+	21,  // 130: web.v1.DailyRewardAdminService.DeleteRewardItem:output_type -> web.v1.AdminAck
+	87,  // 131: web.v1.WorldEventAdminService.GetWorldEventConfig:output_type -> web.v1.GetWorldEventConfigResponse
+	21,  // 132: web.v1.WorldEventAdminService.SetWorldEventConfig:output_type -> web.v1.AdminAck
+	90,  // 133: web.v1.DailyRewardService.ListRewards:output_type -> web.v1.ListRewardsResponse
+	92,  // 134: web.v1.DailyRewardService.GetClaimStatus:output_type -> web.v1.GetClaimStatusResponse
+	94,  // 135: web.v1.DailyRewardService.Claim:output_type -> web.v1.ClaimResponse
+	96,  // 136: web.v1.DonateTopupService.GetPayerProfile:output_type -> web.v1.GetPayerProfileResponse
+	98,  // 137: web.v1.DonateTopupService.SavePayerProfile:output_type -> web.v1.SavePayerProfileResponse
+	100, // 138: web.v1.DonateTopupService.CreateTopupOrder:output_type -> web.v1.CreateTopupOrderResponse
+	102, // 139: web.v1.DonateTopupService.ConfirmTopupOrder:output_type -> web.v1.ConfirmTopupOrderResponse
+	104, // 140: web.v1.DonateTopupService.GetTopupOrder:output_type -> web.v1.GetTopupOrderResponse
+	99,  // [99:141] is the sub-list for method output_type
+	57,  // [57:99] is the sub-list for method input_type
+	57,  // [57:57] is the sub-list for extension type_name
+	57,  // [57:57] is the sub-list for extension extendee
+	0,   // [0:57] is the sub-list for field type_name
 }
 
 func init() { file_api_web_v1_web_proto_init() }
@@ -6871,9 +7180,9 @@ func file_api_web_v1_web_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_web_v1_web_proto_rawDesc), len(file_api_web_v1_web_proto_rawDesc)),
 			NumEnums:      8,
-			NumMessages:   93,
+			NumMessages:   97,
 			NumExtensions: 0,
-			NumServices:   10,
+			NumServices:   11,
 		},
 		GoTypes:           file_api_web_v1_web_proto_goTypes,
 		DependencyIndexes: file_api_web_v1_web_proto_depIdxs,

--- a/api/web/v1/web.proto
+++ b/api/web/v1/web.proto
@@ -666,6 +666,41 @@ message DeleteRewardItemRequest {
   int64 item_id = 2;
 }
 
+// WorldEventAdminService is the moderator-facing global event control surface
+// (issue #116). The portal writes this cold config; tmServer polls it through
+// dbServer and applies it inside the single-owner loop.
+service WorldEventAdminService {
+  // GetWorldEventConfig returns the current global event settings.
+  rpc GetWorldEventConfig(GetWorldEventConfigRequest) returns (GetWorldEventConfigResponse);
+  // SetWorldEventConfig replaces the event settings.
+  rpc SetWorldEventConfig(SetWorldEventConfigRequest) returns (AdminAck);
+}
+
+message WorldEventConfig {
+  bool enabled = 1;
+  int32 item_index = 2;
+  int32 rate = 3;
+  int32 start_index = 4;
+  int32 current_index = 5;
+  int32 end_index = 6;
+  bool indexed = 7;
+  bool notice_enabled = 8;
+  bool double_exp_enabled = 9;
+  bool newbie_event_enabled = 10;
+}
+
+message GetWorldEventConfigRequest { int64 moderator_id = 1; }
+message GetWorldEventConfigResponse {
+  AdminResult result = 1;
+  int64 version = 2;
+  WorldEventConfig config = 3;
+}
+
+message SetWorldEventConfigRequest {
+  int64 moderator_id = 1;
+  WorldEventConfig config = 2;
+}
+
 // DailyRewardService is the player-facing daily reward surface the Next.js BFF
 // calls with the logged account_id from its httpOnly session (never
 // browser-supplied). A claim inserts a daily_reward_claim row for today's UTC

--- a/api/web/v1/web_grpc.pb.go
+++ b/api/web/v1/web_grpc.pb.go
@@ -1952,6 +1952,159 @@ var DailyRewardAdminService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
+	WorldEventAdminService_GetWorldEventConfig_FullMethodName = "/web.v1.WorldEventAdminService/GetWorldEventConfig"
+	WorldEventAdminService_SetWorldEventConfig_FullMethodName = "/web.v1.WorldEventAdminService/SetWorldEventConfig"
+)
+
+// WorldEventAdminServiceClient is the client API for WorldEventAdminService service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// WorldEventAdminService is the moderator-facing global event control surface
+// (issue #116). The portal writes this cold config; tmServer polls it through
+// dbServer and applies it inside the single-owner loop.
+type WorldEventAdminServiceClient interface {
+	// GetWorldEventConfig returns the current global event settings.
+	GetWorldEventConfig(ctx context.Context, in *GetWorldEventConfigRequest, opts ...grpc.CallOption) (*GetWorldEventConfigResponse, error)
+	// SetWorldEventConfig replaces the event settings.
+	SetWorldEventConfig(ctx context.Context, in *SetWorldEventConfigRequest, opts ...grpc.CallOption) (*AdminAck, error)
+}
+
+type worldEventAdminServiceClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewWorldEventAdminServiceClient(cc grpc.ClientConnInterface) WorldEventAdminServiceClient {
+	return &worldEventAdminServiceClient{cc}
+}
+
+func (c *worldEventAdminServiceClient) GetWorldEventConfig(ctx context.Context, in *GetWorldEventConfigRequest, opts ...grpc.CallOption) (*GetWorldEventConfigResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetWorldEventConfigResponse)
+	err := c.cc.Invoke(ctx, WorldEventAdminService_GetWorldEventConfig_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *worldEventAdminServiceClient) SetWorldEventConfig(ctx context.Context, in *SetWorldEventConfigRequest, opts ...grpc.CallOption) (*AdminAck, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AdminAck)
+	err := c.cc.Invoke(ctx, WorldEventAdminService_SetWorldEventConfig_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// WorldEventAdminServiceServer is the server API for WorldEventAdminService service.
+// All implementations must embed UnimplementedWorldEventAdminServiceServer
+// for forward compatibility.
+//
+// WorldEventAdminService is the moderator-facing global event control surface
+// (issue #116). The portal writes this cold config; tmServer polls it through
+// dbServer and applies it inside the single-owner loop.
+type WorldEventAdminServiceServer interface {
+	// GetWorldEventConfig returns the current global event settings.
+	GetWorldEventConfig(context.Context, *GetWorldEventConfigRequest) (*GetWorldEventConfigResponse, error)
+	// SetWorldEventConfig replaces the event settings.
+	SetWorldEventConfig(context.Context, *SetWorldEventConfigRequest) (*AdminAck, error)
+	mustEmbedUnimplementedWorldEventAdminServiceServer()
+}
+
+// UnimplementedWorldEventAdminServiceServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedWorldEventAdminServiceServer struct{}
+
+func (UnimplementedWorldEventAdminServiceServer) GetWorldEventConfig(context.Context, *GetWorldEventConfigRequest) (*GetWorldEventConfigResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetWorldEventConfig not implemented")
+}
+func (UnimplementedWorldEventAdminServiceServer) SetWorldEventConfig(context.Context, *SetWorldEventConfigRequest) (*AdminAck, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetWorldEventConfig not implemented")
+}
+func (UnimplementedWorldEventAdminServiceServer) mustEmbedUnimplementedWorldEventAdminServiceServer() {
+}
+func (UnimplementedWorldEventAdminServiceServer) testEmbeddedByValue() {}
+
+// UnsafeWorldEventAdminServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to WorldEventAdminServiceServer will
+// result in compilation errors.
+type UnsafeWorldEventAdminServiceServer interface {
+	mustEmbedUnimplementedWorldEventAdminServiceServer()
+}
+
+func RegisterWorldEventAdminServiceServer(s grpc.ServiceRegistrar, srv WorldEventAdminServiceServer) {
+	// If the following call panics, it indicates UnimplementedWorldEventAdminServiceServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&WorldEventAdminService_ServiceDesc, srv)
+}
+
+func _WorldEventAdminService_GetWorldEventConfig_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetWorldEventConfigRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WorldEventAdminServiceServer).GetWorldEventConfig(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WorldEventAdminService_GetWorldEventConfig_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WorldEventAdminServiceServer).GetWorldEventConfig(ctx, req.(*GetWorldEventConfigRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _WorldEventAdminService_SetWorldEventConfig_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetWorldEventConfigRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WorldEventAdminServiceServer).SetWorldEventConfig(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WorldEventAdminService_SetWorldEventConfig_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WorldEventAdminServiceServer).SetWorldEventConfig(ctx, req.(*SetWorldEventConfigRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// WorldEventAdminService_ServiceDesc is the grpc.ServiceDesc for WorldEventAdminService service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var WorldEventAdminService_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "web.v1.WorldEventAdminService",
+	HandlerType: (*WorldEventAdminServiceServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "GetWorldEventConfig",
+			Handler:    _WorldEventAdminService_GetWorldEventConfig_Handler,
+		},
+		{
+			MethodName: "SetWorldEventConfig",
+			Handler:    _WorldEventAdminService_SetWorldEventConfig_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "api/web/v1/web.proto",
+}
+
+const (
 	DailyRewardService_ListRewards_FullMethodName    = "/web.v1.DailyRewardService/ListRewards"
 	DailyRewardService_GetClaimStatus_FullMethodName = "/web.v1.DailyRewardService/GetClaimStatus"
 	DailyRewardService_Claim_FullMethodName          = "/web.v1.DailyRewardService/Claim"

--- a/dbserver/cmd/dbserver/main.go
+++ b/dbserver/cmd/dbserver/main.go
@@ -397,6 +397,7 @@ func runServe(args []string, logger *slog.Logger) error {
 	st := store.New(pool)
 	dbv1.RegisterAccountServiceServer(srv, grpcsrv.New(st))
 	dbv1.RegisterNpcConfigServiceServer(srv, grpcsrv.NewNpcConfig(st))
+	dbv1.RegisterWorldEventConfigServiceServer(srv, grpcsrv.NewWorldEventConfig(st))
 
 	ln, err := net.Listen("tcp", *addr)
 	if err != nil {

--- a/dbserver/internal/grpcsrv/worldevent.go
+++ b/dbserver/internal/grpcsrv/worldevent.go
@@ -1,0 +1,70 @@
+package grpcsrv
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	dbv1 "github.com/jeanluca/w2pp-openwyd/api/db/v1"
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+)
+
+// WorldEventConfigStore is the read/progress surface the tmServer needs
+// (satisfied by *store.Store). Moderator writes go through web-api.
+type WorldEventConfigStore interface {
+	WorldEventConfigVersion(ctx context.Context) (int64, error)
+	WorldEventConfig(ctx context.Context) (domain.WorldEventConfig, error)
+	UpdateWorldEventProgress(ctx context.Context, expectedVersion int64, currentIndex int32) (bool, error)
+}
+
+// WorldEventConfigServer implements dbv1.WorldEventConfigServiceServer.
+type WorldEventConfigServer struct {
+	dbv1.UnimplementedWorldEventConfigServiceServer
+	store WorldEventConfigStore
+}
+
+// NewWorldEventConfig builds the service over the given store.
+func NewWorldEventConfig(s WorldEventConfigStore) *WorldEventConfigServer {
+	return &WorldEventConfigServer{store: s}
+}
+
+// WorldEventConfigVersion returns the monotonic config version for tmServer.
+func (s *WorldEventConfigServer) WorldEventConfigVersion(ctx context.Context, _ *dbv1.WorldEventConfigVersionRequest) (*dbv1.WorldEventConfigVersionResponse, error) {
+	v, err := s.store.WorldEventConfigVersion(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "world event config version: %v", err)
+	}
+	return &dbv1.WorldEventConfigVersionResponse{Version: v}, nil
+}
+
+// GetWorldEventConfig returns the full config snapshot and its version.
+func (s *WorldEventConfigServer) GetWorldEventConfig(ctx context.Context, _ *dbv1.GetWorldEventConfigRequest) (*dbv1.GetWorldEventConfigResponse, error) {
+	version, err := s.store.WorldEventConfigVersion(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "world event config version: %v", err)
+	}
+	cfg, err := s.store.WorldEventConfig(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "world event config: %v", err)
+	}
+	return &dbv1.GetWorldEventConfigResponse{Version: version, Config: worldEventConfigToDBProto(cfg)}, nil
+}
+
+// UpdateWorldEventProgress persists tmServer's live event counter.
+func (s *WorldEventConfigServer) UpdateWorldEventProgress(ctx context.Context, req *dbv1.UpdateWorldEventProgressRequest) (*dbv1.UpdateWorldEventProgressResponse, error) {
+	applied, err := s.store.UpdateWorldEventProgress(ctx, req.GetExpectedVersion(), req.GetCurrentIndex())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "update world event progress: %v", err)
+	}
+	return &dbv1.UpdateWorldEventProgressResponse{Applied: applied}, nil
+}
+
+func worldEventConfigToDBProto(cfg domain.WorldEventConfig) *dbv1.WorldEventConfig {
+	return &dbv1.WorldEventConfig{
+		Enabled: cfg.Enabled, ItemIndex: cfg.ItemIndex, Rate: cfg.Rate,
+		StartIndex: cfg.StartIndex, CurrentIndex: cfg.CurrentIndex, EndIndex: cfg.EndIndex,
+		Indexed: cfg.Indexed, NoticeEnabled: cfg.NoticeEnabled,
+		DoubleExpEnabled: cfg.DoubleExpEnabled, NewbieEventEnabled: cfg.NewbieEventEnabled,
+	}
+}

--- a/dbserver/internal/grpcsrv/worldevent_test.go
+++ b/dbserver/internal/grpcsrv/worldevent_test.go
@@ -1,0 +1,70 @@
+package grpcsrv
+
+import (
+	"context"
+	"testing"
+
+	dbv1 "github.com/jeanluca/w2pp-openwyd/api/db/v1"
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+)
+
+type fakeWorldEventStore struct {
+	version         int64
+	cfg             domain.WorldEventConfig
+	progressVersion int64
+	progressIndex   int32
+	progressApplied bool
+}
+
+func (f *fakeWorldEventStore) WorldEventConfigVersion(context.Context) (int64, error) {
+	return f.version, nil
+}
+func (f *fakeWorldEventStore) WorldEventConfig(context.Context) (domain.WorldEventConfig, error) {
+	return f.cfg, nil
+}
+func (f *fakeWorldEventStore) UpdateWorldEventProgress(_ context.Context, expectedVersion int64, currentIndex int32) (bool, error) {
+	f.progressVersion, f.progressIndex = expectedVersion, currentIndex
+	return f.progressApplied, nil
+}
+
+func TestWorldEventConfigServerMapsSnapshot(t *testing.T) {
+	st := &fakeWorldEventStore{
+		version: 12,
+		cfg: domain.WorldEventConfig{
+			Enabled: true, ItemIndex: 777, Rate: 5,
+			StartIndex: 100, CurrentIndex: 101, EndIndex: 200,
+			Indexed: true, NoticeEnabled: true, DoubleExpEnabled: true, NewbieEventEnabled: true,
+		},
+	}
+	s := NewWorldEventConfig(st)
+
+	version, err := s.WorldEventConfigVersion(context.Background(), &dbv1.WorldEventConfigVersionRequest{})
+	if err != nil || version.GetVersion() != 12 {
+		t.Fatalf("WorldEventConfigVersion = (%v,%v), want 12", version, err)
+	}
+	resp, err := s.GetWorldEventConfig(context.Background(), &dbv1.GetWorldEventConfigRequest{})
+	if err != nil {
+		t.Fatalf("GetWorldEventConfig: %v", err)
+	}
+	cfg := resp.GetConfig()
+	if resp.GetVersion() != 12 || !cfg.GetEnabled() || cfg.GetItemIndex() != 777 ||
+		cfg.GetCurrentIndex() != 101 || !cfg.GetDoubleExpEnabled() || !cfg.GetNewbieEventEnabled() {
+		t.Errorf("snapshot = version %d cfg %+v, want mapped config", resp.GetVersion(), cfg)
+	}
+}
+
+func TestWorldEventProgressMapsRequest(t *testing.T) {
+	st := &fakeWorldEventStore{progressApplied: true}
+	s := NewWorldEventConfig(st)
+
+	resp, err := s.UpdateWorldEventProgress(context.Background(), &dbv1.UpdateWorldEventProgressRequest{
+		ExpectedVersion: 3,
+		CurrentIndex:    44,
+	})
+	if err != nil {
+		t.Fatalf("UpdateWorldEventProgress: %v", err)
+	}
+	if !resp.GetApplied() || st.progressVersion != 3 || st.progressIndex != 44 {
+		t.Errorf("progress applied=%v version=%d index=%d, want true/3/44", resp.GetApplied(), st.progressVersion, st.progressIndex)
+	}
+}

--- a/docs/integrations/world-events-nextjs.md
+++ b/docs/integrations/world-events-nextjs.md
@@ -1,0 +1,237 @@
+# Integração Next.js ↔ web-api: eventos de mundo
+
+> Guia para o **front-end Next.js** consumir o controle de **eventos globais de
+> mundo** do portal. Fonte da verdade do contrato: `api/web/v1/web.proto`,
+> serviço `web.v1.WorldEventAdminService`.
+
+## 1. Topologia
+
+```text
+Browser ──HTTPS──> Next.js (Route Handlers / Server Actions = BFF)
+                        │  só server-side; cookie de sessão httpOnly
+                        │ gRPC + mTLS
+                        ▼
+                     web-api (:7600) ──> Postgres (`world_event_config`)
+                                                │
+                                                ▼
+                     dbServer  <── polling ── tmServer
+```
+
+Regras:
+
+- O browser nunca chama gRPC nem recebe certificados mTLS.
+- O Next.js deriva `moderator_id` do cookie de sessão; nunca aceita esse campo do
+  browser.
+- O `web-api` revalida `account.role in ('moderator','admin')` em toda chamada.
+- O portal escreve configuração fria em Postgres. O `tmServer` carrega no boot e
+  recarrega por polling; uma alteração salva no portal não é um push em tempo real.
+
+## 2. RPCs
+
+```proto
+service WorldEventAdminService {
+  rpc GetWorldEventConfig(GetWorldEventConfigRequest)
+      returns (GetWorldEventConfigResponse);
+  rpc SetWorldEventConfig(SetWorldEventConfigRequest)
+      returns (AdminAck);
+}
+
+message WorldEventConfig {
+  bool enabled = 1;
+  int32 item_index = 2;
+  int32 rate = 3;
+  int32 start_index = 4;
+  int32 current_index = 5;
+  int32 end_index = 6;
+  bool indexed = 7;
+  bool notice_enabled = 8;
+  bool double_exp_enabled = 9;
+  bool newbie_event_enabled = 10;
+}
+
+message GetWorldEventConfigRequest {
+  int64 moderator_id = 1;
+}
+
+message GetWorldEventConfigResponse {
+  AdminResult result = 1;
+  int64 version = 2;
+  WorldEventConfig config = 3;
+}
+
+message SetWorldEventConfigRequest {
+  int64 moderator_id = 1;
+  WorldEventConfig config = 2;
+}
+```
+
+`SetWorldEventConfig` substitui a configuração inteira. Não existe patch parcial
+nem `expected_version` no contrato web; o BFF deve buscar o estado mais recente
+antes de salvar para evitar sobrescrever dados de uma aba antiga.
+
+## 3. Campos
+
+| Campo | Tipo | Uso |
+|-------|------|-----|
+| `enabled` | `bool` | liga/desliga o drop global de item |
+| `item_index` | `int32` | índice do item entregue no evento |
+| `rate` | `int32` | divisor do roll: `rand() % rate == 0`; `1` significa sempre que elegível |
+| `start_index` | `int32` | primeiro serial/progresso válido |
+| `current_index` | `int32` | progresso atual; o `tmServer` avança após drop entregue |
+| `end_index` | `int32` | limite superior; o evento para quando `current_index >= end_index` |
+| `indexed` | `bool` | serializa o item com efeitos `62/63` e aleatório `59` |
+| `notice_enabled` | `bool` | anuncia o drop para jogadores online |
+| `double_exp_enabled` | `bool` | liga flag global de EXP dobrada no `tmServer` |
+| `newbie_event_enabled` | `bool` | liga flag global de evento newbie no `tmServer` |
+
+`version` vem apenas no `GetWorldEventConfigResponse`. Ele é incrementado por
+edições de moderador e não muda quando o `tmServer` persiste progresso de
+`current_index`.
+
+## 4. Validação do Backend
+
+Valores negativos são inválidos para `item_index`, `rate`, `start_index`,
+`current_index` e `end_index`.
+
+Limites:
+
+- `item_index <= 32767`;
+- se `enabled = false`, os campos numéricos podem ficar zerados;
+- se `enabled = true`, então:
+  - `item_index > 0`;
+  - `rate > 0`;
+  - `start_index > 0`;
+  - `end_index > start_index`;
+  - `current_index >= start_index`;
+  - `current_index <= end_index`.
+
+Em runtime, o drop só está ativo enquanto `current_index < end_index`. Portanto
+`current_index == end_index` é uma configuração válida, mas representa evento
+esgotado.
+
+## 5. Resultado e Erros
+
+As RPCs usam `AdminResult` no corpo. Erro gRPC representa falha de infraestrutura.
+
+| `AdminResult` | HTTP sugerido no BFF | Significado |
+|---------------|----------------------|-------------|
+| `ADMIN_RESULT_OK` | 200 | sucesso |
+| `ADMIN_RESULT_FORBIDDEN` | 403 | usuário não é moderador/admin |
+| `ADMIN_RESULT_INVALID` | 400 / 422 | request inválido ou falha de persistência validada pelo serviço |
+| `ADMIN_RESULT_NOT_FOUND` | 404 | reservado; não esperado neste serviço |
+| `ADMIN_RESULT_UNSPECIFIED` | 500 | estado inesperado |
+
+O BFF deve transformar erro gRPC em `502` ou `500` e não repassar detalhes
+internos para o browser.
+
+## 6. Rotas BFF Sugeridas
+
+| Rota HTTP | RPC | Observações |
+|-----------|-----|-------------|
+| `GET /api/admin/world-events` | `GetWorldEventConfig` | retorna `version` e `config` |
+| `PUT /api/admin/world-events` | `SetWorldEventConfig` | envia a configuração completa |
+
+Shape sugerido para `GET /api/admin/world-events`:
+
+```json
+{
+  "version": "12",
+  "config": {
+    "enabled": true,
+    "itemIndex": 777,
+    "rate": 10,
+    "startIndex": 100,
+    "currentIndex": 104,
+    "endIndex": 200,
+    "indexed": true,
+    "noticeEnabled": true,
+    "doubleExpEnabled": false,
+    "newbieEventEnabled": false
+  }
+}
+```
+
+`version` é `int64`; serialize como string no JSON público para evitar perda de
+precisão em JavaScript.
+
+Shape sugerido para `PUT /api/admin/world-events`:
+
+```json
+{
+  "enabled": true,
+  "itemIndex": 777,
+  "rate": 10,
+  "startIndex": 100,
+  "currentIndex": 100,
+  "endIndex": 200,
+  "indexed": true,
+  "noticeEnabled": true,
+  "doubleExpEnabled": true,
+  "newbieEventEnabled": false
+}
+```
+
+O BFF deve:
+
+- validar sessão e papel antes de chamar o gRPC;
+- preencher `moderator_id` com `account_id` da sessão;
+- mapear camelCase do JSON para snake_case do proto;
+- enviar todos os campos de `WorldEventConfig` no `PUT`;
+- mapear `AdminResult` para HTTP;
+- transformar `int64` (`version`) em string no JSON.
+
+## 7. Semântica no Jogo
+
+Quando o evento de drop global está ativo e o roll passa:
+
+- o item é entregue direto no carry do jogador que recebe a recompensa da kill;
+- o item não vira ground item público;
+- se `indexed = true`, o serial usa o `current_index` atual;
+- o notice só é enviado depois de entrega bem-sucedida;
+- `current_index` só avança depois de entrega bem-sucedida;
+- se o carry acessível estiver cheio, o drop é perdido e `current_index` não
+  avança.
+
+O `tmServer` persiste o progresso de forma assíncrona. Se uma edição de moderador
+acontecer enquanto um progresso antigo chega do `tmServer`, o backend rejeita o
+progresso antigo pela versão da configuração.
+
+## 8. UI Recomendada
+
+Crie uma tela de moderação com:
+
+- toggle geral do drop global (`enabled`);
+- campo de item por índice (`itemIndex`);
+- campo de divisor de chance (`rate`);
+- controles numéricos para `startIndex`, `currentIndex` e `endIndex`;
+- toggles para `indexed`, `noticeEnabled`, `doubleExpEnabled` e
+  `newbieEventEnabled`;
+- indicação de status: ativo, desligado ou esgotado;
+- botão de salvar que envia a configuração completa;
+- botão de recarregar para buscar o estado mais recente.
+
+Estados obrigatórios:
+
+- carregando;
+- salvo com sucesso;
+- alterações não salvas;
+- `403` sem acesso;
+- validação inválida;
+- erro temporário de upstream;
+- evento esgotado (`enabled = true` e `currentIndex >= endIndex`).
+
+Para UX, mostre `rate` como divisor, não como porcentagem final. Exemplo:
+`1 em N kills elegíveis`, sem prometer chance final exata, porque o servidor
+preserva a ordem de RNG e outras regras de drop do jogo.
+
+## 9. Checklist de Implementação no Portal
+
+- [ ] Regenerar stubs a partir de `api/web/v1/web.proto`.
+- [ ] Adicionar cliente server-side para `WorldEventAdminService`.
+- [ ] Criar rota BFF `GET /api/admin/world-events`.
+- [ ] Criar rota BFF `PUT /api/admin/world-events`.
+- [ ] Derivar `moderator_id` da sessão em todas as chamadas.
+- [ ] Mapear `AdminResult` para HTTP.
+- [ ] Serializar `version` como string no JSON do BFF.
+- [ ] Implementar validação client-side equivalente à validação do backend.
+- [ ] Exibir estado esgotado quando `currentIndex >= endIndex`.

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -223,6 +223,24 @@ type ItemPriceOverride struct {
 	Price     int64
 }
 
+// WorldEventConfig is the moderator-managed global event state (issue #116).
+// It is cold configuration owned by Postgres and materialized into the tmServer
+// loop through dbServer polling. CurrentIndex is live event progress: tmServer
+// advances it after a successful indexed/global event drop and persists it back
+// without treating that progress write as a moderator config change.
+type WorldEventConfig struct {
+	Enabled            bool
+	ItemIndex          int32
+	Rate               int32
+	StartIndex         int32
+	CurrentIndex       int32
+	EndIndex           int32
+	Indexed            bool
+	NoticeEnabled      bool
+	DoubleExpEnabled   bool
+	NewbieEventEnabled bool
+}
+
 // DonateShopItem is one moderator-managed offer in the donate web shop (issue
 // #34): an item (index + up to three effect/value pairs) sold for Price units of
 // the account's donate balance. It is cold config owned by Postgres — the

--- a/internal/migrations/0015_world_event_config.down.sql
+++ b/internal/migrations/0015_world_event_config.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS world_event_audit;
+DROP TABLE IF EXISTS world_event_meta;
+DROP TABLE IF EXISTS world_event_config;

--- a/internal/migrations/0015_world_event_config.up.sql
+++ b/internal/migrations/0015_world_event_config.up.sql
@@ -1,0 +1,37 @@
+-- 0015_world_event_config -- portal-managed global world events (issue #116).
+--
+-- The portal writes this cold configuration through web-api. tmServer reads it
+-- through dbServer, applies it inside the single-owner loop, and only writes
+-- back event progress (current_index) after successful event drops.
+
+CREATE TABLE world_event_config (
+    id                    BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (id),
+    enabled               BOOLEAN NOT NULL DEFAULT FALSE,
+    item_index            INTEGER NOT NULL DEFAULT 0 CHECK (item_index >= 0),
+    rate                  INTEGER NOT NULL DEFAULT 0 CHECK (rate >= 0),
+    start_index           INTEGER NOT NULL DEFAULT 0 CHECK (start_index >= 0),
+    current_index         INTEGER NOT NULL DEFAULT 0 CHECK (current_index >= 0),
+    end_index             INTEGER NOT NULL DEFAULT 0 CHECK (end_index >= 0),
+    indexed               BOOLEAN NOT NULL DEFAULT FALSE,
+    notice_enabled        BOOLEAN NOT NULL DEFAULT TRUE,
+    double_exp_enabled    BOOLEAN NOT NULL DEFAULT FALSE,
+    newbie_event_enabled  BOOLEAN NOT NULL DEFAULT FALSE,
+    updated_by            BIGINT REFERENCES account(id) ON DELETE SET NULL,
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+INSERT INTO world_event_config (id) VALUES (TRUE);
+
+CREATE TABLE world_event_meta (
+    id      BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (id),
+    version BIGINT NOT NULL DEFAULT 0
+);
+INSERT INTO world_event_meta (id, version) VALUES (TRUE, 0);
+
+CREATE TABLE world_event_audit (
+    id         BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    account_id BIGINT NOT NULL,
+    action     TEXT NOT NULL,
+    before     JSONB,
+    after      JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -36,6 +36,9 @@ func testPool(t *testing.T) *pgxpool.Pool {
 func resetTestSchema(ctx context.Context, pool *pgxpool.Pool) {
 	_, _ = pool.Exec(ctx, `
 		DROP TABLE IF EXISTS
+			world_event_audit,
+			world_event_meta,
+			world_event_config,
 			npc_audit,
 			npc_shop_item,
 			npc_definition,

--- a/internal/store/worldevent.go
+++ b/internal/store/worldevent.go
@@ -40,6 +40,9 @@ func (s *Store) WorldEventConfig(ctx context.Context) (domain.WorldEventConfig, 
 // writing an audit row and bumping the config version in the same transaction.
 func (s *Store) UpsertWorldEventConfig(ctx context.Context, cfg domain.WorldEventConfig, moderatorID int64) error {
 	return s.inTx(ctx, func(tx pgx.Tx) error {
+		if err := lockWorldEventMeta(ctx, tx); err != nil {
+			return err
+		}
 		before, _ := fetchWorldEventConfigJSON(ctx, tx)
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO world_event_config (
@@ -76,15 +79,17 @@ func (s *Store) UpsertWorldEventConfig(ctx context.Context, cfg domain.WorldEven
 // from overwriting a newer portal edit; applied is false when the version changed.
 func (s *Store) UpdateWorldEventProgress(ctx context.Context, expectedVersion int64, currentIndex int32) (applied bool, err error) {
 	err = s.inTx(ctx, func(tx pgx.Tx) error {
-		var version int64
-		if err := tx.QueryRow(ctx, `SELECT version FROM world_event_meta WHERE id = TRUE`).Scan(&version); err != nil {
-			return fmt.Errorf("store: world event progress version: %w", err)
-		}
-		if version != expectedVersion {
-			applied = false
-			return nil
-		}
-		ct, err := tx.Exec(ctx, `UPDATE world_event_config SET current_index = GREATEST(current_index, $1) WHERE id = TRUE`, currentIndex)
+		ct, err := tx.Exec(ctx, `
+			WITH matching_meta AS MATERIALIZED (
+				SELECT 1
+				  FROM world_event_meta
+				 WHERE id = TRUE AND version = $1
+				   FOR UPDATE
+			)
+			UPDATE world_event_config
+			   SET current_index = GREATEST(current_index, $2)
+			 WHERE id = TRUE
+			   AND EXISTS (SELECT 1 FROM matching_meta)`, expectedVersion, currentIndex)
 		if err != nil {
 			return fmt.Errorf("store: update world event progress: %w", err)
 		}
@@ -118,6 +123,16 @@ func fetchWorldEventConfigJSON(ctx context.Context, tx pgx.Tx) ([]byte, error) {
 		return nil, nil
 	}
 	return js, err
+}
+
+func lockWorldEventMeta(ctx context.Context, tx pgx.Tx) error {
+	// Portal edits and tmServer progress both take this lock before touching the
+	// config row, so expectedVersion cannot pass while a moderator edit is pending.
+	var version int64
+	if err := tx.QueryRow(ctx, `SELECT version FROM world_event_meta WHERE id = TRUE FOR UPDATE`).Scan(&version); err != nil {
+		return fmt.Errorf("store: lock world event meta: %w", err)
+	}
+	return nil
 }
 
 func auditWorldEventAndBump(ctx context.Context, tx pgx.Tx, moderatorID int64, action string, before, after []byte) error {

--- a/internal/store/worldevent.go
+++ b/internal/store/worldevent.go
@@ -1,0 +1,134 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+)
+
+// WorldEventConfigVersion returns the monotonically increasing moderator config
+// version. Event progress updates do not bump this value.
+func (s *Store) WorldEventConfigVersion(ctx context.Context) (int64, error) {
+	var v int64
+	err := s.pool.QueryRow(ctx, `SELECT version FROM world_event_meta WHERE id = TRUE`).Scan(&v)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("store: world event config version: %w", err)
+	}
+	return v, nil
+}
+
+// WorldEventConfig returns the single global world-event configuration row.
+func (s *Store) WorldEventConfig(ctx context.Context) (domain.WorldEventConfig, error) {
+	cfg, err := scanWorldEventConfig(s.pool.QueryRow(ctx, worldEventConfigSelect))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return domain.WorldEventConfig{NoticeEnabled: true}, nil
+	}
+	if err != nil {
+		return domain.WorldEventConfig{}, fmt.Errorf("store: world event config: %w", err)
+	}
+	return cfg, nil
+}
+
+// UpsertWorldEventConfig replaces the moderator-managed global event config,
+// writing an audit row and bumping the config version in the same transaction.
+func (s *Store) UpsertWorldEventConfig(ctx context.Context, cfg domain.WorldEventConfig, moderatorID int64) error {
+	return s.inTx(ctx, func(tx pgx.Tx) error {
+		before, _ := fetchWorldEventConfigJSON(ctx, tx)
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO world_event_config (
+				id, enabled, item_index, rate, start_index, current_index, end_index,
+				indexed, notice_enabled, double_exp_enabled, newbie_event_enabled,
+				updated_by, updated_at
+			)
+			VALUES (TRUE,$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,now())
+			ON CONFLICT (id) DO UPDATE SET
+				enabled              = EXCLUDED.enabled,
+				item_index           = EXCLUDED.item_index,
+				rate                 = EXCLUDED.rate,
+				start_index          = EXCLUDED.start_index,
+				current_index        = EXCLUDED.current_index,
+				end_index            = EXCLUDED.end_index,
+				indexed              = EXCLUDED.indexed,
+				notice_enabled       = EXCLUDED.notice_enabled,
+				double_exp_enabled   = EXCLUDED.double_exp_enabled,
+				newbie_event_enabled = EXCLUDED.newbie_event_enabled,
+				updated_by           = EXCLUDED.updated_by,
+				updated_at           = now()`,
+			cfg.Enabled, cfg.ItemIndex, cfg.Rate, cfg.StartIndex, cfg.CurrentIndex,
+			cfg.EndIndex, cfg.Indexed, cfg.NoticeEnabled, cfg.DoubleExpEnabled,
+			cfg.NewbieEventEnabled, nullableID(moderatorID)); err != nil {
+			return fmt.Errorf("store: upsert world event config: %w", err)
+		}
+		after, _ := fetchWorldEventConfigJSON(ctx, tx)
+		return auditWorldEventAndBump(ctx, tx, moderatorID, "set_config", before, after)
+	})
+}
+
+// UpdateWorldEventProgress persists tmServer's event counter without bumping the
+// moderator config version. expectedVersion prevents a stale tmServer snapshot
+// from overwriting a newer portal edit; applied is false when the version changed.
+func (s *Store) UpdateWorldEventProgress(ctx context.Context, expectedVersion int64, currentIndex int32) (applied bool, err error) {
+	err = s.inTx(ctx, func(tx pgx.Tx) error {
+		var version int64
+		if err := tx.QueryRow(ctx, `SELECT version FROM world_event_meta WHERE id = TRUE`).Scan(&version); err != nil {
+			return fmt.Errorf("store: world event progress version: %w", err)
+		}
+		if version != expectedVersion {
+			applied = false
+			return nil
+		}
+		ct, err := tx.Exec(ctx, `UPDATE world_event_config SET current_index = GREATEST(current_index, $1) WHERE id = TRUE`, currentIndex)
+		if err != nil {
+			return fmt.Errorf("store: update world event progress: %w", err)
+		}
+		applied = ct.RowsAffected() == 1
+		return nil
+	})
+	return applied, err
+}
+
+const worldEventConfigSelect = `
+	SELECT enabled, item_index, rate, start_index, current_index, end_index,
+	       indexed, notice_enabled, double_exp_enabled, newbie_event_enabled
+	FROM world_event_config WHERE id = TRUE`
+
+type worldEventScanRow interface {
+	Scan(dest ...any) error
+}
+
+func scanWorldEventConfig(row worldEventScanRow) (domain.WorldEventConfig, error) {
+	var cfg domain.WorldEventConfig
+	err := row.Scan(&cfg.Enabled, &cfg.ItemIndex, &cfg.Rate, &cfg.StartIndex,
+		&cfg.CurrentIndex, &cfg.EndIndex, &cfg.Indexed, &cfg.NoticeEnabled,
+		&cfg.DoubleExpEnabled, &cfg.NewbieEventEnabled)
+	return cfg, err
+}
+
+func fetchWorldEventConfigJSON(ctx context.Context, tx pgx.Tx) ([]byte, error) {
+	var js []byte
+	err := tx.QueryRow(ctx, `SELECT to_jsonb(c) FROM world_event_config c WHERE id = TRUE`).Scan(&js)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return js, err
+}
+
+func auditWorldEventAndBump(ctx context.Context, tx pgx.Tx, moderatorID int64, action string, before, after []byte) error {
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO world_event_audit (account_id, action, before, after)
+		VALUES ($1,$2,$3,$4)`,
+		moderatorID, action, nullableJSON(before), nullableJSON(after)); err != nil {
+		return fmt.Errorf("store: write world event audit: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `UPDATE world_event_meta SET version = version + 1 WHERE id = TRUE`); err != nil {
+		return fmt.Errorf("store: bump world event config version: %w", err)
+	}
+	return nil
+}

--- a/internal/store/worldevent_integration_test.go
+++ b/internal/store/worldevent_integration_test.go
@@ -1,0 +1,88 @@
+//go:build integration
+
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+)
+
+func TestWorldEventConfigCRUDAndProgress(t *testing.T) {
+	ctx := context.Background()
+	pool := testPool(t)
+	resetTestSchema(ctx, pool)
+	if err := Migrate(ctx, pool); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	var modID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO account (name, pass_hash, role) VALUES ('mod_worldevent_test','x','moderator') RETURNING id`).
+		Scan(&modID); err != nil {
+		t.Fatalf("seed moderator: %v", err)
+	}
+
+	st := New(pool)
+	v, err := st.WorldEventConfigVersion(ctx)
+	if err != nil || v != 0 {
+		t.Fatalf("initial version = %d/%v, want 0/nil", v, err)
+	}
+	cfg := domain.WorldEventConfig{
+		Enabled: true, ItemIndex: 777, Rate: 2,
+		StartIndex: 100, CurrentIndex: 100, EndIndex: 200,
+		Indexed: true, NoticeEnabled: true, DoubleExpEnabled: true,
+	}
+	if err := st.UpsertWorldEventConfig(ctx, cfg, modID); err != nil {
+		t.Fatalf("UpsertWorldEventConfig: %v", err)
+	}
+	v, err = st.WorldEventConfigVersion(ctx)
+	if err != nil || v != 1 {
+		t.Fatalf("version after upsert = %d/%v, want 1/nil", v, err)
+	}
+	got, err := st.WorldEventConfig(ctx)
+	if err != nil {
+		t.Fatalf("WorldEventConfig: %v", err)
+	}
+	if got.ItemIndex != 777 || got.CurrentIndex != 100 || !got.DoubleExpEnabled {
+		t.Fatalf("config = %+v, want saved values", got)
+	}
+	var auditCount int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM world_event_audit`).Scan(&auditCount); err != nil {
+		t.Fatal(err)
+	}
+	if auditCount != 1 {
+		t.Fatalf("audit count = %d, want 1", auditCount)
+	}
+
+	applied, err := st.UpdateWorldEventProgress(ctx, 1, 101)
+	if err != nil || !applied {
+		t.Fatalf("UpdateWorldEventProgress = %v/%v, want applied", applied, err)
+	}
+	v, err = st.WorldEventConfigVersion(ctx)
+	if err != nil || v != 1 {
+		t.Fatalf("version after progress = %d/%v, want unchanged 1", v, err)
+	}
+	got, _ = st.WorldEventConfig(ctx)
+	if got.CurrentIndex != 101 {
+		t.Fatalf("current after progress = %d, want 101", got.CurrentIndex)
+	}
+
+	applied, err = st.UpdateWorldEventProgress(ctx, 0, 150)
+	if err != nil || applied {
+		t.Fatalf("stale progress = %v/%v, want not applied", applied, err)
+	}
+	got, _ = st.WorldEventConfig(ctx)
+	if got.CurrentIndex != 101 {
+		t.Fatalf("current after stale progress = %d, want unchanged 101", got.CurrentIndex)
+	}
+
+	applied, err = st.UpdateWorldEventProgress(ctx, 1, 100)
+	if err != nil || !applied {
+		t.Fatalf("lower progress = %v/%v, want applied no-op", applied, err)
+	}
+	got, _ = st.WorldEventConfig(ctx)
+	if got.CurrentIndex != 101 {
+		t.Fatalf("current after lower progress = %d, want monotonic 101", got.CurrentIndex)
+	}
+}

--- a/tmserver/cmd/tmserver/main.go
+++ b/tmserver/cmd/tmserver/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/route"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/worldcfg"
 )
 
 func main() {
@@ -169,6 +170,7 @@ func run(logger *slog.Logger) error {
 	// connection is retained (dbConn) so the NPC-config overlay can share it.
 	var persist world.Persistence = world.NopPersistence{}
 	var dbConn *grpc.ClientConn
+	var worldEvents worldcfg.Source
 	if *dbAddr != "" {
 		conn, err := grpc.NewClient(*dbAddr, grpc.WithTransportCredentials(clientCreds))
 		if err != nil {
@@ -177,6 +179,7 @@ func run(logger *slog.Logger) error {
 		defer func() { _ = conn.Close() }()
 		dbConn = conn
 		persist = dbclient.New(conn)
+		worldEvents = dbclient.NewWorldEventConfig(conn)
 		logger.Info("dbServer wired", "addr", *dbAddr)
 	} else {
 		logger.Warn("no -dbserver: using no-op persistence (logins report no account)")
@@ -240,6 +243,7 @@ func run(logger *slog.Logger) error {
 		CombineFamilies: combineFamilies,
 		OdinCatalog:     odinCatalog,
 		NpcConfig:       npcConfig,
+		WorldEvents:     worldEvents,
 	})
 	w := world.New(world.Config{
 		RejectChecksum: *rejectChecksum,
@@ -282,6 +286,9 @@ func run(logger *slog.Logger) error {
 	}
 	if npcConfig != nil {
 		dispatch.ApplyNPCConfigBoot(w)
+	}
+	if worldEvents != nil {
+		dispatch.ApplyWorldEventConfigBoot(w)
 	}
 	dispatch.ApplyGuildStateBoot(w)
 

--- a/tmserver/internal/dbclient/worldevent.go
+++ b/tmserver/internal/dbclient/worldevent.go
@@ -1,0 +1,66 @@
+package dbclient
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc"
+
+	dbv1 "github.com/jeanluca/w2pp-openwyd/api/db/v1"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/worldcfg"
+)
+
+// WorldEventConfig adapts dbServer's WorldEventConfigService to the tmServer
+// worldcfg.Source port.
+type WorldEventConfig struct {
+	api dbv1.WorldEventConfigServiceClient
+}
+
+// NewWorldEventConfig wraps a gRPC connection as a world-event config source.
+func NewWorldEventConfig(conn grpc.ClientConnInterface) *WorldEventConfig {
+	return &WorldEventConfig{api: dbv1.NewWorldEventConfigServiceClient(conn)}
+}
+
+var _ worldcfg.Source = (*WorldEventConfig)(nil)
+
+// Version returns the current portal-managed world-event config version.
+func (c *WorldEventConfig) Version(ctx context.Context) (int64, error) {
+	resp, err := c.api.WorldEventConfigVersion(ctx, &dbv1.WorldEventConfigVersionRequest{})
+	if err != nil {
+		return 0, fmt.Errorf("dbclient: world event config version: %w", err)
+	}
+	return resp.GetVersion(), nil
+}
+
+// Snapshot fetches the full event config snapshot.
+func (c *WorldEventConfig) Snapshot(ctx context.Context) (worldcfg.Snapshot, error) {
+	resp, err := c.api.GetWorldEventConfig(ctx, &dbv1.GetWorldEventConfigRequest{})
+	if err != nil {
+		return worldcfg.Snapshot{}, fmt.Errorf("dbclient: get world event config: %w", err)
+	}
+	return worldcfg.Snapshot{Version: resp.GetVersion(), Event: dbWorldEventToConfig(resp.GetConfig())}, nil
+}
+
+// UpdateProgress persists the current event counter without bumping config version.
+func (c *WorldEventConfig) UpdateProgress(ctx context.Context, expectedVersion int64, currentIndex int32) (bool, error) {
+	resp, err := c.api.UpdateWorldEventProgress(ctx, &dbv1.UpdateWorldEventProgressRequest{
+		ExpectedVersion: expectedVersion,
+		CurrentIndex:    currentIndex,
+	})
+	if err != nil {
+		return false, fmt.Errorf("dbclient: update world event progress: %w", err)
+	}
+	return resp.GetApplied(), nil
+}
+
+func dbWorldEventToConfig(cfg *dbv1.WorldEventConfig) worldcfg.EventConfig {
+	if cfg == nil {
+		return worldcfg.EventConfig{NoticeEnabled: true}
+	}
+	return worldcfg.EventConfig{
+		Enabled: cfg.GetEnabled(), ItemIndex: cfg.GetItemIndex(), Rate: cfg.GetRate(),
+		StartIndex: cfg.GetStartIndex(), CurrentIndex: cfg.GetCurrentIndex(), EndIndex: cfg.GetEndIndex(),
+		Indexed: cfg.GetIndexed(), NoticeEnabled: cfg.GetNoticeEnabled(),
+		DoubleExpEnabled: cfg.GetDoubleExpEnabled(), NewbieEventEnabled: cfg.GetNewbieEventEnabled(),
+	}
+}

--- a/tmserver/internal/dbclient/worldevent_test.go
+++ b/tmserver/internal/dbclient/worldevent_test.go
@@ -1,0 +1,74 @@
+package dbclient
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc"
+
+	dbv1 "github.com/jeanluca/w2pp-openwyd/api/db/v1"
+)
+
+type fakeWorldEventAPI struct {
+	versionReq       bool
+	snapshotResp     *dbv1.GetWorldEventConfigResponse
+	progressVersion  int64
+	progressIndex    int32
+	progressResponse bool
+}
+
+func (f *fakeWorldEventAPI) WorldEventConfigVersion(context.Context, *dbv1.WorldEventConfigVersionRequest, ...grpc.CallOption) (*dbv1.WorldEventConfigVersionResponse, error) {
+	f.versionReq = true
+	return &dbv1.WorldEventConfigVersionResponse{Version: 5}, nil
+}
+func (f *fakeWorldEventAPI) GetWorldEventConfig(context.Context, *dbv1.GetWorldEventConfigRequest, ...grpc.CallOption) (*dbv1.GetWorldEventConfigResponse, error) {
+	return f.snapshotResp, nil
+}
+func (f *fakeWorldEventAPI) UpdateWorldEventProgress(_ context.Context, req *dbv1.UpdateWorldEventProgressRequest, _ ...grpc.CallOption) (*dbv1.UpdateWorldEventProgressResponse, error) {
+	f.progressVersion, f.progressIndex = req.GetExpectedVersion(), req.GetCurrentIndex()
+	return &dbv1.UpdateWorldEventProgressResponse{Applied: f.progressResponse}, nil
+}
+
+func TestWorldEventConfigClientMapsSnapshotAndProgress(t *testing.T) {
+	api := &fakeWorldEventAPI{
+		progressResponse: true,
+		snapshotResp: &dbv1.GetWorldEventConfigResponse{
+			Version: 5,
+			Config: &dbv1.WorldEventConfig{
+				Enabled: true, ItemIndex: 777, Rate: 2,
+				StartIndex: 10, CurrentIndex: 11, EndIndex: 20,
+				Indexed: true, NoticeEnabled: true, DoubleExpEnabled: true, NewbieEventEnabled: true,
+			},
+		},
+	}
+	c := &WorldEventConfig{api: api}
+
+	v, err := c.Version(context.Background())
+	if err != nil || v != 5 || !api.versionReq {
+		t.Fatalf("Version = (%d,%v), req=%v, want 5 nil true", v, err, api.versionReq)
+	}
+	snap, err := c.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if snap.Version != 5 || !snap.Event.Enabled || snap.Event.ItemIndex != 777 ||
+		snap.Event.CurrentIndex != 11 || !snap.Event.DoubleExpEnabled || !snap.Event.NewbieEventEnabled {
+		t.Errorf("snapshot = %+v, want mapped event", snap)
+	}
+	applied, err := c.UpdateProgress(context.Background(), 5, 12)
+	if err != nil || !applied || api.progressVersion != 5 || api.progressIndex != 12 {
+		t.Errorf("UpdateProgress = (%v,%v), version/index=%d/%d; want true nil 5/12",
+			applied, err, api.progressVersion, api.progressIndex)
+	}
+}
+
+func TestWorldEventConfigClientNilSnapshotDefaultsNotice(t *testing.T) {
+	c := &WorldEventConfig{api: &fakeWorldEventAPI{snapshotResp: &dbv1.GetWorldEventConfigResponse{Version: 1}}}
+	snap, err := c.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if !snap.Event.NoticeEnabled {
+		t.Errorf("NoticeEnabled = false, want true default for nil config")
+	}
+}

--- a/tmserver/internal/handler/dispatch.go
+++ b/tmserver/internal/handler/dispatch.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/refine"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/worldcfg"
 )
 
 // Config tunes the dispatcher. Zero values get sensible defaults.
@@ -109,6 +110,11 @@ type Config struct {
 	// When set, the dispatcher overlays DB-defined merchant NPCs on boot and polls
 	// for changes each tick (hot-reload). When nil, NPCs come only from NPCGener.txt.
 	NpcConfig npccfg.Source
+
+	// WorldEvents is the portal-managed global event config source (issue #116).
+	// When set, the dispatcher applies EXP/drop event settings at boot and polls
+	// for moderator edits. When nil, ExpEvents stays as the boot-time flags.
+	WorldEvents worldcfg.Source
 }
 
 type handlerFunc func(w *world.World, s *world.Session, h protocol.Header, payload []byte)
@@ -163,6 +169,13 @@ type Dispatcher struct {
 	npcPolling     bool
 	npcPollTick    int
 
+	// Portal-managed world events (issue #116). worldEventSource is the dbServer
+	// read/progress bridge; the actual event state lives in world.World.
+	worldEventSource   worldcfg.Source
+	worldEventVersion  int64
+	worldEventPolling  bool
+	worldEventPollTick int
+
 	// playersX/Y are per-tick scratch snapshots of in-play player positions
 	// (mob-AI dormancy gate, mobai.go). Loop-only, reused to avoid allocation.
 	playersX, playersY []int16
@@ -188,33 +201,34 @@ func New(cfg Config) *Dispatcher {
 		cfg.Now = time.Now
 	}
 	d := &Dispatcher{
-		cfg:             cfg,
-		log:             cfg.Log,
-		routes:          make(map[protocol.Type]handlerFunc),
-		fails:           make(map[string]int),
-		combineFamilies: cfg.CombineFamilies,
-		odinCatalog:     cfg.OdinCatalog,
-		baseMobs:        cfg.BaseMobs,
-		summonMobs:      cfg.SummonMobs,
-		vineMob:         cfg.VineMob,
-		itemPrices:      cfg.ItemPrices,
-		itemEffects:     cfg.ItemEffects,
-		itemReqs:        cfg.ItemReqs,
-		itemVolatiles:   cfg.ItemVolatiles,
-		itemPos:         cfg.ItemPos,
-		itemUnique:      cfg.ItemUnique,
-		itemGrades:      cfg.ItemGrades,
-		itemExtra:       cfg.ItemExtra,
-		sancRate:        cfg.SancRate,
-		expEvents:       cfg.ExpEvents,
-		spells:          cfg.Spells,
-		heights:         cfg.Heights,
-		now:             cfg.Now,
-		serverIndex:     cfg.ServerIndex,
-		guildWars:       make(map[uint16]uint16),
-		guildAllies:     make(map[uint16]uint16),
-		npcSource:       cfg.NpcConfig,
-		managedNPCs:     make(map[string]int),
+		cfg:              cfg,
+		log:              cfg.Log,
+		routes:           make(map[protocol.Type]handlerFunc),
+		fails:            make(map[string]int),
+		combineFamilies:  cfg.CombineFamilies,
+		odinCatalog:      cfg.OdinCatalog,
+		baseMobs:         cfg.BaseMobs,
+		summonMobs:       cfg.SummonMobs,
+		vineMob:          cfg.VineMob,
+		itemPrices:       cfg.ItemPrices,
+		itemEffects:      cfg.ItemEffects,
+		itemReqs:         cfg.ItemReqs,
+		itemVolatiles:    cfg.ItemVolatiles,
+		itemPos:          cfg.ItemPos,
+		itemUnique:       cfg.ItemUnique,
+		itemGrades:       cfg.ItemGrades,
+		itemExtra:        cfg.ItemExtra,
+		sancRate:         cfg.SancRate,
+		expEvents:        cfg.ExpEvents,
+		spells:           cfg.Spells,
+		heights:          cfg.Heights,
+		now:              cfg.Now,
+		serverIndex:      cfg.ServerIndex,
+		guildWars:        make(map[uint16]uint16),
+		guildAllies:      make(map[uint16]uint16),
+		npcSource:        cfg.NpcConfig,
+		managedNPCs:      make(map[string]int),
+		worldEventSource: cfg.WorldEvents,
 	}
 	for i := range d.guildZones {
 		d.guildZones[i].Zone = i

--- a/tmserver/internal/handler/mobai.go
+++ b/tmserver/internal/handler/mobai.go
@@ -102,6 +102,7 @@ func (d *Dispatcher) Tick(w *world.World) {
 	d.respawnMobs(w)
 	d.generateMobs(w)
 	d.pollNPCConfig(w) // hot-reload moderator NPC edits (npc-editing-plan.md)
+	d.pollWorldEventConfig(w)
 }
 
 type questArea struct {

--- a/tmserver/internal/handler/mobkilled.go
+++ b/tmserver/internal/handler/mobkilled.go
@@ -67,7 +67,7 @@ func (d *Dispatcher) mobKilled(w *world.World, killer, mob *world.Entity) {
 		d.grantExp(w, ks, reward, mob)
 	}
 
-	d.tryWorldEventDrop(w, reward, mob)
+	d.tryWorldEventDrop(w, reward)
 
 	// Item drop: each occupied loot slot rolls against its g_pDropRate odds.
 	for slot := range mob.Carry {

--- a/tmserver/internal/handler/mobkilled.go
+++ b/tmserver/internal/handler/mobkilled.go
@@ -67,6 +67,8 @@ func (d *Dispatcher) mobKilled(w *world.World, killer, mob *world.Entity) {
 		d.grantExp(w, ks, reward, mob)
 	}
 
+	d.tryWorldEventDrop(w, reward, mob)
+
 	// Item drop: each occupied loot slot rolls against its g_pDropRate odds.
 	for slot := range mob.Carry {
 		it := mob.Carry[slot]

--- a/tmserver/internal/handler/mobkilled_test.go
+++ b/tmserver/internal/handler/mobkilled_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/level"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/worldcfg"
 )
 
 // TestAddClamp guards the per-level HP/MP accumulation against int32 overflow and
@@ -168,6 +169,74 @@ func TestMobKilledClan4NoExp(t *testing.T) {
 	d.mobKilled(w, killer, w.Entity(mobID))
 	if killer.Exp != 0 {
 		t.Errorf("killer.Exp = %d, want 0 for a clan-4 mob", killer.Exp)
+	}
+}
+
+func TestApplyWorldEventConfigUpdatesExpAndDropState(t *testing.T) {
+	d, w, _ := mobKilledWorld(t)
+	snap := worldcfg.Snapshot{
+		Version: 9,
+		Event: worldcfg.EventConfig{
+			Enabled: true, ItemIndex: 777, Rate: 10,
+			StartIndex: 100, CurrentIndex: 101, EndIndex: 200,
+			Indexed: true, NoticeEnabled: true,
+			DoubleExpEnabled: true, NewbieEventEnabled: true,
+		},
+	}
+
+	d.applyWorldEventConfig(w, snap)
+	if !d.expEvents.DoubleMode || !d.expEvents.NewbieEvent {
+		t.Fatalf("exp events = %+v, want double+newbie enabled", d.expEvents)
+	}
+	got := w.WorldEventConfig()
+	if got.Version != 9 || !got.Enabled || got.ItemIndex != 777 || got.CurrentIndex != 101 || !got.Indexed {
+		t.Errorf("world event config = %+v, want snapshot applied", got)
+	}
+}
+
+func TestMobKilledWorldEventDropIndexed(t *testing.T) {
+	d, w, killer := mobKilledWorld(t)
+	w.SetWorldEventConfig(world.WorldEventConfig{
+		Version: 3, Enabled: true, ItemIndex: 777, Rate: 1,
+		StartIndex: 100, CurrentIndex: 100, EndIndex: 101,
+		Indexed: true,
+	})
+	mobID := w.SpawnMob(expMobTemplate(1, 1000, 0), 6, 5)
+
+	d.mobKilled(w, killer, w.Entity(mobID))
+
+	if got := w.WorldEventConfig().CurrentIndex; got != 101 {
+		t.Fatalf("CurrentIndex = %d, want 101", got)
+	}
+	gi := w.GroundItemAt(6, 5)
+	if gi == nil {
+		t.Fatal("event drop was not placed on the ground")
+	}
+	if gi.Item.Index != 777 {
+		t.Fatalf("event item index = %d, want 777", gi.Item.Index)
+	}
+	want := [2]world.Effect{{Effect: eventSerialHi, Value: 0}, {Effect: eventSerialLo, Value: 100}}
+	if gi.Item.Effects[0] != want[0] || gi.Item.Effects[1] != want[1] || gi.Item.Effects[2].Effect != eventSerialRand {
+		t.Errorf("event effects = %+v, want serial hi/lo and rand effect", gi.Item.Effects)
+	}
+}
+
+func TestMobKilledWorldEventDropExhaustedDoesNothing(t *testing.T) {
+	d, w, killer := mobKilledWorld(t)
+	w.SetWorldEventConfig(world.WorldEventConfig{
+		Version: 3, Enabled: true, ItemIndex: 777, Rate: 1,
+		StartIndex: 100, CurrentIndex: 101, EndIndex: 101,
+		Indexed: true,
+	})
+	mobID := w.SpawnMob(expMobTemplate(1, 1000, 0), 6, 5)
+
+	d.mobKilled(w, killer, w.Entity(mobID))
+
+	if gi := w.GroundItemAt(6, 5); gi != nil {
+		t.Fatalf("exhausted event placed ground item %+v", gi)
+	}
+	if got := w.WorldEventConfig().CurrentIndex; got != 101 {
+		t.Errorf("CurrentIndex = %d, want unchanged 101", got)
 	}
 }
 

--- a/tmserver/internal/handler/mobkilled_test.go
+++ b/tmserver/internal/handler/mobkilled_test.go
@@ -196,7 +196,7 @@ func TestApplyWorldEventConfigUpdatesExpAndDropState(t *testing.T) {
 
 func TestMobKilledWorldEventDropIndexed(t *testing.T) {
 	d, w, killer := mobKilledWorld(t)
-	w.SetWorldEventConfig(world.WorldEventConfig{
+	w.SetWorldEventConfig(world.EventConfig{
 		Version: 3, Enabled: true, ItemIndex: 777, Rate: 1,
 		StartIndex: 100, CurrentIndex: 100, EndIndex: 101,
 		Indexed: true,
@@ -226,7 +226,7 @@ func TestMobKilledWorldEventDropFullCarryDoesNotAdvance(t *testing.T) {
 	for i := 0; i < baseCarrySlots; i++ {
 		killer.Carry[i] = world.Item{Index: int16(1000 + i)}
 	}
-	w.SetWorldEventConfig(world.WorldEventConfig{
+	w.SetWorldEventConfig(world.EventConfig{
 		Version: 3, Enabled: true, ItemIndex: 777, Rate: 1,
 		StartIndex: 100, CurrentIndex: 100, EndIndex: 101,
 		Indexed: true,
@@ -245,7 +245,7 @@ func TestMobKilledWorldEventDropFullCarryDoesNotAdvance(t *testing.T) {
 
 func TestMobKilledWorldEventDropExhaustedDoesNothing(t *testing.T) {
 	d, w, killer := mobKilledWorld(t)
-	w.SetWorldEventConfig(world.WorldEventConfig{
+	w.SetWorldEventConfig(world.EventConfig{
 		Version: 3, Enabled: true, ItemIndex: 777, Rate: 1,
 		StartIndex: 100, CurrentIndex: 101, EndIndex: 101,
 		Indexed: true,
@@ -441,7 +441,7 @@ func TestKillWorldEventDropSendsCarrySlot(t *testing.T) {
 	binary.LittleEndian.PutUint32(mob[92+16:], 1)
 	binary.LittleEndian.PutUint32(mob[92+24:], 1)
 	addr, stop := startServerExpMob(t, skillCombatDB(0), mob, func(_ *Dispatcher, w *world.World) {
-		w.SetWorldEventConfig(world.WorldEventConfig{
+		w.SetWorldEventConfig(world.EventConfig{
 			Version: 3, Enabled: true, ItemIndex: 777, Rate: 1,
 			StartIndex: 100, CurrentIndex: 100, EndIndex: 101,
 			Indexed: true,

--- a/tmserver/internal/handler/mobkilled_test.go
+++ b/tmserver/internal/handler/mobkilled_test.go
@@ -208,16 +208,38 @@ func TestMobKilledWorldEventDropIndexed(t *testing.T) {
 	if got := w.WorldEventConfig().CurrentIndex; got != 101 {
 		t.Fatalf("CurrentIndex = %d, want 101", got)
 	}
-	gi := w.GroundItemAt(6, 5)
-	if gi == nil {
-		t.Fatal("event drop was not placed on the ground")
+	if gi := w.GroundItemAt(6, 5); gi != nil {
+		t.Fatalf("event drop was placed on the ground: %+v", gi)
 	}
-	if gi.Item.Index != 777 {
-		t.Fatalf("event item index = %d, want 777", gi.Item.Index)
+	it := killer.Carry[0]
+	if it.Index != 777 {
+		t.Fatalf("event item index = %d, want 777 in carry slot 0", it.Index)
 	}
 	want := [2]world.Effect{{Effect: eventSerialHi, Value: 0}, {Effect: eventSerialLo, Value: 100}}
-	if gi.Item.Effects[0] != want[0] || gi.Item.Effects[1] != want[1] || gi.Item.Effects[2].Effect != eventSerialRand {
-		t.Errorf("event effects = %+v, want serial hi/lo and rand effect", gi.Item.Effects)
+	if it.Effects[0] != want[0] || it.Effects[1] != want[1] || it.Effects[2].Effect != eventSerialRand {
+		t.Errorf("event effects = %+v, want serial hi/lo and rand effect", it.Effects)
+	}
+}
+
+func TestMobKilledWorldEventDropFullCarryDoesNotAdvance(t *testing.T) {
+	d, w, killer := mobKilledWorld(t)
+	for i := 0; i < baseCarrySlots; i++ {
+		killer.Carry[i] = world.Item{Index: int16(1000 + i)}
+	}
+	w.SetWorldEventConfig(world.WorldEventConfig{
+		Version: 3, Enabled: true, ItemIndex: 777, Rate: 1,
+		StartIndex: 100, CurrentIndex: 100, EndIndex: 101,
+		Indexed: true,
+	})
+	mobID := w.SpawnMob(expMobTemplate(1, 1000, 0), 6, 5)
+
+	d.mobKilled(w, killer, w.Entity(mobID))
+
+	if got := w.WorldEventConfig().CurrentIndex; got != 100 {
+		t.Fatalf("CurrentIndex = %d, want unchanged 100", got)
+	}
+	if gi := w.GroundItemAt(6, 5); gi != nil {
+		t.Fatalf("full carry event placed ground item %+v", gi)
 	}
 }
 
@@ -349,7 +371,7 @@ func TestBabyMountKillEligible(t *testing.T) {
 
 // startServerExpMob is a serving harness with one killable (1 HP) exp-bearing
 // monster next to the player spawn.
-func startServerExpMob(t *testing.T, persist world.Persistence, mob []byte) (string, func()) {
+func startServerExpMob(t *testing.T, persist world.Persistence, mob []byte, configure ...func(*Dispatcher, *world.World)) (string, func()) {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -361,6 +383,9 @@ func startServerExpMob(t *testing.T, persist world.Persistence, mob []byte) (str
 	d := New(Config{Log: log})
 	w := world.New(world.Config{GridDim: 16, Now: clock.Load}, log, persist, d.Handle)
 	w.SpawnMob(mob, 6, 5) // adjacent to the player spawn (5,5)
+	for _, fn := range configure {
+		fn(d, w)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() { _ = w.Serve(ctx, ln); close(done) }()
@@ -409,4 +434,43 @@ func TestKillGrantsExpOverWire(t *testing.T) {
 		return
 	}
 	t.Fatal("never received the MsgAttack echo")
+}
+
+func TestKillWorldEventDropSendsCarrySlot(t *testing.T) {
+	mob := expMobTemplate(10, 1000, 0)
+	binary.LittleEndian.PutUint32(mob[92+16:], 1)
+	binary.LittleEndian.PutUint32(mob[92+24:], 1)
+	addr, stop := startServerExpMob(t, skillCombatDB(0), mob, func(_ *Dispatcher, w *world.World) {
+		w.SetWorldEventConfig(world.WorldEventConfig{
+			Version: 3, Enabled: true, ItemIndex: 777, Rate: 1,
+			StartIndex: 100, CurrentIndex: 100, EndIndex: 101,
+			Indexed: true,
+		})
+	})
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	skillAttackFrame(t, c, serverTime, world.MaxUser, -1, -2)
+
+	for i := 0; i < 12; i++ {
+		ty, payload, ok := readMaybe(t, c)
+		if !ok {
+			t.Fatal("no MsgSendItem after world event drop")
+		}
+		if ty != protocol.MsgSendItem {
+			continue
+		}
+		if place, slot, idx := le16(payload[0:2]), le16(payload[2:4]), le16(payload[4:6]); place != world.ItemPlaceCarry || slot != 0 || idx != 777 {
+			t.Fatalf("event SendItem = place %d slot %d index %d, want carry/0/777", place, slot, idx)
+		}
+		if payload[6] != eventSerialHi || payload[7] != 0 ||
+			payload[8] != eventSerialLo || payload[9] != 100 ||
+			payload[10] != eventSerialRand {
+			t.Fatalf("event SendItem effects = [%d:%d %d:%d %d:%d], want serial hi/lo/rand",
+				payload[6], payload[7], payload[8], payload[9], payload[10], payload[11])
+		}
+		return
+	}
+	t.Fatal("never received world event SendItem")
 }

--- a/tmserver/internal/handler/worldevent.go
+++ b/tmserver/internal/handler/worldevent.go
@@ -83,7 +83,7 @@ func (d *Dispatcher) applyWorldEventConfig(w *world.World, snap worldcfg.Snapsho
 	ev := snap.Event
 	d.expEvents.DoubleMode = ev.DoubleExpEnabled
 	d.expEvents.NewbieEvent = ev.NewbieEventEnabled
-	w.SetWorldEventConfig(world.WorldEventConfig{
+	w.SetWorldEventConfig(world.EventConfig{
 		Version: snap.Version, Enabled: ev.Enabled, ItemIndex: ev.ItemIndex, Rate: ev.Rate,
 		StartIndex: ev.StartIndex, CurrentIndex: ev.CurrentIndex, EndIndex: ev.EndIndex,
 		Indexed: ev.Indexed, NoticeEnabled: ev.NoticeEnabled,
@@ -133,7 +133,7 @@ func (d *Dispatcher) tryWorldEventDrop(w *world.World, reward *world.Entity) {
 	d.persistWorldEventProgress(w, cfg)
 }
 
-func worldEventDropActive(cfg world.WorldEventConfig) bool {
+func worldEventDropActive(cfg world.EventConfig) bool {
 	return cfg.Enabled &&
 		cfg.ItemIndex > 0 &&
 		cfg.ItemIndex <= maxWorldEventItemIndex &&
@@ -143,7 +143,7 @@ func worldEventDropActive(cfg world.WorldEventConfig) bool {
 		cfg.CurrentIndex < cfg.EndIndex
 }
 
-func (d *Dispatcher) persistWorldEventProgress(w *world.World, cfg world.WorldEventConfig) {
+func (d *Dispatcher) persistWorldEventProgress(w *world.World, cfg world.EventConfig) {
 	if d.worldEventSource == nil {
 		return
 	}

--- a/tmserver/internal/handler/worldevent.go
+++ b/tmserver/internal/handler/worldevent.go
@@ -91,7 +91,7 @@ func (d *Dispatcher) applyWorldEventConfig(w *world.World, snap worldcfg.Snapsho
 	d.worldEventVersion = snap.Version
 }
 
-func (d *Dispatcher) tryWorldEventDrop(w *world.World, reward, mob *world.Entity) {
+func (d *Dispatcher) tryWorldEventDrop(w *world.World, reward *world.Entity) {
 	cfg := w.WorldEventConfig()
 	if !worldEventDropActive(cfg) {
 		return
@@ -108,8 +108,18 @@ func (d *Dispatcher) tryWorldEventDrop(w *world.World, reward, mob *world.Entity
 			{Effect: eventSerialRand, Value: uint8(w.Rand().Rand())},
 		}
 	}
-	if id := w.CreateGroundItem(item, mob.X, mob.Y); id < 0 {
-		d.log.Warn("world event drop lost: ground item table full", "item", cfg.ItemIndex, "serial", serial)
+	slot := firstEmptyAccessibleCarry(reward)
+	if slot < 0 {
+		conn := -1
+		if reward != nil {
+			conn = reward.ID
+		}
+		d.log.Warn("world event drop lost: carry full", "conn", conn, "item", cfg.ItemIndex, "serial", serial)
+		return
+	}
+	reward.Carry[slot] = item
+	if s := w.Session(reward.ID); s != nil {
+		d.sendSlot(w, s, world.ItemPlaceCarry, slot, item)
 	}
 	if cfg.NoticeEnabled {
 		noticeSerial := int32(0)

--- a/tmserver/internal/handler/worldevent.go
+++ b/tmserver/internal/handler/worldevent.go
@@ -1,0 +1,172 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/worldcfg"
+)
+
+const (
+	worldEventPollPeriod   = 15
+	worldEventFetchTimeout = 5 * time.Second
+
+	eventSerialHi   = 62
+	eventSerialLo   = 63
+	eventSerialRand = 59
+
+	maxWorldEventItemIndex = 32767
+)
+
+// ApplyWorldEventConfigBoot fetches the portal-managed world event config
+// synchronously and applies it before the loop starts accepting players.
+func (d *Dispatcher) ApplyWorldEventConfigBoot(w *world.World) {
+	if d.worldEventSource == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), worldEventFetchTimeout)
+	defer cancel()
+	snap, err := d.worldEventSource.Snapshot(ctx)
+	if err != nil {
+		d.log.Warn("world event config boot load failed (will retry via poll)", "err", err)
+		return
+	}
+	d.applyWorldEventConfig(w, snap)
+	d.log.Info("world event config applied at boot", "version", snap.Version)
+}
+
+// pollWorldEventConfig reloads portal-managed event settings when the config
+// version changes. Called from the world tick; gRPC work runs off-loop.
+func (d *Dispatcher) pollWorldEventConfig(w *world.World) {
+	if d.worldEventSource == nil || d.worldEventPolling {
+		return
+	}
+	d.worldEventPollTick++
+	if d.worldEventPollTick%worldEventPollPeriod != 0 {
+		return
+	}
+	known := d.worldEventVersion
+	src := d.worldEventSource
+	d.worldEventPolling = true
+	w.GoDetached(func() func(*world.World) {
+		ctx, cancel := context.WithTimeout(context.Background(), worldEventFetchTimeout)
+		defer cancel()
+		version, err := src.Version(ctx)
+		if err != nil {
+			return func(*world.World) {
+				d.worldEventPolling = false
+				d.log.Warn("world event config version poll failed", "err", err)
+			}
+		}
+		if version == known {
+			return func(*world.World) { d.worldEventPolling = false }
+		}
+		snap, err := src.Snapshot(ctx)
+		if err != nil {
+			return func(*world.World) {
+				d.worldEventPolling = false
+				d.log.Warn("world event config reload failed", "err", err)
+			}
+		}
+		return func(w *world.World) {
+			d.applyWorldEventConfig(w, snap)
+			d.worldEventPolling = false
+			d.log.Info("world event config reloaded", "version", snap.Version)
+		}
+	})
+}
+
+func (d *Dispatcher) applyWorldEventConfig(w *world.World, snap worldcfg.Snapshot) {
+	ev := snap.Event
+	d.expEvents.DoubleMode = ev.DoubleExpEnabled
+	d.expEvents.NewbieEvent = ev.NewbieEventEnabled
+	w.SetWorldEventConfig(world.WorldEventConfig{
+		Version: snap.Version, Enabled: ev.Enabled, ItemIndex: ev.ItemIndex, Rate: ev.Rate,
+		StartIndex: ev.StartIndex, CurrentIndex: ev.CurrentIndex, EndIndex: ev.EndIndex,
+		Indexed: ev.Indexed, NoticeEnabled: ev.NoticeEnabled,
+	})
+	d.worldEventVersion = snap.Version
+}
+
+func (d *Dispatcher) tryWorldEventDrop(w *world.World, reward, mob *world.Entity) {
+	cfg := w.WorldEventConfig()
+	if !worldEventDropActive(cfg) {
+		return
+	}
+	if w.Rand().Intn(int(cfg.Rate)) != 0 {
+		return
+	}
+	serial := cfg.CurrentIndex
+	item := world.Item{Index: int16(cfg.ItemIndex)}
+	if cfg.Indexed {
+		item.Effects = [3]world.Effect{
+			{Effect: eventSerialHi, Value: uint8(serial / 256)},
+			{Effect: eventSerialLo, Value: uint8(serial)},
+			{Effect: eventSerialRand, Value: uint8(w.Rand().Rand())},
+		}
+	}
+	if id := w.CreateGroundItem(item, mob.X, mob.Y); id < 0 {
+		d.log.Warn("world event drop lost: ground item table full", "item", cfg.ItemIndex, "serial", serial)
+	}
+	if cfg.NoticeEnabled {
+		noticeSerial := int32(0)
+		if cfg.Indexed {
+			noticeSerial = serial
+		}
+		d.broadcastWorldEventNotice(w, reward, item, noticeSerial)
+	}
+	cfg.CurrentIndex++
+	w.SetWorldEventConfig(cfg)
+	d.persistWorldEventProgress(w, cfg)
+}
+
+func worldEventDropActive(cfg world.WorldEventConfig) bool {
+	return cfg.Enabled &&
+		cfg.ItemIndex > 0 &&
+		cfg.ItemIndex <= maxWorldEventItemIndex &&
+		cfg.Rate > 0 &&
+		cfg.StartIndex > 0 &&
+		cfg.CurrentIndex >= cfg.StartIndex &&
+		cfg.CurrentIndex < cfg.EndIndex
+}
+
+func (d *Dispatcher) persistWorldEventProgress(w *world.World, cfg world.WorldEventConfig) {
+	if d.worldEventSource == nil {
+		return
+	}
+	src := d.worldEventSource
+	version := cfg.Version
+	current := cfg.CurrentIndex
+	w.GoDetached(func() func(*world.World) {
+		ctx, cancel := context.WithTimeout(context.Background(), worldEventFetchTimeout)
+		defer cancel()
+		applied, err := src.UpdateProgress(ctx, version, current)
+		return func(*world.World) {
+			if err != nil {
+				d.log.Warn("world event progress update failed", "version", version, "current_index", current, "err", err)
+				return
+			}
+			if !applied {
+				d.log.Debug("world event progress update skipped for stale version", "version", version, "current_index", current)
+			}
+		}
+	})
+}
+
+func (d *Dispatcher) broadcastWorldEventNotice(w *world.World, reward *world.Entity, item world.Item, serial int32) {
+	name := "alguem"
+	if reward != nil && reward.Name != "" {
+		name = reward.Name
+	}
+	msg := fmt.Sprintf("[Evento] %s recebeu item %d", name, item.Index)
+	if serial > 0 {
+		msg = fmt.Sprintf("%s #%d", msg, serial)
+	}
+	payload := protocol.EncodeMessageChatBody(msg)
+	w.ForEachPlaying(-1, func(s *world.Session, _ *world.Entity) {
+		w.SendTo(s, protocol.Header{Type: protocol.MsgMessageChat, ID: 0}, payload)
+	})
+}

--- a/tmserver/internal/world/world.go
+++ b/tmserver/internal/world/world.go
@@ -144,6 +144,11 @@ type World struct {
 	// against. Loop-owned.
 	guilds map[uint16]GuildInfo
 
+	// worldEvent is the portal-managed global drop event state. Loop-owned; the
+	// dispatcher applies snapshots from dbServer and advances CurrentIndex on
+	// successful event drops.
+	worldEvent WorldEventConfig
+
 	events    chan event
 	callbacks chan event // async handler results (World.Go / World.GoDetached); separate
 	// from events so a long mob-AI tick cannot block login/db callbacks on the main queue.

--- a/tmserver/internal/world/world.go
+++ b/tmserver/internal/world/world.go
@@ -147,7 +147,7 @@ type World struct {
 	// worldEvent is the portal-managed global drop event state. Loop-owned; the
 	// dispatcher applies snapshots from dbServer and advances CurrentIndex on
 	// successful event drops.
-	worldEvent WorldEventConfig
+	worldEvent EventConfig
 
 	events    chan event
 	callbacks chan event // async handler results (World.Go / World.GoDetached); separate

--- a/tmserver/internal/world/worldevent.go
+++ b/tmserver/internal/world/worldevent.go
@@ -1,9 +1,9 @@
 package world
 
-// WorldEventConfig is the loop-owned global event state applied from the portal
+// EventConfig is the loop-owned global event state applied from the portal
 // config. Version is the dbServer config version that produced the snapshot and
 // is used when persisting progress to avoid stale writes after moderator edits.
-type WorldEventConfig struct {
+type EventConfig struct {
 	Version       int64
 	Enabled       bool
 	ItemIndex     int32
@@ -16,11 +16,11 @@ type WorldEventConfig struct {
 }
 
 // SetWorldEventConfig replaces the global event state. Loop-only.
-func (w *World) SetWorldEventConfig(cfg WorldEventConfig) {
+func (w *World) SetWorldEventConfig(cfg EventConfig) {
 	w.worldEvent = cfg
 }
 
 // WorldEventConfig returns a copy of the global event state. Loop-only.
-func (w *World) WorldEventConfig() WorldEventConfig {
+func (w *World) WorldEventConfig() EventConfig {
 	return w.worldEvent
 }

--- a/tmserver/internal/world/worldevent.go
+++ b/tmserver/internal/world/worldevent.go
@@ -1,0 +1,26 @@
+package world
+
+// WorldEventConfig is the loop-owned global event state applied from the portal
+// config. Version is the dbServer config version that produced the snapshot and
+// is used when persisting progress to avoid stale writes after moderator edits.
+type WorldEventConfig struct {
+	Version       int64
+	Enabled       bool
+	ItemIndex     int32
+	Rate          int32
+	StartIndex    int32
+	CurrentIndex  int32
+	EndIndex      int32
+	Indexed       bool
+	NoticeEnabled bool
+}
+
+// SetWorldEventConfig replaces the global event state. Loop-only.
+func (w *World) SetWorldEventConfig(cfg WorldEventConfig) {
+	w.worldEvent = cfg
+}
+
+// WorldEventConfig returns a copy of the global event state. Loop-only.
+func (w *World) WorldEventConfig() WorldEventConfig {
+	return w.worldEvent
+}

--- a/tmserver/internal/worldcfg/worldcfg.go
+++ b/tmserver/internal/worldcfg/worldcfg.go
@@ -1,0 +1,33 @@
+// Package worldcfg carries portal-managed world configuration into the tmServer.
+// The flow is one-way for moderator edits (web -> Postgres -> dbServer ->
+// tmServer); tmServer only writes back event progress.
+package worldcfg
+
+import "context"
+
+// EventConfig is the global event snapshot used by tmServer's loop.
+type EventConfig struct {
+	Enabled            bool
+	ItemIndex          int32
+	Rate               int32
+	StartIndex         int32
+	CurrentIndex       int32
+	EndIndex           int32
+	Indexed            bool
+	NoticeEnabled      bool
+	DoubleExpEnabled   bool
+	NewbieEventEnabled bool
+}
+
+// Snapshot is the full world config at a given version.
+type Snapshot struct {
+	Version int64
+	Event   EventConfig
+}
+
+// Source is tmServer's read/progress side of portal-managed world config.
+type Source interface {
+	Version(ctx context.Context) (int64, error)
+	Snapshot(ctx context.Context) (Snapshot, error)
+	UpdateProgress(ctx context.Context, expectedVersion int64, currentIndex int32) (bool, error)
+}

--- a/webserver/cmd/webserver/main.go
+++ b/webserver/cmd/webserver/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/npcadmin"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/npctemplates"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/ranking"
+	"github.com/jeanluca/w2pp-openwyd/webserver/internal/worldevent"
 )
 
 func main() {
@@ -86,6 +87,7 @@ func run(logger *slog.Logger) error {
 	dailyRwd := dailyreward.New(st)
 	topup := donatetopup.New(st)
 	attrMap := attributemap.New(st, *contentDir)
+	worldEvents := worldevent.New(st)
 	if *contentDir != "" {
 		templates, err := npctemplates.Scan(*contentDir, logger)
 		if err != nil {
@@ -125,6 +127,7 @@ func run(logger *slog.Logger) error {
 	webv1.RegisterDailyRewardAdminServiceServer(srv, grpcsrv.NewDailyRewardAdmin(dailyRwd))
 	webv1.RegisterDailyRewardServiceServer(srv, grpcsrv.NewDailyReward(dailyRwd))
 	webv1.RegisterDonateTopupServiceServer(srv, grpcsrv.NewDonateTopup(topup))
+	webv1.RegisterWorldEventAdminServiceServer(srv, grpcsrv.NewWorldEventAdmin(worldEvents))
 
 	ln, err := net.Listen("tcp", *addr)
 	if err != nil {

--- a/webserver/internal/grpcsrv/worldevent.go
+++ b/webserver/internal/grpcsrv/worldevent.go
@@ -1,0 +1,81 @@
+package grpcsrv
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	webv1 "github.com/jeanluca/w2pp-openwyd/api/web/v1"
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+	"github.com/jeanluca/w2pp-openwyd/webserver/internal/worldevent"
+)
+
+// WorldEventAdmin is the moderator world-event surface (satisfied by
+// *worldevent.Service). Kept as an interface so the server is unit-testable.
+type WorldEventAdmin interface {
+	Get(ctx context.Context, moderatorID int64) (worldevent.Result, int64, domain.WorldEventConfig, error)
+	Set(ctx context.Context, moderatorID int64, cfg domain.WorldEventConfig) (worldevent.Result, error)
+}
+
+// WorldEventAdminServer implements webv1.WorldEventAdminServiceServer.
+type WorldEventAdminServer struct {
+	webv1.UnimplementedWorldEventAdminServiceServer
+	admin WorldEventAdmin
+}
+
+// NewWorldEventAdmin builds the WorldEventAdminService over the given admin logic.
+func NewWorldEventAdmin(a WorldEventAdmin) *WorldEventAdminServer {
+	return &WorldEventAdminServer{admin: a}
+}
+
+// GetWorldEventConfig returns the current portal-managed event settings.
+func (s *WorldEventAdminServer) GetWorldEventConfig(ctx context.Context, req *webv1.GetWorldEventConfigRequest) (*webv1.GetWorldEventConfigResponse, error) {
+	res, version, cfg, err := s.admin.Get(ctx, req.GetModeratorId())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "get world event config: %v", err)
+	}
+	return &webv1.GetWorldEventConfigResponse{
+		Result:  worldEventResultToProto(res),
+		Version: version,
+		Config:  worldEventConfigToWebProto(cfg),
+	}, nil
+}
+
+// SetWorldEventConfig replaces the current event settings.
+func (s *WorldEventAdminServer) SetWorldEventConfig(ctx context.Context, req *webv1.SetWorldEventConfigRequest) (*webv1.AdminAck, error) {
+	res, err := s.admin.Set(ctx, req.GetModeratorId(), webProtoToWorldEventConfig(req.GetConfig()))
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "set world event config: %v", err)
+	}
+	return &webv1.AdminAck{Result: worldEventResultToProto(res)}, nil
+}
+
+func worldEventConfigToWebProto(cfg domain.WorldEventConfig) *webv1.WorldEventConfig {
+	return &webv1.WorldEventConfig{
+		Enabled: cfg.Enabled, ItemIndex: cfg.ItemIndex, Rate: cfg.Rate,
+		StartIndex: cfg.StartIndex, CurrentIndex: cfg.CurrentIndex, EndIndex: cfg.EndIndex,
+		Indexed: cfg.Indexed, NoticeEnabled: cfg.NoticeEnabled,
+		DoubleExpEnabled: cfg.DoubleExpEnabled, NewbieEventEnabled: cfg.NewbieEventEnabled,
+	}
+}
+
+func webProtoToWorldEventConfig(cfg *webv1.WorldEventConfig) domain.WorldEventConfig {
+	return domain.WorldEventConfig{
+		Enabled: cfg.GetEnabled(), ItemIndex: cfg.GetItemIndex(), Rate: cfg.GetRate(),
+		StartIndex: cfg.GetStartIndex(), CurrentIndex: cfg.GetCurrentIndex(), EndIndex: cfg.GetEndIndex(),
+		Indexed: cfg.GetIndexed(), NoticeEnabled: cfg.GetNoticeEnabled(),
+		DoubleExpEnabled: cfg.GetDoubleExpEnabled(), NewbieEventEnabled: cfg.GetNewbieEventEnabled(),
+	}
+}
+
+func worldEventResultToProto(r worldevent.Result) webv1.AdminResult {
+	switch r {
+	case worldevent.OK:
+		return webv1.AdminResult_ADMIN_RESULT_OK
+	case worldevent.Forbidden:
+		return webv1.AdminResult_ADMIN_RESULT_FORBIDDEN
+	default:
+		return webv1.AdminResult_ADMIN_RESULT_INVALID
+	}
+}

--- a/webserver/internal/worldevent/service.go
+++ b/webserver/internal/worldevent/service.go
@@ -1,0 +1,110 @@
+// Package worldevent holds the portal-facing moderator controls for global
+// tmServer world events (issue #116). The portal writes cold config here; the
+// game server consumes it through dbServer polling and applies it in-loop.
+package worldevent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+	"github.com/jeanluca/w2pp-openwyd/internal/store"
+)
+
+// Store is the persistence surface the service needs (satisfied by *store.Store).
+type Store interface {
+	AccountRole(ctx context.Context, id int64) (string, error)
+	WorldEventConfigVersion(ctx context.Context) (int64, error)
+	WorldEventConfig(ctx context.Context) (domain.WorldEventConfig, error)
+	UpsertWorldEventConfig(ctx context.Context, cfg domain.WorldEventConfig, moderatorID int64) error
+}
+
+// Result is the business outcome of an admin operation. Only infra failures are
+// returned as errors; these ride in the response body.
+type Result int
+
+const (
+	// OK means the operation succeeded.
+	OK Result = iota
+	// Forbidden means the caller is not a moderator/admin.
+	Forbidden
+	// Invalid means the request failed validation.
+	Invalid
+)
+
+// Service implements the world-event admin operations.
+type Service struct {
+	store Store
+}
+
+const maxWorldEventItemIndex = 32767
+
+// New builds the service over the given store.
+func New(s Store) *Service { return &Service{store: s} }
+
+// Get returns the current config and version after authorizing the caller.
+func (s *Service) Get(ctx context.Context, moderatorID int64) (Result, int64, domain.WorldEventConfig, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, 0, domain.WorldEventConfig{}, err
+	}
+	version, err := s.store.WorldEventConfigVersion(ctx)
+	if err != nil {
+		return Invalid, 0, domain.WorldEventConfig{}, fmt.Errorf("worldevent: version: %w", err)
+	}
+	cfg, err := s.store.WorldEventConfig(ctx)
+	if err != nil {
+		return Invalid, 0, domain.WorldEventConfig{}, fmt.Errorf("worldevent: config: %w", err)
+	}
+	return OK, version, cfg, nil
+}
+
+// Set replaces the world-event config after authorizing and validating it.
+func (s *Service) Set(ctx context.Context, moderatorID int64, cfg domain.WorldEventConfig) (Result, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, err
+	}
+	if !validConfig(cfg) {
+		return Invalid, nil
+	}
+	if err := s.store.UpsertWorldEventConfig(ctx, cfg, moderatorID); err != nil {
+		return Invalid, fmt.Errorf("worldevent: set config: %w", err)
+	}
+	return OK, nil
+}
+
+func validConfig(cfg domain.WorldEventConfig) bool {
+	if cfg.ItemIndex < 0 || cfg.ItemIndex > maxWorldEventItemIndex ||
+		cfg.Rate < 0 || cfg.StartIndex < 0 || cfg.CurrentIndex < 0 || cfg.EndIndex < 0 {
+		return false
+	}
+	if !cfg.Enabled {
+		return true
+	}
+	if cfg.ItemIndex <= 0 || cfg.Rate <= 0 || cfg.StartIndex <= 0 {
+		return false
+	}
+	if cfg.EndIndex <= cfg.StartIndex {
+		return false
+	}
+	return cfg.CurrentIndex >= cfg.StartIndex && cfg.CurrentIndex <= cfg.EndIndex
+}
+
+// authorize checks the caller has a moderator/admin role. A missing account or
+// a plain-player role yields Forbidden.
+func (s *Service) authorize(ctx context.Context, moderatorID int64) (Result, error) {
+	if moderatorID <= 0 {
+		return Forbidden, nil
+	}
+	role, err := s.store.AccountRole(ctx, moderatorID)
+	if errors.Is(err, store.ErrNotFound) {
+		return Forbidden, nil
+	}
+	if err != nil {
+		return Invalid, fmt.Errorf("worldevent: role lookup %d: %w", moderatorID, err)
+	}
+	if role != "moderator" && role != "admin" {
+		return Forbidden, nil
+	}
+	return OK, nil
+}

--- a/webserver/internal/worldevent/service_test.go
+++ b/webserver/internal/worldevent/service_test.go
@@ -1,0 +1,126 @@
+package worldevent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+	"github.com/jeanluca/w2pp-openwyd/internal/store"
+)
+
+type fakeStore struct {
+	roles   map[int64]string
+	version int64
+	cfg     domain.WorldEventConfig
+	setCfg  domain.WorldEventConfig
+	setBy   int64
+	set     bool
+}
+
+func (f *fakeStore) AccountRole(_ context.Context, id int64) (string, error) {
+	r, ok := f.roles[id]
+	if !ok {
+		return "", store.ErrNotFound
+	}
+	return r, nil
+}
+func (f *fakeStore) WorldEventConfigVersion(context.Context) (int64, error) {
+	return f.version, nil
+}
+func (f *fakeStore) WorldEventConfig(context.Context) (domain.WorldEventConfig, error) {
+	return f.cfg, nil
+}
+func (f *fakeStore) UpsertWorldEventConfig(_ context.Context, cfg domain.WorldEventConfig, moderatorID int64) error {
+	f.setCfg, f.setBy, f.set = cfg, moderatorID, true
+	return nil
+}
+
+func newFake() *fakeStore {
+	return &fakeStore{
+		roles:   map[int64]string{1: "moderator", 2: "admin", 3: "player"},
+		version: 7,
+		cfg:     domain.WorldEventConfig{NoticeEnabled: true, DoubleExpEnabled: true},
+	}
+}
+
+func TestAuthorization(t *testing.T) {
+	tests := []struct {
+		name      string
+		moderator int64
+		want      Result
+	}{
+		{"moderator", 1, OK},
+		{"admin", 2, OK},
+		{"player", 3, Forbidden},
+		{"missing", 99, Forbidden},
+		{"zero", 0, Forbidden},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := New(newFake())
+			if r, _, _, err := s.Get(context.Background(), tc.moderator); err != nil || r != tc.want {
+				t.Errorf("Get = (%v,%v), want %v", r, err, tc.want)
+			}
+			if r, err := s.Set(context.Background(), tc.moderator, domain.WorldEventConfig{}); err != nil || r != tc.want {
+				t.Errorf("Set = (%v,%v), want %v", r, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetReturnsVersionAndConfig(t *testing.T) {
+	s := New(newFake())
+	res, version, cfg, err := s.Get(context.Background(), 1)
+	if err != nil || res != OK {
+		t.Fatalf("Get = (%v,%v), want OK", res, err)
+	}
+	if version != 7 || !cfg.NoticeEnabled || !cfg.DoubleExpEnabled {
+		t.Errorf("Get version/config = %d/%+v, want version 7 with flags", version, cfg)
+	}
+}
+
+func TestSetValidation(t *testing.T) {
+	valid := domain.WorldEventConfig{
+		Enabled: true, ItemIndex: 777, Rate: 10,
+		StartIndex: 100, CurrentIndex: 100, EndIndex: 200,
+		Indexed: true, NoticeEnabled: true,
+	}
+	bad := []domain.WorldEventConfig{
+		{Enabled: true, ItemIndex: 0, Rate: 10, StartIndex: 1, CurrentIndex: 1, EndIndex: 2},
+		{Enabled: true, ItemIndex: maxWorldEventItemIndex + 1, Rate: 10, StartIndex: 1, CurrentIndex: 1, EndIndex: 2},
+		{Enabled: true, ItemIndex: 1, Rate: 0, StartIndex: 1, CurrentIndex: 1, EndIndex: 2},
+		{Enabled: true, ItemIndex: 1, Rate: 1, StartIndex: 0, CurrentIndex: 0, EndIndex: 2},
+		{Enabled: true, ItemIndex: 1, Rate: 1, StartIndex: 10, CurrentIndex: 9, EndIndex: 20},
+		{Enabled: true, ItemIndex: 1, Rate: 1, StartIndex: 10, CurrentIndex: 21, EndIndex: 20},
+	}
+
+	st := newFake()
+	s := New(st)
+	if r, err := s.Set(context.Background(), 1, valid); err != nil || r != OK {
+		t.Fatalf("Set(valid) = (%v,%v), want OK", r, err)
+	}
+	if !st.set || st.setBy != 1 || st.setCfg.ItemIndex != 777 {
+		t.Fatalf("store set = %v by %d cfg %+v, want item 777 by moderator 1", st.set, st.setBy, st.setCfg)
+	}
+	for _, cfg := range bad {
+		st.set = false
+		if r, err := s.Set(context.Background(), 1, cfg); err != nil || r != Invalid {
+			t.Errorf("Set(%+v) = (%v,%v), want Invalid", cfg, r, err)
+		}
+		if st.set {
+			t.Errorf("Set(%+v) wrote to store despite Invalid", cfg)
+		}
+	}
+}
+
+func TestSetAllowsExpOnlyConfig(t *testing.T) {
+	st := newFake()
+	s := New(st)
+	cfg := domain.WorldEventConfig{DoubleExpEnabled: true, NewbieEventEnabled: true}
+	if r, err := s.Set(context.Background(), 1, cfg); err != nil || r != OK {
+		t.Fatalf("Set(exp-only) = (%v,%v), want OK", r, err)
+	}
+	if !st.setCfg.DoubleExpEnabled || !st.setCfg.NewbieEventEnabled {
+		t.Errorf("set cfg = %+v, want exp flags preserved", st.setCfg)
+	}
+}


### PR DESCRIPTION
## Summary
- add portal-managed world event config persistence, audit/versioning, and gRPC admin/read APIs
- wire tmserver boot/polling to apply EXP event flags and global indexed drops
- persist event progress asynchronously with expected-version protection

## Tests
- make proto
- go test ./...
- make test
- go test -tags=integration ./internal/store