### PR TITLE
Fix Poção Divina buff timer showing absurd duration

### DIFF
--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -1252,8 +1252,13 @@ func magicBeanSlotWritable(ef world.Effect, remover bool) bool {
 }
 
 // sendAffect pushes MSG_SendAffect (0x03B9): the full 32-slot buff snapshot, so the
-// client renders the buff icons/timers. The Divine slot's displayed Time is the
-// remaining seconds until DivineEnd (SendFunc.cpp:1901, captura §D).
+// client renders the buff icons/timers. Time is ticks of 8 real seconds for every
+// slot (affect1H=450, affect1D=10800); Divine's stored Affect.Time is only the
+// "infinite" display sentinel (divineAffectTime) — the real deadline is DivineEnd
+// (wall clock), so the displayed Time is recomputed here as the remaining seconds
+// ÷ 8. Sending the raw remaining seconds (or, once DivineEnd had passed, letting
+// the raw 2e9 sentinel fall through unconverted) showed a wildly inflated
+// duration — issue #202.
 func (d *Dispatcher) sendAffect(w *world.World, s *world.Session, e *world.Entity) {
 	now := time.Now().Unix()
 	var a [protocol.MaxAffect]protocol.AffectData
@@ -1263,8 +1268,11 @@ func (d *Dispatcher) sendAffect(w *world.World, s *world.Session, e *world.Entit
 			continue
 		}
 		ad := protocol.AffectData{Type: af.Type, Value: af.Value, Level: af.Level, Time: af.Time}
-		if af.Type == world.AffectDivine && e.DivineEnd > now {
-			ad.Time = uint32(e.DivineEnd - now)
+		if af.Type == world.AffectDivine && af.Time >= affectInfiniteTime {
+			ad.Time = 0
+			if remaining := e.DivineEnd - now; remaining > 0 {
+				ad.Time = uint32(remaining / 8)
+			}
 		}
 		a[i] = ad
 	}

--- a/tmserver/internal/handler/item_test.go
+++ b/tmserver/internal/handler/item_test.go
@@ -793,6 +793,35 @@ func TestDivineAffectBonus(t *testing.T) {
 	}
 }
 
+// TestSendAffectDivineTicksNotRawSeconds is the issue #202 regression: a Poção
+// Divina's displayed remaining time must reach the client as ticks-of-8s, like
+// every other buff (affect1H=450/h, affect1D=10800/day) — sendAffect used to send
+// the raw DivineEnd-now seconds difference instead, inflating the displayed
+// duration 8x (and, once DivineEnd had passed, letting the raw 2e9 "infinite"
+// sentinel leak through unconverted, showing a wildly garbled duration).
+func TestSendAffectDivineTicksNotRawSeconds(t *testing.T) {
+	db := newDB()
+	const remainingSeconds = 10 * 86400 // a 10-day-remaining Divine buff
+	db.loadResult = world.CharacterState{
+		Slot: 0, Name: "Divine", X: 5, Y: 5, HP: 1000, MaxHP: 1000,
+		DivineEnd: time.Now().Unix() + remainingSeconds,
+	}
+	addr, stop := startServerClockVol(t, db, nil)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	affect := expect(t, c, protocol.MsgSendAffect)
+	if affect[0] != world.AffectDivine {
+		t.Fatalf("slot 0 affect type = %d, want %d (Divine)", affect[0], world.AffectDivine)
+	}
+	ticks := int64(binary.LittleEndian.Uint32(affect[4:8]))
+	if diff := ticks*8 - remainingSeconds; diff < -16 || diff > 16 {
+		t.Errorf("divine affect Time = %d ticks (%ds of 8s-ticks), want ~%ds remaining (diff %ds) — "+
+			"raw seconds or the infinite sentinel leaked onto the wire", ticks, ticks*8, remainingSeconds, diff)
+	}
+}
+
 // TestVigorAffectBonus verifies Poção de Vigor (Affect 35) adds +10% MaxHp/MaxMp.
 func TestVigorAffectBonus(t *testing.T) {
 	e := &world.Entity{BaseMaxHP: 1000, BaseMaxMP: 500}


### PR DESCRIPTION
## Summary
- `sendAffect` (tmserver/internal/handler/item.go) sent the Poção Divina buff's remaining time as raw seconds on the wire, instead of the 8-second ticks every other buff uses (affect1H=450, affect1D=10800) — an 8x inflation.
- Once `DivineEnd` had passed (or was unset), the code fell through to the raw `af.Time`, which for Divine is always the `divineAffectTime` (2e9) "infinite" display sentinel — leaking a multi-hundred-thousand-day value straight to the client. This matches the garbled duration shown in issue #202's screenshot.
- Fix: recompute the Divine slot's displayed `Time` as `(DivineEnd - now) / 8` ticks, sending `0` once the deadline has passed instead of the raw sentinel.
- No changes needed to the skill-cast duration pipeline (`skilldata.go`, `world/affect.go`, `combat.go`) — verified against the legacy source and already correctly tuned by issue #92.

Fixes #202

## Test plan
- [x] New regression test `TestSendAffectDivineTicksNotRawSeconds` (tmserver/internal/handler/item_test.go) — verified it fails against the old code and passes with the fix.
- [x] `go test -race ./tmserver/...` — all packages pass.
- [x] `go vet ./...` and `golangci-lint run` — clean.
- [x] `gofmt -l` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)