### PR TITLE
feat(tmserver): implement Entrada do Território (LAN) entrance item

### DIFF
--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -310,32 +310,33 @@ func (d *Dispatcher) splitItem(w *world.World, s *world.Session, _ protocol.Head
 // Consumable classes (EF_VOLATILE value). Divine's Affect 34 uses Entity.DivineEnd
 // as the real deadline; the other timed buffs store their duration in Affect.Time.
 const (
-	volHpMpPotion    = 1
-	volFairyDust     = 7
-	volBuffKappa     = 10
-	volRecallScroll  = 11 // Pergaminho do Retorno: recalls to the last-city spawn
-	volGemaEstelar   = 12 // Gema Estelar: records the warp save-point
-	volPortalScroll  = 13 // Pergaminho de Portal: teleports to the save-point
-	volBuffCombat    = 52
-	volBuffMental    = 53
-	volBuffKappa30   = 55
-	volBuffCombat60  = 56
-	volBuffMental60  = 57
-	volVigor         = 58
-	volFrango        = 63
-	volDivine7       = 64
-	volDivine30      = 66
-	volGemDiamond    = 180
-	volGemEmerald    = 181
-	volGemCoral      = 182
-	volGemGarnet     = 183
-	volSilverBar     = 185
-	volMagicBean     = 186
-	volPaint         = volMagicBean
-	volExpChest      = 198
-	volBuffKappa20h  = 200
-	volBuffCombat20h = 201
-	volBuffMental20h = 202
+	volHpMpPotion        = 1
+	volFairyDust         = 7
+	volBuffKappa         = 10
+	volRecallScroll      = 11 // Pergaminho do Retorno: recalls to the last-city spawn
+	volGemaEstelar       = 12 // Gema Estelar: records the warp save-point
+	volPortalScroll      = 13 // Pergaminho de Portal: teleports to the save-point
+	volBuffCombat        = 52
+	volBuffMental        = 53
+	volBuffKappa30       = 55
+	volBuffCombat60      = 56
+	volBuffMental60      = 57
+	volVigor             = 58
+	volFrango            = 63
+	volDivine7           = 64
+	volDivine30          = 66
+	volGemDiamond        = 180
+	volGemEmerald        = 181
+	volGemCoral          = 182
+	volGemGarnet         = 183
+	volSilverBar         = 185
+	volMagicBean         = 186
+	volPaint             = volMagicBean
+	volEntradaTerritorio = 188 // Entrada do Território (LAN) ticket (_MSG_UseItem.cpp:4202)
+	volExpChest          = 198
+	volBuffKappa20h      = 200
+	volBuffCombat20h     = 201
+	volBuffMental20h     = 202
 	// affect tick units (Basedef.h): one tick = 8s of real time.
 	affect1H          = 450
 	affect1D          = 10800
@@ -367,6 +368,11 @@ const (
 	// dispatcher — identify them by sIndex instead (_MSG_UseItem.cpp:3184,3325).
 	itemSeloDoGuerreiro = 4146
 	itemPedraMisteriosa = 4148
+
+	// Entrada do Território (LAN) tickets — three tiers sharing EF_VOLATILE 188,
+	// distinguished by sIndex: (N)=4111, (M)=4112, (A)=4113. Tier = sIndex - base
+	// (_MSG_UseItem.cpp:4204).
+	itemEntradaTerritorioBase = 4111
 )
 
 // volClasses (Classes A-E, _MSG_UseItem.cpp:4959) is handled by useClasseItem
@@ -468,6 +474,8 @@ func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header
 		d.useCoracaoDoce(w, s, e, src)
 	case vol == volClasses:
 		d.useClasseItem(w, s, e, body, src)
+	case vol == volEntradaTerritorio:
+		d.useEntradaTerritorio(w, s, e, src)
 	case vol >= volWaterMLo && vol <= volWaterMHi,
 		vol >= volWaterNLo && vol <= volWaterNHi,
 		vol >= volWaterALo && vol <= volWaterAHi:
@@ -812,6 +820,56 @@ func (d *Dispatcher) usePortalScroll(w *world.World, s *world.Session, e *world.
 	consumeOneItem(&e.Carry[src])
 	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
 	d.doTeleport(w, s, e.SaveX, e.SaveY)
+}
+
+// useEntradaTerritorio consumes an "Entrada do Território" (LAN) ticket
+// (EF_VOLATILE 188) and teleports the player into the matching Lan_N/M/A region,
+// porting _MSG_UseItem.cpp:4202-4236. The tier is the item's sIndex minus the
+// (N) base (4111→0, 4112→1, 4113→2); each tier lands at a fixed coordinate on
+// map 0 with a rand()%5-3 spread per axis, inside the region bounds declared in
+// Release/TMsrv/run/Regions.txt:45-47 (Lan_N/M/A).
+//
+// The gate matches legacy exactly — class tier only, no citizenship check: tiers
+// N/M (0,1) require ClassMaster Arch or Mortal; tier A (>=2) requires a celestial
+// tier. On a class mismatch the legacy code re-sends the slot and returns without
+// consuming; we do the same (plus a NoticeReqNotMet, as the other ticket handlers
+// do). In practice only N/M fire today: no character reaches a celestial
+// ClassMaster until the deferred celestial evolution system lands
+// (docs/migration/celestial-system-plan.md), but the (A) gate is ported faithfully
+// so it works automatically once that exists.
+func (d *Dispatcher) useEntradaTerritorio(w *world.World, s *world.Session, e *world.Entity, src int) {
+	territorio := int(e.Carry[src].Index) - itemEntradaTerritorioBase
+
+	reject := func() {
+		d.notify(w, s, NoticeReqNotMet)
+		w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
+	}
+	if territorio <= 1 {
+		if e.ClassMaster != classMasterArch && e.ClassMaster != classMasterMortal {
+			reject()
+			return
+		}
+	} else if e.ClassMaster != classMasterCelestial && e.ClassMaster != classMasterCelestialCS && e.ClassMaster != classMasterSCelestial {
+		reject()
+		return
+	}
+
+	var bx, by int16
+	switch territorio {
+	case 0:
+		bx, by = 3639, 3639
+	case 1:
+		bx, by = 3782, 3527
+	default:
+		bx, by = 3911, 3655
+	}
+	// rand()%5 - 3 per axis, X then Y, to preserve the legacy call order/spread.
+	x := bx + int16(w.Rand().Intn(5)) - 3
+	y := by + int16(w.Rand().Intn(5)) - 3
+
+	consumeOneItem(&e.Carry[src])
+	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
+	d.doTeleport(w, s, x, y)
 }
 
 // useHealPotion consumes an HP/MP potion (EF_VOLATILE 1), porting

--- a/tmserver/internal/handler/item_test.go
+++ b/tmserver/internal/handler/item_test.go
@@ -318,6 +318,94 @@ func TestUseItemEquip(t *testing.T) {
 	}
 }
 
+func territorioDB(item int16, classMaster uint8) *fakeDB {
+	db := newDB()
+	st := world.CharacterState{Slot: 0, Name: "Hero", X: 5, Y: 5, HP: 1000, MaxHP: 1000, ClassMaster: classMaster}
+	st.Carry[0] = world.Item{Index: item}
+	db.loadResult = st
+	return db
+}
+
+// TestUseEntradaTerritorio covers the Vol-188 "Entrada do Território" (LAN)
+// tickets (issue #203, _MSG_UseItem.cpp:4202-4236): the right class tier teleports
+// into the matching Lan_N/M/A coords (center ± [-3,+1] per axis) and consumes one;
+// the wrong tier is rejected with a slot resync and no teleport.
+func TestUseEntradaTerritorio(t *testing.T) {
+	tests := []struct {
+		name         string
+		item         int16
+		classMaster  uint8
+		wantTeleport bool
+		wantX, wantY int16
+	}{
+		{"normal_mortal", 4111, classMasterMortal, true, 3639, 3639},
+		{"medio_mortal", 4112, classMasterMortal, true, 3782, 3527},
+		{"avancado_celestial", 4113, classMasterCelestial, true, 3911, 3655},
+		{"avancado_mortal_rejected", 4113, classMasterMortal, false, 0, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			db := territorioDB(tc.item, tc.classMaster)
+			addr, stop := startServerClockVol(t, db, map[int]int{int(tc.item): volEntradaTerritorio})
+			defer stop()
+			c := enterWorld(t, addr)
+			defer c.Close()
+
+			body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+			send(t, c, protocol.MsgUseItem, body.Encode())
+
+			var sawTeleport, sawConsume, sawKeep bool
+			var gotX, gotY int16
+			for {
+				ty, payload, ok := readMaybe(t, c)
+				if !ok {
+					break
+				}
+				switch ty {
+				case protocol.MsgAction:
+					var ab protocol.MsgActionBody
+					if err := ab.Decode(payload); err != nil {
+						t.Fatalf("decode action: %v", err)
+					}
+					if ab.Effect == 1 {
+						sawTeleport = true
+						gotX, gotY = ab.TargetX, ab.TargetY
+					}
+				case protocol.MsgSendItem:
+					if int(le16(payload[0:2])) != world.ItemPlaceCarry || int(le16(payload[2:4])) != 0 {
+						continue
+					}
+					switch int16(le16(payload[4:6])) {
+					case 0:
+						sawConsume = true
+					case tc.item:
+						sawKeep = true
+					}
+				}
+			}
+
+			if tc.wantTeleport {
+				if !sawTeleport {
+					t.Fatal("expected teleport jump, got none")
+				}
+				if gotX < tc.wantX-3 || gotX > tc.wantX+1 || gotY < tc.wantY-3 || gotY > tc.wantY+1 {
+					t.Errorf("teleport to (%d,%d), want ~(%d,%d) ±[-3,+1]", gotX, gotY, tc.wantX, tc.wantY)
+				}
+				if !sawConsume {
+					t.Error("ticket not consumed")
+				}
+			} else {
+				if sawTeleport {
+					t.Error("rejected ticket teleported the player")
+				}
+				if !sawKeep {
+					t.Error("rejected ticket: expected slot resync keeping the item")
+				}
+			}
+		})
+	}
+}
+
 const (
 	itemMagicBeanBlue    = 3407
 	itemMagicBeanLight   = 3416


### PR DESCRIPTION
## Context

Closes #203. The **"Entrada do Território"** (LAN) tickets — items `4111`/`4112`/`4113` (N/M/A tiers), all with `EF_VOLATILE 188` — did nothing when used. The Go `useItem` dispatch had no case for volatile 188, so the tickets fell through to `default → rejectUnimplementedConsumable`: the player saw nothing happen (no teleport).

## Change

Port the Vol-188 handler from `Source/Code/TMSrv/_MSG_UseItem.cpp:4202-4236` into `useEntradaTerritorio`, mirroring the existing `usePortalScroll` "consume item → teleport" pattern:

- Tier = `sIndex - 4111` (N=0, M=1, A=2).
- **Class-tier gate, matching legacy exactly** (no citizenship check): N/M require `ClassMaster` Arch/Mortal; A requires a celestial tier. On mismatch the slot is resynced and the ticket is **not** consumed.
- Consume one ticket, resync the slot, then `doTeleport` to the tier's fixed coords with the legacy `rand()%5-3` per-axis spread:
  - N → `(3639, 3639)`, M → `(3782, 3527)`, A → `(3911, 3655)` — all inside the `Lan_N/M/A` bounds from `Release/TMsrv/run/Regions.txt:45-47`.

Note: the **(A)** tier requires a celestial `ClassMaster`, which no character reaches until the deferred celestial evolution system lands — so only **(N)/(M)** fire in practice today (the item in the issue is (N)). The (A) gate is ported faithfully so it works automatically once celestial evolution exists.

## Tests

Table-driven `TestUseEntradaTerritorio` exercises the full over-the-wire path (dispatch by volatile → teleport packet + slot resync):

- Mortal + 4111 → jump to ~(3639,3639), consumed
- Mortal + 4112 → ~(3782,3527), consumed
- Celestial + 4113 → ~(3911,3655), consumed
- Mortal + 4113 → **rejected** (no teleport, ticket kept)

`go build ./...`, `go vet`, `golangci-lint` (0 issues), and `go test -race ./tmserver/internal/handler/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)