### PR TITLE
fix(tmserver): apply magic-attack item effects to character score

### DIFF
--- a/tmserver/internal/content/catalog.go
+++ b/tmserver/internal/content/catalog.go
@@ -87,7 +87,7 @@ var efName = map[string]uint8{
 	"EF_POS":        17, "EF_WTYPE": 21, "EF_CRITICAL": 42, "EF_SANC": 43,
 	"EF_HPADD": 45, "EF_MPADD": 46,
 	"EF_RESIST1": 49, "EF_RESIST2": 50, "EF_RESIST3": 51, "EF_RESIST4": 52, "EF_ACADD": 53, "EF_RESISTALL": 54,
-	"EF_MAGIC": 60,
+	"EF_MAGIC":     60,
 	"EF_DAMAGEADD": 67, "EF_MAGICADD": 68, "EF_HPADD2": 69, "EF_MPADD2": 70, "EF_CRITICAL2": 71,
 	"EF_ITEMLEVEL": 87, "EF_MOBTYPE": 112, "EF_RUNSPEED": 29,
 	// Refine gates (_MSG_UseItem.cpp dust path): EF_NOSANC marks an item that can

--- a/tmserver/internal/content/catalog.go
+++ b/tmserver/internal/content/catalog.go
@@ -74,6 +74,11 @@ type BaseEffect struct {
 // BASE_GetMobAbility), so leaving them off this whitelist silently dropped every
 // immunity/resist item's effect at parse time — the items looked correct in the catalog
 // but granted nothing on the character.
+//
+// EF_MAGIC/EF_MAGICADD (ItemEffect.h:117,124-125) are the same bug class again (issue #223):
+// Basedef.cpp:3194-3195 derives the caster's Magic score from BASE_GetMobAbility(EF_MAGIC)+
+// BASE_GetMobAbility(EF_MAGICADD), so an "Ataque Mágico" item's bonus was silently dropped at
+// parse time — the item looked correct in the catalog but granted no extra magic damage.
 var efName = map[string]uint8{
 	"EF_DAMAGE": 2, "EF_AC": 3, "EF_HP": 4, "EF_MP": 5,
 	"EF_STR": 7, "EF_INT": 8, "EF_DEX": 9, "EF_CON": 10,
@@ -82,7 +87,8 @@ var efName = map[string]uint8{
 	"EF_POS":        17, "EF_WTYPE": 21, "EF_CRITICAL": 42, "EF_SANC": 43,
 	"EF_HPADD": 45, "EF_MPADD": 46,
 	"EF_RESIST1": 49, "EF_RESIST2": 50, "EF_RESIST3": 51, "EF_RESIST4": 52, "EF_ACADD": 53, "EF_RESISTALL": 54,
-	"EF_DAMAGEADD": 67, "EF_HPADD2": 69, "EF_MPADD2": 70, "EF_CRITICAL2": 71,
+	"EF_MAGIC": 60,
+	"EF_DAMAGEADD": 67, "EF_MAGICADD": 68, "EF_HPADD2": 69, "EF_MPADD2": 70, "EF_CRITICAL2": 71,
 	"EF_ITEMLEVEL": 87, "EF_MOBTYPE": 112, "EF_RUNSPEED": 29,
 	// Refine gates (_MSG_UseItem.cpp dust path): EF_NOSANC marks an item that can
 	// never be refined; the two incubation effects drive the mount-egg branch.

--- a/tmserver/internal/content/content_test.go
+++ b/tmserver/internal/content/content_test.go
@@ -276,6 +276,57 @@ func TestBaseEffectsResist(t *testing.T) {
 	}
 }
 
+// TestBaseEffectsMagic: EF_MAGIC/EF_MAGICADD are score stats too (Basedef.cpp:3194-3195
+// derives the caster's Magic from BASE_GetMobAbility(EF_MAGIC)+BASE_GetMobAbility(EF_MAGICADD)),
+// not ignored ones — missing from efName is what left every "Ataque Mágico" item granting
+// nothing (issue #223).
+func TestBaseEffectsMagic(t *testing.T) {
+	// Real rows: Bracelete_de_Hecate (ItemList.csv:871, EF_MAGIC,6) and Colar_Mágico
+	// (ItemList.csv:1075, EF_MAGIC,22).
+	const rows = "514,Bracelete_de_Hecate,96.0,132.0.0.0.0,0,73000,256,0,0,EF_CLASS,255,EF_MAGIC,6,EF_ITEMLEVEL,2\n" +
+		"642,Colar_Magico,2.6,306.0.0.0.0,0,125000,256,0,0,EF_CLASS,255,EF_MAGIC,22,EF_ITEMLEVEL,5\n"
+	l, err := parseItemList(strings.NewReader(rows))
+	if err != nil {
+		t.Fatal(err)
+	}
+	eff := l.BaseEffects()
+	for _, tc := range []struct {
+		idx  int
+		eff  uint8
+		want int16
+	}{{514, 60, 6}, {642, 60, 22}} {
+		var got int16
+		var found bool
+		for _, e := range eff[tc.idx] {
+			if e.Eff == tc.eff {
+				got, found = e.Val, true
+			}
+		}
+		if !found || got != tc.want {
+			t.Errorf("BaseEffects()[%d] EF(%d) = %d (found=%v), want %d", tc.idx, tc.eff, got, found, tc.want)
+		}
+	}
+
+	// The real catalog must actually carry magic — the parser silently dropping it is
+	// what issue #223 was. Guards against the effect disappearing from efName again.
+	full, err := LoadItemList(release(t, "Common", "ItemList.csv"))
+	if err != nil {
+		t.Skipf("ItemList.csv unavailable: %v", err)
+	}
+	var withMagic int
+	for _, effs := range full.BaseEffects() {
+		for _, e := range effs {
+			if e.Eff == 60 || e.Eff == 68 {
+				withMagic++
+				break
+			}
+		}
+	}
+	if withMagic < 20 {
+		t.Errorf("real catalog items carrying EF_MAGIC/EF_MAGICADD = %d, want >= 20", withMagic)
+	}
+}
+
 // TestBaseEffectsNoSanc: quest/trophy stones (Almas, Pedras, Sephirot) are
 // equippable but carry no EF_VOLATILE, so nothing stopped the dust-refine
 // handler from planting an EF_SANC pair into them (issue #133). ItemList.csv

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -1558,7 +1558,9 @@ const (
 	efResist4    = 52
 	efAcAdd      = 53 // EF_ACADD: extra AC — FLAT (summed with EF_AC), captura §E
 	efResistAll  = 54 // EF_RESISTALL: folds into all four EF_RESISTi — see itemResist
+	efMagic      = 60 // EF_MAGIC: flat magic-attack — excluded on the off-hand weapon slot only (Basedef.cpp:2447)
 	efDamageAdd  = 67 // EF_DAMAGEADD: extra flat damage — only counts for jewels (nUnique 41-50)
+	efMagicAdd   = 68 // EF_MAGICADD: extra flat magic-attack — jewel-gated like EF_DAMAGEADD (Basedef.cpp:1699-1703)
 	efHpAdd2     = 69 // EF_HPADD2/EF_MPADD2: also fold into the HPADD%/MPADD% multiplier
 	efMpAdd2     = 70
 	efCritical2  = 71 // EF_CRITICAL2: enchanted crit — SUPERSEDES EF_CRITICAL on the same item
@@ -1739,9 +1741,12 @@ type equipBonus struct {
 	// criticalRaw is the pre-/4 EF_CRITICAL sum over the equipment
 	// (BASE_GetMobAbility(EF_CRITICAL), Basedef.cpp:3209) — see itemCritical.
 	criticalRaw int32
-	// Mount (Equip[14]) contributions, from the g_pMountBonus tables rather than item
-	// effects. magicRaw is the pre-scaling EF_MAGIC sum (see mountMagicScore); resist
-	// applies to all four resistances. damage already folds into the field above.
+	// magicRaw is the pre-scaling EF_MAGIC+EF_MAGICADD sum (see mountMagicScore) over ALL
+	// equipment: the mount slot's g_pMountBonus-derived contribution (Equip[14], not
+	// generic item effects) PLUS ordinary gear's flat EF_MAGIC/EF_MAGICADD, folded in by
+	// the add closure below — Basedef.cpp:3194-3195 sums both across every slot before
+	// applying the single (x+1)/4 scaling. parry/resist remain mount-only broadcasts
+	// (Equip[14]); damage already folds into the field above.
 	magicRaw, parry, resist int32
 	// itemResist is the per-type EF_RESIST1..4/EF_RESISTALL sum from ordinary equipment
 	// (see itemResist), refine-scaled — distinct from the flat mount broadcast above.
@@ -1751,8 +1756,10 @@ type equipBonus struct {
 func (d *Dispatcher) equipBonus(e *world.Entity) equipBonus {
 	var b equipBonus
 	// add folds one effect/value pair into the bonus. weaponSlot excludes weapon-hand
-	// EF_DAMAGE; dmgJewel gates EF_DAMAGEADD to the damage-jewel items (nUnique 41-50).
-	add := func(eff uint8, val int32, weaponSlot, dmgJewel bool) {
+	// EF_DAMAGE; dmgJewel gates EF_DAMAGEADD/EF_MAGICADD to the jewel items (nUnique
+	// 41-50); offHand excludes EF_MAGIC on the off-hand weapon slot only (Basedef.cpp:
+	// 2447 — unlike EF_DAMAGE, the right-hand weapon still counts toward magic).
+	add := func(eff uint8, val int32, weaponSlot, dmgJewel, offHand bool) {
 		switch eff {
 		case efStr:
 			b.str += int16(val)
@@ -1783,6 +1790,14 @@ func (d *Dispatcher) equipBonus(e *world.Entity) equipBonus {
 		case efDamageAdd:
 			if dmgJewel { // only jewels (nUnique 41-50) contribute EF_DAMAGEADD
 				b.damage += val
+			}
+		case efMagic:
+			if !offHand { // BASE_GetMobAbility excludes only the off-hand weapon slot
+				b.magicRaw += val
+			}
+		case efMagicAdd:
+			if dmgJewel { // only jewels (nUnique 41-50) contribute EF_MAGICADD
+				b.magicRaw += val
 			}
 		case efHp:
 			b.maxHP += val
@@ -1821,13 +1836,14 @@ func (d *Dispatcher) equipBonus(e *world.Entity) equipBonus {
 			b.itemResist[i] += d.itemResist(it, i)
 		}
 		weaponSlot := slot == weaponSlotR || slot == weaponSlotL
+		offHand := slot == weaponSlotL
 		nUnique := d.itemUnique[int(it.Index)]
 		dmgJewel := nUnique >= 41 && nUnique <= 50
 		for _, be := range d.itemEffects[int(it.Index)] { // catalog base effects
-			add(be.Eff, int32(be.Val), weaponSlot, dmgJewel)
+			add(be.Eff, int32(be.Val), weaponSlot, dmgJewel, offHand)
 		}
 		for _, ef := range it.Effects { // per-item instance refines/divines
-			add(ef.Effect, int32(ef.Value), weaponSlot, dmgJewel)
+			add(ef.Effect, int32(ef.Value), weaponSlot, dmgJewel, offHand)
 		}
 		// Refine (+9) threshold: defense pieces gain +25 AC (weapons' +40 is in
 		// weaponDamage). captura §E.
@@ -1857,8 +1873,8 @@ func (d *Dispatcher) deriveBaseScore(e *world.Entity) {
 	e.BaseDamage = e.Damage - b.damage - d.derivedDamageTotal(e, false)
 	e.BaseMaxHP = e.MaxHP - b.maxHP
 	e.BaseMaxMP = e.MaxMP - b.maxMP
-	// Magic (mount bonus): same subtraction as the fields above so the loaded
-	// CurrentScore round-trips.
+	// Magic (mount bonus + ordinary equipment's EF_MAGIC/EF_MAGICADD): same subtraction
+	// as the fields above so the loaded CurrentScore round-trips.
 	e.BaseMagic = e.Magic - int16(mountMagicScore(b.magicRaw))
 	// Parry/Resist have NO base term at all — see refreshScore's comment: unlike Magic,
 	// they are never persisted, so a subtract-then-add "Base" here would net to zero for
@@ -1897,9 +1913,10 @@ func (d *Dispatcher) refreshScore(e *world.Entity) {
 	// (The low clamp is belt-and-braces: no catalog row carries negative crit, but a
 	// bare uint8 conversion would wrap one into a near-guaranteed crit.)
 	e.Critical = uint8(min(max(b.criticalRaw/4, 0), 255))
-	// Mount bonuses: Magic gets the (sum+1)/4 scaling and keeps a BaseMagic term since it
-	// IS persisted. Parry (evasion) and each Resist are derived ENTIRELY from equipment on
-	// every refresh, like Critical above — there is no BaseParry/BaseResist, because
+	// Magic gets the (sum+1)/4 scaling over mount + ordinary-equipment magic combined
+	// (equipBonus.magicRaw) and keeps a BaseMagic term since it IS persisted. Parry
+	// (evasion) and each Resist are derived ENTIRELY from equipment on every refresh,
+	// like Critical above — there is no BaseParry/BaseResist, because
 	// neither is persisted (world.CharacterState omits them), so a character logging in
 	// already equipped would otherwise always compute Base = 0 − equip, then
 	// Current = Base + equip = 0 regardless of gear (issue #211 bug 3). Resist is capped

--- a/tmserver/internal/handler/magic_test.go
+++ b/tmserver/internal/handler/magic_test.go
@@ -1,0 +1,126 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// Item indices used by the magic tests, synthetic, mirroring resist_test.go's convention.
+const (
+	magicFlat        = 620 // flat EF_MAGIC on an ordinary (non-weapon) slot
+	magicOffHand     = 621 // EF_MAGIC on the off-hand weapon slot (7) — excluded
+	magicRightHand   = 622 // EF_MAGIC on the right-hand weapon slot (6) — still counts
+	magicAddJewel    = 623 // EF_MAGICADD, registered as a jewel (nUnique 41-50) in magicConfig
+	magicAddNonJewel = 624 // EF_MAGICADD, no nUnique entry — must NOT count
+)
+
+// magicConfig is the catalog the magic tests read: static effects and the nUnique each
+// item carries (EF_MAGICADD is gated to jewels, same nUnique 41-50 range as EF_DAMAGEADD).
+func magicConfig() Config {
+	return Config{
+		ItemEffects: map[int][]content.BaseEffect{
+			magicFlat:        {{Eff: efMagic, Val: 40}},
+			magicOffHand:     {{Eff: efMagic, Val: 40}},
+			magicRightHand:   {{Eff: efMagic, Val: 40}},
+			magicAddJewel:    {{Eff: efMagicAdd, Val: 20}},
+			magicAddNonJewel: {{Eff: efMagicAdd, Val: 20}},
+		},
+		ItemUnique: map[int]int{
+			magicAddJewel: 45, // jewel range 41-50
+		},
+	}
+}
+
+// TestMagicFromEquipment covers BASE_GetMobAbility(EF_MAGIC)+BASE_GetMobAbility(EF_MAGICADD)
+// (Basedef.cpp:2415-2521,3194-3195) as refreshScore derives it: ordinary equipment's flat
+// magic-attack now folds into e.Magic alongside the mount bonus (issue #223), with the
+// off-hand-weapon exclusion and the jewel gate on EF_MAGICADD.
+func TestMagicFromEquipment(t *testing.T) {
+	tests := []struct {
+		name  string
+		equip map[int]world.Item
+		want  int16
+	}{
+		{
+			name:  "flat EF_MAGIC on an ordinary slot",
+			equip: map[int]world.Item{0: {Index: magicFlat}},
+			want:  10, // (40+1)/4 = 10
+		},
+		{
+			name:  "EF_MAGIC on the off-hand weapon slot is excluded",
+			equip: map[int]world.Item{weaponSlotL: {Index: magicOffHand}},
+			want:  0,
+		},
+		{
+			name:  "EF_MAGIC on the right-hand weapon slot still counts",
+			equip: map[int]world.Item{weaponSlotR: {Index: magicRightHand}},
+			want:  10, // (40+1)/4 = 10
+		},
+		{
+			name:  "EF_MAGICADD counts only for jewels",
+			equip: map[int]world.Item{0: {Index: magicAddJewel}},
+			want:  5, // (20+1)/4 = 5
+		},
+		{
+			name:  "EF_MAGICADD on a non-jewel grants nothing",
+			equip: map[int]world.Item{0: {Index: magicAddNonJewel}},
+			want:  0,
+		},
+		{
+			// Mount magicRaw (Thoroughbred 30D: 110, mountBonusTable row {750,110,80,32,6})
+			// and item magicRaw (40) combine BEFORE the single (x+1)/4 scaling: (110+40+1)/4.
+			name: "mount magic and item magic combine under one scaling",
+			equip: map[int]world.Item{
+				0:              {Index: magicFlat},
+				mountEquipSlot: {Index: 3987}, // Thoroughbred(30d): magicRaw 110
+			},
+			want: 37, // (150+1)/4 = 37
+		},
+		{
+			name:  "no magic gear",
+			equip: map[int]world.Item{},
+			want:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := New(magicConfig())
+			e := &world.Entity{ID: 1, Level: 50}
+			for slot, it := range tt.equip {
+				e.Equip[slot] = it
+			}
+			d.refreshScore(e)
+			if e.Magic != tt.want {
+				t.Errorf("e.Magic = %d, want %d", e.Magic, tt.want)
+			}
+		})
+	}
+}
+
+// TestMagicLoginRoundTrip: unlike Resist/Parry (issue #211 bug 3), Magic already has a
+// persisted BaseMagic field, so a character reconnecting with magic-attack gear or a mount
+// already equipped must round-trip through deriveBaseScore/refreshScore without double
+// counting or resetting — the same regression shape as TestResistLoginRoundTrip and
+// TestMountScoreRoundTrip, now covering ordinary equipment's contribution too.
+func TestMagicLoginRoundTrip(t *testing.T) {
+	d := New(magicConfig())
+	e := &world.Entity{ID: 1, Level: 50, Magic: 37} // loaded from a save with this gear on
+	e.Equip[0] = world.Item{Index: magicFlat}
+	e.Equip[mountEquipSlot] = world.Item{Index: 3987}
+	d.deriveBaseScore(e)
+	d.refreshScore(e)
+
+	const want = 37 // (110+40+1)/4
+	if e.Magic != want {
+		t.Errorf("login Magic = %d, want %d (equipped gear must not reset or double)", e.Magic, want)
+	}
+
+	// A later refresh (e.g. an unrelated gear change) must not double-count.
+	d.refreshScore(e)
+	if e.Magic != want {
+		t.Errorf("Magic after second refresh = %d, want %d (must not accumulate)", e.Magic, want)
+	}
+}

--- a/tmserver/internal/handler/mount.go
+++ b/tmserver/internal/handler/mount.go
@@ -120,9 +120,10 @@ func mountBonusFor(it world.Item) (mountAttrBonus, bool) {
 	return mountAttrBonus{}, false
 }
 
-// mountMagicScore turns the accumulated raw EF_MAGIC sum into the CurrentScore.Magic
-// addend: magic = (sum + 1) / 4 (Basedef.cpp:3194-3195). Zero when there is no equip
-// magic. Mounts are currently the only equipment feeding this in the Go model.
+// mountMagicScore turns the accumulated raw EF_MAGIC+EF_MAGICADD sum (mount bonus plus
+// ordinary equipment's flat magic-attack, see equipBonus.magicRaw) into the
+// CurrentScore.Magic addend: magic = (sum + 1) / 4 (Basedef.cpp:3194-3195). Zero when
+// there is no equip magic.
 func mountMagicScore(raw int32) int32 {
 	if raw <= 0 {
 		return 0


### PR DESCRIPTION
## Summary
- `EF_MAGIC`/`EF_MAGICADD` ("Ataque Mágico") were missing from the `ItemList.csv` parser whitelist (`efName`), so every magic-attack item's bonus was silently dropped at parse time — the same bug class as issue #211's resist/immunity fix.
- `equipBonus` had no summing path for ordinary equipment's magic-attack either; only the mount slot fed `magicRaw` (the code's own comment flagged mounts as the sole contributor).
- Ordinary gear's `EF_MAGIC` (excluded on the off-hand weapon slot only, matching `BASE_GetMobAbility`) and `EF_MAGICADD` (jewel-gated like `EF_DAMAGEADD`) now fold into the same `magicRaw` accumulator the mount bonus already uses, combining under the single `(sum+1)/4` scaling — matching `Basedef.cpp:3194-3195`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./tmserver/...` (all packages pass)
- [x] `go test -race ./tmserver/internal/handler/...` (new + existing magic/resist/critical/mount tests pass)
- [x] New tests: `TestBaseEffectsMagic` (parser whitelist + real-catalog guard), `TestMagicFromEquipment` (off-hand exclusion, jewel gate, mount+item combination), `TestMagicLoginRoundTrip`

Fixes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)