### PR TITLE
fix(tmserver): prevent consumable item resync rollback

### DIFF
--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -307,26 +307,35 @@ func (d *Dispatcher) splitItem(w *world.World, s *world.Session, _ protocol.Head
 	d.sendSlot(w, s, world.ItemPlaceCarry, slot, *src)
 }
 
-// Divine consumable classes (EF_VOLATILE value): the Poção Divina of 7/15/30 days.
-// The buff (Affect 34) lasts these many days; the real deadline is Entity.DivineEnd.
+// Consumable classes (EF_VOLATILE value). Divine's Affect 34 uses Entity.DivineEnd
+// as the real deadline; the other timed buffs store their duration in Affect.Time.
 const (
-	volHpMpPotion   = 1
-	volFairyDust    = 7
-	volRecallScroll = 11 // Pergaminho do Retorno: recalls to the last-city spawn
-	volGemaEstelar  = 12 // Gema Estelar: records the warp save-point
-	volPortalScroll = 13 // Pergaminho de Portal: teleports to the save-point
-	volVigor        = 58
-	volFrango       = 63
-	volDivine7      = 64
-	volDivine30     = 66
-	volGemDiamond   = 180
-	volGemEmerald   = 181
-	volGemCoral     = 182
-	volGemGarnet    = 183
-	volSilverBar    = 185
-	volMagicBean    = 186
-	volPaint        = volMagicBean
-	volExpChest     = 198
+	volHpMpPotion    = 1
+	volFairyDust     = 7
+	volBuffKappa     = 10
+	volRecallScroll  = 11 // Pergaminho do Retorno: recalls to the last-city spawn
+	volGemaEstelar   = 12 // Gema Estelar: records the warp save-point
+	volPortalScroll  = 13 // Pergaminho de Portal: teleports to the save-point
+	volBuffCombat    = 52
+	volBuffMental    = 53
+	volBuffKappa30   = 55
+	volBuffCombat60  = 56
+	volBuffMental60  = 57
+	volVigor         = 58
+	volFrango        = 63
+	volDivine7       = 64
+	volDivine30      = 66
+	volGemDiamond    = 180
+	volGemEmerald    = 181
+	volGemCoral      = 182
+	volGemGarnet     = 183
+	volSilverBar     = 185
+	volMagicBean     = 186
+	volPaint         = volMagicBean
+	volExpChest      = 198
+	volBuffKappa20h  = 200
+	volBuffCombat20h = 201
+	volBuffMental20h = 202
 	// affect tick units (Basedef.h): one tick = 8s of real time.
 	affect1H          = 450
 	affect1D          = 10800
@@ -376,8 +385,8 @@ const potionDelay = 100
 // useItem handles _MSG_UseItem (0x0373), handlers/_MSG_UseItem.md. The action is
 // classified by the source item's EF_VOLATILE value (BASE_GetItemAbility, captura §B):
 // 0 = equip (CARRY → EQUIP); 11 = Retorno (recall); 12/13 = Gema Estelar/Portal
-// (warp save-point, issue #140); 64-66 = Poção Divina; other consumables are
-// UNVERIFIED and not handled yet.
+// (warp save-point, issue #140); 64-66 = Poção Divina. Unknown consumables are
+// rejected with a slot resync instead of silently no-op'ing.
 // Drag-and-drop between slots is a different message (tradingItem).
 func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header, payload []byte) {
 	e := w.Entity(s.Conn)
@@ -431,6 +440,8 @@ func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header
 		d.useSkillBook(w, s, e, src, vol)
 	case vol == volFairyDust:
 		d.useFairyDust(w, s, e, src)
+	case isLegacyBuffConsumableVol(vol):
+		d.useLegacyBuffConsumable(w, s, e, src, vol)
 	case vol == volExpChest:
 		d.useExpChest(w, s, e, src)
 	case vol >= volDivine7 && vol <= volDivine30:
@@ -465,7 +476,21 @@ func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header
 		// shows a consumption the next slot resync would revert.
 		d.rejectUnimplementedConsumable(w, s, e, src)
 	default:
-		// UNVERIFIED consumable (scrolls/teleport/pet food/keys) — not handled yet.
+		// issue #204: do not silently no-op unknown consumables. The client may
+		// optimistically remove them, then the next slot resync (buy/move/save)
+		// appears to bring the item back.
+		d.rejectUnimplementedConsumable(w, s, e, src)
+	}
+}
+
+func isLegacyBuffConsumableVol(vol int) bool {
+	switch vol {
+	case volBuffKappa, volBuffKappa30, volBuffKappa20h,
+		volBuffCombat, volBuffCombat60, volBuffCombat20h,
+		volBuffMental, volBuffMental60, volBuffMental20h:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -579,6 +604,92 @@ func (d *Dispatcher) useSkillBook(w *world.World, s *world.Session, e *world.Ent
 	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
 	d.sendEtc(w, s, e)
 	d.log.Info("sephira book learned", "conn", s.Conn, "bit", vol-7)
+}
+
+const (
+	affectLegacyConsumableBuff = 4
+	legacyBuffKappa            = 1
+	legacyBuffCombat           = 2
+	legacyBuffMental           = 3
+	legacyBuffSephira          = 4
+	legacyBuffAntidote         = 5
+)
+
+func legacyBuffConsumableEffect(index int16) (value uint8, ticks uint32, ok bool) {
+	ticks = 80
+	switch index {
+	case 787, 3310, 3319:
+		value = legacyBuffKappa
+	case 1764, 3311, 3320:
+		value = legacyBuffCombat
+	case 1765, 3312, 3321:
+		value = legacyBuffMental
+	case 3361, 3362, 3363:
+		value = legacyBuffSephira
+	case 416:
+		value = legacyBuffAntidote
+	default:
+		return 0, 0, false
+	}
+
+	switch index {
+	case 3310:
+		ticks = affect1H / 2
+	case 3311, 3312:
+		ticks = affect1H
+	case 3319, 3320, 3321:
+		ticks = affect1H * 20
+	case 3361:
+		ticks = affect1H * 168
+	case 3362:
+		ticks = affect1H * 360
+	case 3363:
+		ticks = affect1H * 720
+	case 416:
+		ticks = affect1H / 2
+	}
+	return value, ticks, true
+}
+
+func legacyBuffConsumableSlot(e *world.Entity, value uint8) int {
+	for i := range e.Affect {
+		if e.Affect[i].Type == affectLegacyConsumableBuff && e.Affect[i].Value == value {
+			return i
+		}
+	}
+	for i := range e.Affect {
+		if e.Affect[i].Type == 0 {
+			return i
+		}
+	}
+	return -1
+}
+
+// useLegacyBuffConsumable ports _MSG_UseItem.cpp:1215-1341: Kappa,
+// Combatente, Mental, Sephira and Antidoto share Affect type 4 and differ by
+// Value/Time. The slot lookup is narrower than GetEmptyAffect: only an existing
+// type-4 slot with the same Value may be refreshed.
+func (d *Dispatcher) useLegacyBuffConsumable(w *world.World, s *world.Session, e *world.Entity, src, vol int) {
+	itemIdx := e.Carry[src].Index
+	value, ticks, ok := legacyBuffConsumableEffect(itemIdx)
+	if !ok {
+		d.rejectUnimplementedConsumable(w, s, e, src)
+		return
+	}
+	slot := legacyBuffConsumableSlot(e, value)
+	if slot < 0 {
+		d.notify(w, s, NoticeCantEatMore)
+		d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
+		return
+	}
+
+	e.Affect[slot] = world.Affect{Type: affectLegacyConsumableBuff, Value: value, Time: ticks}
+	consumeOneItem(&e.Carry[src])
+	d.refreshScore(e)
+	d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
+	d.sendScore(w, s, e)
+	d.sendAffect(w, s, e)
+	d.log.Info("legacy buff consumable used", "conn", s.Conn, "item", itemIdx, "vol", vol, "value", value, "time", ticks)
 }
 
 // equipItem is the CARRY → EQUIP path of _MSG_UseItem (Vol==0 items).

--- a/tmserver/internal/handler/item_test.go
+++ b/tmserver/internal/handler/item_test.go
@@ -1382,6 +1382,113 @@ func TestUseFrangoAssado(t *testing.T) {
 	}
 }
 
+func TestUseLegacyBuffConsumables(t *testing.T) {
+	cases := []struct {
+		name      string
+		item      int16
+		vol       int
+		wantValue uint8
+		wantTime  uint32
+	}{
+		{"kappa", 787, volBuffKappa, legacyBuffKappa, 80},
+		{"kappa 30m", 3310, volBuffKappa30, legacyBuffKappa, affect1H / 2},
+		{"kappa 20h", 3319, volBuffKappa20h, legacyBuffKappa, affect1H * 20},
+		{"combat", 1764, volBuffCombat, legacyBuffCombat, 80},
+		{"combat 60m", 3311, volBuffCombat60, legacyBuffCombat, affect1H},
+		{"combat 20h", 3320, volBuffCombat20h, legacyBuffCombat, affect1H * 20},
+		{"mental", 1765, volBuffMental, legacyBuffMental, 80},
+		{"mental 60m", 3312, volBuffMental60, legacyBuffMental, affect1H},
+		{"mental 20h", 3321, volBuffMental20h, legacyBuffMental, affect1H * 20},
+		{"sephira 7d", 3361, volBuffMental20h, legacyBuffSephira, affect1H * 168},
+		{"sephira 15d", 3362, volBuffMental20h, legacyBuffSephira, affect1H * 360},
+		{"sephira 30d", 3363, volBuffMental20h, legacyBuffSephira, affect1H * 720},
+		{"antidote", 416, volBuffKappa, legacyBuffAntidote, affect1H / 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := newDB()
+			st := world.CharacterState{Slot: 0, Name: "Hero", X: 5, Y: 5, HP: 1000, MaxHP: 1000}
+			st.Carry[0] = world.Item{Index: tc.item, Effects: [3]world.Effect{{Effect: efAmount, Value: 5}}}
+			db.loadResult = st
+			addr, stop := startServerClockVol(t, db, map[int]int{int(tc.item): tc.vol})
+			defer stop()
+			c := enterWorld(t, addr)
+			defer c.Close()
+
+			body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+			send(t, c, protocol.MsgUseItem, body.Encode())
+
+			item := expect(t, c, protocol.MsgSendItem)
+			if le16(item[4:6]) != uint16(tc.item) || item[6] != efAmount || item[7] != 4 {
+				t.Fatalf("after use item = %d effects (%d,%d), want %d (%d,4)", le16(item[4:6]), item[6], item[7], tc.item, efAmount)
+			}
+			expect(t, c, protocol.MsgUpdateScore)
+			affect := expect(t, c, protocol.MsgSendAffect)
+			if affect[0] != affectLegacyConsumableBuff || affect[1] != tc.wantValue {
+				t.Errorf("affect = type %d value %d, want type %d value %d", affect[0], affect[1], affectLegacyConsumableBuff, tc.wantValue)
+			}
+			if got := binary.LittleEndian.Uint32(affect[4:8]); got != tc.wantTime {
+				t.Errorf("affect time = %d, want %d", got, tc.wantTime)
+			}
+		})
+	}
+}
+
+func TestUseLegacyBuffConsumableFullAffectsDoesNotConsume(t *testing.T) {
+	db := newDB()
+	st := world.CharacterState{Slot: 0, Name: "Hero", X: 5, Y: 5, HP: 1000, MaxHP: 1000}
+	st.Carry[0] = world.Item{Index: 3310, Effects: [3]world.Effect{{Effect: efAmount, Value: 5}}}
+	st.Affects = make([]world.Affect, world.MaxAffect)
+	for i := range st.Affects {
+		st.Affects[i] = world.Affect{Type: uint8(50 + i), Time: 100}
+	}
+	db.loadResult = st
+	addr, stop := startServerClockVol(t, db, map[int]int{3310: volBuffKappa30})
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+	for {
+		if _, _, ok := readMaybe(t, c); !ok {
+			break
+		}
+	}
+
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+
+	notice := expect(t, c, protocol.MsgMessageBoxOk)
+	if noticeCode(t, notice) != NoticeCantEatMore {
+		t.Errorf("notice = %d, want NoticeCantEatMore", noticeCode(t, notice))
+	}
+	item := expect(t, c, protocol.MsgSendItem)
+	if le16(item[4:6]) != 3310 || item[6] != efAmount || item[7] != 5 {
+		t.Errorf("rejected item = %d effects (%d,%d), want 3310 (%d,5)", le16(item[4:6]), item[6], item[7], efAmount)
+	}
+}
+
+func TestUseUnknownVolatileRejectedAndResynced(t *testing.T) {
+	db := newDB()
+	st := world.CharacterState{Slot: 0, Name: "Hero", X: 5, Y: 5, HP: 1000, MaxHP: 1000}
+	st.Carry[0] = world.Item{Index: 496, Effects: [3]world.Effect{{Effect: efAmount, Value: 5}}}
+	db.loadResult = st
+	addr, stop := startServerClockVol(t, db, map[int]int{496: 60})
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+
+	notice := expect(t, c, protocol.MsgMessageBoxOk)
+	if noticeCode(t, notice) != NoticeCantUseHere {
+		t.Errorf("notice = %d, want NoticeCantUseHere", noticeCode(t, notice))
+	}
+	item := expect(t, c, protocol.MsgSendItem)
+	if le16(item[4:6]) != 496 || item[6] != efAmount || item[7] != 5 {
+		t.Errorf("resynced item = %d effects (%d,%d), want 496 (%d,5)", le16(item[4:6]), item[6], item[7], efAmount)
+	}
+}
+
 // TestUseCoracaoDoce is the issue #135 regression for the Vol-205 consumable:
 // it grants Velocidade (Affect 2) + Defesa (Affect 11) and actually decrements
 // the stack (previously a no-op, since Vol 205 had no useItem case).

