### PR TITLE
fix(tmserver): items with immunity/resist bonus now apply to the character

### DIFF
--- a/tmserver/internal/content/catalog.go
+++ b/tmserver/internal/content/catalog.go
@@ -68,12 +68,19 @@ type BaseEffect struct {
 // them) — they were misfiled as visual here, which is why crit gear granted nothing
 // (issue #102). Most crit lives in the catalog: the class body items and the armor sets
 // carry EF_CRITICAL directly.
+//
+// EF_RESIST1..4/EF_RESISTALL (ItemEffect.h:106-111) are the same bug class (issue #211):
+// they ARE score stats too (CMob.cpp:640-643 derives MOB.Resist[0..3] from them via
+// BASE_GetMobAbility), so leaving them off this whitelist silently dropped every
+// immunity/resist item's effect at parse time — the items looked correct in the catalog
+// but granted nothing on the character.
 var efName = map[string]uint8{
 	"EF_DAMAGE": 2, "EF_AC": 3, "EF_HP": 4, "EF_MP": 5,
 	"EF_STR": 7, "EF_INT": 8, "EF_DEX": 9, "EF_CON": 10,
 	"EF_SPECIAL1": 11, "EF_SPECIAL2": 12, "EF_SPECIAL3": 13, "EF_SPECIAL4": 14,
 	"EF_POS": 17, "EF_WTYPE": 21, "EF_CRITICAL": 42, "EF_SANC": 43,
-	"EF_HPADD": 45, "EF_MPADD": 46, "EF_ACADD": 53,
+	"EF_HPADD": 45, "EF_MPADD": 46,
+	"EF_RESIST1": 49, "EF_RESIST2": 50, "EF_RESIST3": 51, "EF_RESIST4": 52, "EF_ACADD": 53, "EF_RESISTALL": 54,
 	"EF_DAMAGEADD": 67, "EF_HPADD2": 69, "EF_MPADD2": 70, "EF_CRITICAL2": 71,
 	"EF_ITEMLEVEL": 87, "EF_MOBTYPE": 112, "EF_RUNSPEED": 29,
 	// Refine gates (_MSG_UseItem.cpp dust path): EF_NOSANC marks an item that can

--- a/tmserver/internal/content/content_test.go
+++ b/tmserver/internal/content/content_test.go
@@ -208,6 +208,56 @@ func TestBaseEffectsCritical(t *testing.T) {
 	}
 }
 
+// TestBaseEffectsResist: EF_RESIST1..4/EF_RESISTALL are score stats too (CMob.cpp:640-643
+// derives MOB.Resist[0..3] from them), not ignored ones — missing from efName is what left
+// every immunity/resist item granting nothing (issue #211).
+func TestBaseEffectsResist(t *testing.T) {
+	// Real rows: Bolsa_Perfumada (ItemList.csv:1009, EF_RESISTALL) and Orb_de_Fogo
+	// (ItemList.csv:1013, EF_RESIST1).
+	const rows = "599,Bolsa_Perfumada,319.0,0.0.0.0.0,0,50000,1024,0,0,EF_CLASS,255,EF_RESISTALL,5\n" +
+		"601,Orb_de_Fogo,63.0,37.0.0.0.0,0,30000,1024,0,0,EF_CLASS,255,EF_RESIST1,3,EF_RESIST2,0,EF_RESIST3,0,EF_RESIST4,0,EF_ITEMLEVEL,1\n"
+	l, err := parseItemList(strings.NewReader(rows))
+	if err != nil {
+		t.Fatal(err)
+	}
+	eff := l.BaseEffects()
+	for _, tc := range []struct {
+		idx  int
+		eff  uint8
+		want int16
+	}{{599, 54, 5}, {601, 49, 3}} {
+		var got int16
+		var found bool
+		for _, e := range eff[tc.idx] {
+			if e.Eff == tc.eff {
+				got, found = e.Val, true
+			}
+		}
+		if !found || got != tc.want {
+			t.Errorf("BaseEffects()[%d] EF(%d) = %d (found=%v), want %d", tc.idx, tc.eff, got, found, tc.want)
+		}
+	}
+
+	// The real catalog must actually carry resist — the parser silently dropping it is
+	// what issue #211 was. Guards against the effects disappearing from efName again.
+	full, err := LoadItemList(release(t, "Common", "ItemList.csv"))
+	if err != nil {
+		t.Skipf("ItemList.csv unavailable: %v", err)
+	}
+	var withResist int
+	for _, effs := range full.BaseEffects() {
+		for _, e := range effs {
+			if e.Eff >= 49 && e.Eff <= 52 || e.Eff == 54 {
+				withResist++
+				break
+			}
+		}
+	}
+	if withResist < 20 {
+		t.Errorf("real catalog items carrying EF_RESIST1..4/EF_RESISTALL = %d, want >= 20", withResist)
+	}
+}
+
 // TestBaseEffectsNoSanc: quest/trophy stones (Almas, Pedras, Sephirot) are
 // equippable but carry no EF_VOLATILE, so nothing stopped the dust-refine
 // handler from planting an EF_SANC pair into them (issue #133). ItemList.csv

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -1551,7 +1551,12 @@ const (
 	efSanc      = 43 // EF_SANC: item refine ("anc"/joias) level — gates the +9 threshold, not a flat stat
 	efHpAdd     = 45 // EF_HPADD: % bonus to MaxHp (MaxHp*(HPADD+HPADD2+100)/100), captura §E
 	efMpAdd     = 46 // EF_MPADD: % bonus to MaxMp
+	efResist1   = 49 // EF_RESIST1..4: per-type resist/immunity, see itemResist
+	efResist2   = 50
+	efResist3   = 51
+	efResist4   = 52
 	efAcAdd     = 53 // EF_ACADD: extra AC — FLAT (summed with EF_AC), captura §E
+	efResistAll = 54 // EF_RESISTALL: folds into all four EF_RESISTi — see itemResist
 	efDamageAdd = 67 // EF_DAMAGEADD: extra flat damage — only counts for jewels (nUnique 41-50)
 	efHpAdd2    = 69 // EF_HPADD2/EF_MPADD2: also fold into the HPADD%/MPADD% multiplier
 	efMpAdd2    = 70
@@ -1663,6 +1668,32 @@ func (d *Dispatcher) itemCritical(it world.Item) int32 {
 	return v * int32(sanc+10) / 10
 }
 
+// resistEffects maps resist index [0..3] to its EF_RESISTn id (CMob.cpp:640-643 assigns
+// MOB.Resist[0..3] from EF_RESIST1..4 in that literal order).
+var resistEffects = [4]uint8{efResist1, efResist2, efResist3, efResist4}
+
+// itemResist is BASE_GetItemAbility(item, EF_RESISTn) (Basedef.cpp:1830-1858): the flat
+// catalog+instance sum for the queried resist index, PLUS any EF_RESISTALL folded in from
+// the same item (catalog+instance), THEN the refine multiplier (sanc+10)/10 — EF_RESIST1-4
+// is not in BASE_GetItemAbility's exemption list, so it scales like EF_CRITICAL, not like
+// the flat AC/Damage model (the item.go:1640-1647 TODO scope call doesn't apply here: there
+// is no already-live flat-resist baseline to preserve, since resist items granted nothing
+// before this — issue #211).
+func (d *Dispatcher) itemResist(it world.Item, i int) int32 {
+	if it.Empty() {
+		return 0
+	}
+	v := int32(d.itemAbility(it, resistEffects[i])) + int32(d.itemAbility(it, efResistAll))
+	if v == 0 {
+		return 0
+	}
+	sanc := itemSanc(it)
+	if sanc == refineThreshold && d.itemPos[int(it.Index)]&accessoryPosMask != 0 {
+		sanc = 10
+	}
+	return v * int32(sanc+10) / 10
+}
+
 // weaponDamage is GetCurrentScore's WeaponDamage (CMob.cpp:756-789): the stronger
 // weapon hand at full damage plus the weaker at half (dual-wield), plus a +40 refine
 // threshold per weapon hand at sanc>=9 (captura §E). It is a SEPARATE field from
@@ -1711,6 +1742,9 @@ type equipBonus struct {
 	// effects. magicRaw is the pre-scaling EF_MAGIC sum (see mountMagicScore); resist
 	// applies to all four resistances. damage already folds into the field above.
 	magicRaw, parry, resist int32
+	// itemResist is the per-type EF_RESIST1..4/EF_RESISTALL sum from ordinary equipment
+	// (see itemResist), refine-scaled — distinct from the flat mount broadcast above.
+	itemResist [4]int32
 }
 
 func (d *Dispatcher) equipBonus(e *world.Entity) equipBonus {
@@ -1778,6 +1812,9 @@ func (d *Dispatcher) equipBonus(e *world.Entity) equipBonus {
 		// the refine multiplier are item-wide) — after the mount slot's early return,
 		// which matches BASE_GetItemAbility returning no crit for mounts.
 		b.criticalRaw += d.itemCritical(it)
+		for i := range b.itemResist {
+			b.itemResist[i] += d.itemResist(it, i)
+		}
 		weaponSlot := slot == weaponSlotR || slot == weaponSlotL
 		nUnique := d.itemUnique[int(it.Index)]
 		dmgJewel := nUnique >= 41 && nUnique <= 50
@@ -1815,14 +1852,12 @@ func (d *Dispatcher) deriveBaseScore(e *world.Entity) {
 	e.BaseDamage = e.Damage - b.damage - d.derivedDamageTotal(e, false)
 	e.BaseMaxHP = e.MaxHP - b.maxHP
 	e.BaseMaxMP = e.MaxMP - b.maxMP
-	// Mount bonuses (Magic/Parry/Resist): same subtraction as the fields above so the
-	// loaded CurrentScore round-trips. Players persist no Parry/Resist (loaded 0), so
-	// their base is 0 until a mount is equipped.
+	// Magic (mount bonus): same subtraction as the fields above so the loaded
+	// CurrentScore round-trips.
 	e.BaseMagic = e.Magic - int16(mountMagicScore(b.magicRaw))
-	e.BaseParry = e.Parry - int(b.parry)
-	for i := range e.BaseResist {
-		e.BaseResist[i] = e.Resist[i] - int16(b.resist)
-	}
+	// Parry/Resist have NO base term at all — see refreshScore's comment: unlike Magic,
+	// they are never persisted, so a subtract-then-add "Base" here would net to zero for
+	// a character who logs in already equipped (issue #211 bug 3).
 }
 
 // refreshScore recomputes the live CurrentScore = BaseScore + FLAT equipment, after any
@@ -1857,16 +1892,21 @@ func (d *Dispatcher) refreshScore(e *world.Entity) {
 	// (The low clamp is belt-and-braces: no catalog row carries negative crit, but a
 	// bare uint8 conversion would wrap one into a near-guaranteed crit.)
 	e.Critical = uint8(min(max(b.criticalRaw/4, 0), 255))
-	// Mount bonuses: Magic gets the (sum+1)/4 scaling, Parry (evasion) and each Resist
-	// are flat, with Resist capped at the legacy ceiling (CMob.cpp:640-643,692). Mounts
-	// live only in a player's Equip[14]; mobs carry their Magic/Parry/Resist straight
-	// from their template (world.SpawnMob) and never derive a BaseScore, so recomputing
-	// them here would zero those template values — guard to players.
+	// Mount bonuses: Magic gets the (sum+1)/4 scaling and keeps a BaseMagic term since it
+	// IS persisted. Parry (evasion) and each Resist are derived ENTIRELY from equipment on
+	// every refresh, like Critical above — there is no BaseParry/BaseResist, because
+	// neither is persisted (world.CharacterState omits them), so a character logging in
+	// already equipped would otherwise always compute Base = 0 − equip, then
+	// Current = Base + equip = 0 regardless of gear (issue #211 bug 3). Resist is capped
+	// at the legacy ceiling (CMob.cpp:640-643,692). Mounts live only in a player's
+	// Equip[14]; mobs carry their Magic/Parry/Resist straight from their template
+	// (world.SpawnMob) and never derive a BaseScore, so recomputing them here would zero
+	// those template values — guard to players.
 	if world.IsPlayer(e.ID) {
 		e.Magic = e.BaseMagic + int16(mountMagicScore(b.magicRaw))
-		e.Parry = e.BaseParry + int(b.parry)
+		e.Parry = int(b.parry)
 		for i := range e.Resist {
-			e.Resist[i] = clampResist(e.BaseResist[i] + int16(b.resist))
+			e.Resist[i] = clampResist(int16(b.resist) + int16(b.itemResist[i]))
 		}
 	}
 	d.applyAffectScore(e)

--- a/tmserver/internal/handler/mount_test.go
+++ b/tmserver/internal/handler/mount_test.go
@@ -99,13 +99,14 @@ func TestMountEquipScore(t *testing.T) {
 	}
 }
 
-// TestMountScoreRoundTrip: a mount already equipped at login round-trips — deriveBaseScore
-// then refreshScore reproduces the loaded CurrentScore exactly (no double count).
+// TestMountScoreRoundTrip: a mount already equipped at login round-trips. Damage/Magic
+// have a real BaseDamage/BaseMagic term (persisted, so pre-seeding them here matters);
+// Parry/Resist have NO base term at all (issue #211 bug 3) — they are derived entirely
+// from the current equip bonus on every refresh, so they come out right regardless of
+// whatever a fresh Entity starts with, which is exactly what avoids the login zero-out.
 func TestMountScoreRoundTrip(t *testing.T) {
 	d := New(Config{})
 	e := &world.Entity{ID: 1, Level: 50, Damage: 955, Magic: 60}
-	e.Resist = [4]int16{32, 32, 32, 32}
-	e.Parry = 80
 	e.Equip[0] = world.Item{Index: 11}
 	e.Equip[mountEquipSlot] = world.Item{Index: 3987}
 	d.deriveBaseScore(e)

--- a/tmserver/internal/handler/resist_test.go
+++ b/tmserver/internal/handler/resist_test.go
@@ -1,0 +1,145 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// Item indices used by the resist tests. resistOrb/resistBag mirror the real catalog rows
+// Orb_de_Fogo (601, EF_RESIST1) and Bolsa_Perfumada (599, EF_RESISTALL); the rest are
+// synthetic, mirroring critical_test.go's convention.
+const (
+	resistOrb       = 610 // flat EF_RESIST1 (mirrors Orb_de_Fogo)
+	resistBag       = 611 // flat EF_RESISTALL (mirrors Bolsa_Perfumada)
+	resistBoth      = 612 // EF_RESIST1 + EF_RESISTALL on the same item, for the fold-in case
+	resistDef       = 613 // non-accessory defense slot, for the +9 refine case
+	resistAccessory = 614 // accessory slot (nPos 3840), for the +9 promotion case
+	resistOverflow  = 615 // EF_RESISTALL large enough to require the resistCap clamp
+)
+
+// resistConfig is the catalog the resist tests read: static effects and the nPos each item
+// equips into (the refine promotion keys off nPos & 0xF00, same as criticalConfig).
+func resistConfig() Config {
+	return Config{
+		ItemEffects: map[int][]content.BaseEffect{
+			resistOrb:       {{Eff: efResist1, Val: 3}},
+			resistBag:       {{Eff: efResistAll, Val: 5}},
+			resistBoth:      {{Eff: efResist1, Val: 3}, {Eff: efResistAll, Val: 5}},
+			resistDef:       {{Eff: efResist1, Val: 50}},
+			resistAccessory: {{Eff: efResist1, Val: 10}},
+			resistOverflow:  {{Eff: efResistAll, Val: 500}},
+		},
+		ItemPos: map[int]int{
+			resistDef:       nPosDef1,
+			resistAccessory: 3840, // accessory slots 8-11
+		},
+	}
+}
+
+// TestResistFromEquipment covers BASE_GetItemAbility(item, EF_RESISTn) (Basedef.cpp:
+// 1830-1858) as refreshScore derives it: the EF_RESISTALL fold-in and the refine
+// multiplier, mirroring TestCriticalFromEquipment's shape for EF_CRITICAL.
+func TestResistFromEquipment(t *testing.T) {
+	sanc9 := world.Effect{Effect: efSanc, Value: 9}
+
+	tests := []struct {
+		name  string
+		equip map[int]world.Item
+		want  [4]int16
+	}{
+		{
+			name:  "flat EF_RESIST1 grants only its own index",
+			equip: map[int]world.Item{0: {Index: resistOrb}},
+			want:  [4]int16{3, 0, 0, 0},
+		},
+		{
+			name:  "EF_RESISTALL grants all four",
+			equip: map[int]world.Item{0: {Index: resistBag}},
+			want:  [4]int16{5, 5, 5, 5},
+		},
+		{
+			name:  "EF_RESIST1 and EF_RESISTALL fold together on the same item",
+			equip: map[int]world.Item{0: {Index: resistBoth}},
+			want:  [4]int16{8, 5, 5, 5},
+		},
+		{
+			// Non-accessory +9 → no promotion → x1.9: 50*19/10 = 95.
+			name:  "non-accessory +9 scales x1.9, not x2",
+			equip: map[int]world.Item{0: {Index: resistDef, Effects: [3]world.Effect{sanc9}}},
+			want:  [4]int16{95, 0, 0, 0},
+		},
+		{
+			// Accessory +9 → sanc promoted to 10 → x2.0: 10*20/10 = 20.
+			name:  "accessory +9 doubles resist",
+			equip: map[int]world.Item{8: {Index: resistAccessory, Effects: [3]world.Effect{sanc9}}},
+			want:  [4]int16{20, 0, 0, 0},
+		},
+		{
+			name:  "resistCap clamps at 100",
+			equip: map[int]world.Item{0: {Index: resistOverflow}},
+			want:  [4]int16{100, 100, 100, 100},
+		},
+		{
+			// Mount resist stays on its own flat broadcast channel (mountBonusFor);
+			// itemResist adds on top for ordinary gear equipped alongside it.
+			name: "mount resist and item resist both contribute",
+			equip: map[int]world.Item{
+				0:              {Index: resistOrb},
+				mountEquipSlot: {Index: 3987}, // Thoroughbred(30d): resist 32 flat
+			},
+			want: [4]int16{3 + 32, 32, 32, 32},
+		},
+		{
+			name:  "no resist gear",
+			equip: map[int]world.Item{},
+			want:  [4]int16{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := New(resistConfig())
+			e := &world.Entity{ID: 1, Level: 50}
+			for slot, it := range tt.equip {
+				e.Equip[slot] = it
+			}
+			d.refreshScore(e)
+			if e.Resist != tt.want {
+				t.Errorf("e.Resist = %v, want %v", e.Resist, tt.want)
+			}
+		})
+	}
+}
+
+// TestResistLoginRoundTrip is the issue #211 bug-3 regression: Resist/Parry are never
+// persisted (world.CharacterState omits them), so a character reconnecting with resist
+// gear or a mount already equipped must still show that gear's bonus right after the login
+// sequence (deriveBaseScore then refreshScore, character.go:286,309) — not reset to 0 just
+// because Resist/Parry start at their zero value on a fresh connection (world/event.go:56).
+func TestResistLoginRoundTrip(t *testing.T) {
+	d := New(resistConfig())
+	e := &world.Entity{ID: 1, Level: 50} // fresh connection: Resist/Parry start zero
+	e.Equip[0] = world.Item{Index: resistOrb}
+	e.Equip[mountEquipSlot] = world.Item{Index: 3987}
+	d.deriveBaseScore(e)
+	d.refreshScore(e)
+
+	want := [4]int16{3 + 32, 32, 32, 32}
+	if e.Resist != want {
+		t.Errorf("login Resist = %v, want %v (equipped gear must not reset to 0)", e.Resist, want)
+	}
+	if e.Parry != 80 {
+		t.Errorf("login Parry = %d, want 80", e.Parry)
+	}
+
+	// A later refresh (e.g. an unrelated gear change) must not double-count.
+	d.refreshScore(e)
+	if e.Resist != want {
+		t.Errorf("Resist after second refresh = %v, want %v (must not accumulate)", e.Resist, want)
+	}
+	if e.Parry != 80 {
+		t.Errorf("Parry after second refresh = %d, want 80 (must not accumulate)", e.Parry)
+	}
+}

--- a/tmserver/internal/world/session.go
+++ b/tmserver/internal/world/session.go
@@ -275,12 +275,12 @@ type Entity struct {
 	BaseStr, BaseInt, BaseDex, BaseCon int16
 	BaseAC, BaseDamage                 int32
 	BaseMaxHP, BaseMaxMP               int32
-	// BaseMagic/BaseParry/BaseResist: the equipment-free Magic/Parry(evasion)/Resist,
-	// the mount-bonus counterparts of the Base* fields above. Same policy — derived on
-	// login (current − equipment) and re-added by refreshScore, never persisted.
-	BaseMagic  int16
-	BaseParry  int
-	BaseResist [4]int16
+	// BaseMagic: the equipment-free Magic, the mount-bonus counterpart of the Base* fields
+	// above. Same policy — derived on login (current − equipment) and re-added by
+	// refreshScore. Unlike Magic, Parry (evasion) and Resist have NO base term: neither is
+	// persisted, so refreshScore derives them entirely from current equipment every call
+	// instead (see its doc comment — issue #211 bug 3).
+	BaseMagic int16
 
 	// HpAddPct/MpAddPct: EF_HPADD/EF_MPADD percent bonus from equipment (e.g. +10 =
 	// +10%). Cached by refreshScore and applied at READ time (effective max HP/MP),


### PR DESCRIPTION
## Summary
- Add `EF_RESIST1..4`/`EF_RESISTALL` (ids 49-52,54) to the `ItemList.csv` parser whitelist (`content/catalog.go`) — they were silently dropped at parse time, the same bug class as issue #102's EF_CRITICAL fix.
- Add `itemResist()` in `handler/item.go` (mirrors `itemCritical`): sums catalog+instance resist per type, folds in `EF_RESISTALL`, applies the legacy refine multiplier `(sanc+10)/10`. Wired into `equipBonus()`.
- Fix a related bug found during investigation: `Resist`/`Parry` had no persisted backing field, so the old subtract-then-add "Base" derivation always reset them to 0 for a character logging in already equipped with resist/mount gear. Removed `BaseResist`/`BaseParry`; both are now derived fresh from equipment on every `refreshScore`, same as `Critical`.

Fixes #211

## Test plan
- [x] `go build ./...` / `go vet ./...`
- [x] `golangci-lint run` (0 issues)
- [x] `go test -race ./tmserver/internal/content/... ./tmserver/internal/handler/... ./tmserver/internal/world/...`
- [x] `make test` (full suite, race + cover)
- [x] New tests: `TestBaseEffectsResist` (parser), `TestResistFromEquipment` + `TestResistLoginRoundTrip` (handler), `TestMountScoreRoundTrip` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)