### PR TITLE
fix(tmserver): include active affects in CreateMob snapshots

### DIFF
--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -504,7 +504,7 @@ func (d *Dispatcher) revealMobsInView(w *world.World, s *world.Session) {
 // EquipVisual/EquipAnct, set at login/spawn from the relevant STRUCT_MOB data.
 // createType: 0 normal, 2 "just entered".
 func createMobFrom(e *world.Entity, createType uint16) protocol.CreateMobData {
-	return protocol.CreateMobData{
+	d := protocol.CreateMobData{
 		MobID:           e.ID,
 		Name:            e.Name,
 		PosX:            e.X,
@@ -533,6 +533,16 @@ func createMobFrom(e *world.Entity, createType uint16) protocol.CreateMobData {
 		CurKill:  e.CurKill,
 		TotKill:  e.TotKill,
 	}
+	for i := range e.Affect {
+		if e.Affect[i].Type == 0 {
+			continue
+		}
+		d.Affect[i] = protocol.PackAffect(protocol.AffectData{
+			Type: e.Affect[i].Type,
+			Time: e.Affect[i].Time,
+		})
+	}
+	return d
 }
 
 // createMobViewPacket mirrors legacy SendCreateMob: a player with an open

--- a/tmserver/internal/handler/view_test.go
+++ b/tmserver/internal/handler/view_test.go
@@ -213,6 +213,35 @@ func TestMoveViewDelta(t *testing.T) {
 	}
 }
 
+func TestCreateMobCarriesAffectIconsOnReveal(t *testing.T) {
+	db := viewDeltaDB()
+	heroB := db.loads[11]
+	heroB.Affects = []world.Affect{{Type: 31, Time: 7}}
+	db.loads[11] = heroB
+	addr, stop := startServerView(t, db, 64)
+	defer stop()
+
+	a := enterWorld(t, addr) // conn 1 at (5,5)
+	defer a.Close()
+	b := enterWorldAs(t, addr, "tradeb") // conn 2 at (5,45), already carrying affect 31
+	defer b.Close()
+	drainRaw(t, a)
+	drainRaw(t, b)
+
+	actionFrameXY(t, b, protocol.MsgAction, serverTime, 5, 45, 5, 21)
+
+	ty, payload, ok := readMaybeRaw(t, a)
+	if !ok || ty != protocol.MsgCreateMob {
+		t.Fatalf("A frame = %#x ok=%v, want CreateMob(B)", ty, ok)
+	}
+	if _, _, id := createMobFields(t, payload); id != 2 {
+		t.Fatalf("A sees mob id %d, want 2", id)
+	}
+	if got, want := binary.LittleEndian.Uint16(payload[54:]), protocol.PackAffect(protocol.AffectData{Type: 31, Time: 7}); got != want {
+		t.Fatalf("CreateMob Affect[0] = %#x, want %#x", got, want)
+	}
+}
+
 func TestPlayersCrossingViewOnMovement(t *testing.T) {
 	addr, stop := startServerView(t, viewDeltaDB(), 64)
 	defer stop()

--- a/tmserver/internal/protocol/createmob.go
+++ b/tmserver/internal/protocol/createmob.go
@@ -13,8 +13,9 @@ const (
 )
 
 // CreateMobData is the subset of MSG_CreateMob needed to render an entity in
-// view. Equip holds VISUAL item codes (u16[16]); AnctCode holds the matching
-// refine/ancient glow overlay bytes. 0 = empty/no overlay.
+// view. Equip holds VISUAL item codes (u16[16]); Affect holds the packed
+// GetAffect icon/visual slots; AnctCode holds the matching refine/ancient glow
+// overlay bytes. 0 = empty/no overlay.
 type CreateMobData struct {
 	MobID                int
 	Name                 string
@@ -29,6 +30,7 @@ type CreateMobData struct {
 	Direction            uint8
 	CreateType           uint16 // 0 normal, 2 "just entered"
 	Equip                [16]uint16
+	Affect               [MaxAffect]uint16
 	AnctCode             [16]uint8
 	// IsPlayer selects the MobName encoding: players (id < MAX_USER) pack PK data
 	// into MobName[12..15]; mobs/NPCs send the full 16-byte name raw (their names
@@ -98,6 +100,9 @@ func EncodeCreateMobBody(d CreateMobData) []byte {
 	}
 	for i := 0; i < 16; i++ { // Equip[16] @abs34 → body22
 		le.PutUint16(b[22+i*2:], d.Equip[i])
+	}
+	for i := 0; i < MaxAffect; i++ { // Affect[32] @abs66 → body54
+		le.PutUint16(b[54+i*2:], d.Affect[i])
 	}
 	le.PutUint16(b[118:], d.Guild)      // Guild @abs130 → body118
 	b[120] = d.GuildMemberType          // GuildMemberType @abs132 → body120

--- a/tmserver/internal/protocol/createmob_test.go
+++ b/tmserver/internal/protocol/createmob_test.go
@@ -16,6 +16,8 @@ func TestCreateMobBodyLayout(t *testing.T) {
 		Merchant: 1, AttackRun: 82, CreateType: 2,
 	}
 	d.Equip[0] = 831
+	d.Affect[0] = PackAffect(AffectData{Type: 31, Time: 7})
+	d.Affect[31] = PackAffect(AffectData{Type: 34, Time: 3000000})
 	d.AnctCode[0] = 43
 	b := EncodeCreateMobBody(d)
 
@@ -31,6 +33,15 @@ func TestCreateMobBodyLayout(t *testing.T) {
 	}
 	if got := le.Uint16(b[22:]); got != 831 { // Equip[0] @abs34 → body22
 		t.Errorf("Equip[0] = %d, want 831", got)
+	}
+	if got := le.Uint16(b[54:]); got != (31<<8)|7 { // Affect[0] @abs66 → body54
+		t.Errorf("Affect[0] = %#x, want %#x", got, (31<<8)|7)
+	}
+	if got := le.Uint16(b[54+31*2:]); got != (34<<8)|uint16(2550000&0xFF) {
+		t.Errorf("Affect[31] = %#x, want clamped time byte", got)
+	}
+	if got := le.Uint16(b[118:]); got != 7 { // Guild @abs130 → body118
+		t.Errorf("Guild = %d, want 7", got)
 	}
 	if b[124+12] != 1 { // Score.Merchant @abs148 → body124+12 (name-visible NPC flag)
 		t.Errorf("Score.Merchant = %d, want 1", b[124+12])


### PR DESCRIPTION
## Summary
- pack active affect icons into MSG_CreateMob at the legacy Affect[32] offset
- populate CreateMob snapshots from entity affects so reveal/spawn carries Escudo Dourado visual state
- add protocol layout and reveal regression coverage

## Tests
- go test ./tmserver/internal/protocol
- go test ./tmserver/internal/handler

Fixes #214