--- a/tmserver/internal/handler/shop_test.go
+++ b/tmserver/internal/handler/shop_test.go
@@ -23,12 +23,17 @@ func shopDB(coin int32) *fakeDB {
 
 func startServerShop(t *testing.T, persist world.Persistence, prices map[int]int32) (string, func()) {
 	t.Helper()
+	return startServerShopItems(t, persist, prices, nil)
+}
+
+func startServerShopItems(t *testing.T, persist world.Persistence, prices map[int]int32, vols map[int]int) (string, func()) {
+	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
-	d := New(Config{Log: log, ItemPrices: prices})
+	d := New(Config{Log: log, ItemPrices: prices, ItemVolatiles: vols})
 	w := world.New(world.Config{GridDim: 16}, log, persist, d.Handle)
 
 	tmpl := make([]byte, 816)
@@ -142,6 +147,36 @@ func TestBuyOccupiedSlotResync(t *testing.T) {
 	}
 	if ty, _, ok := readMaybe(t, c); ok {
 		t.Errorf("occupied-slot buy also produced %#x; should only re-sync", ty)
+	}
+}
+
+func TestBuyAfterConsumableUseResyncsReducedStack(t *testing.T) {
+	db := newDB()
+	st := world.CharacterState{Slot: 0, Name: "Hero", X: 5, Y: 5, HP: 1000, MaxHP: 1000, Coin: 1234}
+	st.Carry[0] = world.Item{Index: 3310, Effects: [3]world.Effect{{Effect: efAmount, Value: 5}}}
+	db.loadResult = st
+	addr, stop := startServerShopItems(t, db, map[int]int32{1100: 0}, map[int]int{3310: volBuffKappa30})
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+	used := expect(t, c, protocol.MsgSendItem)
+	if le16(used[4:6]) != 3310 || used[6] != efAmount || used[7] != 4 {
+		t.Fatalf("after use item = %d effects (%d,%d), want 3310 (%d,4)", le16(used[4:6]), used[6], used[7], efAmount)
+	}
+	expect(t, c, protocol.MsgUpdateScore)
+	expect(t, c, protocol.MsgSendAffect)
+
+	buyFrame(t, c, shopNPCID, 0, 0)
+	item := expect(t, c, protocol.MsgSendItem)
+	if le16(item[2:4]) != 0 || le16(item[4:6]) != 3310 || item[6] != efAmount || item[7] != 4 {
+		t.Errorf("shop resync item slot=%d index=%d effects (%d,%d), want slot 0 item 3310 (%d,4)",
+			le16(item[2:4]), le16(item[4:6]), item[6], item[7], efAmount)
+	}
+	if ty, _, ok := readMaybe(t, c); ok {
+		t.Errorf("occupied-slot buy after use also produced %#x; should only re-sync", ty)
 	}
 }
 


### PR DESCRIPTION
## Summary
- port legacy Kappa/Combatente/Mental/Sephira/Antidoto consumable buff handling
- consume and resync supported stacks server-side so shop/move/save resyncs keep reduced amounts
- reject unknown volatile consumables with slot resync instead of silent no-op

## Tests
- go test ./tmserver/internal/handler -run 'TestUseLegacyBuffConsumables|TestUseLegacyBuffConsumableFullAffectsDoesNotConsume|TestUseUnknownVolatileRejectedAndResynced|TestBuyAfterConsumableUseResyncsReducedStack'
- make test