### PR TITLE
fix(tmserver): Arch→Celestial creation via Pedra Ideal

### DIFF
--- a/docs/migration/celestial-system-plan.md
+++ b/docs/migration/celestial-system-plan.md
@@ -1,14 +1,21 @@
 # Plano: Sistema de Evolução Celestial (Mortal→Arch→Celestial→Sub) + /destravar40/90 + /arcana
 
-> Status (jul/2026, issue #117 fase 1): **Fases 1–3 IMPLEMENTADAS.** Persistência de
-> `class_master` + `QuestInfo.Celestial.{Lv40,Lv90,Circle}` (migração `0012`, todo o caminho
-> save/load), level-up Celestial por tier com os gates 39→40 / 89→90 (`handler.applyLevelUps`
-> genérico, curva `nextLevel2`), e os comandos `/destravar40` `/destravar90` `/arcana`
-> (`handler/chat.go`). **Pendências:** (a) a curva `g_pNextLevel_2` roda contra um **placeholder
-> sintético** — capturar os valores reais (`docs/migration/prompts/agent-prompt-celestial-curve.md`);
-> (b) **Fase 4 (transformação Mortal→Celestial via NPC Evoluções)** continua aberta — sem ela não
-> há caminho in-game para virar Celestial, então o teste end-to-end de `/destravar` no cliente real
-> depende dela.
+> Status (ago/2026, issue #222): **Fases 1–3 IMPLEMENTADAS**, mais o gatilho de criação
+> Arch→Celestial (parte da Fase 4). Persistência de `class_master` +
+> `QuestInfo.Celestial.{Lv40,Lv90,Circle}` (migração `0012`, todo o caminho save/load),
+> level-up Celestial por tier com os gates 39→40 / 89→90 (`handler.applyLevelUps` genérico,
+> curva `nextLevel2`), os comandos `/destravar40` `/destravar90` `/arcana` (`handler/chat.go`),
+> e agora a transformação Arch→Celestial: clicar com o botão direito na Pedra Ideal (item
+> 1742) com um Arch no nível máximo (399) vira Celestial nível 1 (`handler.useIdealStone`,
+> `item.go`) — distinto do fluxo `kingArch` (equipar o mesmo item + visitar o Rei), que segue
+> cobrindo só Mortal→Arch. **Pendências:** (a) a curva `g_pNextLevel_2` roda contra um
+> **placeholder sintético** — capturar os valores reais
+> (`docs/migration/prompts/agent-prompt-celestial-curve.md`); (b) o restante da **Fase 4**
+> segue aberto e sem confirmação de captura: o "NPC Evoluções"/poeira que nivela
+> Mortal/Arch/Celestial/Sub-Celestial, os três resets do Sub-Celestial, e se a transformação
+> real também reseta atributos/skills (o gatilho por item acima só reseta Level/Exp — o mínimo
+> tecnicamente necessário, já que o teto Celestial de nível, `MaxCLevel=199`, é menor que o
+> teto Arch, 399).
 >
 > Correção ao plano original abaixo: a **lógica** (`CheckGetLevel`, `QuestInfo`, os comandos) ESTÁ
 > na fonte local (`Source/Code/`), só os **valores** de `g_pNextLevel_2` faltam — a Fase 0 encolheu

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -417,6 +417,14 @@ func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header
 	if d.useQuest256Ticket(w, s, e, src) {
 		return
 	}
+	// Pedra Ideal (1742) right-clicked by an Arch (issue #222): the Arch→Celestial
+	// transformation. ClassMaster==Mortal falls through unchanged to the vol==0
+	// equip path below — that's the unrelated kingArch flow (equip + visit the
+	// King), which must keep working.
+	if e.Carry[src].Index == idealStoneItem && e.ClassMaster == classMasterArch {
+		d.useIdealStone(w, s, e, src)
+		return
+	}
 	// Selo do Guerreiro and Pedra Misteriosa have no EF_VOLATILE, so d.itemVolatiles
 	// defaults to 0 for them — check sIndex first so they don't fall into the vol==0
 	// equip path (canEquipSlot would just silently reject them, the same "phantom
@@ -1326,6 +1334,45 @@ func (d *Dispatcher) useSeloDoGuerreiro(w *world.World, s *world.Session, e *wor
 
 	consumeOneItem(&e.Carry[src])
 	d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
+}
+
+// celestialArchLevelReq is the Arch level required to use the Pedra Ideal for the
+// Arch→Celestial transformation (issue #222): mirrors kingArch's own near-max-level
+// gate for Mortal→Arch (Level>=299 there); Arch's own cap is level.MaxLevel (399).
+const celestialArchLevelReq = level.MaxLevel
+
+// useIdealStone handles the Arch→Celestial transformation triggered by right-clicking
+// the Pedra Ideal (item 1742, issue #222). This is a distinct self-use path from
+// kingArch's equip-and-visit-the-King Mortal→Arch flow, which reuses the same item —
+// the in-game tooltip instructs "clique na pedra com o botão direito do mouse" and only
+// applies once the character is already Arch (the caller in useItem gates on that).
+//
+// Level/Exp reset to the Celestial curve's start: Celestial's level cap
+// (level.MaxCLevel=199) is lower than Arch's (level.MaxLevel=399), so carrying the Arch
+// level over would leave the character permanently over-cap. The Celestial quest gates
+// (CelLv40/CelLv90/CelCircle) reset too, so a freshly-made Celestial unlocks level
+// 40/90 the normal way via /destravar40/90. Attribute points, HP/MP, and skills are
+// left untouched — no capture data confirms the legacy resets those as well
+// (docs/migration/celestial-system-plan.md), so this fork doesn't invent it.
+func (d *Dispatcher) useIdealStone(w *world.World, s *world.Session, e *world.Entity, src int) {
+	if e.Level < celestialArchLevelReq {
+		d.notify(w, s, NoticeReqNotMet)
+		w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
+		return
+	}
+	e.ClassMaster = classMasterCelestial
+	e.Level = 1
+	e.Exp = 0
+	e.CelLv40, e.CelLv90, e.CelCircle = 0, 0, 0
+	consumeOneItem(&e.Carry[src])
+	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
+	d.refreshScore(e)
+	d.sendScore(w, s, e)
+	d.sendEtc(w, s, e)
+	w.Send(s, protocol.MsgCombineComplete, parmPayload(celestialUnlockParm))
+	d.playUnlockEmote(w, s)
+	w.SaveCharacterThen(s, func(*world.World, *world.Session) {})
+	d.log.Info("celestial created", "conn", s.Conn, "name", e.Name)
 }
 
 const (

--- a/tmserver/internal/handler/item_test.go
+++ b/tmserver/internal/handler/item_test.go
@@ -415,6 +415,119 @@ func TestUseEntradaTerritorio(t *testing.T) {
 	}
 }
 
+// idealStoneDB builds a fakeDB for a character holding a Pedra Ideal (item 1742) in
+// carry slot 0, at the given tier/level (issue #222).
+func idealStoneDB(classMaster uint8, lvl int) *fakeDB {
+	db := newDB()
+	st := world.CharacterState{Slot: 0, Name: "Hero", X: 5, Y: 5, HP: 1000, MaxHP: 1000, ClassMaster: classMaster, Level: lvl}
+	st.Carry[0] = world.Item{Index: idealStoneItem}
+	db.loadResult = st
+	return db
+}
+
+// TestUseIdealStoneCreatesCelestial covers the Arch→Celestial transformation
+// (issue #222): an Arch at the tier cap (level.MaxLevel) right-clicking the Pedra
+// Ideal becomes a Celestial at level 1, with the item consumed and the celestial
+// quest gates reset, and the change persists.
+func TestUseIdealStoneCreatesCelestial(t *testing.T) {
+	db := idealStoneDB(classMasterArch, int(level.MaxLevel))
+	addr, stop, _ := startServerClock(t, db)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+
+	expect(t, c, protocol.MsgSendItem)        // Pedra Ideal removed from carry
+	expect(t, c, protocol.MsgCombineComplete) // unlock signal
+	expect(t, c, protocol.MsgMotion)          // unlock emote
+
+	send(t, c, protocol.MsgCharacterLogout, nil)
+	expect(t, c, protocol.MsgCNFCharacterLogout)
+	char, n := db.lastSavedChar()
+	if n == 0 {
+		t.Fatal("character was never saved")
+	}
+	if char.ClassMaster != classMasterCelestial {
+		t.Errorf("saved ClassMaster = %d, want %d (celestial)", char.ClassMaster, classMasterCelestial)
+	}
+	if char.Level != 1 {
+		t.Errorf("saved Level = %d, want 1 (reset)", char.Level)
+	}
+	if char.Exp != 0 {
+		t.Errorf("saved Exp = %d, want 0 (reset)", char.Exp)
+	}
+	if char.CelLv40 != 0 || char.CelLv90 != 0 || char.CelCircle != 0 {
+		t.Errorf("saved celestial gates = %d/%d/%d, want all 0 (fresh)", char.CelLv40, char.CelLv90, char.CelCircle)
+	}
+	if hasItem(char.Carry, idealStoneItem) {
+		t.Error("saved carry still has the Pedra Ideal; want consumed")
+	}
+}
+
+// TestUseIdealStoneRequiresMaxArchLevel verifies an Arch below the tier cap is
+// rejected: no tier change, the item stays put, and the client gets a slot resync
+// instead of the unlock signals.
+func TestUseIdealStoneRequiresMaxArchLevel(t *testing.T) {
+	db := idealStoneDB(classMasterArch, int(level.MaxLevel)-1)
+	addr, stop, _ := startServerClock(t, db)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+
+	sawResync := false
+	for {
+		ty, payload, ok := readMaybe(t, c)
+		if !ok {
+			break
+		}
+		if ty == protocol.MsgCombineComplete || ty == protocol.MsgMotion {
+			t.Fatalf("got %#x for a below-level Arch; want no unlock signal", ty)
+		}
+		if ty == protocol.MsgSendItem && int16(le16(payload[4:6])) == idealStoneItem {
+			sawResync = true
+		}
+	}
+	if !sawResync {
+		t.Error("expected a slot resync keeping the Pedra Ideal")
+	}
+
+	send(t, c, protocol.MsgCharacterLogout, nil)
+	expect(t, c, protocol.MsgCNFCharacterLogout)
+	char, n := db.lastSavedChar()
+	if n == 0 {
+		t.Fatal("character was never saved")
+	}
+	if char.ClassMaster != classMasterArch {
+		t.Errorf("saved ClassMaster = %d, want %d (unchanged, still arch)", char.ClassMaster, classMasterArch)
+	}
+}
+
+// TestUseIdealStoneMortalStillEquips is a regression guard: a Mortal carrying the
+// Pedra Ideal must still fall through to the normal equip path (the kingArch
+// Mortal→Arch flow needs it equipped in slot 10), unaffected by the new Arch-only
+// self-use interception.
+func TestUseIdealStoneMortalStillEquips(t *testing.T) {
+	db := idealStoneDB(classMasterMortal, 100)
+	addr, stop, _ := startServerClock(t, db)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	body := protocol.MsgUseItemBody{
+		SourType: world.ItemPlaceCarry, SourPos: 0,
+		DestType: world.ItemPlaceEquip, DestPos: idealStoneEquipSlot,
+	}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+	if ty, _, ok := readMaybe(t, c); !ok || ty != protocol.MsgUseItem {
+		t.Errorf("mortal equip got %#x ok=%v, want UseItem echo (equip path)", ty, ok)
+	}
+}
+
 const (
 	itemMagicBeanBlue    = 3407
 	itemMagicBeanLight   = 3416


### PR DESCRIPTION
## Summary
- Right-clicking the Pedra Ideal (item 1742) as an Arch character did nothing — `useItem` had no case for it, so it fell into the generic equip path meant for the unrelated `kingArch` Mortal→Arch flow (equip the same item + visit the King NPC).
- Adds `useIdealStone`: an Arch at the level cap (399) right-clicking the stone now transforms into a Celestial (level reset to 1, celestial quest gates reset), consuming the item and persisting the change. Mortal still falls through to the normal equip path unchanged.
- Updates `docs/migration/celestial-system-plan.md` status header to reflect this piece of the open "Fase 4" transformation work.

Closes #222

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./tmserver/internal/handler/... -race` (new tests: happy path, level-gate rejection, Mortal-equip regression guard)
- [x] `go test ./...` (full suite)
- [ ] Manual: right-click Pedra Ideal on a max-level Arch in a real client and confirm the Celestial transformation

🤖 Generated with [Claude Code](https://claude.com/claude-code)