### PR TITLE
feat(webserver): painel de faturamento (DonateRevenueAdminService)

### DIFF
--- a/api/web/v1/web.pb.go
+++ b/api/web/v1/web.pb.go
@@ -470,6 +470,114 @@ func (TopupStatus) EnumDescriptor() ([]byte, []int) {
 	return file_api_web_v1_web_proto_rawDescGZIP(), []int{7}
 }
 
+// RevenueBucket is the time-series granularity. UNSPECIFIED skips the series
+// entirely — the cheapest call, for a header-only refresh. An unrecognized value
+// degrades to UNSPECIFIED rather than failing, so a newer portal cannot break an
+// older server.
+type RevenueBucket int32
+
+const (
+	RevenueBucket_REVENUE_BUCKET_UNSPECIFIED RevenueBucket = 0
+	RevenueBucket_REVENUE_BUCKET_DAY         RevenueBucket = 1
+	RevenueBucket_REVENUE_BUCKET_WEEK        RevenueBucket = 2 // date_trunc('week') — ISO week, starts on MONDAY
+	RevenueBucket_REVENUE_BUCKET_MONTH       RevenueBucket = 3
+)
+
+// Enum value maps for RevenueBucket.
+var (
+	RevenueBucket_name = map[int32]string{
+		0: "REVENUE_BUCKET_UNSPECIFIED",
+		1: "REVENUE_BUCKET_DAY",
+		2: "REVENUE_BUCKET_WEEK",
+		3: "REVENUE_BUCKET_MONTH",
+	}
+	RevenueBucket_value = map[string]int32{
+		"REVENUE_BUCKET_UNSPECIFIED": 0,
+		"REVENUE_BUCKET_DAY":         1,
+		"REVENUE_BUCKET_WEEK":        2,
+		"REVENUE_BUCKET_MONTH":       3,
+	}
+)
+
+func (x RevenueBucket) Enum() *RevenueBucket {
+	p := new(RevenueBucket)
+	*p = x
+	return p
+}
+
+func (x RevenueBucket) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RevenueBucket) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_web_v1_web_proto_enumTypes[8].Descriptor()
+}
+
+func (RevenueBucket) Type() protoreflect.EnumType {
+	return &file_api_web_v1_web_proto_enumTypes[8]
+}
+
+func (x RevenueBucket) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use RevenueBucket.Descriptor instead.
+func (RevenueBucket) EnumDescriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{8}
+}
+
+// DonateLedgerAction filters the donate_shop_audit read. UNSPECIFIED returns both
+// movement kinds; the catalog CRUD actions ('create'/'update'/'delete'/
+// 'set_enabled') are never returned — they move no wallet.
+type DonateLedgerAction int32
+
+const (
+	DonateLedgerAction_DONATE_LEDGER_ACTION_UNSPECIFIED DonateLedgerAction = 0
+	DonateLedgerAction_DONATE_LEDGER_ACTION_PURCHASE    DonateLedgerAction = 1 // donate_shop_audit.action = 'purchase'
+	DonateLedgerAction_DONATE_LEDGER_ACTION_CREDIT      DonateLedgerAction = 2 // donate_shop_audit.action = 'credit_balance'
+)
+
+// Enum value maps for DonateLedgerAction.
+var (
+	DonateLedgerAction_name = map[int32]string{
+		0: "DONATE_LEDGER_ACTION_UNSPECIFIED",
+		1: "DONATE_LEDGER_ACTION_PURCHASE",
+		2: "DONATE_LEDGER_ACTION_CREDIT",
+	}
+	DonateLedgerAction_value = map[string]int32{
+		"DONATE_LEDGER_ACTION_UNSPECIFIED": 0,
+		"DONATE_LEDGER_ACTION_PURCHASE":    1,
+		"DONATE_LEDGER_ACTION_CREDIT":      2,
+	}
+)
+
+func (x DonateLedgerAction) Enum() *DonateLedgerAction {
+	p := new(DonateLedgerAction)
+	*p = x
+	return p
+}
+
+func (x DonateLedgerAction) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (DonateLedgerAction) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_web_v1_web_proto_enumTypes[9].Descriptor()
+}
+
+func (DonateLedgerAction) Type() protoreflect.EnumType {
+	return &file_api_web_v1_web_proto_enumTypes[9]
+}
+
+func (x DonateLedgerAction) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use DonateLedgerAction.Descriptor instead.
+func (DonateLedgerAction) EnumDescriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{9}
+}
+
 type CreateAccountRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`         // canonicalized to lowercase server-side
@@ -7298,6 +7406,1572 @@ func (x *GetTopupOrderResponse) GetNewBalance() int64 {
 	return 0
 }
 
+// RevenueWindow is the half-open [from_unix, to_unix) interval that scopes every
+// read on this service. Both 0 = the last 30 days ending now; only to_unix 0 =
+// now. The server rejects from >= to and any window wider than 366 days, and
+// always resolves the window to a concrete bounded range before it reaches SQL.
+type RevenueWindow struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	FromUnix      int64                  `protobuf:"varint,1,opt,name=from_unix,json=fromUnix,proto3" json:"from_unix,omitempty"` // inclusive, Unix seconds; 0 = to_unix minus 30 days
+	ToUnix        int64                  `protobuf:"varint,2,opt,name=to_unix,json=toUnix,proto3" json:"to_unix,omitempty"`       // exclusive, Unix seconds; 0 = now
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RevenueWindow) Reset() {
+	*x = RevenueWindow{}
+	mi := &file_api_web_v1_web_proto_msgTypes[108]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RevenueWindow) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RevenueWindow) ProtoMessage() {}
+
+func (x *RevenueWindow) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[108]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RevenueWindow.ProtoReflect.Descriptor instead.
+func (*RevenueWindow) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{108}
+}
+
+func (x *RevenueWindow) GetFromUnix() int64 {
+	if x != nil {
+		return x.FromUnix
+	}
+	return 0
+}
+
+func (x *RevenueWindow) GetToUnix() int64 {
+	if x != nil {
+		return x.ToUnix
+	}
+	return 0
+}
+
+// RevenueTotals is the KPI header. The first block is real money recognized on
+// confirmed_at; the second is orders CREATED in the window (any status), the
+// conversion denominator; the third is donate wallet flow, in CREDITS, not money.
+type RevenueTotals struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	PaidOrders     int64                  `protobuf:"varint,1,opt,name=paid_orders,json=paidOrders,proto3" json:"paid_orders,omitempty"`
+	GrossCents     int64                  `protobuf:"varint,2,opt,name=gross_cents,json=grossCents,proto3" json:"gross_cents,omitempty"` // serialize as string in public JSON
+	CreditsSold    int64                  `protobuf:"varint,3,opt,name=credits_sold,json=creditsSold,proto3" json:"credits_sold,omitempty"`
+	DistinctBuyers int64                  `protobuf:"varint,4,opt,name=distinct_buyers,json=distinctBuyers,proto3" json:"distinct_buyers,omitempty"`
+	CreatedOrders  int64                  `protobuf:"varint,5,opt,name=created_orders,json=createdOrders,proto3" json:"created_orders,omitempty"`     // created in the window, any status
+	PendingOrders  int64                  `protobuf:"varint,6,opt,name=pending_orders,json=pendingOrders,proto3" json:"pending_orders,omitempty"`     // created in the window and still PENDING today
+	PendingCents   int64                  `protobuf:"varint,7,opt,name=pending_cents,json=pendingCents,proto3" json:"pending_cents,omitempty"`        // string in public JSON; NOT revenue, never add to gross_cents
+	ShopPurchases  int64                  `protobuf:"varint,8,opt,name=shop_purchases,json=shopPurchases,proto3" json:"shop_purchases,omitempty"`     // donate_shop_audit rows with action='purchase'
+	CreditsSpent   int64                  `protobuf:"varint,9,opt,name=credits_spent,json=creditsSpent,proto3" json:"credits_spent,omitempty"`        // sum of after->>'price' over those rows
+	ManualCredits  int64                  `protobuf:"varint,10,opt,name=manual_credits,json=manualCredits,proto3" json:"manual_credits,omitempty"`    // rows with action='credit_balance' (moderator grants)
+	CreditsGranted int64                  `protobuf:"varint,11,opt,name=credits_granted,json=creditsGranted,proto3" json:"credits_granted,omitempty"` // sum of after->>'amount' over those rows
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *RevenueTotals) Reset() {
+	*x = RevenueTotals{}
+	mi := &file_api_web_v1_web_proto_msgTypes[109]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RevenueTotals) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RevenueTotals) ProtoMessage() {}
+
+func (x *RevenueTotals) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[109]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RevenueTotals.ProtoReflect.Descriptor instead.
+func (*RevenueTotals) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{109}
+}
+
+func (x *RevenueTotals) GetPaidOrders() int64 {
+	if x != nil {
+		return x.PaidOrders
+	}
+	return 0
+}
+
+func (x *RevenueTotals) GetGrossCents() int64 {
+	if x != nil {
+		return x.GrossCents
+	}
+	return 0
+}
+
+func (x *RevenueTotals) GetCreditsSold() int64 {
+	if x != nil {
+		return x.CreditsSold
+	}
+	return 0
+}
+
+func (x *RevenueTotals) GetDistinctBuyers() int64 {
+	if x != nil {
+		return x.DistinctBuyers
+	}
+	return 0
+}
+
+func (x *RevenueTotals) GetCreatedOrders() int64 {
+	if x != nil {
+		return x.CreatedOrders
+	}
+	return 0
+}
+
+func (x *RevenueTotals) GetPendingOrders() int64 {
+	if x != nil {
+		return x.PendingOrders
+	}
+	return 0
+}
+
+func (x *RevenueTotals) GetPendingCents() int64 {
+	if x != nil {
+		return x.PendingCents
+	}
+	return 0
+}
+
+func (x *RevenueTotals) GetShopPurchases() int64 {
+	if x != nil {
+		return x.ShopPurchases
+	}
+	return 0
+}
+
+func (x *RevenueTotals) GetCreditsSpent() int64 {
+	if x != nil {
+		return x.CreditsSpent
+	}
+	return 0
+}
+
+func (x *RevenueTotals) GetManualCredits() int64 {
+	if x != nil {
+		return x.ManualCredits
+	}
+	return 0
+}
+
+func (x *RevenueTotals) GetCreditsGranted() int64 {
+	if x != nil {
+		return x.CreditsGranted
+	}
+	return 0
+}
+
+// RevenueByMethod breaks recognized revenue down by gateway. Repeated rather than
+// fixed pix_/card_ fields so adding a PaymentMethod never changes this message.
+type RevenueByMethod struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	PaymentMethod PaymentMethod          `protobuf:"varint,1,opt,name=payment_method,json=paymentMethod,proto3,enum=web.v1.PaymentMethod" json:"payment_method,omitempty"`
+	PaidOrders    int64                  `protobuf:"varint,2,opt,name=paid_orders,json=paidOrders,proto3" json:"paid_orders,omitempty"`
+	GrossCents    int64                  `protobuf:"varint,3,opt,name=gross_cents,json=grossCents,proto3" json:"gross_cents,omitempty"` // serialize as string in public JSON
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RevenueByMethod) Reset() {
+	*x = RevenueByMethod{}
+	mi := &file_api_web_v1_web_proto_msgTypes[110]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RevenueByMethod) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RevenueByMethod) ProtoMessage() {}
+
+func (x *RevenueByMethod) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[110]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RevenueByMethod.ProtoReflect.Descriptor instead.
+func (*RevenueByMethod) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{110}
+}
+
+func (x *RevenueByMethod) GetPaymentMethod() PaymentMethod {
+	if x != nil {
+		return x.PaymentMethod
+	}
+	return PaymentMethod_PAYMENT_METHOD_UNSPECIFIED
+}
+
+func (x *RevenueByMethod) GetPaidOrders() int64 {
+	if x != nil {
+		return x.PaidOrders
+	}
+	return 0
+}
+
+func (x *RevenueByMethod) GetGrossCents() int64 {
+	if x != nil {
+		return x.GrossCents
+	}
+	return 0
+}
+
+// RevenuePoint is one bucket of the series. Buckets with no orders ARE returned
+// with zeroes, so the chart axis is continuous and the front-end never gap-fills.
+type RevenuePoint struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	BucketStartUnix int64                  `protobuf:"varint,1,opt,name=bucket_start_unix,json=bucketStartUnix,proto3" json:"bucket_start_unix,omitempty"` // instant the bucket opens (America/Sao_Paulo boundary)
+	PaidOrders      int64                  `protobuf:"varint,2,opt,name=paid_orders,json=paidOrders,proto3" json:"paid_orders,omitempty"`
+	GrossCents      int64                  `protobuf:"varint,3,opt,name=gross_cents,json=grossCents,proto3" json:"gross_cents,omitempty"` // serialize as string in public JSON
+	CreditsSold     int64                  `protobuf:"varint,4,opt,name=credits_sold,json=creditsSold,proto3" json:"credits_sold,omitempty"`
+	DistinctBuyers  int64                  `protobuf:"varint,5,opt,name=distinct_buyers,json=distinctBuyers,proto3" json:"distinct_buyers,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *RevenuePoint) Reset() {
+	*x = RevenuePoint{}
+	mi := &file_api_web_v1_web_proto_msgTypes[111]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RevenuePoint) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RevenuePoint) ProtoMessage() {}
+
+func (x *RevenuePoint) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[111]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RevenuePoint.ProtoReflect.Descriptor instead.
+func (*RevenuePoint) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{111}
+}
+
+func (x *RevenuePoint) GetBucketStartUnix() int64 {
+	if x != nil {
+		return x.BucketStartUnix
+	}
+	return 0
+}
+
+func (x *RevenuePoint) GetPaidOrders() int64 {
+	if x != nil {
+		return x.PaidOrders
+	}
+	return 0
+}
+
+func (x *RevenuePoint) GetGrossCents() int64 {
+	if x != nil {
+		return x.GrossCents
+	}
+	return 0
+}
+
+func (x *RevenuePoint) GetCreditsSold() int64 {
+	if x != nil {
+		return x.CreditsSold
+	}
+	return 0
+}
+
+func (x *RevenuePoint) GetDistinctBuyers() int64 {
+	if x != nil {
+		return x.DistinctBuyers
+	}
+	return 0
+}
+
+type GetRevenueSummaryRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId   int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	Window        *RevenueWindow         `protobuf:"bytes,2,opt,name=window,proto3" json:"window,omitempty"`
+	Bucket        RevenueBucket          `protobuf:"varint,3,opt,name=bucket,proto3,enum=web.v1.RevenueBucket" json:"bucket,omitempty"`
+	AccountId     int64                  `protobuf:"varint,4,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"` // 0 = all accounts; set for the per-account drill-down
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetRevenueSummaryRequest) Reset() {
+	*x = GetRevenueSummaryRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[112]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetRevenueSummaryRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetRevenueSummaryRequest) ProtoMessage() {}
+
+func (x *GetRevenueSummaryRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[112]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetRevenueSummaryRequest.ProtoReflect.Descriptor instead.
+func (*GetRevenueSummaryRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{112}
+}
+
+func (x *GetRevenueSummaryRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+func (x *GetRevenueSummaryRequest) GetWindow() *RevenueWindow {
+	if x != nil {
+		return x.Window
+	}
+	return nil
+}
+
+func (x *GetRevenueSummaryRequest) GetBucket() RevenueBucket {
+	if x != nil {
+		return x.Bucket
+	}
+	return RevenueBucket_REVENUE_BUCKET_UNSPECIFIED
+}
+
+func (x *GetRevenueSummaryRequest) GetAccountId() int64 {
+	if x != nil {
+		return x.AccountId
+	}
+	return 0
+}
+
+type GetRevenueSummaryResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Result        AdminResult            `protobuf:"varint,1,opt,name=result,proto3,enum=web.v1.AdminResult" json:"result,omitempty"`
+	Totals        *RevenueTotals         `protobuf:"bytes,2,opt,name=totals,proto3" json:"totals,omitempty"`
+	ByMethod      []*RevenueByMethod     `protobuf:"bytes,3,rep,name=by_method,json=byMethod,proto3" json:"by_method,omitempty"`
+	Series        []*RevenuePoint        `protobuf:"bytes,4,rep,name=series,proto3" json:"series,omitempty"`                      // empty when bucket is UNSPECIFIED
+	FromUnix      int64                  `protobuf:"varint,5,opt,name=from_unix,json=fromUnix,proto3" json:"from_unix,omitempty"` // the window the server actually applied, after defaults
+	ToUnix        int64                  `protobuf:"varint,6,opt,name=to_unix,json=toUnix,proto3" json:"to_unix,omitempty"`       // echo it back so the UI can label the period truthfully
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetRevenueSummaryResponse) Reset() {
+	*x = GetRevenueSummaryResponse{}
+	mi := &file_api_web_v1_web_proto_msgTypes[113]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetRevenueSummaryResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetRevenueSummaryResponse) ProtoMessage() {}
+
+func (x *GetRevenueSummaryResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[113]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetRevenueSummaryResponse.ProtoReflect.Descriptor instead.
+func (*GetRevenueSummaryResponse) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{113}
+}
+
+func (x *GetRevenueSummaryResponse) GetResult() AdminResult {
+	if x != nil {
+		return x.Result
+	}
+	return AdminResult_ADMIN_RESULT_UNSPECIFIED
+}
+
+func (x *GetRevenueSummaryResponse) GetTotals() *RevenueTotals {
+	if x != nil {
+		return x.Totals
+	}
+	return nil
+}
+
+func (x *GetRevenueSummaryResponse) GetByMethod() []*RevenueByMethod {
+	if x != nil {
+		return x.ByMethod
+	}
+	return nil
+}
+
+func (x *GetRevenueSummaryResponse) GetSeries() []*RevenuePoint {
+	if x != nil {
+		return x.Series
+	}
+	return nil
+}
+
+func (x *GetRevenueSummaryResponse) GetFromUnix() int64 {
+	if x != nil {
+		return x.FromUnix
+	}
+	return 0
+}
+
+func (x *GetRevenueSummaryResponse) GetToUnix() int64 {
+	if x != nil {
+		return x.ToUnix
+	}
+	return 0
+}
+
+// TopupOrderRow is one row of the order table, with the buyer identity resolved
+// server-side in the same SQL (a JOIN, never N+1 lookups from the BFF).
+type TopupOrderRow struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Id                int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`                                                       // serialize as string in public JSON
+	ExternalReference string                 `protobuf:"bytes,2,opt,name=external_reference,json=externalReference,proto3" json:"external_reference,omitempty"` // the portal UUID — the reconciliation key
+	AccountId         int64                  `protobuf:"varint,3,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`                        // serialize as string in public JSON
+	AccountName       string                 `protobuf:"bytes,4,opt,name=account_name,json=accountName,proto3" json:"account_name,omitempty"`                   // account.name (canonical lowercase login)
+	AccountEmail      string                 `protobuf:"bytes,5,opt,name=account_email,json=accountEmail,proto3" json:"account_email,omitempty"`
+	PayerName         string                 `protobuf:"bytes,6,opt,name=payer_name,json=payerName,proto3" json:"payer_name,omitempty"` // donate_payer_profile; empty when never filled
+	// ALWAYS masked (***.456.789-**). The raw 11 digits never leave the web-api:
+	// 'moderator' is a coarse role and a revenue report has no use for the full
+	// number — a chargeback is reconciled by external_reference.
+	PayerCpfMasked string        `protobuf:"bytes,7,opt,name=payer_cpf_masked,json=payerCpfMasked,proto3" json:"payer_cpf_masked,omitempty"`
+	Credits        int32         `protobuf:"varint,8,opt,name=credits,proto3" json:"credits,omitempty"`
+	AmountCents    int64         `protobuf:"varint,9,opt,name=amount_cents,json=amountCents,proto3" json:"amount_cents,omitempty"` // serialize as string in public JSON
+	PaymentMethod  PaymentMethod `protobuf:"varint,10,opt,name=payment_method,json=paymentMethod,proto3,enum=web.v1.PaymentMethod" json:"payment_method,omitempty"`
+	// ALWAYS empty today: CreateTopupOrder never writes donate_topup_order.provider.
+	// Do not build UI on it.
+	Provider        string      `protobuf:"bytes,11,opt,name=provider,proto3" json:"provider,omitempty"`
+	Status          TopupStatus `protobuf:"varint,12,opt,name=status,proto3,enum=web.v1.TopupStatus" json:"status,omitempty"`
+	CreatedAtUnix   int64       `protobuf:"varint,13,opt,name=created_at_unix,json=createdAtUnix,proto3" json:"created_at_unix,omitempty"`
+	ConfirmedAtUnix int64       `protobuf:"varint,14,opt,name=confirmed_at_unix,json=confirmedAtUnix,proto3" json:"confirmed_at_unix,omitempty"` // 0 while PENDING
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *TopupOrderRow) Reset() {
+	*x = TopupOrderRow{}
+	mi := &file_api_web_v1_web_proto_msgTypes[114]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TopupOrderRow) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopupOrderRow) ProtoMessage() {}
+
+func (x *TopupOrderRow) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[114]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TopupOrderRow.ProtoReflect.Descriptor instead.
+func (*TopupOrderRow) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{114}
+}
+
+func (x *TopupOrderRow) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *TopupOrderRow) GetExternalReference() string {
+	if x != nil {
+		return x.ExternalReference
+	}
+	return ""
+}
+
+func (x *TopupOrderRow) GetAccountId() int64 {
+	if x != nil {
+		return x.AccountId
+	}
+	return 0
+}
+
+func (x *TopupOrderRow) GetAccountName() string {
+	if x != nil {
+		return x.AccountName
+	}
+	return ""
+}
+
+func (x *TopupOrderRow) GetAccountEmail() string {
+	if x != nil {
+		return x.AccountEmail
+	}
+	return ""
+}
+
+func (x *TopupOrderRow) GetPayerName() string {
+	if x != nil {
+		return x.PayerName
+	}
+	return ""
+}
+
+func (x *TopupOrderRow) GetPayerCpfMasked() string {
+	if x != nil {
+		return x.PayerCpfMasked
+	}
+	return ""
+}
+
+func (x *TopupOrderRow) GetCredits() int32 {
+	if x != nil {
+		return x.Credits
+	}
+	return 0
+}
+
+func (x *TopupOrderRow) GetAmountCents() int64 {
+	if x != nil {
+		return x.AmountCents
+	}
+	return 0
+}
+
+func (x *TopupOrderRow) GetPaymentMethod() PaymentMethod {
+	if x != nil {
+		return x.PaymentMethod
+	}
+	return PaymentMethod_PAYMENT_METHOD_UNSPECIFIED
+}
+
+func (x *TopupOrderRow) GetProvider() string {
+	if x != nil {
+		return x.Provider
+	}
+	return ""
+}
+
+func (x *TopupOrderRow) GetStatus() TopupStatus {
+	if x != nil {
+		return x.Status
+	}
+	return TopupStatus_TOPUP_STATUS_UNSPECIFIED
+}
+
+func (x *TopupOrderRow) GetCreatedAtUnix() int64 {
+	if x != nil {
+		return x.CreatedAtUnix
+	}
+	return 0
+}
+
+func (x *TopupOrderRow) GetConfirmedAtUnix() int64 {
+	if x != nil {
+		return x.ConfirmedAtUnix
+	}
+	return 0
+}
+
+type ListTopupOrdersRequest struct {
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	Window      *RevenueWindow         `protobuf:"bytes,2,opt,name=window,proto3" json:"window,omitempty"`
+	// status also picks the date column the window filters on: PAID filters and
+	// orders by confirmed_at (revenue recognition); anything else uses created_at.
+	Status        TopupStatus   `protobuf:"varint,3,opt,name=status,proto3,enum=web.v1.TopupStatus" json:"status,omitempty"`                                      // UNSPECIFIED = any status
+	PaymentMethod PaymentMethod `protobuf:"varint,4,opt,name=payment_method,json=paymentMethod,proto3,enum=web.v1.PaymentMethod" json:"payment_method,omitempty"` // UNSPECIFIED = any method
+	AccountId     int64         `protobuf:"varint,5,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`                                       // 0 = all accounts
+	Limit         int32         `protobuf:"varint,6,opt,name=limit,proto3" json:"limit,omitempty"`                                                                // default 50, max 100
+	Offset        int32         `protobuf:"varint,7,opt,name=offset,proto3" json:"offset,omitempty"`                                                              // negative values are treated as 0
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTopupOrdersRequest) Reset() {
+	*x = ListTopupOrdersRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[115]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTopupOrdersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTopupOrdersRequest) ProtoMessage() {}
+
+func (x *ListTopupOrdersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[115]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTopupOrdersRequest.ProtoReflect.Descriptor instead.
+func (*ListTopupOrdersRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{115}
+}
+
+func (x *ListTopupOrdersRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+func (x *ListTopupOrdersRequest) GetWindow() *RevenueWindow {
+	if x != nil {
+		return x.Window
+	}
+	return nil
+}
+
+func (x *ListTopupOrdersRequest) GetStatus() TopupStatus {
+	if x != nil {
+		return x.Status
+	}
+	return TopupStatus_TOPUP_STATUS_UNSPECIFIED
+}
+
+func (x *ListTopupOrdersRequest) GetPaymentMethod() PaymentMethod {
+	if x != nil {
+		return x.PaymentMethod
+	}
+	return PaymentMethod_PAYMENT_METHOD_UNSPECIFIED
+}
+
+func (x *ListTopupOrdersRequest) GetAccountId() int64 {
+	if x != nil {
+		return x.AccountId
+	}
+	return 0
+}
+
+func (x *ListTopupOrdersRequest) GetLimit() int32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+func (x *ListTopupOrdersRequest) GetOffset() int32 {
+	if x != nil {
+		return x.Offset
+	}
+	return 0
+}
+
+type ListTopupOrdersResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Result        AdminResult            `protobuf:"varint,1,opt,name=result,proto3,enum=web.v1.AdminResult" json:"result,omitempty"`
+	Orders        []*TopupOrderRow       `protobuf:"bytes,2,rep,name=orders,proto3" json:"orders,omitempty"`
+	TotalCount    int32                  `protobuf:"varint,3,opt,name=total_count,json=totalCount,proto3" json:"total_count,omitempty"`
+	FromUnix      int64                  `protobuf:"varint,4,opt,name=from_unix,json=fromUnix,proto3" json:"from_unix,omitempty"`
+	ToUnix        int64                  `protobuf:"varint,5,opt,name=to_unix,json=toUnix,proto3" json:"to_unix,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTopupOrdersResponse) Reset() {
+	*x = ListTopupOrdersResponse{}
+	mi := &file_api_web_v1_web_proto_msgTypes[116]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTopupOrdersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTopupOrdersResponse) ProtoMessage() {}
+
+func (x *ListTopupOrdersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[116]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTopupOrdersResponse.ProtoReflect.Descriptor instead.
+func (*ListTopupOrdersResponse) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{116}
+}
+
+func (x *ListTopupOrdersResponse) GetResult() AdminResult {
+	if x != nil {
+		return x.Result
+	}
+	return AdminResult_ADMIN_RESULT_UNSPECIFIED
+}
+
+func (x *ListTopupOrdersResponse) GetOrders() []*TopupOrderRow {
+	if x != nil {
+		return x.Orders
+	}
+	return nil
+}
+
+func (x *ListTopupOrdersResponse) GetTotalCount() int32 {
+	if x != nil {
+		return x.TotalCount
+	}
+	return 0
+}
+
+func (x *ListTopupOrdersResponse) GetFromUnix() int64 {
+	if x != nil {
+		return x.FromUnix
+	}
+	return 0
+}
+
+func (x *ListTopupOrdersResponse) GetToUnix() int64 {
+	if x != nil {
+		return x.ToUnix
+	}
+	return 0
+}
+
+// TopBuyerRow carries both the window aggregate (what the panel ranks on) and the
+// all-time aggregate (the LTV), because "who spent most this month" and "who is
+// worth most overall" are different questions and the panel shows both.
+type TopBuyerRow struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	AccountId          int64                  `protobuf:"varint,1,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"` // serialize as string in public JSON
+	AccountName        string                 `protobuf:"bytes,2,opt,name=account_name,json=accountName,proto3" json:"account_name,omitempty"`
+	AccountEmail       string                 `protobuf:"bytes,3,opt,name=account_email,json=accountEmail,proto3" json:"account_email,omitempty"`
+	WindowPaidOrders   int64                  `protobuf:"varint,4,opt,name=window_paid_orders,json=windowPaidOrders,proto3" json:"window_paid_orders,omitempty"`
+	WindowGrossCents   int64                  `protobuf:"varint,5,opt,name=window_gross_cents,json=windowGrossCents,proto3" json:"window_gross_cents,omitempty"` // string in public JSON; the ranking key
+	LifetimePaidOrders int64                  `protobuf:"varint,6,opt,name=lifetime_paid_orders,json=lifetimePaidOrders,proto3" json:"lifetime_paid_orders,omitempty"`
+	LifetimeGrossCents int64                  `protobuf:"varint,7,opt,name=lifetime_gross_cents,json=lifetimeGrossCents,proto3" json:"lifetime_gross_cents,omitempty"` // string in public JSON; the LTV
+	LifetimeCredits    int64                  `protobuf:"varint,8,opt,name=lifetime_credits,json=lifetimeCredits,proto3" json:"lifetime_credits,omitempty"`
+	FirstPaidAtUnix    int64                  `protobuf:"varint,9,opt,name=first_paid_at_unix,json=firstPaidAtUnix,proto3" json:"first_paid_at_unix,omitempty"` // all-time, not window-scoped
+	LastPaidAtUnix     int64                  `protobuf:"varint,10,opt,name=last_paid_at_unix,json=lastPaidAtUnix,proto3" json:"last_paid_at_unix,omitempty"`   // all-time, not window-scoped
+	DonateBalance      int32                  `protobuf:"varint,11,opt,name=donate_balance,json=donateBalance,proto3" json:"donate_balance,omitempty"`          // current wallet — point-in-time, not a window value
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *TopBuyerRow) Reset() {
+	*x = TopBuyerRow{}
+	mi := &file_api_web_v1_web_proto_msgTypes[117]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TopBuyerRow) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TopBuyerRow) ProtoMessage() {}
+
+func (x *TopBuyerRow) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[117]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TopBuyerRow.ProtoReflect.Descriptor instead.
+func (*TopBuyerRow) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{117}
+}
+
+func (x *TopBuyerRow) GetAccountId() int64 {
+	if x != nil {
+		return x.AccountId
+	}
+	return 0
+}
+
+func (x *TopBuyerRow) GetAccountName() string {
+	if x != nil {
+		return x.AccountName
+	}
+	return ""
+}
+
+func (x *TopBuyerRow) GetAccountEmail() string {
+	if x != nil {
+		return x.AccountEmail
+	}
+	return ""
+}
+
+func (x *TopBuyerRow) GetWindowPaidOrders() int64 {
+	if x != nil {
+		return x.WindowPaidOrders
+	}
+	return 0
+}
+
+func (x *TopBuyerRow) GetWindowGrossCents() int64 {
+	if x != nil {
+		return x.WindowGrossCents
+	}
+	return 0
+}
+
+func (x *TopBuyerRow) GetLifetimePaidOrders() int64 {
+	if x != nil {
+		return x.LifetimePaidOrders
+	}
+	return 0
+}
+
+func (x *TopBuyerRow) GetLifetimeGrossCents() int64 {
+	if x != nil {
+		return x.LifetimeGrossCents
+	}
+	return 0
+}
+
+func (x *TopBuyerRow) GetLifetimeCredits() int64 {
+	if x != nil {
+		return x.LifetimeCredits
+	}
+	return 0
+}
+
+func (x *TopBuyerRow) GetFirstPaidAtUnix() int64 {
+	if x != nil {
+		return x.FirstPaidAtUnix
+	}
+	return 0
+}
+
+func (x *TopBuyerRow) GetLastPaidAtUnix() int64 {
+	if x != nil {
+		return x.LastPaidAtUnix
+	}
+	return 0
+}
+
+func (x *TopBuyerRow) GetDonateBalance() int32 {
+	if x != nil {
+		return x.DonateBalance
+	}
+	return 0
+}
+
+type ListTopBuyersRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId   int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	Window        *RevenueWindow         `protobuf:"bytes,2,opt,name=window,proto3" json:"window,omitempty"`
+	Limit         int32                  `protobuf:"varint,3,opt,name=limit,proto3" json:"limit,omitempty"`   // default 50, max 100
+	Offset        int32                  `protobuf:"varint,4,opt,name=offset,proto3" json:"offset,omitempty"` // negative values are treated as 0
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTopBuyersRequest) Reset() {
+	*x = ListTopBuyersRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[118]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTopBuyersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTopBuyersRequest) ProtoMessage() {}
+
+func (x *ListTopBuyersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[118]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTopBuyersRequest.ProtoReflect.Descriptor instead.
+func (*ListTopBuyersRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{118}
+}
+
+func (x *ListTopBuyersRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+func (x *ListTopBuyersRequest) GetWindow() *RevenueWindow {
+	if x != nil {
+		return x.Window
+	}
+	return nil
+}
+
+func (x *ListTopBuyersRequest) GetLimit() int32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+func (x *ListTopBuyersRequest) GetOffset() int32 {
+	if x != nil {
+		return x.Offset
+	}
+	return 0
+}
+
+type ListTopBuyersResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Result        AdminResult            `protobuf:"varint,1,opt,name=result,proto3,enum=web.v1.AdminResult" json:"result,omitempty"`
+	Buyers        []*TopBuyerRow         `protobuf:"bytes,2,rep,name=buyers,proto3" json:"buyers,omitempty"`
+	TotalCount    int32                  `protobuf:"varint,3,opt,name=total_count,json=totalCount,proto3" json:"total_count,omitempty"` // distinct accounts that paid inside the window
+	FromUnix      int64                  `protobuf:"varint,4,opt,name=from_unix,json=fromUnix,proto3" json:"from_unix,omitempty"`
+	ToUnix        int64                  `protobuf:"varint,5,opt,name=to_unix,json=toUnix,proto3" json:"to_unix,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTopBuyersResponse) Reset() {
+	*x = ListTopBuyersResponse{}
+	mi := &file_api_web_v1_web_proto_msgTypes[119]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTopBuyersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTopBuyersResponse) ProtoMessage() {}
+
+func (x *ListTopBuyersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[119]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTopBuyersResponse.ProtoReflect.Descriptor instead.
+func (*ListTopBuyersResponse) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{119}
+}
+
+func (x *ListTopBuyersResponse) GetResult() AdminResult {
+	if x != nil {
+		return x.Result
+	}
+	return AdminResult_ADMIN_RESULT_UNSPECIFIED
+}
+
+func (x *ListTopBuyersResponse) GetBuyers() []*TopBuyerRow {
+	if x != nil {
+		return x.Buyers
+	}
+	return nil
+}
+
+func (x *ListTopBuyersResponse) GetTotalCount() int32 {
+	if x != nil {
+		return x.TotalCount
+	}
+	return 0
+}
+
+func (x *ListTopBuyersResponse) GetFromUnix() int64 {
+	if x != nil {
+		return x.FromUnix
+	}
+	return 0
+}
+
+func (x *ListTopBuyersResponse) GetToUnix() int64 {
+	if x != nil {
+		return x.ToUnix
+	}
+	return 0
+}
+
+// DonateLedgerRow is one donate wallet movement. credits_delta is SIGNED so the
+// column sums to a meaningful net: negative for a purchase (debit), positive for
+// a moderator credit. It is in donate credits, never money.
+type DonateLedgerRow struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	Id                 int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"` // donate_shop_audit.id; string in public JSON
+	Action             DonateLedgerAction     `protobuf:"varint,2,opt,name=action,proto3,enum=web.v1.DonateLedgerAction" json:"action,omitempty"`
+	CreatedAtUnix      int64                  `protobuf:"varint,3,opt,name=created_at_unix,json=createdAtUnix,proto3" json:"created_at_unix,omitempty"`
+	SubjectAccountId   int64                  `protobuf:"varint,4,opt,name=subject_account_id,json=subjectAccountId,proto3" json:"subject_account_id,omitempty"` // whose wallet moved; string in public JSON
+	SubjectAccountName string                 `protobuf:"bytes,5,opt,name=subject_account_name,json=subjectAccountName,proto3" json:"subject_account_name,omitempty"`
+	ActorAccountId     int64                  `protobuf:"varint,6,opt,name=actor_account_id,json=actorAccountId,proto3" json:"actor_account_id,omitempty"` // == subject on a purchase, the MODERATOR on a credit
+	ActorAccountName   string                 `protobuf:"bytes,7,opt,name=actor_account_name,json=actorAccountName,proto3" json:"actor_account_name,omitempty"`
+	CreditsDelta       int64                  `protobuf:"varint,8,opt,name=credits_delta,json=creditsDelta,proto3" json:"credits_delta,omitempty"` // signed: -price on purchase, +amount on credit
+	BalanceAfter       int64                  `protobuf:"varint,9,opt,name=balance_after,json=balanceAfter,proto3" json:"balance_after,omitempty"` // wallet balance recorded at the time
+	ShopItemId         int64                  `protobuf:"varint,10,opt,name=shop_item_id,json=shopItemId,proto3" json:"shop_item_id,omitempty"`    // 0 for credit_balance; string in public JSON
+	// Empty when the offer was deleted since the purchase (shop_item_id is
+	// deliberately not an FK, so history survives). Fall back to shop_item_id.
+	ShopItemTitle string `protobuf:"bytes,11,opt,name=shop_item_title,json=shopItemTitle,proto3" json:"shop_item_title,omitempty"`
+	Reason        string `protobuf:"bytes,12,opt,name=reason,proto3" json:"reason,omitempty"` // credit_balance only; the moderator's note
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DonateLedgerRow) Reset() {
+	*x = DonateLedgerRow{}
+	mi := &file_api_web_v1_web_proto_msgTypes[120]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DonateLedgerRow) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DonateLedgerRow) ProtoMessage() {}
+
+func (x *DonateLedgerRow) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[120]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DonateLedgerRow.ProtoReflect.Descriptor instead.
+func (*DonateLedgerRow) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{120}
+}
+
+func (x *DonateLedgerRow) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *DonateLedgerRow) GetAction() DonateLedgerAction {
+	if x != nil {
+		return x.Action
+	}
+	return DonateLedgerAction_DONATE_LEDGER_ACTION_UNSPECIFIED
+}
+
+func (x *DonateLedgerRow) GetCreatedAtUnix() int64 {
+	if x != nil {
+		return x.CreatedAtUnix
+	}
+	return 0
+}
+
+func (x *DonateLedgerRow) GetSubjectAccountId() int64 {
+	if x != nil {
+		return x.SubjectAccountId
+	}
+	return 0
+}
+
+func (x *DonateLedgerRow) GetSubjectAccountName() string {
+	if x != nil {
+		return x.SubjectAccountName
+	}
+	return ""
+}
+
+func (x *DonateLedgerRow) GetActorAccountId() int64 {
+	if x != nil {
+		return x.ActorAccountId
+	}
+	return 0
+}
+
+func (x *DonateLedgerRow) GetActorAccountName() string {
+	if x != nil {
+		return x.ActorAccountName
+	}
+	return ""
+}
+
+func (x *DonateLedgerRow) GetCreditsDelta() int64 {
+	if x != nil {
+		return x.CreditsDelta
+	}
+	return 0
+}
+
+func (x *DonateLedgerRow) GetBalanceAfter() int64 {
+	if x != nil {
+		return x.BalanceAfter
+	}
+	return 0
+}
+
+func (x *DonateLedgerRow) GetShopItemId() int64 {
+	if x != nil {
+		return x.ShopItemId
+	}
+	return 0
+}
+
+func (x *DonateLedgerRow) GetShopItemTitle() string {
+	if x != nil {
+		return x.ShopItemTitle
+	}
+	return ""
+}
+
+func (x *DonateLedgerRow) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+type ListDonateSpendRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId   int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	Window        *RevenueWindow         `protobuf:"bytes,2,opt,name=window,proto3" json:"window,omitempty"`
+	Action        DonateLedgerAction     `protobuf:"varint,3,opt,name=action,proto3,enum=web.v1.DonateLedgerAction" json:"action,omitempty"` // UNSPECIFIED = both movement kinds
+	AccountId     int64                  `protobuf:"varint,4,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`         // matched against the SUBJECT, not the raw audit column
+	Limit         int32                  `protobuf:"varint,5,opt,name=limit,proto3" json:"limit,omitempty"`                                  // default 50, max 100
+	Offset        int32                  `protobuf:"varint,6,opt,name=offset,proto3" json:"offset,omitempty"`                                // negative values are treated as 0
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListDonateSpendRequest) Reset() {
+	*x = ListDonateSpendRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[121]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListDonateSpendRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListDonateSpendRequest) ProtoMessage() {}
+
+func (x *ListDonateSpendRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[121]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListDonateSpendRequest.ProtoReflect.Descriptor instead.
+func (*ListDonateSpendRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{121}
+}
+
+func (x *ListDonateSpendRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+func (x *ListDonateSpendRequest) GetWindow() *RevenueWindow {
+	if x != nil {
+		return x.Window
+	}
+	return nil
+}
+
+func (x *ListDonateSpendRequest) GetAction() DonateLedgerAction {
+	if x != nil {
+		return x.Action
+	}
+	return DonateLedgerAction_DONATE_LEDGER_ACTION_UNSPECIFIED
+}
+
+func (x *ListDonateSpendRequest) GetAccountId() int64 {
+	if x != nil {
+		return x.AccountId
+	}
+	return 0
+}
+
+func (x *ListDonateSpendRequest) GetLimit() int32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+func (x *ListDonateSpendRequest) GetOffset() int32 {
+	if x != nil {
+		return x.Offset
+	}
+	return 0
+}
+
+type ListDonateSpendResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Result        AdminResult            `protobuf:"varint,1,opt,name=result,proto3,enum=web.v1.AdminResult" json:"result,omitempty"`
+	Entries       []*DonateLedgerRow     `protobuf:"bytes,2,rep,name=entries,proto3" json:"entries,omitempty"`
+	TotalCount    int32                  `protobuf:"varint,3,opt,name=total_count,json=totalCount,proto3" json:"total_count,omitempty"`
+	FromUnix      int64                  `protobuf:"varint,4,opt,name=from_unix,json=fromUnix,proto3" json:"from_unix,omitempty"`
+	ToUnix        int64                  `protobuf:"varint,5,opt,name=to_unix,json=toUnix,proto3" json:"to_unix,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListDonateSpendResponse) Reset() {
+	*x = ListDonateSpendResponse{}
+	mi := &file_api_web_v1_web_proto_msgTypes[122]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListDonateSpendResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListDonateSpendResponse) ProtoMessage() {}
+
+func (x *ListDonateSpendResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[122]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListDonateSpendResponse.ProtoReflect.Descriptor instead.
+func (*ListDonateSpendResponse) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{122}
+}
+
+func (x *ListDonateSpendResponse) GetResult() AdminResult {
+	if x != nil {
+		return x.Result
+	}
+	return AdminResult_ADMIN_RESULT_UNSPECIFIED
+}
+
+func (x *ListDonateSpendResponse) GetEntries() []*DonateLedgerRow {
+	if x != nil {
+		return x.Entries
+	}
+	return nil
+}
+
+func (x *ListDonateSpendResponse) GetTotalCount() int32 {
+	if x != nil {
+		return x.TotalCount
+	}
+	return 0
+}
+
+func (x *ListDonateSpendResponse) GetFromUnix() int64 {
+	if x != nil {
+		return x.FromUnix
+	}
+	return 0
+}
+
+func (x *ListDonateSpendResponse) GetToUnix() int64 {
+	if x != nil {
+		return x.ToUnix
+	}
+	return 0
+}
+
+// AccountSummary is the minimum identity the panel needs to turn a typed login
+// into an account_id filter. It exposes no credentials.
+type AccountSummary struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"` // serialize as string in public JSON
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Email         string                 `protobuf:"bytes,3,opt,name=email,proto3" json:"email,omitempty"`
+	DonateBalance int32                  `protobuf:"varint,4,opt,name=donate_balance,json=donateBalance,proto3" json:"donate_balance,omitempty"`
+	Role          string                 `protobuf:"bytes,5,opt,name=role,proto3" json:"role,omitempty"` // 'player' | 'moderator' | 'admin'
+	IsBlocked     bool                   `protobuf:"varint,6,opt,name=is_blocked,json=isBlocked,proto3" json:"is_blocked,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AccountSummary) Reset() {
+	*x = AccountSummary{}
+	mi := &file_api_web_v1_web_proto_msgTypes[123]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AccountSummary) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AccountSummary) ProtoMessage() {}
+
+func (x *AccountSummary) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[123]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AccountSummary.ProtoReflect.Descriptor instead.
+func (*AccountSummary) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{123}
+}
+
+func (x *AccountSummary) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *AccountSummary) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *AccountSummary) GetEmail() string {
+	if x != nil {
+		return x.Email
+	}
+	return ""
+}
+
+func (x *AccountSummary) GetDonateBalance() int32 {
+	if x != nil {
+		return x.DonateBalance
+	}
+	return 0
+}
+
+func (x *AccountSummary) GetRole() string {
+	if x != nil {
+		return x.Role
+	}
+	return ""
+}
+
+func (x *AccountSummary) GetIsBlocked() bool {
+	if x != nil {
+		return x.IsBlocked
+	}
+	return false
+}
+
+type SearchAccountsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ModeratorId   int64                  `protobuf:"varint,1,opt,name=moderator_id,json=moderatorId,proto3" json:"moderator_id,omitempty"`
+	NamePrefix    string                 `protobuf:"bytes,2,opt,name=name_prefix,json=namePrefix,proto3" json:"name_prefix,omitempty"` // canonicalized to lowercase server-side; minimum 2 chars
+	Limit         int32                  `protobuf:"varint,3,opt,name=limit,proto3" json:"limit,omitempty"`                            // default 20, max 50
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SearchAccountsRequest) Reset() {
+	*x = SearchAccountsRequest{}
+	mi := &file_api_web_v1_web_proto_msgTypes[124]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SearchAccountsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SearchAccountsRequest) ProtoMessage() {}
+
+func (x *SearchAccountsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[124]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SearchAccountsRequest.ProtoReflect.Descriptor instead.
+func (*SearchAccountsRequest) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{124}
+}
+
+func (x *SearchAccountsRequest) GetModeratorId() int64 {
+	if x != nil {
+		return x.ModeratorId
+	}
+	return 0
+}
+
+func (x *SearchAccountsRequest) GetNamePrefix() string {
+	if x != nil {
+		return x.NamePrefix
+	}
+	return ""
+}
+
+func (x *SearchAccountsRequest) GetLimit() int32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+type SearchAccountsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Result        AdminResult            `protobuf:"varint,1,opt,name=result,proto3,enum=web.v1.AdminResult" json:"result,omitempty"`
+	Accounts      []*AccountSummary      `protobuf:"bytes,2,rep,name=accounts,proto3" json:"accounts,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SearchAccountsResponse) Reset() {
+	*x = SearchAccountsResponse{}
+	mi := &file_api_web_v1_web_proto_msgTypes[125]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SearchAccountsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SearchAccountsResponse) ProtoMessage() {}
+
+func (x *SearchAccountsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_web_v1_web_proto_msgTypes[125]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SearchAccountsResponse.ProtoReflect.Descriptor instead.
+func (*SearchAccountsResponse) Descriptor() ([]byte, []int) {
+	return file_api_web_v1_web_proto_rawDescGZIP(), []int{125}
+}
+
+func (x *SearchAccountsResponse) GetResult() AdminResult {
+	if x != nil {
+		return x.Result
+	}
+	return AdminResult_ADMIN_RESULT_UNSPECIFIED
+}
+
+func (x *SearchAccountsResponse) GetAccounts() []*AccountSummary {
+	if x != nil {
+		return x.Accounts
+	}
+	return nil
+}
+
 var File_api_web_v1_web_proto protoreflect.FileDescriptor
 
 const file_api_web_v1_web_proto_rawDesc = "" +
@@ -7831,7 +9505,158 @@ const file_api_web_v1_web_proto_rawDesc = "" +
 	"\x06status\x18\x01 \x01(\x0e2\x13.web.v1.TopupStatusR\x06status\x12\x18\n" +
 	"\acredits\x18\x02 \x01(\x05R\acredits\x12\x1f\n" +
 	"\vnew_balance\x18\x03 \x01(\x03R\n" +
-	"newBalance*|\n" +
+	"newBalance\"E\n" +
+	"\rRevenueWindow\x12\x1b\n" +
+	"\tfrom_unix\x18\x01 \x01(\x03R\bfromUnix\x12\x17\n" +
+	"\ato_unix\x18\x02 \x01(\x03R\x06toUnix\"\xac\x03\n" +
+	"\rRevenueTotals\x12\x1f\n" +
+	"\vpaid_orders\x18\x01 \x01(\x03R\n" +
+	"paidOrders\x12\x1f\n" +
+	"\vgross_cents\x18\x02 \x01(\x03R\n" +
+	"grossCents\x12!\n" +
+	"\fcredits_sold\x18\x03 \x01(\x03R\vcreditsSold\x12'\n" +
+	"\x0fdistinct_buyers\x18\x04 \x01(\x03R\x0edistinctBuyers\x12%\n" +
+	"\x0ecreated_orders\x18\x05 \x01(\x03R\rcreatedOrders\x12%\n" +
+	"\x0epending_orders\x18\x06 \x01(\x03R\rpendingOrders\x12#\n" +
+	"\rpending_cents\x18\a \x01(\x03R\fpendingCents\x12%\n" +
+	"\x0eshop_purchases\x18\b \x01(\x03R\rshopPurchases\x12#\n" +
+	"\rcredits_spent\x18\t \x01(\x03R\fcreditsSpent\x12%\n" +
+	"\x0emanual_credits\x18\n" +
+	" \x01(\x03R\rmanualCredits\x12'\n" +
+	"\x0fcredits_granted\x18\v \x01(\x03R\x0ecreditsGranted\"\x91\x01\n" +
+	"\x0fRevenueByMethod\x12<\n" +
+	"\x0epayment_method\x18\x01 \x01(\x0e2\x15.web.v1.PaymentMethodR\rpaymentMethod\x12\x1f\n" +
+	"\vpaid_orders\x18\x02 \x01(\x03R\n" +
+	"paidOrders\x12\x1f\n" +
+	"\vgross_cents\x18\x03 \x01(\x03R\n" +
+	"grossCents\"\xc8\x01\n" +
+	"\fRevenuePoint\x12*\n" +
+	"\x11bucket_start_unix\x18\x01 \x01(\x03R\x0fbucketStartUnix\x12\x1f\n" +
+	"\vpaid_orders\x18\x02 \x01(\x03R\n" +
+	"paidOrders\x12\x1f\n" +
+	"\vgross_cents\x18\x03 \x01(\x03R\n" +
+	"grossCents\x12!\n" +
+	"\fcredits_sold\x18\x04 \x01(\x03R\vcreditsSold\x12'\n" +
+	"\x0fdistinct_buyers\x18\x05 \x01(\x03R\x0edistinctBuyers\"\xba\x01\n" +
+	"\x18GetRevenueSummaryRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\x12-\n" +
+	"\x06window\x18\x02 \x01(\v2\x15.web.v1.RevenueWindowR\x06window\x12-\n" +
+	"\x06bucket\x18\x03 \x01(\x0e2\x15.web.v1.RevenueBucketR\x06bucket\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x04 \x01(\x03R\taccountId\"\x91\x02\n" +
+	"\x19GetRevenueSummaryResponse\x12+\n" +
+	"\x06result\x18\x01 \x01(\x0e2\x13.web.v1.AdminResultR\x06result\x12-\n" +
+	"\x06totals\x18\x02 \x01(\v2\x15.web.v1.RevenueTotalsR\x06totals\x124\n" +
+	"\tby_method\x18\x03 \x03(\v2\x17.web.v1.RevenueByMethodR\bbyMethod\x12,\n" +
+	"\x06series\x18\x04 \x03(\v2\x14.web.v1.RevenuePointR\x06series\x12\x1b\n" +
+	"\tfrom_unix\x18\x05 \x01(\x03R\bfromUnix\x12\x17\n" +
+	"\ato_unix\x18\x06 \x01(\x03R\x06toUnix\"\x96\x04\n" +
+	"\rTopupOrderRow\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\x12-\n" +
+	"\x12external_reference\x18\x02 \x01(\tR\x11externalReference\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x03 \x01(\x03R\taccountId\x12!\n" +
+	"\faccount_name\x18\x04 \x01(\tR\vaccountName\x12#\n" +
+	"\raccount_email\x18\x05 \x01(\tR\faccountEmail\x12\x1d\n" +
+	"\n" +
+	"payer_name\x18\x06 \x01(\tR\tpayerName\x12(\n" +
+	"\x10payer_cpf_masked\x18\a \x01(\tR\x0epayerCpfMasked\x12\x18\n" +
+	"\acredits\x18\b \x01(\x05R\acredits\x12!\n" +
+	"\famount_cents\x18\t \x01(\x03R\vamountCents\x12<\n" +
+	"\x0epayment_method\x18\n" +
+	" \x01(\x0e2\x15.web.v1.PaymentMethodR\rpaymentMethod\x12\x1a\n" +
+	"\bprovider\x18\v \x01(\tR\bprovider\x12+\n" +
+	"\x06status\x18\f \x01(\x0e2\x13.web.v1.TopupStatusR\x06status\x12&\n" +
+	"\x0fcreated_at_unix\x18\r \x01(\x03R\rcreatedAtUnix\x12*\n" +
+	"\x11confirmed_at_unix\x18\x0e \x01(\x03R\x0fconfirmedAtUnix\"\xa2\x02\n" +
+	"\x16ListTopupOrdersRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\x12-\n" +
+	"\x06window\x18\x02 \x01(\v2\x15.web.v1.RevenueWindowR\x06window\x12+\n" +
+	"\x06status\x18\x03 \x01(\x0e2\x13.web.v1.TopupStatusR\x06status\x12<\n" +
+	"\x0epayment_method\x18\x04 \x01(\x0e2\x15.web.v1.PaymentMethodR\rpaymentMethod\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x05 \x01(\x03R\taccountId\x12\x14\n" +
+	"\x05limit\x18\x06 \x01(\x05R\x05limit\x12\x16\n" +
+	"\x06offset\x18\a \x01(\x05R\x06offset\"\xcc\x01\n" +
+	"\x17ListTopupOrdersResponse\x12+\n" +
+	"\x06result\x18\x01 \x01(\x0e2\x13.web.v1.AdminResultR\x06result\x12-\n" +
+	"\x06orders\x18\x02 \x03(\v2\x15.web.v1.TopupOrderRowR\x06orders\x12\x1f\n" +
+	"\vtotal_count\x18\x03 \x01(\x05R\n" +
+	"totalCount\x12\x1b\n" +
+	"\tfrom_unix\x18\x04 \x01(\x03R\bfromUnix\x12\x17\n" +
+	"\ato_unix\x18\x05 \x01(\x03R\x06toUnix\"\xde\x03\n" +
+	"\vTopBuyerRow\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x01 \x01(\x03R\taccountId\x12!\n" +
+	"\faccount_name\x18\x02 \x01(\tR\vaccountName\x12#\n" +
+	"\raccount_email\x18\x03 \x01(\tR\faccountEmail\x12,\n" +
+	"\x12window_paid_orders\x18\x04 \x01(\x03R\x10windowPaidOrders\x12,\n" +
+	"\x12window_gross_cents\x18\x05 \x01(\x03R\x10windowGrossCents\x120\n" +
+	"\x14lifetime_paid_orders\x18\x06 \x01(\x03R\x12lifetimePaidOrders\x120\n" +
+	"\x14lifetime_gross_cents\x18\a \x01(\x03R\x12lifetimeGrossCents\x12)\n" +
+	"\x10lifetime_credits\x18\b \x01(\x03R\x0flifetimeCredits\x12+\n" +
+	"\x12first_paid_at_unix\x18\t \x01(\x03R\x0ffirstPaidAtUnix\x12)\n" +
+	"\x11last_paid_at_unix\x18\n" +
+	" \x01(\x03R\x0elastPaidAtUnix\x12%\n" +
+	"\x0edonate_balance\x18\v \x01(\x05R\rdonateBalance\"\x96\x01\n" +
+	"\x14ListTopBuyersRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\x12-\n" +
+	"\x06window\x18\x02 \x01(\v2\x15.web.v1.RevenueWindowR\x06window\x12\x14\n" +
+	"\x05limit\x18\x03 \x01(\x05R\x05limit\x12\x16\n" +
+	"\x06offset\x18\x04 \x01(\x05R\x06offset\"\xc8\x01\n" +
+	"\x15ListTopBuyersResponse\x12+\n" +
+	"\x06result\x18\x01 \x01(\x0e2\x13.web.v1.AdminResultR\x06result\x12+\n" +
+	"\x06buyers\x18\x02 \x03(\v2\x13.web.v1.TopBuyerRowR\x06buyers\x12\x1f\n" +
+	"\vtotal_count\x18\x03 \x01(\x05R\n" +
+	"totalCount\x12\x1b\n" +
+	"\tfrom_unix\x18\x04 \x01(\x03R\bfromUnix\x12\x17\n" +
+	"\ato_unix\x18\x05 \x01(\x03R\x06toUnix\"\xe1\x03\n" +
+	"\x0fDonateLedgerRow\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\x122\n" +
+	"\x06action\x18\x02 \x01(\x0e2\x1a.web.v1.DonateLedgerActionR\x06action\x12&\n" +
+	"\x0fcreated_at_unix\x18\x03 \x01(\x03R\rcreatedAtUnix\x12,\n" +
+	"\x12subject_account_id\x18\x04 \x01(\x03R\x10subjectAccountId\x120\n" +
+	"\x14subject_account_name\x18\x05 \x01(\tR\x12subjectAccountName\x12(\n" +
+	"\x10actor_account_id\x18\x06 \x01(\x03R\x0eactorAccountId\x12,\n" +
+	"\x12actor_account_name\x18\a \x01(\tR\x10actorAccountName\x12#\n" +
+	"\rcredits_delta\x18\b \x01(\x03R\fcreditsDelta\x12#\n" +
+	"\rbalance_after\x18\t \x01(\x03R\fbalanceAfter\x12 \n" +
+	"\fshop_item_id\x18\n" +
+	" \x01(\x03R\n" +
+	"shopItemId\x12&\n" +
+	"\x0fshop_item_title\x18\v \x01(\tR\rshopItemTitle\x12\x16\n" +
+	"\x06reason\x18\f \x01(\tR\x06reason\"\xeb\x01\n" +
+	"\x16ListDonateSpendRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\x12-\n" +
+	"\x06window\x18\x02 \x01(\v2\x15.web.v1.RevenueWindowR\x06window\x122\n" +
+	"\x06action\x18\x03 \x01(\x0e2\x1a.web.v1.DonateLedgerActionR\x06action\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x04 \x01(\x03R\taccountId\x12\x14\n" +
+	"\x05limit\x18\x05 \x01(\x05R\x05limit\x12\x16\n" +
+	"\x06offset\x18\x06 \x01(\x05R\x06offset\"\xd0\x01\n" +
+	"\x17ListDonateSpendResponse\x12+\n" +
+	"\x06result\x18\x01 \x01(\x0e2\x13.web.v1.AdminResultR\x06result\x121\n" +
+	"\aentries\x18\x02 \x03(\v2\x17.web.v1.DonateLedgerRowR\aentries\x12\x1f\n" +
+	"\vtotal_count\x18\x03 \x01(\x05R\n" +
+	"totalCount\x12\x1b\n" +
+	"\tfrom_unix\x18\x04 \x01(\x03R\bfromUnix\x12\x17\n" +
+	"\ato_unix\x18\x05 \x01(\x03R\x06toUnix\"\xa4\x01\n" +
+	"\x0eAccountSummary\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
+	"\x05email\x18\x03 \x01(\tR\x05email\x12%\n" +
+	"\x0edonate_balance\x18\x04 \x01(\x05R\rdonateBalance\x12\x12\n" +
+	"\x04role\x18\x05 \x01(\tR\x04role\x12\x1d\n" +
+	"\n" +
+	"is_blocked\x18\x06 \x01(\bR\tisBlocked\"q\n" +
+	"\x15SearchAccountsRequest\x12!\n" +
+	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\x12\x1f\n" +
+	"\vname_prefix\x18\x02 \x01(\tR\n" +
+	"namePrefix\x12\x14\n" +
+	"\x05limit\x18\x03 \x01(\x05R\x05limit\"y\n" +
+	"\x16SearchAccountsResponse\x12+\n" +
+	"\x06result\x18\x01 \x01(\x0e2\x13.web.v1.AdminResultR\x06result\x122\n" +
+	"\baccounts\x18\x02 \x03(\v2\x16.web.v1.AccountSummaryR\baccounts*|\n" +
 	"\fCreateResult\x12\x1d\n" +
 	"\x19CREATE_RESULT_UNSPECIFIED\x10\x00\x12\x14\n" +
 	"\x10CREATE_RESULT_OK\x10\x01\x12\x1c\n" +
@@ -7874,7 +9699,16 @@ const file_api_web_v1_web_proto_rawDesc = "" +
 	"\vTopupStatus\x12\x1c\n" +
 	"\x18TOPUP_STATUS_UNSPECIFIED\x10\x00\x12\x18\n" +
 	"\x14TOPUP_STATUS_PENDING\x10\x01\x12\x15\n" +
-	"\x11TOPUP_STATUS_PAID\x10\x022\xbb\x01\n" +
+	"\x11TOPUP_STATUS_PAID\x10\x02*z\n" +
+	"\rRevenueBucket\x12\x1e\n" +
+	"\x1aREVENUE_BUCKET_UNSPECIFIED\x10\x00\x12\x16\n" +
+	"\x12REVENUE_BUCKET_DAY\x10\x01\x12\x17\n" +
+	"\x13REVENUE_BUCKET_WEEK\x10\x02\x12\x18\n" +
+	"\x14REVENUE_BUCKET_MONTH\x10\x03*~\n" +
+	"\x12DonateLedgerAction\x12$\n" +
+	" DONATE_LEDGER_ACTION_UNSPECIFIED\x10\x00\x12!\n" +
+	"\x1dDONATE_LEDGER_ACTION_PURCHASE\x10\x01\x12\x1f\n" +
+	"\x1bDONATE_LEDGER_ACTION_CREDIT\x10\x022\xbb\x01\n" +
 	"\x11AccountWebService\x12L\n" +
 	"\rCreateAccount\x12\x1c.web.v1.CreateAccountRequest\x1a\x1d.web.v1.CreateAccountResponse\x12X\n" +
 	"\x11VerifyCredentials\x12 .web.v1.VerifyCredentialsRequest\x1a!.web.v1.VerifyCredentialsResponse2\xb8\x01\n" +
@@ -7935,7 +9769,13 @@ const file_api_web_v1_web_proto_rawDesc = "" +
 	"\x10SavePayerProfile\x12\x1f.web.v1.SavePayerProfileRequest\x1a .web.v1.SavePayerProfileResponse\x12U\n" +
 	"\x10CreateTopupOrder\x12\x1f.web.v1.CreateTopupOrderRequest\x1a .web.v1.CreateTopupOrderResponse\x12X\n" +
 	"\x11ConfirmTopupOrder\x12 .web.v1.ConfirmTopupOrderRequest\x1a!.web.v1.ConfirmTopupOrderResponse\x12L\n" +
-	"\rGetTopupOrder\x12\x1c.web.v1.GetTopupOrderRequest\x1a\x1d.web.v1.GetTopupOrderResponseB3Z1github.com/jeanluca/w2pp-openwyd/api/web/v1;webv1b\x06proto3"
+	"\rGetTopupOrder\x12\x1c.web.v1.GetTopupOrderRequest\x1a\x1d.web.v1.GetTopupOrderResponse2\xbc\x03\n" +
+	"\x19DonateRevenueAdminService\x12X\n" +
+	"\x11GetRevenueSummary\x12 .web.v1.GetRevenueSummaryRequest\x1a!.web.v1.GetRevenueSummaryResponse\x12R\n" +
+	"\x0fListTopupOrders\x12\x1e.web.v1.ListTopupOrdersRequest\x1a\x1f.web.v1.ListTopupOrdersResponse\x12L\n" +
+	"\rListTopBuyers\x12\x1c.web.v1.ListTopBuyersRequest\x1a\x1d.web.v1.ListTopBuyersResponse\x12R\n" +
+	"\x0fListDonateSpend\x12\x1e.web.v1.ListDonateSpendRequest\x1a\x1f.web.v1.ListDonateSpendResponse\x12O\n" +
+	"\x0eSearchAccounts\x12\x1d.web.v1.SearchAccountsRequest\x1a\x1e.web.v1.SearchAccountsResponseB3Z1github.com/jeanluca/w2pp-openwyd/api/web/v1;webv1b\x06proto3"
 
 var (
 	file_api_web_v1_web_proto_rawDescOnce sync.Once
@@ -7949,8 +9789,8 @@ func file_api_web_v1_web_proto_rawDescGZIP() []byte {
 	return file_api_web_v1_web_proto_rawDescData
 }
 
-var file_api_web_v1_web_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_api_web_v1_web_proto_msgTypes = make([]protoimpl.MessageInfo, 108)
+var file_api_web_v1_web_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
+var file_api_web_v1_web_proto_msgTypes = make([]protoimpl.MessageInfo, 126)
 var file_api_web_v1_web_proto_goTypes = []any{
 	(CreateResult)(0),                     // 0: web.v1.CreateResult
 	(AdminResult)(0),                      // 1: web.v1.AdminResult
@@ -7960,280 +9800,334 @@ var file_api_web_v1_web_proto_goTypes = []any{
 	(PaymentMethod)(0),                    // 5: web.v1.PaymentMethod
 	(TopupResult)(0),                      // 6: web.v1.TopupResult
 	(TopupStatus)(0),                      // 7: web.v1.TopupStatus
-	(*CreateAccountRequest)(nil),          // 8: web.v1.CreateAccountRequest
-	(*CreateAccountResponse)(nil),         // 9: web.v1.CreateAccountResponse
-	(*VerifyCredentialsRequest)(nil),      // 10: web.v1.VerifyCredentialsRequest
-	(*VerifyCredentialsResponse)(nil),     // 11: web.v1.VerifyCredentialsResponse
-	(*ListExpRankingRequest)(nil),         // 12: web.v1.ListExpRankingRequest
-	(*RankingEntry)(nil),                  // 13: web.v1.RankingEntry
-	(*ListExpRankingResponse)(nil),        // 14: web.v1.ListExpRankingResponse
-	(*ListDuelRankingRequest)(nil),        // 15: web.v1.ListDuelRankingRequest
-	(*DuelRankingEntry)(nil),              // 16: web.v1.DuelRankingEntry
-	(*ListDuelRankingResponse)(nil),       // 17: web.v1.ListDuelRankingResponse
-	(*ListMyCharactersRequest)(nil),       // 18: web.v1.ListMyCharactersRequest
-	(*WebCharacterSummary)(nil),           // 19: web.v1.WebCharacterSummary
-	(*ListMyCharactersResponse)(nil),      // 20: web.v1.ListMyCharactersResponse
-	(*AdminAck)(nil),                      // 21: web.v1.AdminAck
-	(*AdminNpcShopItem)(nil),              // 22: web.v1.AdminNpcShopItem
-	(*AdminNpc)(nil),                      // 23: web.v1.AdminNpc
-	(*ListNpcsRequest)(nil),               // 24: web.v1.ListNpcsRequest
-	(*ListNpcsResponse)(nil),              // 25: web.v1.ListNpcsResponse
-	(*GetNpcRequest)(nil),                 // 26: web.v1.GetNpcRequest
-	(*GetNpcResponse)(nil),                // 27: web.v1.GetNpcResponse
-	(*UpsertNpcRequest)(nil),              // 28: web.v1.UpsertNpcRequest
-	(*UpsertNpcResponse)(nil),             // 29: web.v1.UpsertNpcResponse
-	(*SetNpcVisibilityRequest)(nil),       // 30: web.v1.SetNpcVisibilityRequest
-	(*SetNpcShopRequest)(nil),             // 31: web.v1.SetNpcShopRequest
-	(*SetItemPriceRequest)(nil),           // 32: web.v1.SetItemPriceRequest
-	(*DeleteNpcRequest)(nil),              // 33: web.v1.DeleteNpcRequest
-	(*MerchantTemplate)(nil),              // 34: web.v1.MerchantTemplate
-	(*ListMerchantTemplatesRequest)(nil),  // 35: web.v1.ListMerchantTemplatesRequest
-	(*ListMerchantTemplatesResponse)(nil), // 36: web.v1.ListMerchantTemplatesResponse
-	(*ItemCatalogEntry)(nil),              // 37: web.v1.ItemCatalogEntry
-	(*ListItemCatalogRequest)(nil),        // 38: web.v1.ListItemCatalogRequest
-	(*ListItemCatalogResponse)(nil),       // 39: web.v1.ListItemCatalogResponse
-	(*DropItemMob)(nil),                   // 40: web.v1.DropItemMob
-	(*DropItemEntry)(nil),                 // 41: web.v1.DropItemEntry
-	(*ListDropItemsRequest)(nil),          // 42: web.v1.ListDropItemsRequest
-	(*ListDropItemsResponse)(nil),         // 43: web.v1.ListDropItemsResponse
-	(*MobDropItem)(nil),                   // 44: web.v1.MobDropItem
-	(*MobDropEntry)(nil),                  // 45: web.v1.MobDropEntry
-	(*ListMobDropsRequest)(nil),           // 46: web.v1.ListMobDropsRequest
-	(*ListMobDropsResponse)(nil),          // 47: web.v1.ListMobDropsResponse
-	(*ItemPrice)(nil),                     // 48: web.v1.ItemPrice
-	(*ListItemPricesRequest)(nil),         // 49: web.v1.ListItemPricesRequest
-	(*ListItemPricesResponse)(nil),        // 50: web.v1.ListItemPricesResponse
-	(*MapZone)(nil),                       // 51: web.v1.MapZone
-	(*ListMapZonesRequest)(nil),           // 52: web.v1.ListMapZonesRequest
-	(*ListMapZonesResponse)(nil),          // 53: web.v1.ListMapZonesResponse
-	(*MobTemplateFile)(nil),               // 54: web.v1.MobTemplateFile
-	(*ListMobTemplatesRequest)(nil),       // 55: web.v1.ListMobTemplatesRequest
-	(*ListMobTemplatesResponse)(nil),      // 56: web.v1.ListMobTemplatesResponse
-	(*AdminMobTemplateEquipItem)(nil),     // 57: web.v1.AdminMobTemplateEquipItem
-	(*AdminMobTemplateStat)(nil),          // 58: web.v1.AdminMobTemplateStat
-	(*GetMobTemplateStatRequest)(nil),     // 59: web.v1.GetMobTemplateStatRequest
-	(*GetMobTemplateStatResponse)(nil),    // 60: web.v1.GetMobTemplateStatResponse
-	(*UpsertMobTemplateStatRequest)(nil),  // 61: web.v1.UpsertMobTemplateStatRequest
-	(*UpsertMobTemplateStatResponse)(nil), // 62: web.v1.UpsertMobTemplateStatResponse
-	(*SetMobTemplateEquipRequest)(nil),    // 63: web.v1.SetMobTemplateEquipRequest
-	(*DeleteMobTemplateStatRequest)(nil),  // 64: web.v1.DeleteMobTemplateStatRequest
-	(*GetAttributeMapInfoRequest)(nil),    // 65: web.v1.GetAttributeMapInfoRequest
-	(*GetAttributeMapInfoResponse)(nil),   // 66: web.v1.GetAttributeMapInfoResponse
-	(*AttributeMapInfo)(nil),              // 67: web.v1.AttributeMapInfo
-	(*AttributeMapValueCount)(nil),        // 68: web.v1.AttributeMapValueCount
-	(*AttributeMapMeaning)(nil),           // 69: web.v1.AttributeMapMeaning
-	(*AttributeMapRect)(nil),              // 70: web.v1.AttributeMapRect
-	(*AttributeMapTransformFilter)(nil),   // 71: web.v1.AttributeMapTransformFilter
-	(*TransformAttributeMapRequest)(nil),  // 72: web.v1.TransformAttributeMapRequest
-	(*TransformAttributeMapResponse)(nil), // 73: web.v1.TransformAttributeMapResponse
-	(*DonateShopItem)(nil),                // 74: web.v1.DonateShopItem
-	(*ListShopItemsRequest)(nil),          // 75: web.v1.ListShopItemsRequest
-	(*ListShopItemsResponse)(nil),         // 76: web.v1.ListShopItemsResponse
-	(*UpsertShopItemRequest)(nil),         // 77: web.v1.UpsertShopItemRequest
-	(*UpsertShopItemResponse)(nil),        // 78: web.v1.UpsertShopItemResponse
-	(*SetShopItemEnabledRequest)(nil),     // 79: web.v1.SetShopItemEnabledRequest
-	(*DeleteShopItemRequest)(nil),         // 80: web.v1.DeleteShopItemRequest
-	(*CreditDonateBalanceRequest)(nil),    // 81: web.v1.CreditDonateBalanceRequest
-	(*CreditDonateBalanceResponse)(nil),   // 82: web.v1.CreditDonateBalanceResponse
-	(*ListStoreItemsRequest)(nil),         // 83: web.v1.ListStoreItemsRequest
-	(*ListStoreItemsResponse)(nil),        // 84: web.v1.ListStoreItemsResponse
-	(*GetBalanceRequest)(nil),             // 85: web.v1.GetBalanceRequest
-	(*GetBalanceResponse)(nil),            // 86: web.v1.GetBalanceResponse
-	(*BuyRequest)(nil),                    // 87: web.v1.BuyRequest
-	(*BuyResponse)(nil),                   // 88: web.v1.BuyResponse
-	(*DailyRewardItem)(nil),               // 89: web.v1.DailyRewardItem
-	(*ListRewardItemsRequest)(nil),        // 90: web.v1.ListRewardItemsRequest
-	(*ListRewardItemsResponse)(nil),       // 91: web.v1.ListRewardItemsResponse
-	(*UpsertRewardItemRequest)(nil),       // 92: web.v1.UpsertRewardItemRequest
-	(*UpsertRewardItemResponse)(nil),      // 93: web.v1.UpsertRewardItemResponse
-	(*SetRewardItemEnabledRequest)(nil),   // 94: web.v1.SetRewardItemEnabledRequest
-	(*DeleteRewardItemRequest)(nil),       // 95: web.v1.DeleteRewardItemRequest
-	(*WorldEventConfig)(nil),              // 96: web.v1.WorldEventConfig
-	(*GetWorldEventConfigRequest)(nil),    // 97: web.v1.GetWorldEventConfigRequest
-	(*GetWorldEventConfigResponse)(nil),   // 98: web.v1.GetWorldEventConfigResponse
-	(*SetWorldEventConfigRequest)(nil),    // 99: web.v1.SetWorldEventConfigRequest
-	(*ListRewardsRequest)(nil),            // 100: web.v1.ListRewardsRequest
-	(*ListRewardsResponse)(nil),           // 101: web.v1.ListRewardsResponse
-	(*GetClaimStatusRequest)(nil),         // 102: web.v1.GetClaimStatusRequest
-	(*GetClaimStatusResponse)(nil),        // 103: web.v1.GetClaimStatusResponse
-	(*ClaimRequest)(nil),                  // 104: web.v1.ClaimRequest
-	(*ClaimResponse)(nil),                 // 105: web.v1.ClaimResponse
-	(*GetPayerProfileRequest)(nil),        // 106: web.v1.GetPayerProfileRequest
-	(*GetPayerProfileResponse)(nil),       // 107: web.v1.GetPayerProfileResponse
-	(*SavePayerProfileRequest)(nil),       // 108: web.v1.SavePayerProfileRequest
-	(*SavePayerProfileResponse)(nil),      // 109: web.v1.SavePayerProfileResponse
-	(*CreateTopupOrderRequest)(nil),       // 110: web.v1.CreateTopupOrderRequest
-	(*CreateTopupOrderResponse)(nil),      // 111: web.v1.CreateTopupOrderResponse
-	(*ConfirmTopupOrderRequest)(nil),      // 112: web.v1.ConfirmTopupOrderRequest
-	(*ConfirmTopupOrderResponse)(nil),     // 113: web.v1.ConfirmTopupOrderResponse
-	(*GetTopupOrderRequest)(nil),          // 114: web.v1.GetTopupOrderRequest
-	(*GetTopupOrderResponse)(nil),         // 115: web.v1.GetTopupOrderResponse
+	(RevenueBucket)(0),                    // 8: web.v1.RevenueBucket
+	(DonateLedgerAction)(0),               // 9: web.v1.DonateLedgerAction
+	(*CreateAccountRequest)(nil),          // 10: web.v1.CreateAccountRequest
+	(*CreateAccountResponse)(nil),         // 11: web.v1.CreateAccountResponse
+	(*VerifyCredentialsRequest)(nil),      // 12: web.v1.VerifyCredentialsRequest
+	(*VerifyCredentialsResponse)(nil),     // 13: web.v1.VerifyCredentialsResponse
+	(*ListExpRankingRequest)(nil),         // 14: web.v1.ListExpRankingRequest
+	(*RankingEntry)(nil),                  // 15: web.v1.RankingEntry
+	(*ListExpRankingResponse)(nil),        // 16: web.v1.ListExpRankingResponse
+	(*ListDuelRankingRequest)(nil),        // 17: web.v1.ListDuelRankingRequest
+	(*DuelRankingEntry)(nil),              // 18: web.v1.DuelRankingEntry
+	(*ListDuelRankingResponse)(nil),       // 19: web.v1.ListDuelRankingResponse
+	(*ListMyCharactersRequest)(nil),       // 20: web.v1.ListMyCharactersRequest
+	(*WebCharacterSummary)(nil),           // 21: web.v1.WebCharacterSummary
+	(*ListMyCharactersResponse)(nil),      // 22: web.v1.ListMyCharactersResponse
+	(*AdminAck)(nil),                      // 23: web.v1.AdminAck
+	(*AdminNpcShopItem)(nil),              // 24: web.v1.AdminNpcShopItem
+	(*AdminNpc)(nil),                      // 25: web.v1.AdminNpc
+	(*ListNpcsRequest)(nil),               // 26: web.v1.ListNpcsRequest
+	(*ListNpcsResponse)(nil),              // 27: web.v1.ListNpcsResponse
+	(*GetNpcRequest)(nil),                 // 28: web.v1.GetNpcRequest
+	(*GetNpcResponse)(nil),                // 29: web.v1.GetNpcResponse
+	(*UpsertNpcRequest)(nil),              // 30: web.v1.UpsertNpcRequest
+	(*UpsertNpcResponse)(nil),             // 31: web.v1.UpsertNpcResponse
+	(*SetNpcVisibilityRequest)(nil),       // 32: web.v1.SetNpcVisibilityRequest
+	(*SetNpcShopRequest)(nil),             // 33: web.v1.SetNpcShopRequest
+	(*SetItemPriceRequest)(nil),           // 34: web.v1.SetItemPriceRequest
+	(*DeleteNpcRequest)(nil),              // 35: web.v1.DeleteNpcRequest
+	(*MerchantTemplate)(nil),              // 36: web.v1.MerchantTemplate
+	(*ListMerchantTemplatesRequest)(nil),  // 37: web.v1.ListMerchantTemplatesRequest
+	(*ListMerchantTemplatesResponse)(nil), // 38: web.v1.ListMerchantTemplatesResponse
+	(*ItemCatalogEntry)(nil),              // 39: web.v1.ItemCatalogEntry
+	(*ListItemCatalogRequest)(nil),        // 40: web.v1.ListItemCatalogRequest
+	(*ListItemCatalogResponse)(nil),       // 41: web.v1.ListItemCatalogResponse
+	(*DropItemMob)(nil),                   // 42: web.v1.DropItemMob
+	(*DropItemEntry)(nil),                 // 43: web.v1.DropItemEntry
+	(*ListDropItemsRequest)(nil),          // 44: web.v1.ListDropItemsRequest
+	(*ListDropItemsResponse)(nil),         // 45: web.v1.ListDropItemsResponse
+	(*MobDropItem)(nil),                   // 46: web.v1.MobDropItem
+	(*MobDropEntry)(nil),                  // 47: web.v1.MobDropEntry
+	(*ListMobDropsRequest)(nil),           // 48: web.v1.ListMobDropsRequest
+	(*ListMobDropsResponse)(nil),          // 49: web.v1.ListMobDropsResponse
+	(*ItemPrice)(nil),                     // 50: web.v1.ItemPrice
+	(*ListItemPricesRequest)(nil),         // 51: web.v1.ListItemPricesRequest
+	(*ListItemPricesResponse)(nil),        // 52: web.v1.ListItemPricesResponse
+	(*MapZone)(nil),                       // 53: web.v1.MapZone
+	(*ListMapZonesRequest)(nil),           // 54: web.v1.ListMapZonesRequest
+	(*ListMapZonesResponse)(nil),          // 55: web.v1.ListMapZonesResponse
+	(*MobTemplateFile)(nil),               // 56: web.v1.MobTemplateFile
+	(*ListMobTemplatesRequest)(nil),       // 57: web.v1.ListMobTemplatesRequest
+	(*ListMobTemplatesResponse)(nil),      // 58: web.v1.ListMobTemplatesResponse
+	(*AdminMobTemplateEquipItem)(nil),     // 59: web.v1.AdminMobTemplateEquipItem
+	(*AdminMobTemplateStat)(nil),          // 60: web.v1.AdminMobTemplateStat
+	(*GetMobTemplateStatRequest)(nil),     // 61: web.v1.GetMobTemplateStatRequest
+	(*GetMobTemplateStatResponse)(nil),    // 62: web.v1.GetMobTemplateStatResponse
+	(*UpsertMobTemplateStatRequest)(nil),  // 63: web.v1.UpsertMobTemplateStatRequest
+	(*UpsertMobTemplateStatResponse)(nil), // 64: web.v1.UpsertMobTemplateStatResponse
+	(*SetMobTemplateEquipRequest)(nil),    // 65: web.v1.SetMobTemplateEquipRequest
+	(*DeleteMobTemplateStatRequest)(nil),  // 66: web.v1.DeleteMobTemplateStatRequest
+	(*GetAttributeMapInfoRequest)(nil),    // 67: web.v1.GetAttributeMapInfoRequest
+	(*GetAttributeMapInfoResponse)(nil),   // 68: web.v1.GetAttributeMapInfoResponse
+	(*AttributeMapInfo)(nil),              // 69: web.v1.AttributeMapInfo
+	(*AttributeMapValueCount)(nil),        // 70: web.v1.AttributeMapValueCount
+	(*AttributeMapMeaning)(nil),           // 71: web.v1.AttributeMapMeaning
+	(*AttributeMapRect)(nil),              // 72: web.v1.AttributeMapRect
+	(*AttributeMapTransformFilter)(nil),   // 73: web.v1.AttributeMapTransformFilter
+	(*TransformAttributeMapRequest)(nil),  // 74: web.v1.TransformAttributeMapRequest
+	(*TransformAttributeMapResponse)(nil), // 75: web.v1.TransformAttributeMapResponse
+	(*DonateShopItem)(nil),                // 76: web.v1.DonateShopItem
+	(*ListShopItemsRequest)(nil),          // 77: web.v1.ListShopItemsRequest
+	(*ListShopItemsResponse)(nil),         // 78: web.v1.ListShopItemsResponse
+	(*UpsertShopItemRequest)(nil),         // 79: web.v1.UpsertShopItemRequest
+	(*UpsertShopItemResponse)(nil),        // 80: web.v1.UpsertShopItemResponse
+	(*SetShopItemEnabledRequest)(nil),     // 81: web.v1.SetShopItemEnabledRequest
+	(*DeleteShopItemRequest)(nil),         // 82: web.v1.DeleteShopItemRequest
+	(*CreditDonateBalanceRequest)(nil),    // 83: web.v1.CreditDonateBalanceRequest
+	(*CreditDonateBalanceResponse)(nil),   // 84: web.v1.CreditDonateBalanceResponse
+	(*ListStoreItemsRequest)(nil),         // 85: web.v1.ListStoreItemsRequest
+	(*ListStoreItemsResponse)(nil),        // 86: web.v1.ListStoreItemsResponse
+	(*GetBalanceRequest)(nil),             // 87: web.v1.GetBalanceRequest
+	(*GetBalanceResponse)(nil),            // 88: web.v1.GetBalanceResponse
+	(*BuyRequest)(nil),                    // 89: web.v1.BuyRequest
+	(*BuyResponse)(nil),                   // 90: web.v1.BuyResponse
+	(*DailyRewardItem)(nil),               // 91: web.v1.DailyRewardItem
+	(*ListRewardItemsRequest)(nil),        // 92: web.v1.ListRewardItemsRequest
+	(*ListRewardItemsResponse)(nil),       // 93: web.v1.ListRewardItemsResponse
+	(*UpsertRewardItemRequest)(nil),       // 94: web.v1.UpsertRewardItemRequest
+	(*UpsertRewardItemResponse)(nil),      // 95: web.v1.UpsertRewardItemResponse
+	(*SetRewardItemEnabledRequest)(nil),   // 96: web.v1.SetRewardItemEnabledRequest
+	(*DeleteRewardItemRequest)(nil),       // 97: web.v1.DeleteRewardItemRequest
+	(*WorldEventConfig)(nil),              // 98: web.v1.WorldEventConfig
+	(*GetWorldEventConfigRequest)(nil),    // 99: web.v1.GetWorldEventConfigRequest
+	(*GetWorldEventConfigResponse)(nil),   // 100: web.v1.GetWorldEventConfigResponse
+	(*SetWorldEventConfigRequest)(nil),    // 101: web.v1.SetWorldEventConfigRequest
+	(*ListRewardsRequest)(nil),            // 102: web.v1.ListRewardsRequest
+	(*ListRewardsResponse)(nil),           // 103: web.v1.ListRewardsResponse
+	(*GetClaimStatusRequest)(nil),         // 104: web.v1.GetClaimStatusRequest
+	(*GetClaimStatusResponse)(nil),        // 105: web.v1.GetClaimStatusResponse
+	(*ClaimRequest)(nil),                  // 106: web.v1.ClaimRequest
+	(*ClaimResponse)(nil),                 // 107: web.v1.ClaimResponse
+	(*GetPayerProfileRequest)(nil),        // 108: web.v1.GetPayerProfileRequest
+	(*GetPayerProfileResponse)(nil),       // 109: web.v1.GetPayerProfileResponse
+	(*SavePayerProfileRequest)(nil),       // 110: web.v1.SavePayerProfileRequest
+	(*SavePayerProfileResponse)(nil),      // 111: web.v1.SavePayerProfileResponse
+	(*CreateTopupOrderRequest)(nil),       // 112: web.v1.CreateTopupOrderRequest
+	(*CreateTopupOrderResponse)(nil),      // 113: web.v1.CreateTopupOrderResponse
+	(*ConfirmTopupOrderRequest)(nil),      // 114: web.v1.ConfirmTopupOrderRequest
+	(*ConfirmTopupOrderResponse)(nil),     // 115: web.v1.ConfirmTopupOrderResponse
+	(*GetTopupOrderRequest)(nil),          // 116: web.v1.GetTopupOrderRequest
+	(*GetTopupOrderResponse)(nil),         // 117: web.v1.GetTopupOrderResponse
+	(*RevenueWindow)(nil),                 // 118: web.v1.RevenueWindow
+	(*RevenueTotals)(nil),                 // 119: web.v1.RevenueTotals
+	(*RevenueByMethod)(nil),               // 120: web.v1.RevenueByMethod
+	(*RevenuePoint)(nil),                  // 121: web.v1.RevenuePoint
+	(*GetRevenueSummaryRequest)(nil),      // 122: web.v1.GetRevenueSummaryRequest
+	(*GetRevenueSummaryResponse)(nil),     // 123: web.v1.GetRevenueSummaryResponse
+	(*TopupOrderRow)(nil),                 // 124: web.v1.TopupOrderRow
+	(*ListTopupOrdersRequest)(nil),        // 125: web.v1.ListTopupOrdersRequest
+	(*ListTopupOrdersResponse)(nil),       // 126: web.v1.ListTopupOrdersResponse
+	(*TopBuyerRow)(nil),                   // 127: web.v1.TopBuyerRow
+	(*ListTopBuyersRequest)(nil),          // 128: web.v1.ListTopBuyersRequest
+	(*ListTopBuyersResponse)(nil),         // 129: web.v1.ListTopBuyersResponse
+	(*DonateLedgerRow)(nil),               // 130: web.v1.DonateLedgerRow
+	(*ListDonateSpendRequest)(nil),        // 131: web.v1.ListDonateSpendRequest
+	(*ListDonateSpendResponse)(nil),       // 132: web.v1.ListDonateSpendResponse
+	(*AccountSummary)(nil),                // 133: web.v1.AccountSummary
+	(*SearchAccountsRequest)(nil),         // 134: web.v1.SearchAccountsRequest
+	(*SearchAccountsResponse)(nil),        // 135: web.v1.SearchAccountsResponse
 }
 var file_api_web_v1_web_proto_depIdxs = []int32{
 	0,   // 0: web.v1.CreateAccountResponse.result:type_name -> web.v1.CreateResult
-	13,  // 1: web.v1.ListExpRankingResponse.entries:type_name -> web.v1.RankingEntry
-	16,  // 2: web.v1.ListDuelRankingResponse.entries:type_name -> web.v1.DuelRankingEntry
-	19,  // 3: web.v1.ListMyCharactersResponse.characters:type_name -> web.v1.WebCharacterSummary
+	15,  // 1: web.v1.ListExpRankingResponse.entries:type_name -> web.v1.RankingEntry
+	18,  // 2: web.v1.ListDuelRankingResponse.entries:type_name -> web.v1.DuelRankingEntry
+	21,  // 3: web.v1.ListMyCharactersResponse.characters:type_name -> web.v1.WebCharacterSummary
 	1,   // 4: web.v1.AdminAck.result:type_name -> web.v1.AdminResult
-	22,  // 5: web.v1.AdminNpc.shop:type_name -> web.v1.AdminNpcShopItem
+	24,  // 5: web.v1.AdminNpc.shop:type_name -> web.v1.AdminNpcShopItem
 	1,   // 6: web.v1.ListNpcsResponse.result:type_name -> web.v1.AdminResult
-	23,  // 7: web.v1.ListNpcsResponse.npcs:type_name -> web.v1.AdminNpc
+	25,  // 7: web.v1.ListNpcsResponse.npcs:type_name -> web.v1.AdminNpc
 	1,   // 8: web.v1.GetNpcResponse.result:type_name -> web.v1.AdminResult
-	23,  // 9: web.v1.GetNpcResponse.npc:type_name -> web.v1.AdminNpc
+	25,  // 9: web.v1.GetNpcResponse.npc:type_name -> web.v1.AdminNpc
 	1,   // 10: web.v1.UpsertNpcResponse.result:type_name -> web.v1.AdminResult
-	22,  // 11: web.v1.SetNpcShopRequest.items:type_name -> web.v1.AdminNpcShopItem
+	24,  // 11: web.v1.SetNpcShopRequest.items:type_name -> web.v1.AdminNpcShopItem
 	1,   // 12: web.v1.ListMerchantTemplatesResponse.result:type_name -> web.v1.AdminResult
-	34,  // 13: web.v1.ListMerchantTemplatesResponse.templates:type_name -> web.v1.MerchantTemplate
+	36,  // 13: web.v1.ListMerchantTemplatesResponse.templates:type_name -> web.v1.MerchantTemplate
 	1,   // 14: web.v1.ListItemCatalogResponse.result:type_name -> web.v1.AdminResult
-	37,  // 15: web.v1.ListItemCatalogResponse.items:type_name -> web.v1.ItemCatalogEntry
-	40,  // 16: web.v1.DropItemEntry.mobs:type_name -> web.v1.DropItemMob
+	39,  // 15: web.v1.ListItemCatalogResponse.items:type_name -> web.v1.ItemCatalogEntry
+	42,  // 16: web.v1.DropItemEntry.mobs:type_name -> web.v1.DropItemMob
 	1,   // 17: web.v1.ListDropItemsResponse.result:type_name -> web.v1.AdminResult
-	41,  // 18: web.v1.ListDropItemsResponse.items:type_name -> web.v1.DropItemEntry
-	44,  // 19: web.v1.MobDropEntry.items:type_name -> web.v1.MobDropItem
+	43,  // 18: web.v1.ListDropItemsResponse.items:type_name -> web.v1.DropItemEntry
+	46,  // 19: web.v1.MobDropEntry.items:type_name -> web.v1.MobDropItem
 	1,   // 20: web.v1.ListMobDropsResponse.result:type_name -> web.v1.AdminResult
-	45,  // 21: web.v1.ListMobDropsResponse.mobs:type_name -> web.v1.MobDropEntry
+	47,  // 21: web.v1.ListMobDropsResponse.mobs:type_name -> web.v1.MobDropEntry
 	1,   // 22: web.v1.ListItemPricesResponse.result:type_name -> web.v1.AdminResult
-	48,  // 23: web.v1.ListItemPricesResponse.prices:type_name -> web.v1.ItemPrice
+	50,  // 23: web.v1.ListItemPricesResponse.prices:type_name -> web.v1.ItemPrice
 	1,   // 24: web.v1.ListMapZonesResponse.result:type_name -> web.v1.AdminResult
-	51,  // 25: web.v1.ListMapZonesResponse.zones:type_name -> web.v1.MapZone
+	53,  // 25: web.v1.ListMapZonesResponse.zones:type_name -> web.v1.MapZone
 	1,   // 26: web.v1.ListMobTemplatesResponse.result:type_name -> web.v1.AdminResult
-	54,  // 27: web.v1.ListMobTemplatesResponse.templates:type_name -> web.v1.MobTemplateFile
-	57,  // 28: web.v1.AdminMobTemplateStat.equip:type_name -> web.v1.AdminMobTemplateEquipItem
+	56,  // 27: web.v1.ListMobTemplatesResponse.templates:type_name -> web.v1.MobTemplateFile
+	59,  // 28: web.v1.AdminMobTemplateStat.equip:type_name -> web.v1.AdminMobTemplateEquipItem
 	1,   // 29: web.v1.GetMobTemplateStatResponse.result:type_name -> web.v1.AdminResult
-	58,  // 30: web.v1.GetMobTemplateStatResponse.stat:type_name -> web.v1.AdminMobTemplateStat
-	58,  // 31: web.v1.UpsertMobTemplateStatRequest.stat:type_name -> web.v1.AdminMobTemplateStat
+	60,  // 30: web.v1.GetMobTemplateStatResponse.stat:type_name -> web.v1.AdminMobTemplateStat
+	60,  // 31: web.v1.UpsertMobTemplateStatRequest.stat:type_name -> web.v1.AdminMobTemplateStat
 	1,   // 32: web.v1.UpsertMobTemplateStatResponse.result:type_name -> web.v1.AdminResult
-	57,  // 33: web.v1.SetMobTemplateEquipRequest.items:type_name -> web.v1.AdminMobTemplateEquipItem
+	59,  // 33: web.v1.SetMobTemplateEquipRequest.items:type_name -> web.v1.AdminMobTemplateEquipItem
 	1,   // 34: web.v1.GetAttributeMapInfoResponse.result:type_name -> web.v1.AdminResult
-	67,  // 35: web.v1.GetAttributeMapInfoResponse.info:type_name -> web.v1.AttributeMapInfo
-	68,  // 36: web.v1.AttributeMapInfo.histogram:type_name -> web.v1.AttributeMapValueCount
-	69,  // 37: web.v1.AttributeMapInfo.meanings:type_name -> web.v1.AttributeMapMeaning
+	69,  // 35: web.v1.GetAttributeMapInfoResponse.info:type_name -> web.v1.AttributeMapInfo
+	70,  // 36: web.v1.AttributeMapInfo.histogram:type_name -> web.v1.AttributeMapValueCount
+	71,  // 37: web.v1.AttributeMapInfo.meanings:type_name -> web.v1.AttributeMapMeaning
 	2,   // 38: web.v1.TransformAttributeMapRequest.operation:type_name -> web.v1.AttributeMapTransformOperation
-	70,  // 39: web.v1.TransformAttributeMapRequest.rect:type_name -> web.v1.AttributeMapRect
-	71,  // 40: web.v1.TransformAttributeMapRequest.filter:type_name -> web.v1.AttributeMapTransformFilter
+	72,  // 39: web.v1.TransformAttributeMapRequest.rect:type_name -> web.v1.AttributeMapRect
+	73,  // 40: web.v1.TransformAttributeMapRequest.filter:type_name -> web.v1.AttributeMapTransformFilter
 	1,   // 41: web.v1.TransformAttributeMapResponse.result:type_name -> web.v1.AdminResult
-	68,  // 42: web.v1.TransformAttributeMapResponse.before_histogram:type_name -> web.v1.AttributeMapValueCount
-	68,  // 43: web.v1.TransformAttributeMapResponse.after_histogram:type_name -> web.v1.AttributeMapValueCount
+	70,  // 42: web.v1.TransformAttributeMapResponse.before_histogram:type_name -> web.v1.AttributeMapValueCount
+	70,  // 43: web.v1.TransformAttributeMapResponse.after_histogram:type_name -> web.v1.AttributeMapValueCount
 	1,   // 44: web.v1.ListShopItemsResponse.result:type_name -> web.v1.AdminResult
-	74,  // 45: web.v1.ListShopItemsResponse.items:type_name -> web.v1.DonateShopItem
-	74,  // 46: web.v1.UpsertShopItemRequest.item:type_name -> web.v1.DonateShopItem
+	76,  // 45: web.v1.ListShopItemsResponse.items:type_name -> web.v1.DonateShopItem
+	76,  // 46: web.v1.UpsertShopItemRequest.item:type_name -> web.v1.DonateShopItem
 	1,   // 47: web.v1.UpsertShopItemResponse.result:type_name -> web.v1.AdminResult
 	1,   // 48: web.v1.CreditDonateBalanceResponse.result:type_name -> web.v1.AdminResult
-	74,  // 49: web.v1.ListStoreItemsResponse.items:type_name -> web.v1.DonateShopItem
+	76,  // 49: web.v1.ListStoreItemsResponse.items:type_name -> web.v1.DonateShopItem
 	3,   // 50: web.v1.BuyResponse.result:type_name -> web.v1.BuyResult
 	1,   // 51: web.v1.ListRewardItemsResponse.result:type_name -> web.v1.AdminResult
-	89,  // 52: web.v1.ListRewardItemsResponse.items:type_name -> web.v1.DailyRewardItem
-	89,  // 53: web.v1.UpsertRewardItemRequest.item:type_name -> web.v1.DailyRewardItem
+	91,  // 52: web.v1.ListRewardItemsResponse.items:type_name -> web.v1.DailyRewardItem
+	91,  // 53: web.v1.UpsertRewardItemRequest.item:type_name -> web.v1.DailyRewardItem
 	1,   // 54: web.v1.UpsertRewardItemResponse.result:type_name -> web.v1.AdminResult
 	1,   // 55: web.v1.GetWorldEventConfigResponse.result:type_name -> web.v1.AdminResult
-	96,  // 56: web.v1.GetWorldEventConfigResponse.config:type_name -> web.v1.WorldEventConfig
-	96,  // 57: web.v1.SetWorldEventConfigRequest.config:type_name -> web.v1.WorldEventConfig
-	89,  // 58: web.v1.ListRewardsResponse.items:type_name -> web.v1.DailyRewardItem
+	98,  // 56: web.v1.GetWorldEventConfigResponse.config:type_name -> web.v1.WorldEventConfig
+	98,  // 57: web.v1.SetWorldEventConfigRequest.config:type_name -> web.v1.WorldEventConfig
+	91,  // 58: web.v1.ListRewardsResponse.items:type_name -> web.v1.DailyRewardItem
 	4,   // 59: web.v1.ClaimResponse.result:type_name -> web.v1.ClaimResult
 	1,   // 60: web.v1.SavePayerProfileResponse.result:type_name -> web.v1.AdminResult
 	5,   // 61: web.v1.CreateTopupOrderRequest.payment_method:type_name -> web.v1.PaymentMethod
 	1,   // 62: web.v1.CreateTopupOrderResponse.result:type_name -> web.v1.AdminResult
 	6,   // 63: web.v1.ConfirmTopupOrderResponse.result:type_name -> web.v1.TopupResult
 	7,   // 64: web.v1.GetTopupOrderResponse.status:type_name -> web.v1.TopupStatus
-	8,   // 65: web.v1.AccountWebService.CreateAccount:input_type -> web.v1.CreateAccountRequest
-	10,  // 66: web.v1.AccountWebService.VerifyCredentials:input_type -> web.v1.VerifyCredentialsRequest
-	12,  // 67: web.v1.RankingWebService.ListExpRanking:input_type -> web.v1.ListExpRankingRequest
-	15,  // 68: web.v1.RankingWebService.ListDuelRanking:input_type -> web.v1.ListDuelRankingRequest
-	18,  // 69: web.v1.CharacterWebService.ListMyCharacters:input_type -> web.v1.ListMyCharactersRequest
-	24,  // 70: web.v1.NpcAdminService.ListNpcs:input_type -> web.v1.ListNpcsRequest
-	26,  // 71: web.v1.NpcAdminService.GetNpc:input_type -> web.v1.GetNpcRequest
-	28,  // 72: web.v1.NpcAdminService.UpsertNpc:input_type -> web.v1.UpsertNpcRequest
-	30,  // 73: web.v1.NpcAdminService.SetNpcVisibility:input_type -> web.v1.SetNpcVisibilityRequest
-	31,  // 74: web.v1.NpcAdminService.SetNpcShop:input_type -> web.v1.SetNpcShopRequest
-	32,  // 75: web.v1.NpcAdminService.SetItemPrice:input_type -> web.v1.SetItemPriceRequest
-	33,  // 76: web.v1.NpcAdminService.DeleteNpc:input_type -> web.v1.DeleteNpcRequest
-	35,  // 77: web.v1.NpcAdminService.ListMerchantTemplates:input_type -> web.v1.ListMerchantTemplatesRequest
-	38,  // 78: web.v1.NpcAdminService.ListItemCatalog:input_type -> web.v1.ListItemCatalogRequest
-	42,  // 79: web.v1.NpcAdminService.ListDropItems:input_type -> web.v1.ListDropItemsRequest
-	46,  // 80: web.v1.NpcAdminService.ListMobDrops:input_type -> web.v1.ListMobDropsRequest
-	49,  // 81: web.v1.NpcAdminService.ListItemPrices:input_type -> web.v1.ListItemPricesRequest
-	52,  // 82: web.v1.NpcAdminService.ListMapZones:input_type -> web.v1.ListMapZonesRequest
-	55,  // 83: web.v1.MobTemplateAdminService.ListMobTemplates:input_type -> web.v1.ListMobTemplatesRequest
-	59,  // 84: web.v1.MobTemplateAdminService.GetMobTemplateStat:input_type -> web.v1.GetMobTemplateStatRequest
-	61,  // 85: web.v1.MobTemplateAdminService.UpsertMobTemplateStat:input_type -> web.v1.UpsertMobTemplateStatRequest
-	63,  // 86: web.v1.MobTemplateAdminService.SetMobTemplateEquip:input_type -> web.v1.SetMobTemplateEquipRequest
-	64,  // 87: web.v1.MobTemplateAdminService.DeleteMobTemplateStat:input_type -> web.v1.DeleteMobTemplateStatRequest
-	65,  // 88: web.v1.AttributeMapAdminService.GetAttributeMapInfo:input_type -> web.v1.GetAttributeMapInfoRequest
-	72,  // 89: web.v1.AttributeMapAdminService.TransformAttributeMap:input_type -> web.v1.TransformAttributeMapRequest
-	75,  // 90: web.v1.DonateAdminService.ListShopItems:input_type -> web.v1.ListShopItemsRequest
-	77,  // 91: web.v1.DonateAdminService.UpsertShopItem:input_type -> web.v1.UpsertShopItemRequest
-	79,  // 92: web.v1.DonateAdminService.SetShopItemEnabled:input_type -> web.v1.SetShopItemEnabledRequest
-	80,  // 93: web.v1.DonateAdminService.DeleteShopItem:input_type -> web.v1.DeleteShopItemRequest
-	81,  // 94: web.v1.DonateAdminService.CreditDonateBalance:input_type -> web.v1.CreditDonateBalanceRequest
-	83,  // 95: web.v1.DonateShopService.ListShopItems:input_type -> web.v1.ListStoreItemsRequest
-	85,  // 96: web.v1.DonateShopService.GetBalance:input_type -> web.v1.GetBalanceRequest
-	87,  // 97: web.v1.DonateShopService.Buy:input_type -> web.v1.BuyRequest
-	90,  // 98: web.v1.DailyRewardAdminService.ListRewardItems:input_type -> web.v1.ListRewardItemsRequest
-	92,  // 99: web.v1.DailyRewardAdminService.UpsertRewardItem:input_type -> web.v1.UpsertRewardItemRequest
-	94,  // 100: web.v1.DailyRewardAdminService.SetRewardItemEnabled:input_type -> web.v1.SetRewardItemEnabledRequest
-	95,  // 101: web.v1.DailyRewardAdminService.DeleteRewardItem:input_type -> web.v1.DeleteRewardItemRequest
-	97,  // 102: web.v1.WorldEventAdminService.GetWorldEventConfig:input_type -> web.v1.GetWorldEventConfigRequest
-	99,  // 103: web.v1.WorldEventAdminService.SetWorldEventConfig:input_type -> web.v1.SetWorldEventConfigRequest
-	100, // 104: web.v1.DailyRewardService.ListRewards:input_type -> web.v1.ListRewardsRequest
-	102, // 105: web.v1.DailyRewardService.GetClaimStatus:input_type -> web.v1.GetClaimStatusRequest
-	104, // 106: web.v1.DailyRewardService.Claim:input_type -> web.v1.ClaimRequest
-	106, // 107: web.v1.DonateTopupService.GetPayerProfile:input_type -> web.v1.GetPayerProfileRequest
-	108, // 108: web.v1.DonateTopupService.SavePayerProfile:input_type -> web.v1.SavePayerProfileRequest
-	110, // 109: web.v1.DonateTopupService.CreateTopupOrder:input_type -> web.v1.CreateTopupOrderRequest
-	112, // 110: web.v1.DonateTopupService.ConfirmTopupOrder:input_type -> web.v1.ConfirmTopupOrderRequest
-	114, // 111: web.v1.DonateTopupService.GetTopupOrder:input_type -> web.v1.GetTopupOrderRequest
-	9,   // 112: web.v1.AccountWebService.CreateAccount:output_type -> web.v1.CreateAccountResponse
-	11,  // 113: web.v1.AccountWebService.VerifyCredentials:output_type -> web.v1.VerifyCredentialsResponse
-	14,  // 114: web.v1.RankingWebService.ListExpRanking:output_type -> web.v1.ListExpRankingResponse
-	17,  // 115: web.v1.RankingWebService.ListDuelRanking:output_type -> web.v1.ListDuelRankingResponse
-	20,  // 116: web.v1.CharacterWebService.ListMyCharacters:output_type -> web.v1.ListMyCharactersResponse
-	25,  // 117: web.v1.NpcAdminService.ListNpcs:output_type -> web.v1.ListNpcsResponse
-	27,  // 118: web.v1.NpcAdminService.GetNpc:output_type -> web.v1.GetNpcResponse
-	29,  // 119: web.v1.NpcAdminService.UpsertNpc:output_type -> web.v1.UpsertNpcResponse
-	21,  // 120: web.v1.NpcAdminService.SetNpcVisibility:output_type -> web.v1.AdminAck
-	21,  // 121: web.v1.NpcAdminService.SetNpcShop:output_type -> web.v1.AdminAck
-	21,  // 122: web.v1.NpcAdminService.SetItemPrice:output_type -> web.v1.AdminAck
-	21,  // 123: web.v1.NpcAdminService.DeleteNpc:output_type -> web.v1.AdminAck
-	36,  // 124: web.v1.NpcAdminService.ListMerchantTemplates:output_type -> web.v1.ListMerchantTemplatesResponse
-	39,  // 125: web.v1.NpcAdminService.ListItemCatalog:output_type -> web.v1.ListItemCatalogResponse
-	43,  // 126: web.v1.NpcAdminService.ListDropItems:output_type -> web.v1.ListDropItemsResponse
-	47,  // 127: web.v1.NpcAdminService.ListMobDrops:output_type -> web.v1.ListMobDropsResponse
-	50,  // 128: web.v1.NpcAdminService.ListItemPrices:output_type -> web.v1.ListItemPricesResponse
-	53,  // 129: web.v1.NpcAdminService.ListMapZones:output_type -> web.v1.ListMapZonesResponse
-	56,  // 130: web.v1.MobTemplateAdminService.ListMobTemplates:output_type -> web.v1.ListMobTemplatesResponse
-	60,  // 131: web.v1.MobTemplateAdminService.GetMobTemplateStat:output_type -> web.v1.GetMobTemplateStatResponse
-	62,  // 132: web.v1.MobTemplateAdminService.UpsertMobTemplateStat:output_type -> web.v1.UpsertMobTemplateStatResponse
-	21,  // 133: web.v1.MobTemplateAdminService.SetMobTemplateEquip:output_type -> web.v1.AdminAck
-	21,  // 134: web.v1.MobTemplateAdminService.DeleteMobTemplateStat:output_type -> web.v1.AdminAck
-	66,  // 135: web.v1.AttributeMapAdminService.GetAttributeMapInfo:output_type -> web.v1.GetAttributeMapInfoResponse
-	73,  // 136: web.v1.AttributeMapAdminService.TransformAttributeMap:output_type -> web.v1.TransformAttributeMapResponse
-	76,  // 137: web.v1.DonateAdminService.ListShopItems:output_type -> web.v1.ListShopItemsResponse
-	78,  // 138: web.v1.DonateAdminService.UpsertShopItem:output_type -> web.v1.UpsertShopItemResponse
-	21,  // 139: web.v1.DonateAdminService.SetShopItemEnabled:output_type -> web.v1.AdminAck
-	21,  // 140: web.v1.DonateAdminService.DeleteShopItem:output_type -> web.v1.AdminAck
-	82,  // 141: web.v1.DonateAdminService.CreditDonateBalance:output_type -> web.v1.CreditDonateBalanceResponse
-	84,  // 142: web.v1.DonateShopService.ListShopItems:output_type -> web.v1.ListStoreItemsResponse
-	86,  // 143: web.v1.DonateShopService.GetBalance:output_type -> web.v1.GetBalanceResponse
-	88,  // 144: web.v1.DonateShopService.Buy:output_type -> web.v1.BuyResponse
-	91,  // 145: web.v1.DailyRewardAdminService.ListRewardItems:output_type -> web.v1.ListRewardItemsResponse
-	93,  // 146: web.v1.DailyRewardAdminService.UpsertRewardItem:output_type -> web.v1.UpsertRewardItemResponse
-	21,  // 147: web.v1.DailyRewardAdminService.SetRewardItemEnabled:output_type -> web.v1.AdminAck
-	21,  // 148: web.v1.DailyRewardAdminService.DeleteRewardItem:output_type -> web.v1.AdminAck
-	98,  // 149: web.v1.WorldEventAdminService.GetWorldEventConfig:output_type -> web.v1.GetWorldEventConfigResponse
-	21,  // 150: web.v1.WorldEventAdminService.SetWorldEventConfig:output_type -> web.v1.AdminAck
-	101, // 151: web.v1.DailyRewardService.ListRewards:output_type -> web.v1.ListRewardsResponse
-	103, // 152: web.v1.DailyRewardService.GetClaimStatus:output_type -> web.v1.GetClaimStatusResponse
-	105, // 153: web.v1.DailyRewardService.Claim:output_type -> web.v1.ClaimResponse
-	107, // 154: web.v1.DonateTopupService.GetPayerProfile:output_type -> web.v1.GetPayerProfileResponse
-	109, // 155: web.v1.DonateTopupService.SavePayerProfile:output_type -> web.v1.SavePayerProfileResponse
-	111, // 156: web.v1.DonateTopupService.CreateTopupOrder:output_type -> web.v1.CreateTopupOrderResponse
-	113, // 157: web.v1.DonateTopupService.ConfirmTopupOrder:output_type -> web.v1.ConfirmTopupOrderResponse
-	115, // 158: web.v1.DonateTopupService.GetTopupOrder:output_type -> web.v1.GetTopupOrderResponse
-	112, // [112:159] is the sub-list for method output_type
-	65,  // [65:112] is the sub-list for method input_type
-	65,  // [65:65] is the sub-list for extension type_name
-	65,  // [65:65] is the sub-list for extension extendee
-	0,   // [0:65] is the sub-list for field type_name
+	5,   // 65: web.v1.RevenueByMethod.payment_method:type_name -> web.v1.PaymentMethod
+	118, // 66: web.v1.GetRevenueSummaryRequest.window:type_name -> web.v1.RevenueWindow
+	8,   // 67: web.v1.GetRevenueSummaryRequest.bucket:type_name -> web.v1.RevenueBucket
+	1,   // 68: web.v1.GetRevenueSummaryResponse.result:type_name -> web.v1.AdminResult
+	119, // 69: web.v1.GetRevenueSummaryResponse.totals:type_name -> web.v1.RevenueTotals
+	120, // 70: web.v1.GetRevenueSummaryResponse.by_method:type_name -> web.v1.RevenueByMethod
+	121, // 71: web.v1.GetRevenueSummaryResponse.series:type_name -> web.v1.RevenuePoint
+	5,   // 72: web.v1.TopupOrderRow.payment_method:type_name -> web.v1.PaymentMethod
+	7,   // 73: web.v1.TopupOrderRow.status:type_name -> web.v1.TopupStatus
+	118, // 74: web.v1.ListTopupOrdersRequest.window:type_name -> web.v1.RevenueWindow
+	7,   // 75: web.v1.ListTopupOrdersRequest.status:type_name -> web.v1.TopupStatus
+	5,   // 76: web.v1.ListTopupOrdersRequest.payment_method:type_name -> web.v1.PaymentMethod
+	1,   // 77: web.v1.ListTopupOrdersResponse.result:type_name -> web.v1.AdminResult
+	124, // 78: web.v1.ListTopupOrdersResponse.orders:type_name -> web.v1.TopupOrderRow
+	118, // 79: web.v1.ListTopBuyersRequest.window:type_name -> web.v1.RevenueWindow
+	1,   // 80: web.v1.ListTopBuyersResponse.result:type_name -> web.v1.AdminResult
+	127, // 81: web.v1.ListTopBuyersResponse.buyers:type_name -> web.v1.TopBuyerRow
+	9,   // 82: web.v1.DonateLedgerRow.action:type_name -> web.v1.DonateLedgerAction
+	118, // 83: web.v1.ListDonateSpendRequest.window:type_name -> web.v1.RevenueWindow
+	9,   // 84: web.v1.ListDonateSpendRequest.action:type_name -> web.v1.DonateLedgerAction
+	1,   // 85: web.v1.ListDonateSpendResponse.result:type_name -> web.v1.AdminResult
+	130, // 86: web.v1.ListDonateSpendResponse.entries:type_name -> web.v1.DonateLedgerRow
+	1,   // 87: web.v1.SearchAccountsResponse.result:type_name -> web.v1.AdminResult
+	133, // 88: web.v1.SearchAccountsResponse.accounts:type_name -> web.v1.AccountSummary
+	10,  // 89: web.v1.AccountWebService.CreateAccount:input_type -> web.v1.CreateAccountRequest
+	12,  // 90: web.v1.AccountWebService.VerifyCredentials:input_type -> web.v1.VerifyCredentialsRequest
+	14,  // 91: web.v1.RankingWebService.ListExpRanking:input_type -> web.v1.ListExpRankingRequest
+	17,  // 92: web.v1.RankingWebService.ListDuelRanking:input_type -> web.v1.ListDuelRankingRequest
+	20,  // 93: web.v1.CharacterWebService.ListMyCharacters:input_type -> web.v1.ListMyCharactersRequest
+	26,  // 94: web.v1.NpcAdminService.ListNpcs:input_type -> web.v1.ListNpcsRequest
+	28,  // 95: web.v1.NpcAdminService.GetNpc:input_type -> web.v1.GetNpcRequest
+	30,  // 96: web.v1.NpcAdminService.UpsertNpc:input_type -> web.v1.UpsertNpcRequest
+	32,  // 97: web.v1.NpcAdminService.SetNpcVisibility:input_type -> web.v1.SetNpcVisibilityRequest
+	33,  // 98: web.v1.NpcAdminService.SetNpcShop:input_type -> web.v1.SetNpcShopRequest
+	34,  // 99: web.v1.NpcAdminService.SetItemPrice:input_type -> web.v1.SetItemPriceRequest
+	35,  // 100: web.v1.NpcAdminService.DeleteNpc:input_type -> web.v1.DeleteNpcRequest
+	37,  // 101: web.v1.NpcAdminService.ListMerchantTemplates:input_type -> web.v1.ListMerchantTemplatesRequest
+	40,  // 102: web.v1.NpcAdminService.ListItemCatalog:input_type -> web.v1.ListItemCatalogRequest
+	44,  // 103: web.v1.NpcAdminService.ListDropItems:input_type -> web.v1.ListDropItemsRequest
+	48,  // 104: web.v1.NpcAdminService.ListMobDrops:input_type -> web.v1.ListMobDropsRequest
+	51,  // 105: web.v1.NpcAdminService.ListItemPrices:input_type -> web.v1.ListItemPricesRequest
+	54,  // 106: web.v1.NpcAdminService.ListMapZones:input_type -> web.v1.ListMapZonesRequest
+	57,  // 107: web.v1.MobTemplateAdminService.ListMobTemplates:input_type -> web.v1.ListMobTemplatesRequest
+	61,  // 108: web.v1.MobTemplateAdminService.GetMobTemplateStat:input_type -> web.v1.GetMobTemplateStatRequest
+	63,  // 109: web.v1.MobTemplateAdminService.UpsertMobTemplateStat:input_type -> web.v1.UpsertMobTemplateStatRequest
+	65,  // 110: web.v1.MobTemplateAdminService.SetMobTemplateEquip:input_type -> web.v1.SetMobTemplateEquipRequest
+	66,  // 111: web.v1.MobTemplateAdminService.DeleteMobTemplateStat:input_type -> web.v1.DeleteMobTemplateStatRequest
+	67,  // 112: web.v1.AttributeMapAdminService.GetAttributeMapInfo:input_type -> web.v1.GetAttributeMapInfoRequest
+	74,  // 113: web.v1.AttributeMapAdminService.TransformAttributeMap:input_type -> web.v1.TransformAttributeMapRequest
+	77,  // 114: web.v1.DonateAdminService.ListShopItems:input_type -> web.v1.ListShopItemsRequest
+	79,  // 115: web.v1.DonateAdminService.UpsertShopItem:input_type -> web.v1.UpsertShopItemRequest
+	81,  // 116: web.v1.DonateAdminService.SetShopItemEnabled:input_type -> web.v1.SetShopItemEnabledRequest
+	82,  // 117: web.v1.DonateAdminService.DeleteShopItem:input_type -> web.v1.DeleteShopItemRequest
+	83,  // 118: web.v1.DonateAdminService.CreditDonateBalance:input_type -> web.v1.CreditDonateBalanceRequest
+	85,  // 119: web.v1.DonateShopService.ListShopItems:input_type -> web.v1.ListStoreItemsRequest
+	87,  // 120: web.v1.DonateShopService.GetBalance:input_type -> web.v1.GetBalanceRequest
+	89,  // 121: web.v1.DonateShopService.Buy:input_type -> web.v1.BuyRequest
+	92,  // 122: web.v1.DailyRewardAdminService.ListRewardItems:input_type -> web.v1.ListRewardItemsRequest
+	94,  // 123: web.v1.DailyRewardAdminService.UpsertRewardItem:input_type -> web.v1.UpsertRewardItemRequest
+	96,  // 124: web.v1.DailyRewardAdminService.SetRewardItemEnabled:input_type -> web.v1.SetRewardItemEnabledRequest
+	97,  // 125: web.v1.DailyRewardAdminService.DeleteRewardItem:input_type -> web.v1.DeleteRewardItemRequest
+	99,  // 126: web.v1.WorldEventAdminService.GetWorldEventConfig:input_type -> web.v1.GetWorldEventConfigRequest
+	101, // 127: web.v1.WorldEventAdminService.SetWorldEventConfig:input_type -> web.v1.SetWorldEventConfigRequest
+	102, // 128: web.v1.DailyRewardService.ListRewards:input_type -> web.v1.ListRewardsRequest
+	104, // 129: web.v1.DailyRewardService.GetClaimStatus:input_type -> web.v1.GetClaimStatusRequest
+	106, // 130: web.v1.DailyRewardService.Claim:input_type -> web.v1.ClaimRequest
+	108, // 131: web.v1.DonateTopupService.GetPayerProfile:input_type -> web.v1.GetPayerProfileRequest
+	110, // 132: web.v1.DonateTopupService.SavePayerProfile:input_type -> web.v1.SavePayerProfileRequest
+	112, // 133: web.v1.DonateTopupService.CreateTopupOrder:input_type -> web.v1.CreateTopupOrderRequest
+	114, // 134: web.v1.DonateTopupService.ConfirmTopupOrder:input_type -> web.v1.ConfirmTopupOrderRequest
+	116, // 135: web.v1.DonateTopupService.GetTopupOrder:input_type -> web.v1.GetTopupOrderRequest
+	122, // 136: web.v1.DonateRevenueAdminService.GetRevenueSummary:input_type -> web.v1.GetRevenueSummaryRequest
+	125, // 137: web.v1.DonateRevenueAdminService.ListTopupOrders:input_type -> web.v1.ListTopupOrdersRequest
+	128, // 138: web.v1.DonateRevenueAdminService.ListTopBuyers:input_type -> web.v1.ListTopBuyersRequest
+	131, // 139: web.v1.DonateRevenueAdminService.ListDonateSpend:input_type -> web.v1.ListDonateSpendRequest
+	134, // 140: web.v1.DonateRevenueAdminService.SearchAccounts:input_type -> web.v1.SearchAccountsRequest
+	11,  // 141: web.v1.AccountWebService.CreateAccount:output_type -> web.v1.CreateAccountResponse
+	13,  // 142: web.v1.AccountWebService.VerifyCredentials:output_type -> web.v1.VerifyCredentialsResponse
+	16,  // 143: web.v1.RankingWebService.ListExpRanking:output_type -> web.v1.ListExpRankingResponse
+	19,  // 144: web.v1.RankingWebService.ListDuelRanking:output_type -> web.v1.ListDuelRankingResponse
+	22,  // 145: web.v1.CharacterWebService.ListMyCharacters:output_type -> web.v1.ListMyCharactersResponse
+	27,  // 146: web.v1.NpcAdminService.ListNpcs:output_type -> web.v1.ListNpcsResponse
+	29,  // 147: web.v1.NpcAdminService.GetNpc:output_type -> web.v1.GetNpcResponse
+	31,  // 148: web.v1.NpcAdminService.UpsertNpc:output_type -> web.v1.UpsertNpcResponse
+	23,  // 149: web.v1.NpcAdminService.SetNpcVisibility:output_type -> web.v1.AdminAck
+	23,  // 150: web.v1.NpcAdminService.SetNpcShop:output_type -> web.v1.AdminAck
+	23,  // 151: web.v1.NpcAdminService.SetItemPrice:output_type -> web.v1.AdminAck
+	23,  // 152: web.v1.NpcAdminService.DeleteNpc:output_type -> web.v1.AdminAck
+	38,  // 153: web.v1.NpcAdminService.ListMerchantTemplates:output_type -> web.v1.ListMerchantTemplatesResponse
+	41,  // 154: web.v1.NpcAdminService.ListItemCatalog:output_type -> web.v1.ListItemCatalogResponse
+	45,  // 155: web.v1.NpcAdminService.ListDropItems:output_type -> web.v1.ListDropItemsResponse
+	49,  // 156: web.v1.NpcAdminService.ListMobDrops:output_type -> web.v1.ListMobDropsResponse
+	52,  // 157: web.v1.NpcAdminService.ListItemPrices:output_type -> web.v1.ListItemPricesResponse
+	55,  // 158: web.v1.NpcAdminService.ListMapZones:output_type -> web.v1.ListMapZonesResponse
+	58,  // 159: web.v1.MobTemplateAdminService.ListMobTemplates:output_type -> web.v1.ListMobTemplatesResponse
+	62,  // 160: web.v1.MobTemplateAdminService.GetMobTemplateStat:output_type -> web.v1.GetMobTemplateStatResponse
+	64,  // 161: web.v1.MobTemplateAdminService.UpsertMobTemplateStat:output_type -> web.v1.UpsertMobTemplateStatResponse
+	23,  // 162: web.v1.MobTemplateAdminService.SetMobTemplateEquip:output_type -> web.v1.AdminAck
+	23,  // 163: web.v1.MobTemplateAdminService.DeleteMobTemplateStat:output_type -> web.v1.AdminAck
+	68,  // 164: web.v1.AttributeMapAdminService.GetAttributeMapInfo:output_type -> web.v1.GetAttributeMapInfoResponse
+	75,  // 165: web.v1.AttributeMapAdminService.TransformAttributeMap:output_type -> web.v1.TransformAttributeMapResponse
+	78,  // 166: web.v1.DonateAdminService.ListShopItems:output_type -> web.v1.ListShopItemsResponse
+	80,  // 167: web.v1.DonateAdminService.UpsertShopItem:output_type -> web.v1.UpsertShopItemResponse
+	23,  // 168: web.v1.DonateAdminService.SetShopItemEnabled:output_type -> web.v1.AdminAck
+	23,  // 169: web.v1.DonateAdminService.DeleteShopItem:output_type -> web.v1.AdminAck
+	84,  // 170: web.v1.DonateAdminService.CreditDonateBalance:output_type -> web.v1.CreditDonateBalanceResponse
+	86,  // 171: web.v1.DonateShopService.ListShopItems:output_type -> web.v1.ListStoreItemsResponse
+	88,  // 172: web.v1.DonateShopService.GetBalance:output_type -> web.v1.GetBalanceResponse
+	90,  // 173: web.v1.DonateShopService.Buy:output_type -> web.v1.BuyResponse
+	93,  // 174: web.v1.DailyRewardAdminService.ListRewardItems:output_type -> web.v1.ListRewardItemsResponse
+	95,  // 175: web.v1.DailyRewardAdminService.UpsertRewardItem:output_type -> web.v1.UpsertRewardItemResponse
+	23,  // 176: web.v1.DailyRewardAdminService.SetRewardItemEnabled:output_type -> web.v1.AdminAck
+	23,  // 177: web.v1.DailyRewardAdminService.DeleteRewardItem:output_type -> web.v1.AdminAck
+	100, // 178: web.v1.WorldEventAdminService.GetWorldEventConfig:output_type -> web.v1.GetWorldEventConfigResponse
+	23,  // 179: web.v1.WorldEventAdminService.SetWorldEventConfig:output_type -> web.v1.AdminAck
+	103, // 180: web.v1.DailyRewardService.ListRewards:output_type -> web.v1.ListRewardsResponse
+	105, // 181: web.v1.DailyRewardService.GetClaimStatus:output_type -> web.v1.GetClaimStatusResponse
+	107, // 182: web.v1.DailyRewardService.Claim:output_type -> web.v1.ClaimResponse
+	109, // 183: web.v1.DonateTopupService.GetPayerProfile:output_type -> web.v1.GetPayerProfileResponse
+	111, // 184: web.v1.DonateTopupService.SavePayerProfile:output_type -> web.v1.SavePayerProfileResponse
+	113, // 185: web.v1.DonateTopupService.CreateTopupOrder:output_type -> web.v1.CreateTopupOrderResponse
+	115, // 186: web.v1.DonateTopupService.ConfirmTopupOrder:output_type -> web.v1.ConfirmTopupOrderResponse
+	117, // 187: web.v1.DonateTopupService.GetTopupOrder:output_type -> web.v1.GetTopupOrderResponse
+	123, // 188: web.v1.DonateRevenueAdminService.GetRevenueSummary:output_type -> web.v1.GetRevenueSummaryResponse
+	126, // 189: web.v1.DonateRevenueAdminService.ListTopupOrders:output_type -> web.v1.ListTopupOrdersResponse
+	129, // 190: web.v1.DonateRevenueAdminService.ListTopBuyers:output_type -> web.v1.ListTopBuyersResponse
+	132, // 191: web.v1.DonateRevenueAdminService.ListDonateSpend:output_type -> web.v1.ListDonateSpendResponse
+	135, // 192: web.v1.DonateRevenueAdminService.SearchAccounts:output_type -> web.v1.SearchAccountsResponse
+	141, // [141:193] is the sub-list for method output_type
+	89,  // [89:141] is the sub-list for method input_type
+	89,  // [89:89] is the sub-list for extension type_name
+	89,  // [89:89] is the sub-list for extension extendee
+	0,   // [0:89] is the sub-list for field type_name
 }
 
 func init() { file_api_web_v1_web_proto_init() }
@@ -8246,10 +10140,10 @@ func file_api_web_v1_web_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_web_v1_web_proto_rawDesc), len(file_api_web_v1_web_proto_rawDesc)),
-			NumEnums:      8,
-			NumMessages:   108,
+			NumEnums:      10,
+			NumMessages:   126,
 			NumExtensions: 0,
-			NumServices:   12,
+			NumServices:   13,
 		},
 		GoTypes:           file_api_web_v1_web_proto_goTypes,
 		DependencyIndexes: file_api_web_v1_web_proto_depIdxs,

--- a/api/web/v1/web.proto
+++ b/api/web/v1/web.proto
@@ -963,3 +963,261 @@ message GetTopupOrderResponse {
   int32 credits = 2;
   int64 new_balance = 3; // account balance when PAID; 0 otherwise
 }
+
+// DonateRevenueAdminService is the read-only revenue reporting surface behind the
+// painel de faturamento. It answers "how much money came in this month, who paid,
+// and where did the donate go", over data that has been persisted since
+// 0008_donate_shop and 0010_donate_topup but had no read path until now.
+//
+// It is NOT bin.v1.BillingService: that is the login entitlement gate and, per
+// web-platform-plan.md, explicitly not the cash wallet. This service reads
+// donate_topup_order (real money), donate_shop_audit (wallet movements),
+// account and donate_payer_profile.
+//
+// Like every *AdminService here, request field 1 is the caller's account id,
+// re-authorized server-side against account.role ('moderator' or 'admin'). It
+// writes NOTHING — not even an audit row — so it never interacts with the
+// tmServer's single-owner loop.
+//
+// Money vs credits: *_cents is real BRL in integer cents; credits/*_credits is
+// the in-game donate wallet unit. They are different units and must never be
+// summed. Revenue is recognized on confirmed_at, never created_at: an order is
+// only money once the gateway settled it.
+//
+// Time: every instant is int64 Unix SECONDS, matching db.v1's expires_at /
+// updated_at_unix; web.v1 pulls in no google.protobuf well-known types and this
+// service does not introduce that dependency. 0 means absent, so a PENDING order
+// reports confirmed_at_unix = 0.
+//
+// Bucketing timezone: day/week/month buckets close in America/Sao_Paulo, so the
+// panel agrees with a Brazilian bank statement. The instants on the wire are
+// still absolute. See docs/integrations/faturamento-nextjs.md.
+service DonateRevenueAdminService {
+  // GetRevenueSummary returns the KPI header plus an optional gap-filled series.
+  rpc GetRevenueSummary(GetRevenueSummaryRequest) returns (GetRevenueSummaryResponse);
+  // ListTopupOrders is the paginated order table with the buyer identity already
+  // joined in, so the BFF never fans out one account lookup per row.
+  rpc ListTopupOrders(ListTopupOrdersRequest) returns (ListTopupOrdersResponse);
+  // ListTopBuyers ranks accounts by revenue inside the window and carries the
+  // all-time (LTV) aggregate alongside. Drill-down is ListTopupOrders or
+  // ListDonateSpend with account_id set; there is no per-account RPC.
+  rpc ListTopBuyers(ListTopBuyersRequest) returns (ListTopBuyersResponse);
+  // ListDonateSpend is the donate wallet ledger over donate_shop_audit. It
+  // normalizes that table's asymmetry: for action='purchase' the audit's
+  // account_id column is the BUYER, but for action='credit_balance' it is the
+  // MODERATOR and the credited account lives in after->>'account_id'. Each row
+  // therefore reports subject (whose wallet moved) and actor (who caused it).
+  rpc ListDonateSpend(ListDonateSpendRequest) returns (ListDonateSpendResponse);
+  // SearchAccounts resolves a login prefix to account ids so the panel's filter
+  // box and the top-buyer drill-down can work from a name the operator typed.
+  rpc SearchAccounts(SearchAccountsRequest) returns (SearchAccountsResponse);
+}
+
+// RevenueWindow is the half-open [from_unix, to_unix) interval that scopes every
+// read on this service. Both 0 = the last 30 days ending now; only to_unix 0 =
+// now. The server rejects from >= to and any window wider than 366 days, and
+// always resolves the window to a concrete bounded range before it reaches SQL.
+message RevenueWindow {
+  int64 from_unix = 1; // inclusive, Unix seconds; 0 = to_unix minus 30 days
+  int64 to_unix   = 2; // exclusive, Unix seconds; 0 = now
+}
+
+// RevenueBucket is the time-series granularity. UNSPECIFIED skips the series
+// entirely — the cheapest call, for a header-only refresh. An unrecognized value
+// degrades to UNSPECIFIED rather than failing, so a newer portal cannot break an
+// older server.
+enum RevenueBucket {
+  REVENUE_BUCKET_UNSPECIFIED = 0;
+  REVENUE_BUCKET_DAY = 1;
+  REVENUE_BUCKET_WEEK = 2;  // date_trunc('week') — ISO week, starts on MONDAY
+  REVENUE_BUCKET_MONTH = 3;
+}
+
+// DonateLedgerAction filters the donate_shop_audit read. UNSPECIFIED returns both
+// movement kinds; the catalog CRUD actions ('create'/'update'/'delete'/
+// 'set_enabled') are never returned — they move no wallet.
+enum DonateLedgerAction {
+  DONATE_LEDGER_ACTION_UNSPECIFIED = 0;
+  DONATE_LEDGER_ACTION_PURCHASE = 1; // donate_shop_audit.action = 'purchase'
+  DONATE_LEDGER_ACTION_CREDIT   = 2; // donate_shop_audit.action = 'credit_balance'
+}
+
+// RevenueTotals is the KPI header. The first block is real money recognized on
+// confirmed_at; the second is orders CREATED in the window (any status), the
+// conversion denominator; the third is donate wallet flow, in CREDITS, not money.
+message RevenueTotals {
+  int64 paid_orders     = 1;
+  int64 gross_cents     = 2; // serialize as string in public JSON
+  int64 credits_sold    = 3;
+  int64 distinct_buyers = 4;
+
+  int64 created_orders  = 5; // created in the window, any status
+  int64 pending_orders  = 6; // created in the window and still PENDING today
+  int64 pending_cents   = 7; // string in public JSON; NOT revenue, never add to gross_cents
+
+  int64 shop_purchases  = 8;  // donate_shop_audit rows with action='purchase'
+  int64 credits_spent   = 9;  // sum of after->>'price' over those rows
+  int64 manual_credits  = 10; // rows with action='credit_balance' (moderator grants)
+  int64 credits_granted = 11; // sum of after->>'amount' over those rows
+}
+
+// RevenueByMethod breaks recognized revenue down by gateway. Repeated rather than
+// fixed pix_/card_ fields so adding a PaymentMethod never changes this message.
+message RevenueByMethod {
+  PaymentMethod payment_method = 1;
+  int64 paid_orders = 2;
+  int64 gross_cents = 3; // serialize as string in public JSON
+}
+
+// RevenuePoint is one bucket of the series. Buckets with no orders ARE returned
+// with zeroes, so the chart axis is continuous and the front-end never gap-fills.
+message RevenuePoint {
+  int64 bucket_start_unix = 1; // instant the bucket opens (America/Sao_Paulo boundary)
+  int64 paid_orders       = 2;
+  int64 gross_cents       = 3; // serialize as string in public JSON
+  int64 credits_sold      = 4;
+  int64 distinct_buyers   = 5;
+}
+
+message GetRevenueSummaryRequest {
+  int64 moderator_id = 1;
+  RevenueWindow window = 2;
+  RevenueBucket bucket = 3;
+  int64 account_id = 4; // 0 = all accounts; set for the per-account drill-down
+}
+message GetRevenueSummaryResponse {
+  AdminResult result = 1;
+  RevenueTotals totals = 2;
+  repeated RevenueByMethod by_method = 3;
+  repeated RevenuePoint series = 4; // empty when bucket is UNSPECIFIED
+  int64 from_unix = 5; // the window the server actually applied, after defaults
+  int64 to_unix   = 6; // echo it back so the UI can label the period truthfully
+}
+
+// TopupOrderRow is one row of the order table, with the buyer identity resolved
+// server-side in the same SQL (a JOIN, never N+1 lookups from the BFF).
+message TopupOrderRow {
+  int64  id = 1;                 // serialize as string in public JSON
+  string external_reference = 2; // the portal UUID — the reconciliation key
+  int64  account_id = 3;         // serialize as string in public JSON
+  string account_name = 4;       // account.name (canonical lowercase login)
+  string account_email = 5;
+  string payer_name = 6;         // donate_payer_profile; empty when never filled
+  // ALWAYS masked (***.456.789-**). The raw 11 digits never leave the web-api:
+  // 'moderator' is a coarse role and a revenue report has no use for the full
+  // number — a chargeback is reconciled by external_reference.
+  string payer_cpf_masked = 7;
+  int32  credits = 8;
+  int64  amount_cents = 9;       // serialize as string in public JSON
+  PaymentMethod payment_method = 10;
+  // ALWAYS empty today: CreateTopupOrder never writes donate_topup_order.provider.
+  // Do not build UI on it.
+  string provider = 11;
+  TopupStatus status = 12;
+  int64  created_at_unix = 13;
+  int64  confirmed_at_unix = 14; // 0 while PENDING
+}
+
+message ListTopupOrdersRequest {
+  int64 moderator_id = 1;
+  RevenueWindow window = 2;
+  // status also picks the date column the window filters on: PAID filters and
+  // orders by confirmed_at (revenue recognition); anything else uses created_at.
+  TopupStatus status = 3;           // UNSPECIFIED = any status
+  PaymentMethod payment_method = 4; // UNSPECIFIED = any method
+  int64 account_id = 5;             // 0 = all accounts
+  int32 limit = 6;                  // default 50, max 100
+  int32 offset = 7;                 // negative values are treated as 0
+}
+message ListTopupOrdersResponse {
+  AdminResult result = 1;
+  repeated TopupOrderRow orders = 2;
+  int32 total_count = 3;
+  int64 from_unix = 4;
+  int64 to_unix   = 5;
+}
+
+// TopBuyerRow carries both the window aggregate (what the panel ranks on) and the
+// all-time aggregate (the LTV), because "who spent most this month" and "who is
+// worth most overall" are different questions and the panel shows both.
+message TopBuyerRow {
+  int64  account_id = 1; // serialize as string in public JSON
+  string account_name = 2;
+  string account_email = 3;
+  int64  window_paid_orders   = 4;
+  int64  window_gross_cents   = 5; // string in public JSON; the ranking key
+  int64  lifetime_paid_orders = 6;
+  int64  lifetime_gross_cents = 7; // string in public JSON; the LTV
+  int64  lifetime_credits     = 8;
+  int64  first_paid_at_unix   = 9;  // all-time, not window-scoped
+  int64  last_paid_at_unix    = 10; // all-time, not window-scoped
+  int32  donate_balance       = 11; // current wallet — point-in-time, not a window value
+}
+message ListTopBuyersRequest {
+  int64 moderator_id = 1;
+  RevenueWindow window = 2;
+  int32 limit = 3;  // default 50, max 100
+  int32 offset = 4; // negative values are treated as 0
+}
+message ListTopBuyersResponse {
+  AdminResult result = 1;
+  repeated TopBuyerRow buyers = 2;
+  int32 total_count = 3; // distinct accounts that paid inside the window
+  int64 from_unix = 4;
+  int64 to_unix   = 5;
+}
+
+// DonateLedgerRow is one donate wallet movement. credits_delta is SIGNED so the
+// column sums to a meaningful net: negative for a purchase (debit), positive for
+// a moderator credit. It is in donate credits, never money.
+message DonateLedgerRow {
+  int64  id = 1; // donate_shop_audit.id; string in public JSON
+  DonateLedgerAction action = 2;
+  int64  created_at_unix = 3;
+  int64  subject_account_id = 4; // whose wallet moved; string in public JSON
+  string subject_account_name = 5;
+  int64  actor_account_id = 6;   // == subject on a purchase, the MODERATOR on a credit
+  string actor_account_name = 7;
+  int64  credits_delta = 8;      // signed: -price on purchase, +amount on credit
+  int64  balance_after = 9;      // wallet balance recorded at the time
+  int64  shop_item_id = 10;      // 0 for credit_balance; string in public JSON
+  // Empty when the offer was deleted since the purchase (shop_item_id is
+  // deliberately not an FK, so history survives). Fall back to shop_item_id.
+  string shop_item_title = 11;
+  string reason = 12; // credit_balance only; the moderator's note
+}
+message ListDonateSpendRequest {
+  int64 moderator_id = 1;
+  RevenueWindow window = 2;
+  DonateLedgerAction action = 3; // UNSPECIFIED = both movement kinds
+  int64 account_id = 4;          // matched against the SUBJECT, not the raw audit column
+  int32 limit = 5;               // default 50, max 100
+  int32 offset = 6;              // negative values are treated as 0
+}
+message ListDonateSpendResponse {
+  AdminResult result = 1;
+  repeated DonateLedgerRow entries = 2;
+  int32 total_count = 3;
+  int64 from_unix = 4;
+  int64 to_unix   = 5;
+}
+
+// AccountSummary is the minimum identity the panel needs to turn a typed login
+// into an account_id filter. It exposes no credentials.
+message AccountSummary {
+  int64  id = 1; // serialize as string in public JSON
+  string name = 2;
+  string email = 3;
+  int32  donate_balance = 4;
+  string role = 5; // 'player' | 'moderator' | 'admin'
+  bool   is_blocked = 6;
+}
+message SearchAccountsRequest {
+  int64  moderator_id = 1;
+  string name_prefix = 2; // canonicalized to lowercase server-side; minimum 2 chars
+  int32  limit = 3;       // default 20, max 50
+}
+message SearchAccountsResponse {
+  AdminResult result = 1;
+  repeated AccountSummary accounts = 2;
+}

--- a/api/web/v1/web_grpc.pb.go
+++ b/api/web/v1/web_grpc.pb.go
@@ -2892,3 +2892,342 @@ var DonateTopupService_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "api/web/v1/web.proto",
 }
+
+const (
+	DonateRevenueAdminService_GetRevenueSummary_FullMethodName = "/web.v1.DonateRevenueAdminService/GetRevenueSummary"
+	DonateRevenueAdminService_ListTopupOrders_FullMethodName   = "/web.v1.DonateRevenueAdminService/ListTopupOrders"
+	DonateRevenueAdminService_ListTopBuyers_FullMethodName     = "/web.v1.DonateRevenueAdminService/ListTopBuyers"
+	DonateRevenueAdminService_ListDonateSpend_FullMethodName   = "/web.v1.DonateRevenueAdminService/ListDonateSpend"
+	DonateRevenueAdminService_SearchAccounts_FullMethodName    = "/web.v1.DonateRevenueAdminService/SearchAccounts"
+)
+
+// DonateRevenueAdminServiceClient is the client API for DonateRevenueAdminService service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// DonateRevenueAdminService is the read-only revenue reporting surface behind the
+// painel de faturamento. It answers "how much money came in this month, who paid,
+// and where did the donate go", over data that has been persisted since
+// 0008_donate_shop and 0010_donate_topup but had no read path until now.
+//
+// It is NOT bin.v1.BillingService: that is the login entitlement gate and, per
+// web-platform-plan.md, explicitly not the cash wallet. This service reads
+// donate_topup_order (real money), donate_shop_audit (wallet movements),
+// account and donate_payer_profile.
+//
+// Like every *AdminService here, request field 1 is the caller's account id,
+// re-authorized server-side against account.role ('moderator' or 'admin'). It
+// writes NOTHING — not even an audit row — so it never interacts with the
+// tmServer's single-owner loop.
+//
+// Money vs credits: *_cents is real BRL in integer cents; credits/*_credits is
+// the in-game donate wallet unit. They are different units and must never be
+// summed. Revenue is recognized on confirmed_at, never created_at: an order is
+// only money once the gateway settled it.
+//
+// Time: every instant is int64 Unix SECONDS, matching db.v1's expires_at /
+// updated_at_unix; web.v1 pulls in no google.protobuf well-known types and this
+// service does not introduce that dependency. 0 means absent, so a PENDING order
+// reports confirmed_at_unix = 0.
+//
+// Bucketing timezone: day/week/month buckets close in America/Sao_Paulo, so the
+// panel agrees with a Brazilian bank statement. The instants on the wire are
+// still absolute. See docs/integrations/faturamento-nextjs.md.
+type DonateRevenueAdminServiceClient interface {
+	// GetRevenueSummary returns the KPI header plus an optional gap-filled series.
+	GetRevenueSummary(ctx context.Context, in *GetRevenueSummaryRequest, opts ...grpc.CallOption) (*GetRevenueSummaryResponse, error)
+	// ListTopupOrders is the paginated order table with the buyer identity already
+	// joined in, so the BFF never fans out one account lookup per row.
+	ListTopupOrders(ctx context.Context, in *ListTopupOrdersRequest, opts ...grpc.CallOption) (*ListTopupOrdersResponse, error)
+	// ListTopBuyers ranks accounts by revenue inside the window and carries the
+	// all-time (LTV) aggregate alongside. Drill-down is ListTopupOrders or
+	// ListDonateSpend with account_id set; there is no per-account RPC.
+	ListTopBuyers(ctx context.Context, in *ListTopBuyersRequest, opts ...grpc.CallOption) (*ListTopBuyersResponse, error)
+	// ListDonateSpend is the donate wallet ledger over donate_shop_audit. It
+	// normalizes that table's asymmetry: for action='purchase' the audit's
+	// account_id column is the BUYER, but for action='credit_balance' it is the
+	// MODERATOR and the credited account lives in after->>'account_id'. Each row
+	// therefore reports subject (whose wallet moved) and actor (who caused it).
+	ListDonateSpend(ctx context.Context, in *ListDonateSpendRequest, opts ...grpc.CallOption) (*ListDonateSpendResponse, error)
+	// SearchAccounts resolves a login prefix to account ids so the panel's filter
+	// box and the top-buyer drill-down can work from a name the operator typed.
+	SearchAccounts(ctx context.Context, in *SearchAccountsRequest, opts ...grpc.CallOption) (*SearchAccountsResponse, error)
+}
+
+type donateRevenueAdminServiceClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewDonateRevenueAdminServiceClient(cc grpc.ClientConnInterface) DonateRevenueAdminServiceClient {
+	return &donateRevenueAdminServiceClient{cc}
+}
+
+func (c *donateRevenueAdminServiceClient) GetRevenueSummary(ctx context.Context, in *GetRevenueSummaryRequest, opts ...grpc.CallOption) (*GetRevenueSummaryResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetRevenueSummaryResponse)
+	err := c.cc.Invoke(ctx, DonateRevenueAdminService_GetRevenueSummary_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *donateRevenueAdminServiceClient) ListTopupOrders(ctx context.Context, in *ListTopupOrdersRequest, opts ...grpc.CallOption) (*ListTopupOrdersResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListTopupOrdersResponse)
+	err := c.cc.Invoke(ctx, DonateRevenueAdminService_ListTopupOrders_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *donateRevenueAdminServiceClient) ListTopBuyers(ctx context.Context, in *ListTopBuyersRequest, opts ...grpc.CallOption) (*ListTopBuyersResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListTopBuyersResponse)
+	err := c.cc.Invoke(ctx, DonateRevenueAdminService_ListTopBuyers_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *donateRevenueAdminServiceClient) ListDonateSpend(ctx context.Context, in *ListDonateSpendRequest, opts ...grpc.CallOption) (*ListDonateSpendResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListDonateSpendResponse)
+	err := c.cc.Invoke(ctx, DonateRevenueAdminService_ListDonateSpend_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *donateRevenueAdminServiceClient) SearchAccounts(ctx context.Context, in *SearchAccountsRequest, opts ...grpc.CallOption) (*SearchAccountsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SearchAccountsResponse)
+	err := c.cc.Invoke(ctx, DonateRevenueAdminService_SearchAccounts_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// DonateRevenueAdminServiceServer is the server API for DonateRevenueAdminService service.
+// All implementations must embed UnimplementedDonateRevenueAdminServiceServer
+// for forward compatibility.
+//
+// DonateRevenueAdminService is the read-only revenue reporting surface behind the
+// painel de faturamento. It answers "how much money came in this month, who paid,
+// and where did the donate go", over data that has been persisted since
+// 0008_donate_shop and 0010_donate_topup but had no read path until now.
+//
+// It is NOT bin.v1.BillingService: that is the login entitlement gate and, per
+// web-platform-plan.md, explicitly not the cash wallet. This service reads
+// donate_topup_order (real money), donate_shop_audit (wallet movements),
+// account and donate_payer_profile.
+//
+// Like every *AdminService here, request field 1 is the caller's account id,
+// re-authorized server-side against account.role ('moderator' or 'admin'). It
+// writes NOTHING — not even an audit row — so it never interacts with the
+// tmServer's single-owner loop.
+//
+// Money vs credits: *_cents is real BRL in integer cents; credits/*_credits is
+// the in-game donate wallet unit. They are different units and must never be
+// summed. Revenue is recognized on confirmed_at, never created_at: an order is
+// only money once the gateway settled it.
+//
+// Time: every instant is int64 Unix SECONDS, matching db.v1's expires_at /
+// updated_at_unix; web.v1 pulls in no google.protobuf well-known types and this
+// service does not introduce that dependency. 0 means absent, so a PENDING order
+// reports confirmed_at_unix = 0.
+//
+// Bucketing timezone: day/week/month buckets close in America/Sao_Paulo, so the
+// panel agrees with a Brazilian bank statement. The instants on the wire are
+// still absolute. See docs/integrations/faturamento-nextjs.md.
+type DonateRevenueAdminServiceServer interface {
+	// GetRevenueSummary returns the KPI header plus an optional gap-filled series.
+	GetRevenueSummary(context.Context, *GetRevenueSummaryRequest) (*GetRevenueSummaryResponse, error)
+	// ListTopupOrders is the paginated order table with the buyer identity already
+	// joined in, so the BFF never fans out one account lookup per row.
+	ListTopupOrders(context.Context, *ListTopupOrdersRequest) (*ListTopupOrdersResponse, error)
+	// ListTopBuyers ranks accounts by revenue inside the window and carries the
+	// all-time (LTV) aggregate alongside. Drill-down is ListTopupOrders or
+	// ListDonateSpend with account_id set; there is no per-account RPC.
+	ListTopBuyers(context.Context, *ListTopBuyersRequest) (*ListTopBuyersResponse, error)
+	// ListDonateSpend is the donate wallet ledger over donate_shop_audit. It
+	// normalizes that table's asymmetry: for action='purchase' the audit's
+	// account_id column is the BUYER, but for action='credit_balance' it is the
+	// MODERATOR and the credited account lives in after->>'account_id'. Each row
+	// therefore reports subject (whose wallet moved) and actor (who caused it).
+	ListDonateSpend(context.Context, *ListDonateSpendRequest) (*ListDonateSpendResponse, error)
+	// SearchAccounts resolves a login prefix to account ids so the panel's filter
+	// box and the top-buyer drill-down can work from a name the operator typed.
+	SearchAccounts(context.Context, *SearchAccountsRequest) (*SearchAccountsResponse, error)
+	mustEmbedUnimplementedDonateRevenueAdminServiceServer()
+}
+
+// UnimplementedDonateRevenueAdminServiceServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedDonateRevenueAdminServiceServer struct{}
+
+func (UnimplementedDonateRevenueAdminServiceServer) GetRevenueSummary(context.Context, *GetRevenueSummaryRequest) (*GetRevenueSummaryResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetRevenueSummary not implemented")
+}
+func (UnimplementedDonateRevenueAdminServiceServer) ListTopupOrders(context.Context, *ListTopupOrdersRequest) (*ListTopupOrdersResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListTopupOrders not implemented")
+}
+func (UnimplementedDonateRevenueAdminServiceServer) ListTopBuyers(context.Context, *ListTopBuyersRequest) (*ListTopBuyersResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListTopBuyers not implemented")
+}
+func (UnimplementedDonateRevenueAdminServiceServer) ListDonateSpend(context.Context, *ListDonateSpendRequest) (*ListDonateSpendResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListDonateSpend not implemented")
+}
+func (UnimplementedDonateRevenueAdminServiceServer) SearchAccounts(context.Context, *SearchAccountsRequest) (*SearchAccountsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SearchAccounts not implemented")
+}
+func (UnimplementedDonateRevenueAdminServiceServer) mustEmbedUnimplementedDonateRevenueAdminServiceServer() {
+}
+func (UnimplementedDonateRevenueAdminServiceServer) testEmbeddedByValue() {}
+
+// UnsafeDonateRevenueAdminServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to DonateRevenueAdminServiceServer will
+// result in compilation errors.
+type UnsafeDonateRevenueAdminServiceServer interface {
+	mustEmbedUnimplementedDonateRevenueAdminServiceServer()
+}
+
+func RegisterDonateRevenueAdminServiceServer(s grpc.ServiceRegistrar, srv DonateRevenueAdminServiceServer) {
+	// If the following call panics, it indicates UnimplementedDonateRevenueAdminServiceServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&DonateRevenueAdminService_ServiceDesc, srv)
+}
+
+func _DonateRevenueAdminService_GetRevenueSummary_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetRevenueSummaryRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DonateRevenueAdminServiceServer).GetRevenueSummary(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DonateRevenueAdminService_GetRevenueSummary_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DonateRevenueAdminServiceServer).GetRevenueSummary(ctx, req.(*GetRevenueSummaryRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DonateRevenueAdminService_ListTopupOrders_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListTopupOrdersRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DonateRevenueAdminServiceServer).ListTopupOrders(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DonateRevenueAdminService_ListTopupOrders_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DonateRevenueAdminServiceServer).ListTopupOrders(ctx, req.(*ListTopupOrdersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DonateRevenueAdminService_ListTopBuyers_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListTopBuyersRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DonateRevenueAdminServiceServer).ListTopBuyers(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DonateRevenueAdminService_ListTopBuyers_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DonateRevenueAdminServiceServer).ListTopBuyers(ctx, req.(*ListTopBuyersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DonateRevenueAdminService_ListDonateSpend_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListDonateSpendRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DonateRevenueAdminServiceServer).ListDonateSpend(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DonateRevenueAdminService_ListDonateSpend_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DonateRevenueAdminServiceServer).ListDonateSpend(ctx, req.(*ListDonateSpendRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DonateRevenueAdminService_SearchAccounts_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SearchAccountsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DonateRevenueAdminServiceServer).SearchAccounts(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DonateRevenueAdminService_SearchAccounts_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DonateRevenueAdminServiceServer).SearchAccounts(ctx, req.(*SearchAccountsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// DonateRevenueAdminService_ServiceDesc is the grpc.ServiceDesc for DonateRevenueAdminService service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var DonateRevenueAdminService_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "web.v1.DonateRevenueAdminService",
+	HandlerType: (*DonateRevenueAdminServiceServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "GetRevenueSummary",
+			Handler:    _DonateRevenueAdminService_GetRevenueSummary_Handler,
+		},
+		{
+			MethodName: "ListTopupOrders",
+			Handler:    _DonateRevenueAdminService_ListTopupOrders_Handler,
+		},
+		{
+			MethodName: "ListTopBuyers",
+			Handler:    _DonateRevenueAdminService_ListTopBuyers_Handler,
+		},
+		{
+			MethodName: "ListDonateSpend",
+			Handler:    _DonateRevenueAdminService_ListDonateSpend_Handler,
+		},
+		{
+			MethodName: "SearchAccounts",
+			Handler:    _DonateRevenueAdminService_SearchAccounts_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "api/web/v1/web.proto",
+}

--- a/docs/integrations/faturamento-nextjs.md
+++ b/docs/integrations/faturamento-nextjs.md
@@ -1,0 +1,406 @@
+# Integração Next.js ↔ web-api: painel de faturamento
+
+> Guia para o **front-end Next.js** consumir o **painel de faturamento** (receita
+> de donate, pedidos, compradores e extrato de créditos). Fonte da verdade do
+> contrato: `api/web/v1/web.proto`, serviço `web.v1.DonateRevenueAdminService`.
+>
+> ⚠️ **Isto não é o `binServer`.** `bin.v1.BillingService.CheckBilling` é o portão
+> de *entitlement* de login; `docs/migration/web-platform-plan.md` diz
+> explicitamente que ele **não** é a carteira de cash. Faturamento no sentido de
+> receita vive aqui: `donate_topup_order` + `donate_shop_audit` + `account`.
+
+## 1. Topologia
+
+```text
+Browser ──HTTPS──> Next.js (Route Handlers / Server Actions = BFF)
+                        │  só server-side; cookie de sessão httpOnly
+                        │ gRPC + mTLS
+                        ▼
+                     web-api (:7600) ──leitura──> Postgres
+                                                   ├── donate_topup_order   (dinheiro real)
+                                                   ├── donate_shop_audit    (créditos donate)
+                                                   ├── account              (identidade + carteira)
+                                                   └── donate_payer_profile (nome + CPF)
+```
+
+Regras:
+
+- O browser nunca chama gRPC nem recebe certificados mTLS.
+- O Next.js deriva `moderator_id` do cookie de sessão; **nunca** aceita esse campo
+  do browser.
+- O `web-api` revalida `account.role in ('moderator','admin')` em toda chamada.
+  Um cookie adulterado recebe `ADMIN_RESULT_FORBIDDEN`.
+- **Este serviço não escreve nada** — nem linha de auditoria. Por isso não
+  interage com o loop single-owner do `tmServer` e pode ser chamado à vontade.
+- Os dados vêm do Postgres (armazenamento frio). Um pedido confirmado agora
+  aparece imediatamente; estado de personagem online não é relevante aqui.
+
+## 2. RPCs
+
+```proto
+service DonateRevenueAdminService {
+  rpc GetRevenueSummary(GetRevenueSummaryRequest) returns (GetRevenueSummaryResponse);
+  rpc ListTopupOrders(ListTopupOrdersRequest)     returns (ListTopupOrdersResponse);
+  rpc ListTopBuyers(ListTopBuyersRequest)         returns (ListTopBuyersResponse);
+  rpc ListDonateSpend(ListDonateSpendRequest)     returns (ListDonateSpendResponse);
+  rpc SearchAccounts(SearchAccountsRequest)       returns (SearchAccountsResponse);
+}
+
+message RevenueWindow {
+  int64 from_unix = 1; // inclusive, Unix seconds; 0 = to_unix menos 30 dias
+  int64 to_unix   = 2; // exclusive, Unix seconds; 0 = agora
+}
+
+enum RevenueBucket {
+  REVENUE_BUCKET_UNSPECIFIED = 0; // não retorna série
+  REVENUE_BUCKET_DAY = 1;
+  REVENUE_BUCKET_WEEK = 2;        // semana ISO, começa SEGUNDA
+  REVENUE_BUCKET_MONTH = 3;
+}
+
+enum DonateLedgerAction {
+  DONATE_LEDGER_ACTION_UNSPECIFIED = 0; // ambos os tipos
+  DONATE_LEDGER_ACTION_PURCHASE = 1;
+  DONATE_LEDGER_ACTION_CREDIT   = 2;
+}
+
+message RevenueTotals {
+  int64 paid_orders     = 1;
+  int64 gross_cents     = 2;
+  int64 credits_sold    = 3;
+  int64 distinct_buyers = 4;
+
+  int64 created_orders  = 5;
+  int64 pending_orders  = 6;
+  int64 pending_cents   = 7;
+
+  int64 shop_purchases  = 8;
+  int64 credits_spent   = 9;
+  int64 manual_credits  = 10;
+  int64 credits_granted = 11;
+}
+
+message RevenueByMethod {
+  PaymentMethod payment_method = 1;
+  int64 paid_orders = 2;
+  int64 gross_cents = 3;
+}
+
+message RevenuePoint {
+  int64 bucket_start_unix = 1;
+  int64 paid_orders       = 2;
+  int64 gross_cents       = 3;
+  int64 credits_sold      = 4;
+  int64 distinct_buyers   = 5;
+}
+
+message TopupOrderRow {
+  int64  id = 1;
+  string external_reference = 2;
+  int64  account_id = 3;
+  string account_name = 4;
+  string account_email = 5;
+  string payer_name = 6;
+  string payer_cpf_masked = 7;
+  int32  credits = 8;
+  int64  amount_cents = 9;
+  PaymentMethod payment_method = 10;
+  string provider = 11;
+  TopupStatus status = 12;
+  int64  created_at_unix = 13;
+  int64  confirmed_at_unix = 14;
+}
+
+message TopBuyerRow {
+  int64  account_id = 1;
+  string account_name = 2;
+  string account_email = 3;
+  int64  window_paid_orders   = 4;
+  int64  window_gross_cents   = 5;
+  int64  lifetime_paid_orders = 6;
+  int64  lifetime_gross_cents = 7;
+  int64  lifetime_credits     = 8;
+  int64  first_paid_at_unix   = 9;
+  int64  last_paid_at_unix    = 10;
+  int32  donate_balance       = 11;
+}
+
+message DonateLedgerRow {
+  int64  id = 1;
+  DonateLedgerAction action = 2;
+  int64  created_at_unix = 3;
+  int64  subject_account_id = 4;
+  string subject_account_name = 5;
+  int64  actor_account_id = 6;
+  string actor_account_name = 7;
+  int64  credits_delta = 8;
+  int64  balance_after = 9;
+  int64  shop_item_id = 10;
+  string shop_item_title = 11;
+  string reason = 12;
+}
+
+message AccountSummary {
+  int64  id = 1;
+  string name = 2;
+  string email = 3;
+  int32  donate_balance = 4;
+  string role = 5;
+  bool   is_blocked = 6;
+}
+```
+
+Todo request tem `moderator_id` como **primeiro campo**. Todas as respostas
+paginadas ecoam `from_unix`/`to_unix` **efetivamente aplicados** pelo servidor.
+
+## 3. Campos
+
+### `RevenueTotals`
+
+| Campo | Tipo | Uso |
+|-------|------|-----|
+| `paid_orders` / `gross_cents` | int64 | **Receita reconhecida** no período (base `confirmed_at`). O número principal do painel. |
+| `credits_sold` | int64 | Créditos donate emitidos pelos pedidos pagos. Unidade de jogo, **não** dinheiro. |
+| `distinct_buyers` | int64 | Contas distintas que pagaram no período. |
+| `created_orders` | int64 | Pedidos **criados** no período, qualquer status. Denominador da conversão. |
+| `pending_orders` / `pending_cents` | int64 | Criados no período e ainda PENDING. **Não é receita e não é "a receber"** — ver §7. |
+| `shop_purchases` / `credits_spent` | int64 | Compras na loja e créditos gastos. Saída de carteira, em créditos. |
+| `manual_credits` / `credits_granted` | int64 | Créditos manuais de moderador (cortesia/compensação). Entrada de créditos **sem** entrada de dinheiro. |
+
+### `TopupOrderRow`
+
+| Campo | Tipo | Uso |
+|-------|------|-----|
+| `external_reference` | string | UUID do portal. **Chave de reconciliação** com o gateway e em chargeback. |
+| `account_name` / `account_email` | string | Identidade do comprador, já resolvida por JOIN — não faça lookup por linha. |
+| `payer_name` | string | Do `donate_payer_profile`; vazio se o pagador nunca preencheu. |
+| `payer_cpf_masked` | string | **Sempre mascarado** (`***.456.789-**`). O CPF completo nunca sai da web-api; não existe variante sem máscara no contrato. Vazio quando não há perfil. |
+| `amount_cents` | int64 | Dinheiro em centavos inteiros. |
+| `credits` | int32 | Créditos donate do pedido. **Outra unidade** — nunca some com `amount_cents`. |
+| `provider` | string | **Sempre vazio hoje**: nada escreve `donate_topup_order.provider`. Não construa UI em cima dele. |
+| `confirmed_at_unix` | int64 | `0` enquanto PENDING. |
+
+### `DonateLedgerRow`
+
+| Campo | Tipo | Uso |
+|-------|------|-----|
+| `subject_account_id` / `_name` | int64/string | **De quem é a carteira que se moveu.** É por aqui que se filtra e se agrupa. |
+| `actor_account_id` / `_name` | int64/string | **Quem causou.** Igual ao subject numa compra; é o **moderador** num crédito manual. |
+| `credits_delta` | int64 | **Assinado**: negativo em compra (débito), positivo em crédito. Soma da coluna = fluxo líquido. |
+| `balance_after` | int64 | Saldo registrado no momento do movimento. |
+| `shop_item_title` | string | Vazio se a oferta foi deletada depois (`shop_item_id` não é FK, de propósito). **Caia para `shop_item_id`** ou compras antigas parecem corrompidas. |
+| `reason` | string | Só em `credit_balance`: a nota do moderador. |
+
+> **A assimetria que importa.** Em `donate_shop_audit`, a coluna `account_id` é o
+> comprador quando `action='purchase'`, mas é o **moderador** quando
+> `action='credit_balance'` — a conta creditada só existe no JSON. O backend já
+> normaliza isso em `subject`/`actor`; a UI só precisa usar os campos certos.
+> Exemplo: moderador `admin1` credita 100 para `jogador7` → `subject=jogador7`,
+> `actor=admin1`, `credits_delta=+100`.
+
+## 4. Validação do Backend
+
+- Janela: `from_unix=0` e `to_unix=0` → **últimos 30 dias**; só `to_unix=0` → até agora.
+- `from >= to` → `INVALID`. Valores negativos → `INVALID`.
+- Janela maior que **366 dias** → `INVALID`.
+- `limit`: default **50**, máximo **100**. `offset` negativo vira `0`.
+- `SearchAccounts`: prefixo mínimo **2 caracteres** (senão `INVALID`); é
+  minusculizado e tem `%`/`_` escapados no servidor. `limit` default **20**, máx **50**.
+- `account_id < 0` → `INVALID`. `account_id = 0` significa "todas as contas".
+- `bucket` desconhecido → **não é erro**: degrada para "sem série", para um portal
+  mais novo não quebrar contra um servidor mais velho.
+
+## 5. Resultado e Erros
+
+As RPCs usam `AdminResult` no corpo. Erro gRPC representa falha de infraestrutura.
+
+| `AdminResult` | HTTP sugerido no BFF | Significado |
+|---------------|----------------------|-------------|
+| `ADMIN_RESULT_OK` | 200 | sucesso |
+| `ADMIN_RESULT_FORBIDDEN` | 403 | usuário não é moderador/admin |
+| `ADMIN_RESULT_INVALID` | 400 / 422 | janela inválida, prefixo curto, `account_id` negativo |
+| `ADMIN_RESULT_NOT_FOUND` | 404 | reservado; **não retornado por este serviço** — uma janela sem dados é 200 com listas vazias |
+| `ADMIN_RESULT_UNSPECIFIED` | 500 | estado inesperado |
+
+O BFF deve transformar erro gRPC em `502` ou `500` e não repassar detalhes
+internos para o browser.
+
+## 6. Rotas BFF Sugeridas
+
+| Rota HTTP | RPC | Observações |
+|-----------|-----|-------------|
+| `GET /api/admin/faturamento/resumo?from=&to=&bucket=&accountId=` | `GetRevenueSummary` | KPIs + série do gráfico |
+| `GET /api/admin/faturamento/pedidos?from=&to=&status=&method=&accountId=&limit=&offset=` | `ListTopupOrders` | tabela de pedidos |
+| `GET /api/admin/faturamento/top-compradores?from=&to=&limit=&offset=` | `ListTopBuyers` | ranking + LTV |
+| `GET /api/admin/faturamento/extrato-donate?from=&to=&action=&accountId=&limit=&offset=` | `ListDonateSpend` | extrato de créditos |
+| `GET /api/admin/faturamento/contas?q=` | `SearchAccounts` | autocomplete do filtro de conta |
+
+Shape sugerido para `GET /api/admin/faturamento/resumo`:
+
+```json
+{
+  "period": { "from": "2026-07-01T03:00:00Z", "to": "2026-08-01T03:00:00Z" },
+  "totals": {
+    "paidOrders": 128,
+    "grossCents": "4560000",
+    "creditsSold": "256000",
+    "distinctBuyers": 97,
+    "createdOrders": 190,
+    "pendingOrders": 62,
+    "pendingCents": "1880000",
+    "shopPurchases": 340,
+    "creditsSpent": "198000",
+    "manualCredits": 4,
+    "creditsGranted": "1200"
+  },
+  "byMethod": [
+    { "paymentMethod": "PIX", "paidOrders": 120, "grossCents": "4300000" },
+    { "paymentMethod": "CREDIT_CARD", "paidOrders": 8, "grossCents": "260000" }
+  ],
+  "series": [
+    { "bucketStart": "2026-07-01T03:00:00Z", "paidOrders": 4, "grossCents": "150000", "creditsSold": "8000", "distinctBuyers": 4 }
+  ]
+}
+```
+
+Shape sugerido para `GET /api/admin/faturamento/pedidos`:
+
+```json
+{
+  "period": { "from": "2026-07-01T03:00:00Z", "to": "2026-08-01T03:00:00Z" },
+  "totalCount": 128,
+  "orders": [
+    {
+      "id": "9012",
+      "externalReference": "6f1c…-uuid",
+      "accountId": "34",
+      "accountName": "zarco",
+      "accountEmail": "zarco@exemplo.com",
+      "payerName": "Fulano de Tal",
+      "payerCpfMasked": "***.456.789-**",
+      "credits": 500,
+      "amountCents": "2500",
+      "paymentMethod": "PIX",
+      "status": "PAID",
+      "createdAt": "2026-07-10T15:00:00Z",
+      "confirmedAt": "2026-07-10T15:02:11Z"
+    }
+  ]
+}
+```
+
+Shape sugerido para `GET /api/admin/faturamento/extrato-donate`:
+
+```json
+{
+  "totalCount": 344,
+  "entries": [
+    {
+      "id": "771",
+      "action": "CREDIT",
+      "createdAt": "2026-07-12T18:30:00Z",
+      "subject": { "accountId": "34", "accountName": "zarco" },
+      "actor":   { "accountId": "2",  "accountName": "admin1" },
+      "creditsDelta": "100",
+      "balanceAfter": "600",
+      "reason": "compensacao evento"
+    }
+  ]
+}
+```
+
+O BFF deve:
+
+- Derivar `moderator_id` **da sessão**, nunca do query string.
+- Serializar todo `int64` como **string** no JSON público (`id`, `accountId`,
+  `amountCents`, `grossCents`, `creditsDelta`, `shopItemId`, …) — acima de 2^53 o
+  JavaScript perde precisão silenciosamente.
+- Converter todo `*_unix` para ISO-8601 (`0` → `null`, não `1970-01-01`).
+- Mapear `AdminResult` para os HTTP da §5.
+- **Nunca** dividir centavos por 100 no cálculo — só na formatação final.
+
+## 7. Semântica de Faturamento
+
+Esta seção é o que impede um painel numericamente correto de contar a história errada.
+
+1. **Receita é reconhecida em `confirmed_at`, não em `created_at`.** Um pedido
+   criado em janeiro e pago em fevereiro é receita **de fevereiro**. Em janeiro
+   ele aparece apenas em `created_orders`.
+2. **Os buckets fecham em `America/Sao_Paulo`.** "Hoje" começa à 00h de Brasília e
+   o mês fecha no último dia às 23h59 BRT — de propósito, para bater com o
+   extrato bancário. Os instantes no fio continuam absolutos (Unix seconds); é só
+   a fronteira do agrupamento que é BRT. Note que isso diverge do resto do
+   servidor (a regra de dia da recompensa diária é UTC) — é intencional.
+3. **Semana começa segunda-feira** (`date_trunc('week')` do Postgres).
+4. **Não existe status de reembolso nem de expirado.** Um pedido PENDING fica
+   PENDING para sempre; nada varre pedidos abandonados. Consequências:
+   - `paid_orders / created_orders` é um **piso** da conversão, que decai com o tempo.
+   - `pending_cents` cresce monotonicamente e **não é dinheiro a receber**.
+     Rotule como "aguardando pagamento (histórico)".
+   - Para uma conversão honesta, considere só pedidos criados nas últimas 24–48h.
+5. **`credit_balance` é cortesia, não receita.** É valor entregue ao jogador sem
+   entrada de dinheiro. Mostre separado dos KPIs de receita.
+6. **Créditos ≠ dinheiro.** `credits_sold`, `credits_spent` e `credits_granted`
+   estão na moeda do jogo; `*_cents` está em BRL. Nunca some as duas, e não
+   converta uma na outra — a taxa varia por pedido.
+7. **Passivo em circulação está fora de escopo.** O total de donate comprado e
+   ainda não gasto (`SUM(account.donate_balance)`) **não** é exposto por este
+   serviço. `TopBuyerRow.donate_balance` é o saldo de *uma* conta, para contexto
+   no drill-down — não agregue essa coluna para estimar o passivo, porque ela só
+   vem das contas da página atual.
+8. **`provider` está sempre vazio.** A coluna existe para reconciliação futura por
+   gateway, mas `CreateTopupOrder` nunca a escreve. Não há breakdown por gateway
+   além de `payment_method`.
+
+## 8. UI Recomendada
+
+- **Cabeçalho de KPIs**: receita bruta, pedidos pagos, ticket médio
+  (`gross_cents / paid_orders`, calculado no front), compradores distintos.
+  Separe visualmente o bloco de créditos (gasto/cortesia) do bloco de dinheiro.
+- **Gráfico da série**: barras/linha sobre `series`, com seletor dia/semana/mês.
+  Os buckets vazios já vêm zerados — não faça gap fill.
+- **Tabela de pedidos**: filtros de período, status, método e conta. Coluna
+  `external_reference` copiável (é a chave de reconciliação).
+- **Ranking de compradores**: ordenado por `window_gross_cents`, com `lifetime_*`
+  ao lado. O drill-down é a **mesma** rota de pedidos com `accountId`.
+- **Extrato de donate**: `credits_delta` com sinal e cor, colunas separadas para
+  *subject* e *actor*.
+
+**Estados obrigatórios:**
+
+- carregando;
+- **janela sem dados** (200 com listas vazias) — visualmente distinto de erro;
+- `403` sem acesso (esconder o item de menu, mas ainda tratar a resposta);
+- janela inválida (`>366 dias` ou `from >= to`);
+- página além do fim (lista vazia mas `totalCount > 0` — volte para a página 1);
+- erro temporário de upstream (502/500) com retry;
+- **aviso de fuso**: rotular o período como horário de Brasília;
+- **aviso de que PENDING não expira**, junto de `pending_cents`;
+- oferta deletada no extrato (`shopItemTitle` vazio → mostrar o id).
+
+## 9. Checklist de Implementação no Portal
+
+- [ ] Regenerar os stubs a partir de `api/web/v1/web.proto`.
+- [ ] Cliente gRPC server-side com mTLS (reusar o singleton de `npc-admin-nextjs.md`).
+- [ ] As 5 rotas BFF da §6.
+- [ ] `moderator_id` sempre derivado da sessão.
+- [ ] Mapear `AdminResult` → HTTP conforme §5.
+- [ ] Serializar `int64` como string; converter `*_unix` para ISO (0 → `null`).
+- [ ] Rotular o período como horário de Brasília.
+- [ ] Não somar centavos com créditos em lugar nenhum.
+- [ ] Não exibir `provider` (sempre vazio).
+- [ ] Fallback de `shopItemTitle` vazio para `shopItemId`.
+- [ ] Rotular `pending_cents` como histórico, não como "a receber".
+
+## 10. Fora de escopo (não existe endpoint)
+
+- **CPF completo.** Só a forma mascarada existe no contrato. Se um chargeback
+  exigir o número, isso deve virar uma RPC admin-only separada que escreve a
+  própria linha de auditoria — não um parâmetro nesta.
+- **Passivo em circulação** (`SUM(account.donate_balance)`) — ver §7.7.
+- **Exportação CSV/planilha** — o BFF pode montar a partir das rotas paginadas.
+- **Estorno/cancelamento de pedido** — não há write path; o contrato é read-only.
+- **Breakdown por gateway** além de `payment_method` — ver §7.8.
+- **Guia do fluxo de compra** (`DonateTopupService`, o lado do jogador): ainda
+  **não documentado**. O contrato está em `api/web/v1/web.proto`; falta um
+  `docs/integrations/donate-topup-nextjs.md`.

--- a/docs/migration/donate-shop-frontend.md
+++ b/docs/migration/donate-shop-frontend.md
@@ -86,9 +86,17 @@ Liga/desliga a oferta na vitrine.
 Remove a oferta.
 
 ### `CreditDonateBalance(moderator_id, account_id, amount, reason) → { result, new_balance }`
-**Adiciona `amount` de donate à conta `account_id`** (crédito manual/administrativo — é a mesma porta
-que o gateway de pagamento vai usar no futuro). `amount` deve ser > 0. `reason` fica no audit trail.
-`new_balance` só vem em `OK`. Conta inexistente → `ADMIN_RESULT_NOT_FOUND`.
+**Adiciona `amount` de donate à conta `account_id`** (crédito manual/administrativo). `amount` deve
+ser > 0. `reason` fica no audit trail. `new_balance` só vem em `OK`. Conta inexistente →
+`ADMIN_RESULT_NOT_FOUND`.
+
+> O gateway de pagamento **não** passa por aqui: ele tem seu próprio caminho idempotente em
+> `DonateTopupService.ConfirmTopupOrder`. Este RPC é a cortesia/compensação manual.
+>
+> Cada crédito vira uma linha `credit_balance` em `donate_shop_audit`, hoje legível via
+> `DonateRevenueAdminService.ListDonateSpend` — onde o **moderador aparece como `actor`** e a conta
+> creditada como `subject` (a coluna `account_id` da auditoria guarda o moderador, não o beneficiado).
+> Ver [`docs/integrations/faturamento-nextjs.md`](../integrations/faturamento-nextjs.md).
 
 `AdminAck` = `{ AdminResult result }`.
 
@@ -169,7 +177,10 @@ export async function upsertOffer(item: DonateShopItemInput) {
 
 ## 9. Fora de escopo (não existe endpoint ainda)
 
-- **Gateway de pagamento / compra real de donate**: por enquanto o saldo só é creditado por
-  `CreditDonateBalance` (moderador). O webhook de pagamento futuro chamará a mesma lógica.
+- ~~**Gateway de pagamento / compra real de donate**~~ — **já existe**: `DonateTopupService`
+  (`api/web/v1/web.proto`, migração `0010_donate_topup`) cobre o ciclo PIX completo
+  (`CreateTopupOrder` → `ConfirmTopupOrder` idempotente → `GetTopupOrder`). `CreditDonateBalance`
+  continua sendo o crédito **manual** de moderador. Para os relatórios de receita sobre esses
+  pedidos, ver [`docs/integrations/faturamento-nextjs.md`](../integrations/faturamento-nextjs.md).
 - **Entrega instantânea para quem já está online** (só há dreno no login).
 - **Mercado P2P / consignação de item pelo jogador** (feature separada — ver `web-platform-plan.md`).

--- a/docs/migration/web-platform-plan.md
+++ b/docs/migration/web-platform-plan.md
@@ -119,7 +119,8 @@ reaproveitar o protocolo legado para a web.
 | Login web | web-api valida hash → cookie de sessão | separado do login do jogo |
 | Ranking | web-api → SELECT read-only no Postgres | dado de char online fica levemente atrasado — aceitável |
 | Ver perfil/personagem | idem, read-only | |
-| Comprar cash | gateway → webhook → web-api credita `donate_balance` + `delivery_queue` | `donate_balance` é coluna por-conta (`account`); ver gotcha abaixo |
+| Comprar cash | gateway → webhook → web-api credita `donate_balance` + `delivery_queue` | implementado via `DonateTopupService` (PIX, migração `0010`); `donate_balance` é coluna por-conta (`account`); ver gotcha abaixo |
+| Relatório de faturamento | web-api lê `donate_topup_order`/`donate_shop_audit` (read-only) | `DonateRevenueAdminService`; ver [faturamento-nextjs.md](../integrations/faturamento-nextjs.md) |
 | Recompensa diária | web-api → `delivery_queue` + `daily_reward_claim` ("resgatou hoje") | implementado, issue #35 |
 | Loja-web | consignação in-game + entrega via `delivery_queue` | ver seção ⚠️ acima |
 
@@ -134,6 +135,12 @@ padrão** (`AllowAllBilling` sem `-binserver`), **sem persistência** (map em me
 
 Decisão: **manter o binServer como o serviço de _entitlement/acesso_** (premium/assinatura/ban
 administrativo). Ele **NÃO** é a carteira de cash — cash = `donate_balance` no Postgres.
+
+> **Se você chegou aqui procurando "faturamento"/"billing" no sentido de receita, é o outro lado.**
+> A superfície de relatório da carteira é `web.v1.DonateRevenueAdminService`
+> (`donate_topup_order` + `donate_shop_audit` + `account`), documentada em
+> [`docs/integrations/faturamento-nextjs.md`](../integrations/faturamento-nextjs.md).
+> `bin.v1.BillingService` só responde "esta conta pode logar?".
 
 Upgrades necessários antes de servir a web:
 1. **Persistência** — tabela própria `billing_entitlement(account_id, status, expires_at)` (não

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -5,6 +5,8 @@
 // normalized into slices; empty item slots (sIndex==0) are dropped.
 package domain
 
+import "time"
+
 // Account is one migrated account with its characters and shared cargo.
 //
 // Secrets are stored ONLY as hashes: PassHash, PinHash and BlockPassHash are
@@ -361,4 +363,126 @@ type TopupOrder struct {
 	AmountCents       int64
 	PaymentMethod     int16
 	Status            int16
+}
+
+// --- painel de faturamento read models (web.v1.DonateRevenueAdminService) ---
+//
+// These are READ projections only. TopupOrder above stays the write-path input
+// for CreateTopupOrder: created_at/confirmed_at are set by Postgres and provider
+// is written by nothing, so carrying them there would be three fields that lie.
+//
+// Two units appear below and they NEVER mix. *Cents is real money in integer BRL
+// cents (never a float). Credits/*Credits is the in-game donate wallet unit,
+// whose exchange rate is a property of each individual order.
+//
+// Revenue is recognized on ConfirmedAt, not CreatedAt: an order is only money
+// once the gateway settled it and ConfirmTopupOrder flipped it to PAID.
+
+// TopupOrderRow is one donate_topup_order joined with its buyer's account and
+// payer profile — the moderation table's row. PayerCPF holds the raw 11 digits
+// as stored; the service masks it before it reaches the wire.
+type TopupOrderRow struct {
+	ID                int64
+	ExternalReference string
+	AccountID         int64
+	AccountName       string
+	AccountEmail      string
+	PayerName         string
+	PayerCPF          string
+	Credits           int32
+	AmountCents       int64
+	PaymentMethod     int16
+	Provider          string // always "" today: CreateTopupOrder never writes it
+	Status            int16
+	CreatedAt         time.Time
+	ConfirmedAt       *time.Time // nil while PENDING
+}
+
+// RevenueTotals is the money KPI header. Paid* are recognized on confirmed_at;
+// Created/Pending* are scoped by created_at instead, because they measure funnel
+// volume rather than revenue. PendingCents is NOT revenue and must never be
+// added to GrossCents.
+type RevenueTotals struct {
+	PaidOrders     int64
+	GrossCents     int64
+	CreditsSold    int64
+	DistinctBuyers int64
+	CreatedOrders  int64
+	PendingOrders  int64
+	PendingCents   int64
+}
+
+// RevenueByMethod is recognized revenue split by payment gateway.
+type RevenueByMethod struct {
+	PaymentMethod int16
+	PaidOrders    int64
+	GrossCents    int64
+}
+
+// RevenuePoint is one bucket of the revenue time series. BucketStart is the
+// instant the bucket opens; empty buckets are present with zeroed counters, so
+// callers never do date math to fill gaps.
+type RevenuePoint struct {
+	BucketStart    time.Time
+	PaidOrders     int64
+	GrossCents     int64
+	CreditsSold    int64
+	DistinctBuyers int64
+}
+
+// TopBuyer ranks one account by revenue inside a window alongside its all-time
+// aggregate. The Lifetime* fields ignore the window on purpose — that is what
+// makes them an LTV.
+type TopBuyer struct {
+	AccountID          int64
+	AccountName        string
+	AccountEmail       string
+	WindowPaidOrders   int64
+	WindowGrossCents   int64
+	LifetimePaidOrders int64
+	LifetimeGrossCents int64
+	LifetimeCredits    int64
+	FirstPaidAt        time.Time
+	LastPaidAt         time.Time
+	DonateBalance      int32 // current wallet: point-in-time, not a window value
+}
+
+// DonateLedgerEntry is one donate wallet movement read from donate_shop_audit.
+// Subject is whose balance moved; Actor is who caused it. They differ only for
+// 'credit_balance', where the actor is the granting moderator and the subject
+// lives in the audit JSON (internal/store/donate.go:207). CreditsDelta is
+// SIGNED — negative on a purchase, positive on a credit — so the column sums to
+// a meaningful net.
+type DonateLedgerEntry struct {
+	ID                 int64
+	Action             string // "purchase" | "credit_balance"
+	CreatedAt          time.Time
+	SubjectAccountID   int64
+	SubjectAccountName string
+	ActorAccountID     int64
+	ActorAccountName   string
+	CreditsDelta       int64
+	BalanceAfter       int64
+	ShopItemID         int64  // 0 for credit_balance
+	ShopItemTitle      string // "" when the offer was deleted since the purchase
+	Reason             string // credit_balance only: the moderator's note
+}
+
+// DonateLedgerTotals aggregates the wallet movements in a window, in credits.
+type DonateLedgerTotals struct {
+	ShopPurchases  int64
+	CreditsSpent   int64
+	ManualCredits  int64
+	CreditsGranted int64
+}
+
+// AccountSummary is the identity projection the panel's account picker needs to
+// turn a typed login into an account_id filter. It exposes no credentials.
+type AccountSummary struct {
+	ID            int64
+	Name          string
+	Email         string
+	DonateBalance int32
+	Role          string
+	IsBlocked     bool
 }

--- a/internal/migrations/0017_donate_revenue_indexes.down.sql
+++ b/internal/migrations/0017_donate_revenue_indexes.down.sql
@@ -1,0 +1,7 @@
+-- Reverses 0017_donate_revenue_indexes. Indexes only — no data is lost.
+
+DROP INDEX IF EXISTS account_name_prefix_idx;
+DROP INDEX IF EXISTS donate_shop_audit_subject_idx;
+DROP INDEX IF EXISTS donate_shop_audit_action_created_idx;
+DROP INDEX IF EXISTS donate_topup_order_created_idx;
+DROP INDEX IF EXISTS donate_topup_order_confirmed_idx;

--- a/internal/migrations/0017_donate_revenue_indexes.up.sql
+++ b/internal/migrations/0017_donate_revenue_indexes.up.sql
@@ -1,0 +1,55 @@
+-- 0017_donate_revenue_indexes — read paths for the painel de faturamento
+-- (web.v1.DonateRevenueAdminService).
+--
+-- No new tables and no column changes: every number the panel shows has been
+-- persisted since 0008_donate_shop and 0010_donate_topup. What was missing is
+-- indexes — donate_topup_order only had (account_id) and donate_shop_audit only
+-- had (shop_item_id), so every date-windowed report would sequentially scan.
+
+-- Recognized revenue is ALWAYS "status = PAID, filtered and ordered by
+-- confirmed_at" (an order is only money once the gateway settled it). A partial
+-- index keeps it to the settled rows — PENDING rows have confirmed_at NULL and
+-- are excluded for free — and DESC matches the order table's ORDER BY so the
+-- pager needs no sort step.
+-- Serves: RevenueTotals (the paid FILTERs), RevenueByMethod, RevenueSeries,
+--         ListTopupOrders variant A, ListTopBuyers.
+CREATE INDEX IF NOT EXISTS donate_topup_order_confirmed_idx
+    ON donate_topup_order (confirmed_at DESC)
+    WHERE status = 2;
+
+-- The funnel side is scoped by created_at regardless of status: a PENDING order
+-- has no confirmed_at at all, so it is invisible to the index above.
+-- Serves: RevenueTotals (the created/pending FILTERs and the second branch of
+--         its outer WHERE), ListTopupOrders variant B.
+CREATE INDEX IF NOT EXISTS donate_topup_order_created_idx
+    ON donate_topup_order (created_at DESC);
+
+-- Every donate_shop_audit read in the panel filters by action FIRST and then by
+-- a created_at window, so the composite in that order serves both the ledger
+-- list (action = ANY(...)) and the ledger totals. A bare (created_at) index
+-- would be strictly weaker and is deliberately NOT created.
+-- Serves: ListDonateLedger, DonateLedgerTotals.
+CREATE INDEX IF NOT EXISTS donate_shop_audit_action_created_idx
+    ON donate_shop_audit (action, created_at DESC);
+
+-- Per-account drill-down into the ledger. This CANNOT be a plain (account_id)
+-- index: donate_shop_audit is asymmetric. For action='purchase' the account_id
+-- column IS the buyer, but for action='credit_balance' it is the MODERATOR who
+-- granted the credit, and the credited account exists only inside
+-- after->>'account_id' (internal/store/donate.go:207). Indexing the raw column
+-- would silently attribute every courtesy credit to the moderator.
+--
+-- This expression is byte-identical to ledgerSubjectExpr in
+-- internal/store/donate_revenue.go (modulo the `au.` alias, which is not part of
+-- an index expression). If you edit one, edit the other, or the planner quietly
+-- stops using this index.
+CREATE INDEX IF NOT EXISTS donate_shop_audit_subject_idx
+    ON donate_shop_audit ((COALESCE(NULLIF(after->>'account_id', '')::bigint, account_id)))
+    WHERE action IN ('purchase', 'credit_balance');
+
+-- SearchAccounts does `name LIKE 'prefix%'`. The UNIQUE constraint on
+-- account.name only helps that under the C collation; text_pattern_ops makes the
+-- prefix search index-backed under whatever collation the database was
+-- initdb'd with.
+CREATE INDEX IF NOT EXISTS account_name_prefix_idx
+    ON account (name text_pattern_ops);

--- a/internal/store/donate_revenue.go
+++ b/internal/store/donate_revenue.go
@@ -1,0 +1,547 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+)
+
+// Donate revenue read models for the painel de faturamento
+// (web.v1.DonateRevenueAdminService). Everything here is READ-ONLY and spans
+// donate_topup_order (real money), donate_shop_audit (wallet movements),
+// account (buyer identity) and donate_payer_profile. The write lifecycle lives
+// in donate_topup.go and donate.go; this file deliberately adds nothing to it.
+//
+// Revenue recognition: money is recognized on confirmed_at, never created_at —
+// an order is only revenue once the gateway settled it and ConfirmTopupOrder
+// flipped it to PAID. created_at is used ONLY for the funnel counters
+// (created/pending), which measure volume, not revenue.
+//
+// The indexes these queries depend on are in
+// internal/migrations/0017_donate_revenue_indexes.up.sql.
+
+// RevenueWindow is the half-open [From, To) instant range every revenue read is
+// scoped to. The caller always resolves it to a concrete bounded range before
+// calling in, so no query here needs a NULL-guarded date predicate and every
+// range scan stays sargable on an indexed column.
+type RevenueWindow struct {
+	From time.Time
+	To   time.Time
+}
+
+// TopupOrderFilter narrows ListTopupOrders. Zero means "any" on every dimension.
+type TopupOrderFilter struct {
+	Status        int16 // 0 = any; 1 = PENDING; 2 = PAID
+	PaymentMethod int16 // 0 = any
+	AccountID     int64 // 0 = any
+}
+
+// Series bucket keywords. Passed to date_trunc as a BIND PARAMETER (never string
+// concatenation) and always one of these server-owned constants — a caller's
+// enum is mapped to them, never forwarded as free text.
+const (
+	BucketDay   = "day"
+	BucketWeek  = "week"
+	BucketMonth = "month"
+)
+
+// Donate ledger actions that move a wallet. The catalog CRUD actions written by
+// UpsertDonateShopItem/SetDonateShopItemEnabled/DeleteDonateShopItem are
+// deliberately excluded — they change config, not balances.
+const (
+	LedgerActionPurchase = "purchase"
+	LedgerActionCredit   = "credit_balance"
+)
+
+// The status discriminators below are written as SQL literals (1 = PENDING,
+// 2 = PAID, matching TopupStatusPending/TopupStatusPaid) rather than bind
+// parameters on purpose: donate_topup_order_confirmed_idx (migration 0017) is a
+// PARTIAL index on `status = 2`, and Postgres can only prove a query implies a
+// partial index predicate when the value is a literal. A `$n` would defeat the
+// index under a generic plan.
+
+// revenueZone is the timezone the day/week/month buckets close in. The panel is
+// read against Brazilian bank statements, so "hoje" and "este mês" must end at
+// midnight in Brasília — NOT at midnight UTC, which would shift every boundary
+// three hours and make month-end totals disagree with the statement. This is a
+// deliberate divergence from the rest of the server (the daily-reward day rule
+// is UTC); do not "fix" it to UTC.
+//
+// It is always passed to the three-argument date_trunc, which pins the boundary
+// regardless of the session TimeZone. The two-argument form would silently
+// follow the session and make results environment-dependent.
+//
+// Brazil has had no DST since 2019, so the generate_series steps below do not
+// currently cross a DST discontinuity.
+const revenueZone = "America/Sao_Paulo"
+
+// ledgerSubjectExpr is the canonical "whose wallet moved" expression over
+// donate_shop_audit. It exists because that table is asymmetric: for
+// action='purchase' the account_id column IS the buyer, but for
+// action='credit_balance' the column is the MODERATOR who granted the credit and
+// the credited account exists only in after->>'account_id' (donate.go:207). A
+// naive "GROUP BY account_id" spend report would therefore attribute every
+// courtesy credit to whichever moderator granted it.
+//
+// The expression index donate_shop_audit_subject_idx (migration 0017) matches
+// this text. If you edit one, edit the other, or the planner quietly stops using
+// the index.
+const ledgerSubjectExpr = `COALESCE(NULLIF(au.after->>'account_id', '')::bigint, au.account_id)`
+
+// bucketStep maps a validated bucket keyword to its generate_series step.
+func bucketStep(bucket string) (string, error) {
+	switch bucket {
+	case BucketDay:
+		return "1 day", nil
+	case BucketWeek:
+		return "1 week", nil
+	case BucketMonth:
+		return "1 month", nil
+	default:
+		return "", fmt.Errorf("store: revenue series: unknown bucket %q", bucket)
+	}
+}
+
+// escapeLike neutralizes the LIKE metacharacters in a user-typed prefix so a
+// literal '%' cannot turn a prefix search into a full-table wildcard scan. The
+// default ESCAPE '\' applies.
+func escapeLike(s string) string {
+	r := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return r.Replace(s)
+}
+
+// RevenueTotals is the KPI header over donate_topup_order. PAID figures are
+// scoped by confirmed_at (revenue recognition); created/pending figures by
+// created_at (funnel volume). accountID 0 means all accounts.
+func (s *Store) RevenueTotals(ctx context.Context, w RevenueWindow, accountID int64) (domain.RevenueTotals, error) {
+	var t domain.RevenueTotals
+	// The outer WHERE ORs the two date ranges so the planner can BitmapOr the
+	// confirmed_at and created_at indexes; the FILTERs then split the row set.
+	//
+	// `status = 2` has to appear in the OUTER WHERE, not only inside the FILTERs:
+	// FILTER clauses are applied after the scan and contribute no index quals, so
+	// without it the planner cannot prove the query implies
+	// donate_topup_order_confirmed_idx's partial predicate and the whole query
+	// degrades to a seq scan. It costs nothing semantically — confirmed_at is
+	// only ever set when an order flips to PAID, so a non-PAID row can never
+	// satisfy the first branch anyway.
+	err := s.pool.QueryRow(ctx, `
+		SELECT
+			count(*)                   FILTER (WHERE status = 2 AND confirmed_at >= $1 AND confirmed_at < $2),
+			COALESCE(sum(amount_cents) FILTER (WHERE status = 2 AND confirmed_at >= $1 AND confirmed_at < $2), 0),
+			COALESCE(sum(credits)      FILTER (WHERE status = 2 AND confirmed_at >= $1 AND confirmed_at < $2), 0),
+			count(DISTINCT account_id) FILTER (WHERE status = 2 AND confirmed_at >= $1 AND confirmed_at < $2),
+			count(*)                   FILTER (WHERE created_at >= $1 AND created_at < $2),
+			count(*)                   FILTER (WHERE status = 1 AND created_at >= $1 AND created_at < $2),
+			COALESCE(sum(amount_cents) FILTER (WHERE status = 1 AND created_at >= $1 AND created_at < $2), 0)
+		FROM donate_topup_order
+		WHERE ((status = 2 AND confirmed_at >= $1 AND confirmed_at < $2)
+		    OR (created_at >= $1 AND created_at < $2))
+		  AND ($3 = 0 OR account_id = $3)`,
+		w.From, w.To, accountID,
+	).Scan(&t.PaidOrders, &t.GrossCents, &t.CreditsSold, &t.DistinctBuyers,
+		&t.CreatedOrders, &t.PendingOrders, &t.PendingCents)
+	if err != nil {
+		return domain.RevenueTotals{}, fmt.Errorf("store: revenue totals: %w", err)
+	}
+	return t, nil
+}
+
+// RevenueByMethod splits recognized revenue by payment gateway.
+func (s *Store) RevenueByMethod(ctx context.Context, w RevenueWindow, accountID int64) ([]domain.RevenueByMethod, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT payment_method, count(*), COALESCE(sum(amount_cents), 0)
+		FROM donate_topup_order
+		WHERE status = 2 AND confirmed_at >= $1 AND confirmed_at < $2
+		  AND ($3 = 0 OR account_id = $3)
+		GROUP BY payment_method
+		ORDER BY payment_method`,
+		w.From, w.To, accountID)
+	if err != nil {
+		return nil, fmt.Errorf("store: revenue by method: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]domain.RevenueByMethod, 0, 4)
+	for rows.Next() {
+		var m domain.RevenueByMethod
+		if err := rows.Scan(&m.PaymentMethod, &m.PaidOrders, &m.GrossCents); err != nil {
+			return nil, fmt.Errorf("store: scan revenue by method: %w", err)
+		}
+		out = append(out, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("store: revenue by method: %w", err)
+	}
+	return out, nil
+}
+
+// RevenueSeries buckets recognized revenue by day/week/month in revenueZone.
+// bucket must be one of BucketDay/BucketWeek/BucketMonth. Buckets with no orders
+// are returned with zeroed counters (generate_series LEFT JOIN aggregate), so
+// callers never gap-fill. Note date_trunc('week') starts on MONDAY.
+func (s *Store) RevenueSeries(ctx context.Context, w RevenueWindow, bucket string, accountID int64) ([]domain.RevenuePoint, error) {
+	step, err := bucketStep(bucket)
+	if err != nil {
+		return nil, err
+	}
+	// The first bucket is aligned to its own boundary, so it may open slightly
+	// before w.From — that is a genuine partial bucket, not an off-by-one.
+	rows, err := s.pool.Query(ctx, `
+		WITH buckets AS (
+			SELECT gs AS bucket_start
+			FROM generate_series(
+				date_trunc($3, $1::timestamptz, $6),
+				$2::timestamptz - interval '1 microsecond',
+				$4::interval) AS gs
+		), agg AS (
+			SELECT date_trunc($3, o.confirmed_at, $6) AS bucket_start,
+			       count(*)                         AS paid_orders,
+			       COALESCE(sum(o.amount_cents), 0) AS gross_cents,
+			       COALESCE(sum(o.credits), 0)      AS credits_sold,
+			       count(DISTINCT o.account_id)     AS distinct_buyers
+			FROM donate_topup_order o
+			WHERE o.status = 2 AND o.confirmed_at >= $1 AND o.confirmed_at < $2
+			  AND ($5 = 0 OR o.account_id = $5)
+			GROUP BY 1
+		)
+		SELECT b.bucket_start,
+		       COALESCE(a.paid_orders, 0),
+		       COALESCE(a.gross_cents, 0),
+		       COALESCE(a.credits_sold, 0),
+		       COALESCE(a.distinct_buyers, 0)
+		FROM buckets b
+		LEFT JOIN agg a ON a.bucket_start = b.bucket_start
+		ORDER BY b.bucket_start`,
+		w.From, w.To, bucket, step, accountID, revenueZone)
+	if err != nil {
+		return nil, fmt.Errorf("store: revenue series: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]domain.RevenuePoint, 0, 32)
+	for rows.Next() {
+		var p domain.RevenuePoint
+		if err := rows.Scan(&p.BucketStart, &p.PaidOrders, &p.GrossCents, &p.CreditsSold, &p.DistinctBuyers); err != nil {
+			return nil, fmt.Errorf("store: scan revenue series: %w", err)
+		}
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("store: revenue series: %w", err)
+	}
+	return out, nil
+}
+
+// topupOrderRowCols is the column list shared by both ListTopupOrders variants,
+// matched positionally by the scan below. count(*) OVER() rides along as the
+// last column so the pager needs no second round trip.
+const topupOrderRowCols = `
+	o.id, o.external_reference, o.account_id, a.name, a.email,
+	COALESCE(p.name, ''), COALESCE(p.cpf, ''),
+	o.credits, o.amount_cents, o.payment_method, COALESCE(o.provider, ''),
+	o.status, o.created_at, o.confirmed_at, count(*) OVER()`
+
+// topupOrderFrom joins the buyer identity in one query. Both joins are on a
+// primary key, which is why this is a JOIN and not up to `limit` extra lookups
+// per rendered page. donate_payer_profile is LEFT — a buyer who never filled the
+// PIX payer form still has orders.
+const topupOrderFrom = `
+	FROM donate_topup_order o
+	JOIN account a ON a.id = o.account_id
+	LEFT JOIN donate_payer_profile p ON p.account_id = o.account_id`
+
+// topupOrderPaidWhere scopes the window to confirmed_at — the revenue basis. The
+// literal `status = 2` is what lets the partial index apply; see the status note
+// at the top of this file. Shared verbatim between the page and count queries so
+// the two can never drift.
+const topupOrderPaidWhere = `
+	WHERE o.status = 2 AND o.confirmed_at >= $1 AND o.confirmed_at < $2
+	  AND ($3 = 0 OR o.payment_method = $3)
+	  AND ($4 = 0 OR o.account_id = $4)`
+
+// topupOrderAnyWhere is the funnel basis: created_at, any status. A PENDING order
+// has no confirmed_at at all, so it is invisible to the predicate above.
+const topupOrderAnyWhere = `
+	WHERE o.created_at >= $1 AND o.created_at < $2
+	  AND ($3 = 0 OR o.status = $3)
+	  AND ($4 = 0 OR o.payment_method = $4)
+	  AND ($5 = 0 OR o.account_id = $5)`
+
+// ListTopupOrders returns one page of the order table plus the total row count.
+//
+// The status filter also picks which date column the window applies to: PAID
+// filters and orders by confirmed_at (the revenue basis, matching the partial
+// index), anything else by created_at. The two variants are separate constant
+// predicates rather than one query with a conditional date column so each gets a
+// clean sargable predicate.
+func (s *Store) ListTopupOrders(ctx context.Context, w RevenueWindow, f TopupOrderFilter, limit, offset int) ([]domain.TopupOrderRow, int, error) {
+	var (
+		where string
+		order string
+		args  []any
+	)
+	if f.Status == TopupStatusPaid {
+		where = topupOrderPaidWhere
+		order = `
+			ORDER BY o.confirmed_at DESC, o.id DESC
+			LIMIT $5 OFFSET $6`
+		args = []any{w.From, w.To, f.PaymentMethod, f.AccountID, limit, offset}
+	} else {
+		where = topupOrderAnyWhere
+		order = `
+			ORDER BY o.created_at DESC, o.id DESC
+			LIMIT $6 OFFSET $7`
+		args = []any{w.From, w.To, f.Status, f.PaymentMethod, f.AccountID, limit, offset}
+	}
+	// The count reuses the same predicate minus the two pagination binds, and
+	// drops the identity joins — it counts orders, which the joins cannot change.
+	countQ := `SELECT count(*) FROM donate_topup_order o` + where
+	cArgs := args[:len(args)-2]
+
+	rows, err := s.pool.Query(ctx, `SELECT `+topupOrderRowCols+topupOrderFrom+where+order, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("store: list topup orders: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]domain.TopupOrderRow, 0, limit)
+	total := 0
+	for rows.Next() {
+		var r domain.TopupOrderRow
+		var confirmed *time.Time
+		if err := rows.Scan(&r.ID, &r.ExternalReference, &r.AccountID, &r.AccountName, &r.AccountEmail,
+			&r.PayerName, &r.PayerCPF,
+			&r.Credits, &r.AmountCents, &r.PaymentMethod, &r.Provider,
+			&r.Status, &r.CreatedAt, &confirmed, &total); err != nil {
+			return nil, 0, fmt.Errorf("store: scan topup order: %w", err)
+		}
+		r.ConfirmedAt = confirmed
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("store: list topup orders: %w", err)
+	}
+
+	total, err = fallbackTotal(ctx, len(out), offset, total, func(ctx context.Context) (int, error) {
+		var n int
+		if err := s.pool.QueryRow(ctx, countQ, cArgs...).Scan(&n); err != nil {
+			return 0, fmt.Errorf("store: count topup orders: %w", err)
+		}
+		return n, nil
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	return out, total, nil
+}
+
+// listTopBuyersBody is shared between the page query and its count closure so
+// the two can never drift. The outer WHERE is status-only with NO date bound —
+// that is what makes the lifetime_* aggregates a true LTV; the window is applied
+// inside the FILTERs and the HAVING.
+const listTopBuyersBody = `
+	FROM donate_topup_order o
+	JOIN account a ON a.id = o.account_id
+	WHERE o.status = 2
+	GROUP BY o.account_id, a.name, a.email, a.donate_balance
+	HAVING count(*) FILTER (WHERE o.confirmed_at >= $1 AND o.confirmed_at < $2) > 0`
+
+// ListTopBuyers ranks accounts by revenue inside the window and carries the
+// all-time aggregate alongside. Only accounts that paid inside the window are
+// returned (the HAVING); total is the number of such accounts.
+func (s *Store) ListTopBuyers(ctx context.Context, w RevenueWindow, limit, offset int) ([]domain.TopBuyer, int, error) {
+	// count(*) OVER() runs AFTER grouping, so it counts GROUPS — exactly the
+	// distinct-buyer total the pager needs, not the underlying order count.
+	rows, err := s.pool.Query(ctx, `
+		SELECT o.account_id, a.name, a.email,
+		       count(*)                     FILTER (WHERE o.confirmed_at >= $1 AND o.confirmed_at < $2) AS window_orders,
+		       COALESCE(sum(o.amount_cents) FILTER (WHERE o.confirmed_at >= $1 AND o.confirmed_at < $2), 0) AS window_cents,
+		       count(*)                         AS lifetime_orders,
+		       COALESCE(sum(o.amount_cents), 0) AS lifetime_cents,
+		       COALESCE(sum(o.credits), 0)      AS lifetime_credits,
+		       min(o.confirmed_at)              AS first_paid_at,
+		       max(o.confirmed_at)              AS last_paid_at,
+		       a.donate_balance,
+		       count(*) OVER()                  AS total`+
+		listTopBuyersBody+`
+		ORDER BY window_cents DESC, o.account_id
+		LIMIT $3 OFFSET $4`,
+		w.From, w.To, limit, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("store: list top buyers: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]domain.TopBuyer, 0, limit)
+	total := 0
+	for rows.Next() {
+		var b domain.TopBuyer
+		var first, last *time.Time
+		if err := rows.Scan(&b.AccountID, &b.AccountName, &b.AccountEmail,
+			&b.WindowPaidOrders, &b.WindowGrossCents,
+			&b.LifetimePaidOrders, &b.LifetimeGrossCents, &b.LifetimeCredits,
+			&first, &last, &b.DonateBalance, &total); err != nil {
+			return nil, 0, fmt.Errorf("store: scan top buyer: %w", err)
+		}
+		if first != nil {
+			b.FirstPaidAt = *first
+		}
+		if last != nil {
+			b.LastPaidAt = *last
+		}
+		out = append(out, b)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("store: list top buyers: %w", err)
+	}
+
+	total, err = fallbackTotal(ctx, len(out), offset, total, func(ctx context.Context) (int, error) {
+		// Must count GROUPS, mirroring count(*) OVER() above — a plain count(*)
+		// over the table would report orders instead of buyers.
+		var n int
+		if err := s.pool.QueryRow(ctx,
+			`SELECT count(*) FROM (SELECT 1`+listTopBuyersBody+`) t`, w.From, w.To).Scan(&n); err != nil {
+			return 0, fmt.Errorf("store: count top buyers: %w", err)
+		}
+		return n, nil
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	return out, total, nil
+}
+
+// ListDonateLedger reads donate_shop_audit as a signed wallet ledger. actions
+// must be a subset of {LedgerActionPurchase, LedgerActionCredit}; empty means
+// both. accountID 0 means all accounts and is matched against the SUBJECT (see
+// ledgerSubjectExpr), never the raw audit column.
+func (s *Store) ListDonateLedger(ctx context.Context, w RevenueWindow, actions []string, accountID int64, limit, offset int) ([]domain.DonateLedgerEntry, int, error) {
+	if len(actions) == 0 {
+		actions = []string{LedgerActionPurchase, LedgerActionCredit}
+	}
+	// The account and donate_shop_item joins are LEFT on purpose:
+	// donate_shop_audit.shop_item_id is deliberately not an FK so history
+	// survives offer deletion (0008_donate_shop), and an audit row can outlive
+	// the account. Inner joins would silently erase that history.
+	const body = `
+		FROM donate_shop_audit au
+		WHERE au.action = ANY($3::text[])
+		  AND au.created_at >= $1 AND au.created_at < $2
+		  AND ($4 = 0 OR ` + ledgerSubjectExpr + ` = $4)`
+
+	rows, err := s.pool.Query(ctx, `
+		WITH led AS (
+			SELECT au.id, au.action, au.created_at, au.shop_item_id, au.after,
+			       au.account_id AS actor_account_id,
+			       `+ledgerSubjectExpr+` AS subject_account_id`+body+`
+		)
+		SELECT l.id, l.action, l.created_at,
+		       l.subject_account_id, COALESCE(subj.name, ''),
+		       l.actor_account_id,   COALESCE(actor.name, ''),
+		       CASE l.action
+		           WHEN '`+LedgerActionPurchase+`' THEN -COALESCE((l.after->>'price')::bigint, 0)
+		           WHEN '`+LedgerActionCredit+`'   THEN  COALESCE((l.after->>'amount')::bigint, 0)
+		           ELSE 0
+		       END,
+		       COALESCE((l.after->>'balance')::bigint, 0),
+		       COALESCE(l.shop_item_id, 0),
+		       COALESCE(si.title, ''),
+		       COALESCE(l.after->>'reason', ''),
+		       count(*) OVER()
+		FROM led l
+		LEFT JOIN account          subj  ON subj.id  = l.subject_account_id
+		LEFT JOIN account          actor ON actor.id = l.actor_account_id
+		LEFT JOIN donate_shop_item si    ON si.id    = l.shop_item_id
+		ORDER BY l.created_at DESC, l.id DESC
+		LIMIT $5 OFFSET $6`,
+		w.From, w.To, actions, accountID, limit, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("store: list donate ledger: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]domain.DonateLedgerEntry, 0, limit)
+	total := 0
+	for rows.Next() {
+		var e domain.DonateLedgerEntry
+		if err := rows.Scan(&e.ID, &e.Action, &e.CreatedAt,
+			&e.SubjectAccountID, &e.SubjectAccountName,
+			&e.ActorAccountID, &e.ActorAccountName,
+			&e.CreditsDelta, &e.BalanceAfter,
+			&e.ShopItemID, &e.ShopItemTitle, &e.Reason, &total); err != nil {
+			return nil, 0, fmt.Errorf("store: scan donate ledger: %w", err)
+		}
+		out = append(out, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("store: list donate ledger: %w", err)
+	}
+
+	total, err = fallbackTotal(ctx, len(out), offset, total, func(ctx context.Context) (int, error) {
+		var n int
+		if err := s.pool.QueryRow(ctx, `SELECT count(*)`+body,
+			w.From, w.To, actions, accountID).Scan(&n); err != nil {
+			return 0, fmt.Errorf("store: count donate ledger: %w", err)
+		}
+		return n, nil
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	return out, total, nil
+}
+
+// DonateLedgerTotals aggregates the wallet movements in the window, in credits.
+// accountID 0 means all accounts; otherwise it matches the SUBJECT.
+func (s *Store) DonateLedgerTotals(ctx context.Context, w RevenueWindow, accountID int64) (domain.DonateLedgerTotals, error) {
+	var t domain.DonateLedgerTotals
+	err := s.pool.QueryRow(ctx, `
+		SELECT
+			count(*)                                    FILTER (WHERE au.action = '`+LedgerActionPurchase+`'),
+			COALESCE(sum((au.after->>'price')::bigint)  FILTER (WHERE au.action = '`+LedgerActionPurchase+`'), 0),
+			count(*)                                    FILTER (WHERE au.action = '`+LedgerActionCredit+`'),
+			COALESCE(sum((au.after->>'amount')::bigint) FILTER (WHERE au.action = '`+LedgerActionCredit+`'), 0)
+		FROM donate_shop_audit au
+		WHERE au.action IN ('`+LedgerActionPurchase+`', '`+LedgerActionCredit+`')
+		  AND au.created_at >= $1 AND au.created_at < $2
+		  AND ($3 = 0 OR `+ledgerSubjectExpr+` = $3)`,
+		w.From, w.To, accountID,
+	).Scan(&t.ShopPurchases, &t.CreditsSpent, &t.ManualCredits, &t.CreditsGranted)
+	if err != nil {
+		return domain.DonateLedgerTotals{}, fmt.Errorf("store: donate ledger totals: %w", err)
+	}
+	return t, nil
+}
+
+// SearchAccountsByNamePrefix resolves a canonical (lowercase) login prefix so the
+// panel can turn a typed name into an account_id filter. The caller lowercases
+// and length-checks the prefix; this escapes the LIKE metacharacters.
+func (s *Store) SearchAccountsByNamePrefix(ctx context.Context, prefix string, limit int) ([]domain.AccountSummary, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, name, email, donate_balance, role, is_blocked
+		FROM account
+		WHERE name LIKE $1
+		ORDER BY name
+		LIMIT $2`, escapeLike(prefix)+"%", limit)
+	if err != nil {
+		return nil, fmt.Errorf("store: search accounts: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]domain.AccountSummary, 0, limit)
+	for rows.Next() {
+		var a domain.AccountSummary
+		if err := rows.Scan(&a.ID, &a.Name, &a.Email, &a.DonateBalance, &a.Role, &a.IsBlocked); err != nil {
+			return nil, fmt.Errorf("store: scan account summary: %w", err)
+		}
+		out = append(out, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("store: search accounts: %w", err)
+	}
+	return out, nil
+}

--- a/internal/store/donate_revenue_integration_test.go
+++ b/internal/store/donate_revenue_integration_test.go
@@ -1,0 +1,720 @@
+//go:build integration
+
+// Integration tests for the donate revenue read models (painel de faturamento).
+// They require a real database and are excluded from the default build. Run with:
+//
+//	W2PP_TEST_DSN=postgres://postgres:dev@localhost:5432/postgres go test -tags=integration ./internal/store/
+//
+// Orders are seeded with raw INSERTs rather than CreateTopupOrder because the
+// write path can only produce now() for created_at and has no way to set
+// confirmed_at — and the whole point of these tests is which date column each
+// figure is scoped to.
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+)
+
+// revenueFixture is a freshly-migrated store with the donate tables emptied.
+func revenueFixture(t *testing.T) (context.Context, *pgxpool.Pool, *Store) {
+	t.Helper()
+	ctx := context.Background()
+	pool := testPool(t)
+	if err := Migrate(ctx, pool); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	_, _ = pool.Exec(ctx, `DELETE FROM donate_topup_order`)
+	_, _ = pool.Exec(ctx, `DELETE FROM donate_shop_audit`)
+	_, _ = pool.Exec(ctx, `DELETE FROM donate_shop_item`)
+	_, _ = pool.Exec(ctx, `DELETE FROM delivery_queue`)
+	return ctx, pool, New(pool)
+}
+
+func seedAccount(t *testing.T, ctx context.Context, pool *pgxpool.Pool, name, email, role string, balance int32) int64 {
+	t.Helper()
+	var id int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO account (name, pass_hash, email, role, donate_balance)
+		 VALUES ($1,'x',$2,$3,$4) RETURNING id`, name, email, role, balance).Scan(&id); err != nil {
+		t.Fatalf("seed account %q: %v", name, err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM account WHERE id = $1`, id) })
+	return id
+}
+
+// seedOrder inserts one order with explicit timestamps. confirmedAt nil = PENDING.
+func seedOrder(t *testing.T, ctx context.Context, pool *pgxpool.Pool, ref string, accID int64,
+	credits int32, cents int64, method int16, createdAt time.Time, confirmedAt *time.Time,
+) {
+	t.Helper()
+	status := int16(TopupStatusPending)
+	if confirmedAt != nil {
+		status = TopupStatusPaid
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO donate_topup_order
+			(external_reference, account_id, credits, amount_cents, payment_method, status, created_at, confirmed_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
+		ref, accID, credits, cents, method, status, createdAt, confirmedAt); err != nil {
+		t.Fatalf("seed order %q: %v", ref, err)
+	}
+}
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	ts, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return ts
+}
+
+func window(from, to time.Time) RevenueWindow { return RevenueWindow{From: from, To: to} }
+
+// --- revenue recognition ---
+
+// TestRevenueTotalsRecognizesOnConfirmedAt pins the core accounting rule: an
+// order created in January but settled in February is FEBRUARY revenue. January
+// still sees it as funnel volume (created_orders) but not as money.
+func TestRevenueTotalsRecognizesOnConfirmedAt(t *testing.T) {
+	ctx, pool, s := revenueFixture(t)
+	acc := seedAccount(t, ctx, pool, "rev_recog", "a@b.c", "player", 0)
+
+	created := mustTime(t, "2026-01-20T12:00:00Z")
+	confirmed := mustTime(t, "2026-02-03T12:00:00Z")
+	seedOrder(t, ctx, pool, "rev-recog-1", acc, 50, 2500, 1, created, &confirmed)
+
+	jan := window(mustTime(t, "2026-01-01T00:00:00Z"), mustTime(t, "2026-02-01T00:00:00Z"))
+	feb := window(mustTime(t, "2026-02-01T00:00:00Z"), mustTime(t, "2026-03-01T00:00:00Z"))
+
+	janT, err := s.RevenueTotals(ctx, jan, 0)
+	if err != nil {
+		t.Fatalf("jan totals: %v", err)
+	}
+	if janT.GrossCents != 0 || janT.PaidOrders != 0 {
+		t.Errorf("january recognized revenue = (%d cents, %d orders), want zero", janT.GrossCents, janT.PaidOrders)
+	}
+	if janT.CreatedOrders != 1 {
+		t.Errorf("january created_orders = %d, want 1 (funnel volume still counts)", janT.CreatedOrders)
+	}
+
+	febT, err := s.RevenueTotals(ctx, feb, 0)
+	if err != nil {
+		t.Fatalf("feb totals: %v", err)
+	}
+	if febT.GrossCents != 2500 || febT.PaidOrders != 1 || febT.CreditsSold != 50 || febT.DistinctBuyers != 1 {
+		t.Errorf("february totals = %+v, want gross=2500 paid=1 credits=50 buyers=1", febT)
+	}
+	if febT.CreatedOrders != 0 {
+		t.Errorf("february created_orders = %d, want 0 (it was created in January)", febT.CreatedOrders)
+	}
+}
+
+// TestRevenueTotalsExcludesPendingFromGross: a PENDING order is funnel volume and
+// pending_cents, never revenue.
+func TestRevenueTotalsExcludesPendingFromGross(t *testing.T) {
+	ctx, pool, s := revenueFixture(t)
+	acc := seedAccount(t, ctx, pool, "rev_pending", "a@b.c", "player", 0)
+
+	created := mustTime(t, "2026-03-10T12:00:00Z")
+	seedOrder(t, ctx, pool, "rev-pend-1", acc, 20, 1000, 1, created, nil)
+
+	w := window(mustTime(t, "2026-03-01T00:00:00Z"), mustTime(t, "2026-04-01T00:00:00Z"))
+	got, err := s.RevenueTotals(ctx, w, 0)
+	if err != nil {
+		t.Fatalf("totals: %v", err)
+	}
+	if got.GrossCents != 0 || got.PaidOrders != 0 {
+		t.Errorf("gross=%d paid=%d, want zero for a PENDING order", got.GrossCents, got.PaidOrders)
+	}
+	if got.PendingOrders != 1 || got.PendingCents != 1000 || got.CreatedOrders != 1 {
+		t.Errorf("pending=%d pendingCents=%d created=%d, want 1/1000/1", got.PendingOrders, got.PendingCents, got.CreatedOrders)
+	}
+}
+
+// TestRevenueByMethodSplitsGateways checks the per-gateway breakdown.
+func TestRevenueByMethodSplitsGateways(t *testing.T) {
+	ctx, pool, s := revenueFixture(t)
+	acc := seedAccount(t, ctx, pool, "rev_method", "a@b.c", "player", 0)
+
+	at := mustTime(t, "2026-04-10T12:00:00Z")
+	seedOrder(t, ctx, pool, "m-pix-1", acc, 10, 1000, 1, at, &at)
+	seedOrder(t, ctx, pool, "m-pix-2", acc, 10, 1500, 1, at, &at)
+	seedOrder(t, ctx, pool, "m-card-1", acc, 10, 700, 2, at, &at)
+
+	w := window(mustTime(t, "2026-04-01T00:00:00Z"), mustTime(t, "2026-05-01T00:00:00Z"))
+	got, err := s.RevenueByMethod(ctx, w, 0)
+	if err != nil {
+		t.Fatalf("by method: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d method rows, want 2: %+v", len(got), got)
+	}
+	if got[0].PaymentMethod != 1 || got[0].PaidOrders != 2 || got[0].GrossCents != 2500 {
+		t.Errorf("pix row = %+v, want method=1 orders=2 cents=2500", got[0])
+	}
+	if got[1].PaymentMethod != 2 || got[1].PaidOrders != 1 || got[1].GrossCents != 700 {
+		t.Errorf("card row = %+v, want method=2 orders=1 cents=700", got[1])
+	}
+}
+
+// --- series bucketing ---
+
+// TestRevenueSeriesMonthBoundaryBRT is the timezone test. Both orders settle on
+// 2026-02-01 in UTC, but in America/Sao_Paulo (UTC-3) the first is still
+// 2026-01-31T22:00 and belongs to JANUARY. It is run with the session forced to
+// UTC to prove the three-argument date_trunc ignores the session TimeZone.
+func TestRevenueSeriesMonthBoundaryBRT(t *testing.T) {
+	ctx, pool, s := revenueFixture(t)
+	if _, err := pool.Exec(ctx, `SET TIME ZONE 'UTC'`); err != nil {
+		t.Fatalf("set session tz: %v", err)
+	}
+	acc := seedAccount(t, ctx, pool, "rev_tz", "a@b.c", "player", 0)
+
+	janBRT := mustTime(t, "2026-02-01T01:00:00Z") // = 2026-01-31 22:00 BRT
+	febBRT := mustTime(t, "2026-02-01T05:00:00Z") // = 2026-02-01 02:00 BRT
+	seedOrder(t, ctx, pool, "tz-jan", acc, 10, 1000, 1, janBRT, &janBRT)
+	seedOrder(t, ctx, pool, "tz-feb", acc, 10, 2000, 1, febBRT, &febBRT)
+
+	w := window(mustTime(t, "2026-01-01T03:00:00Z"), mustTime(t, "2026-03-01T03:00:00Z"))
+	pts, err := s.RevenueSeries(ctx, w, BucketMonth, 0)
+	if err != nil {
+		t.Fatalf("series: %v", err)
+	}
+	if len(pts) != 2 {
+		t.Fatalf("got %d month buckets, want 2: %+v", len(pts), pts)
+	}
+	if pts[0].GrossCents != 1000 {
+		t.Errorf("january bucket gross = %d, want 1000 (22:00 BRT on Jan 31)", pts[0].GrossCents)
+	}
+	if pts[1].GrossCents != 2000 {
+		t.Errorf("february bucket gross = %d, want 2000", pts[1].GrossCents)
+	}
+}
+
+// TestRevenueSeriesWeekStartsMonday documents Postgres' ISO week boundary.
+func TestRevenueSeriesWeekStartsMonday(t *testing.T) {
+	ctx, pool, s := revenueFixture(t)
+	acc := seedAccount(t, ctx, pool, "rev_week", "a@b.c", "player", 0)
+
+	// 2026-03-08 is a Sunday, 2026-03-09 a Monday (both midday BRT).
+	sun := mustTime(t, "2026-03-08T15:00:00Z")
+	mon := mustTime(t, "2026-03-09T15:00:00Z")
+	seedOrder(t, ctx, pool, "wk-sun", acc, 10, 100, 1, sun, &sun)
+	seedOrder(t, ctx, pool, "wk-mon", acc, 10, 200, 1, mon, &mon)
+
+	w := window(mustTime(t, "2026-03-02T03:00:00Z"), mustTime(t, "2026-03-16T03:00:00Z"))
+	pts, err := s.RevenueSeries(ctx, w, BucketWeek, 0)
+	if err != nil {
+		t.Fatalf("series: %v", err)
+	}
+	if len(pts) != 2 {
+		t.Fatalf("got %d week buckets, want 2: %+v", len(pts), pts)
+	}
+	if pts[0].GrossCents != 100 || pts[1].GrossCents != 200 {
+		t.Errorf("week buckets = (%d, %d), want (100, 200) — Sunday closes the previous week",
+			pts[0].GrossCents, pts[1].GrossCents)
+	}
+}
+
+// TestRevenueSeriesFillsEmptyBuckets: a 5-day window with orders only on days 1
+// and 5 still returns 5 rows, so the chart axis is continuous.
+func TestRevenueSeriesFillsEmptyBuckets(t *testing.T) {
+	ctx, pool, s := revenueFixture(t)
+	acc := seedAccount(t, ctx, pool, "rev_gaps", "a@b.c", "player", 0)
+
+	d1 := mustTime(t, "2026-05-01T15:00:00Z")
+	d5 := mustTime(t, "2026-05-05T15:00:00Z")
+	seedOrder(t, ctx, pool, "gap-1", acc, 10, 100, 1, d1, &d1)
+	seedOrder(t, ctx, pool, "gap-5", acc, 10, 500, 1, d5, &d5)
+
+	w := window(mustTime(t, "2026-05-01T03:00:00Z"), mustTime(t, "2026-05-06T03:00:00Z"))
+	pts, err := s.RevenueSeries(ctx, w, BucketDay, 0)
+	if err != nil {
+		t.Fatalf("series: %v", err)
+	}
+	if len(pts) != 5 {
+		t.Fatalf("got %d day buckets, want 5 (gap-filled): %+v", len(pts), pts)
+	}
+	want := []int64{100, 0, 0, 0, 500}
+	for i, w := range want {
+		if pts[i].GrossCents != w {
+			t.Errorf("bucket %d gross = %d, want %d", i, pts[i].GrossCents, w)
+		}
+	}
+}
+
+// TestRevenueSeriesEmptyWindowReturnsZeroedBuckets: no orders at all still yields
+// a continuous axis rather than an empty slice.
+func TestRevenueSeriesEmptyWindowReturnsZeroedBuckets(t *testing.T) {
+	ctx, _, s := revenueFixture(t)
+	w := window(mustTime(t, "2026-06-01T03:00:00Z"), mustTime(t, "2026-06-04T03:00:00Z"))
+	pts, err := s.RevenueSeries(ctx, w, BucketDay, 0)
+	if err != nil {
+		t.Fatalf("series: %v", err)
+	}
+	if len(pts) != 3 {
+		t.Fatalf("got %d buckets, want 3", len(pts))
+	}
+	for i, p := range pts {
+		if p.PaidOrders != 0 || p.GrossCents != 0 || p.DistinctBuyers != 0 {
+			t.Errorf("bucket %d = %+v, want all zero", i, p)
+		}
+	}
+}
+
+// TestRevenueSeriesRejectsUnknownBucket guards the defense-in-depth check.
+func TestRevenueSeriesRejectsUnknownBucket(t *testing.T) {
+	ctx, _, s := revenueFixture(t)
+	w := window(mustTime(t, "2026-06-01T00:00:00Z"), mustTime(t, "2026-06-02T00:00:00Z"))
+	if _, err := s.RevenueSeries(ctx, w, "century", 0); err == nil {
+		t.Fatal("RevenueSeries with an unknown bucket = nil error, want an error")
+	}
+}
+
+// --- order table ---
+
+// TestListTopupOrdersPaidUsesConfirmedAtBasis: the PAID filter selects the
+// confirmed_at variant, so an order created before the window but settled inside
+// it IS returned.
+func TestListTopupOrdersPaidUsesConfirmedAtBasis(t *testing.T) {
+	ctx, pool, s := revenueFixture(t)
+	acc := seedAccount(t, ctx, pool, "ord_basis", "a@b.c", "player", 0)
+
+	created := mustTime(t, "2026-01-20T12:00:00Z")
+	confirmed := mustTime(t, "2026-02-03T12:00:00Z")
+	seedOrder(t, ctx, pool, "basis-1", acc, 50, 2500, 1, created, &confirmed)
+
+	feb := window(mustTime(t, "2026-02-01T00:00:00Z"), mustTime(t, "2026-03-01T00:00:00Z"))
+	rows, total, err := s.ListTopupOrders(ctx, feb, TopupOrderFilter{Status: TopupStatusPaid}, 50, 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 || total != 1 {
+		t.Fatalf("got %d rows total=%d, want 1/1", len(rows), total)
+	}
+	if rows[0].ConfirmedAt == nil || !rows[0].ConfirmedAt.Equal(confirmed) {
+		t.Errorf("confirmed_at = %v, want %v", rows[0].ConfirmedAt, confirmed)
+	}
+
+	// The created_at basis (no status filter) must NOT see it in February.
+	rows, _, err = s.ListTopupOrders(ctx, feb, TopupOrderFilter{}, 50, 0)
+	if err != nil {
+		t.Fatalf("list any-status: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("created_at basis returned %d rows in February, want 0", len(rows))
+	}
+}
+
+// TestListTopupOrdersJoinsBuyerAndPayerProfile: identity comes from the JOIN, and
+// a buyer with no payer profile still appears (LEFT JOIN) with empty payer fields.
+func TestListTopupOrdersJoinsBuyerAndPayerProfile(t *testing.T) {
+	ctx, pool, s := revenueFixture(t)
+	withProfile := seedAccount(t, ctx, pool, "ord_withprof", "wp@x.c", "player", 0)
+	noProfile := seedAccount(t, ctx, pool, "ord_noprof", "np@x.c", "player", 0)
+
+	if err := s.SavePayerProfile(ctx, withProfile, "Fulano de Tal", "12345678909"); err != nil {
+		t.Fatalf("save payer profile: %v", err)
+	}
+
+	at := mustTime(t, "2026-07-10T12:00:00Z")
+	seedOrder(t, ctx, pool, "join-wp", withProfile, 10, 1000, 1, at, &at)
+	seedOrder(t, ctx, pool, "join-np", noProfile, 10, 2000, 1, at, &at)
+
+	w := window(mustTime(t, "2026-07-01T00:00:00Z"), mustTime(t, "2026-08-01T00:00:00Z"))
+	rows, _, err := s.ListTopupOrders(ctx, w, TopupOrderFilter{Status: TopupStatusPaid}, 50, 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
+	}
+	byRef := map[string]domain.TopupOrderRow{}
+	for _, r := range rows {
+		byRef[r.ExternalReference] = r
+	}
+	wp := byRef["join-wp"]
+	if wp.AccountName != "ord_withprof" || wp.AccountEmail != "wp@x.c" {
+		t.Errorf("buyer identity = (%q,%q), want (ord_withprof, wp@x.c)", wp.AccountName, wp.AccountEmail)
+	}
+	if wp.PayerName != "Fulano de Tal" || wp.PayerCPF != "12345678909" {
+		t.Errorf("payer = (%q,%q), want the profile values raw", wp.PayerName, wp.PayerCPF)
+	}
+	np := byRef["join-np"]
+	if np.AccountName != "ord_noprof" {
+		t.Errorf("no-profile buyer name = %q, want ord_noprof", np.AccountName)
+	}
+	if np.PayerName != "" || np.PayerCPF != "" {
+		t.Errorf("no-profile payer = (%q,%q), want empty (LEFT JOIN)", np.PayerName, np.PayerCPF)
+	}
+	if np.Provider != "" {
+		t.Errorf("provider = %q, want empty — nothing writes that column today", np.Provider)
+	}
+}
+
+// TestListTopupOrdersPagination covers the pager, including the fallbackTotal
+// path where a page past the end must still report the true total.
+func TestListTopupOrdersPagination(t *testing.T) {
+	ctx, pool, s := revenueFixture(t)
+	acc := seedAccount(t, ctx, pool, "ord_page", "a@b.c", "player", 0)
+
+	base := mustTime(t, "2026-08-01T12:00:00Z")
+	for i := 0; i < 5; i++ {
+		at := base.Add(time.Duration(i) * time.Hour)
+		seedOrder(t, ctx, pool, "page-"+string(rune('a'+i)), acc, 10, int64(100*(i+1)), 1, at, &at)
+	}
+
+	w := window(mustTime(t, "2026-08-01T00:00:00Z"), mustTime(t, "2026-09-01T00:00:00Z"))
+	f := TopupOrderFilter{Status: TopupStatusPaid}
+
+	rows, total, err := s.ListTopupOrders(ctx, w, f, 2, 2)
+	if err != nil {
+		t.Fatalf("page: %v", err)
+	}
+	if len(rows) != 2 || total != 5 {
+		t.Fatalf("page(limit=2,offset=2) = %d rows total=%d, want 2/5", len(rows), total)
+	}
+	// Ordered confirmed_at DESC: offset 2 is the 3rd newest = 300 cents.
+	if rows[0].AmountCents != 300 || rows[1].AmountCents != 200 {
+		t.Errorf("page contents = (%d,%d), want (300,200)", rows[0].AmountCents, rows[1].AmountCents)
+	}
+
+	rows, total, err = s.ListTopupOrders(ctx, w, f, 2, 10)
+	if err != nil {
+		t.Fatalf("past-end page: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("past-end page returned %d rows, want 0", len(rows))
+	}
+	if total != 5 {
+		t.Errorf("past-end total = %d, want 5 (fallbackTotal path)", total)
+	}
+}
+
+// TestListTopupOrdersFiltersStatusAndMethod covers the non-PAID variant's filters.
+func TestListTopupOrdersFiltersStatusAndMethod(t *testing.T) {
+	ctx, pool, s := revenueFixture(t)
+	acc := seedAccount(t, ctx, pool, "ord_filter", "a@b.c", "player", 0)
+
+	at := mustTime(t, "2026-09-10T12:00:00Z")
+	seedOrder(t, ctx, pool, "f-pend-pix", acc, 10, 100, 1, at, nil)
+	seedOrder(t, ctx, pool, "f-pend-card", acc, 10, 200, 2, at, nil)
+	seedOrder(t, ctx, pool, "f-paid-pix", acc, 10, 300, 1, at, &at)
+
+	w := window(mustTime(t, "2026-09-01T00:00:00Z"), mustTime(t, "2026-10-01T00:00:00Z"))
+
+	rows, total, err := s.ListTopupOrders(ctx, w, TopupOrderFilter{Status: TopupStatusPending}, 50, 0)
+	if err != nil {
+		t.Fatalf("pending: %v", err)
+	}
+	if len(rows) != 2 || total != 2 {
+		t.Errorf("pending filter = %d rows total=%d, want 2/2", len(rows), total)
+	}
+
+	rows, _, err = s.ListTopupOrders(ctx, w, TopupOrderFilter{PaymentMethod: 2}, 50, 0)
+	if err != nil {
+		t.Fatalf("card: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ExternalReference != "f-pend-card" {
+		t.Errorf("card filter = %+v, want just f-pend-card", rows)
+	}
+
+	rows, _, err = s.ListTopupOrders(ctx, w, TopupOrderFilter{}, 50, 0)
+	if err != nil {
+		t.Fatalf("any: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Errorf("no filter = %d rows, want all 3", len(rows))
+	}
+}
+
+// --- top buyers ---
+
+// TestListTopBuyersLifetimeVsWindow: the ranking is window-scoped but the
+// lifetime aggregate is not, and a buyer with no in-window order is absent.
+func TestListTopBuyersLifetimeVsWindow(t *testing.T) {
+	ctx, pool, s := revenueFixture(t)
+	a := seedAccount(t, ctx, pool, "buyer_a", "a@x.c", "player", 7)
+	b := seedAccount(t, ctx, pool, "buyer_b", "b@x.c", "player", 0)
+
+	old := mustTime(t, "2025-01-15T12:00:00Z")
+	inWin := mustTime(t, "2026-10-15T12:00:00Z")
+
+	// A: one big old order + one small in-window order.
+	seedOrder(t, ctx, pool, "tb-a-old", a, 100, 90000, 1, old, &old)
+	seedOrder(t, ctx, pool, "tb-a-new", a, 10, 500, 1, inWin, &inWin)
+	// B: only an old order -> must not appear.
+	seedOrder(t, ctx, pool, "tb-b-old", b, 10, 50000, 1, old, &old)
+
+	w := window(mustTime(t, "2026-10-01T00:00:00Z"), mustTime(t, "2026-11-01T00:00:00Z"))
+	rows, total, err := s.ListTopBuyers(ctx, w, 50, 0)
+	if err != nil {
+		t.Fatalf("top buyers: %v", err)
+	}
+	if len(rows) != 1 || total != 1 {
+		t.Fatalf("got %d rows total=%d, want 1/1 (B has no in-window order)", len(rows), total)
+	}
+	got := rows[0]
+	if got.AccountID != a || got.AccountName != "buyer_a" {
+		t.Errorf("ranked account = (%d,%q), want buyer_a", got.AccountID, got.AccountName)
+	}
+	if got.WindowGrossCents != 500 || got.WindowPaidOrders != 1 {
+		t.Errorf("window = (%d cents, %d orders), want (500, 1)", got.WindowGrossCents, got.WindowPaidOrders)
+	}
+	if got.LifetimeGrossCents != 90500 || got.LifetimePaidOrders != 2 || got.LifetimeCredits != 110 {
+		t.Errorf("lifetime = (%d cents, %d orders, %d credits), want (90500, 2, 110)",
+			got.LifetimeGrossCents, got.LifetimePaidOrders, got.LifetimeCredits)
+	}
+	if !got.FirstPaidAt.Equal(old) || !got.LastPaidAt.Equal(inWin) {
+		t.Errorf("first/last paid = (%v,%v), want (%v,%v)", got.FirstPaidAt, got.LastPaidAt, old, inWin)
+	}
+	if got.DonateBalance != 7 {
+		t.Errorf("donate_balance = %d, want 7", got.DonateBalance)
+	}
+
+	// Past-the-end page must still report the group count, not the order count.
+	rows, total, err = s.ListTopBuyers(ctx, w, 50, 10)
+	if err != nil {
+		t.Fatalf("past-end: %v", err)
+	}
+	if len(rows) != 0 || total != 1 {
+		t.Errorf("past-end = %d rows total=%d, want 0/1 (groups, not orders)", len(rows), total)
+	}
+}
+
+// --- donate ledger ---
+
+// TestListDonateLedgerCreditBalanceSubjectIsCreditedAccount is THE critical test.
+// donate_shop_audit.account_id holds the MODERATOR for a manual credit; the
+// credited account lives only in the JSON. A naive report would bill the
+// moderator for every courtesy credit.
+func TestListDonateLedgerCreditBalanceSubjectIsCreditedAccount(t *testing.T) {
+	ctx, pool, s := revenueFixture(t)
+	player := seedAccount(t, ctx, pool, "led_player", "p@x.c", "player", 0)
+	mod := seedAccount(t, ctx, pool, "led_mod", "m@x.c", "moderator", 0)
+
+	if _, err := s.CreditDonateBalance(ctx, player, 100, mod, "compensacao evento"); err != nil {
+		t.Fatalf("credit: %v", err)
+	}
+
+	w := window(time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	rows, total, err := s.ListDonateLedger(ctx, w, nil, 0, 50, 0)
+	if err != nil {
+		t.Fatalf("ledger: %v", err)
+	}
+	if len(rows) != 1 || total != 1 {
+		t.Fatalf("got %d rows total=%d, want 1/1", len(rows), total)
+	}
+	e := rows[0]
+	if e.SubjectAccountID != player {
+		t.Errorf("subject = %d, want the CREDITED player %d (not the moderator)", e.SubjectAccountID, player)
+	}
+	if e.SubjectAccountName != "led_player" {
+		t.Errorf("subject name = %q, want led_player", e.SubjectAccountName)
+	}
+	if e.ActorAccountID != mod || e.ActorAccountName != "led_mod" {
+		t.Errorf("actor = (%d,%q), want the moderator (%d, led_mod)", e.ActorAccountID, e.ActorAccountName, mod)
+	}
+	if e.CreditsDelta != 100 {
+		t.Errorf("credits_delta = %d, want +100 (a credit is positive)", e.CreditsDelta)
+	}
+	if e.BalanceAfter != 100 || e.Reason != "compensacao evento" {
+		t.Errorf("balance_after=%d reason=%q, want 100/compensacao evento", e.BalanceAfter, e.Reason)
+	}
+	if e.ShopItemID != 0 {
+		t.Errorf("shop_item_id = %d, want 0 for a manual credit", e.ShopItemID)
+	}
+
+	// The subject filter must find it by the credited account, not the moderator.
+	rows, _, err = s.ListDonateLedger(ctx, w, nil, player, 50, 0)
+	if err != nil {
+		t.Fatalf("subject filter: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("filtering by the credited account returned %d rows, want 1", len(rows))
+	}
+	rows, _, err = s.ListDonateLedger(ctx, w, nil, mod, 50, 0)
+	if err != nil {
+		t.Fatalf("moderator filter: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("filtering by the MODERATOR returned %d rows, want 0 — the moderator is the actor, not the subject", len(rows))
+	}
+}
+
+// TestListDonateLedgerPurchaseIsNegativeAndSubjectIsBuyer: on a purchase the
+// subject and actor are the same account and the delta is a debit.
+func TestListDonateLedgerPurchaseIsNegativeAndSubjectIsBuyer(t *testing.T) {
+	ctx, pool, s := revenueFixture(t)
+	buyer := seedAccount(t, ctx, pool, "led_buyer", "b@x.c", "player", 500)
+	mod := seedAccount(t, ctx, pool, "led_mod2", "m@x.c", "moderator", 0)
+
+	offerID, err := s.UpsertDonateShopItem(ctx, domain.DonateShopItem{
+		ItemIndex: 3540, Price: 120, Title: "Asa Celestial", Enabled: true,
+	}, mod)
+	if err != nil {
+		t.Fatalf("upsert offer: %v", err)
+	}
+	if _, err := s.BuyDonateItem(ctx, buyer, offerID); err != nil {
+		t.Fatalf("buy: %v", err)
+	}
+
+	w := window(time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	rows, _, err := s.ListDonateLedger(ctx, w, []string{LedgerActionPurchase}, 0, 50, 0)
+	if err != nil {
+		t.Fatalf("ledger: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d purchase rows, want 1", len(rows))
+	}
+	e := rows[0]
+	if e.SubjectAccountID != buyer || e.ActorAccountID != buyer {
+		t.Errorf("subject=%d actor=%d, want both = buyer %d", e.SubjectAccountID, e.ActorAccountID, buyer)
+	}
+	if e.CreditsDelta != -120 {
+		t.Errorf("credits_delta = %d, want -120 (a purchase is a debit)", e.CreditsDelta)
+	}
+	if e.BalanceAfter != 380 {
+		t.Errorf("balance_after = %d, want 380", e.BalanceAfter)
+	}
+	if e.ShopItemID != offerID || e.ShopItemTitle != "Asa Celestial" {
+		t.Errorf("offer = (%d,%q), want (%d, Asa Celestial)", e.ShopItemID, e.ShopItemTitle, offerID)
+	}
+}
+
+// TestListDonateLedgerSurvivesDeletedOffer: shop_item_id is deliberately not an
+// FK, so history outlives the offer — with an empty title, not a missing row.
+func TestListDonateLedgerSurvivesDeletedOffer(t *testing.T) {
+	ctx, pool, s := revenueFixture(t)
+	buyer := seedAccount(t, ctx, pool, "led_del_buyer", "b@x.c", "player", 500)
+	mod := seedAccount(t, ctx, pool, "led_del_mod", "m@x.c", "moderator", 0)
+
+	offerID, err := s.UpsertDonateShopItem(ctx, domain.DonateShopItem{
+		ItemIndex: 10, Price: 50, Title: "Efemero", Enabled: true,
+	}, mod)
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if _, err := s.BuyDonateItem(ctx, buyer, offerID); err != nil {
+		t.Fatalf("buy: %v", err)
+	}
+	if err := s.DeleteDonateShopItem(ctx, offerID, mod); err != nil {
+		t.Fatalf("delete offer: %v", err)
+	}
+
+	w := window(time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	rows, _, err := s.ListDonateLedger(ctx, w, []string{LedgerActionPurchase}, 0, 50, 0)
+	if err != nil {
+		t.Fatalf("ledger: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows after deleting the offer, want the purchase to survive", len(rows))
+	}
+	if rows[0].ShopItemTitle != "" {
+		t.Errorf("title = %q, want empty after the offer was deleted", rows[0].ShopItemTitle)
+	}
+	if rows[0].ShopItemID != offerID {
+		t.Errorf("shop_item_id = %d, want %d preserved as the UI fallback", rows[0].ShopItemID, offerID)
+	}
+}
+
+// TestListDonateLedgerExcludesCatalogActions: CRUD audit rows move no wallet and
+// must never reach the ledger.
+func TestListDonateLedgerExcludesCatalogActions(t *testing.T) {
+	ctx, pool, s := revenueFixture(t)
+	mod := seedAccount(t, ctx, pool, "led_cat_mod", "m@x.c", "moderator", 0)
+
+	id, err := s.UpsertDonateShopItem(ctx, domain.DonateShopItem{
+		ItemIndex: 11, Price: 10, Title: "Cfg", Enabled: true,
+	}, mod)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := s.SetDonateShopItemEnabled(ctx, id, false, mod); err != nil {
+		t.Fatalf("toggle: %v", err)
+	}
+
+	w := window(time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	rows, total, err := s.ListDonateLedger(ctx, w, nil, 0, 50, 0)
+	if err != nil {
+		t.Fatalf("ledger: %v", err)
+	}
+	if len(rows) != 0 || total != 0 {
+		t.Errorf("got %d rows total=%d, want 0 — 'create'/'set_enabled' are config, not wallet movements", len(rows), total)
+	}
+}
+
+// TestDonateLedgerTotals aggregates both movement kinds.
+func TestDonateLedgerTotals(t *testing.T) {
+	ctx, pool, s := revenueFixture(t)
+	buyer := seedAccount(t, ctx, pool, "tot_buyer", "b@x.c", "player", 1000)
+	mod := seedAccount(t, ctx, pool, "tot_mod", "m@x.c", "moderator", 0)
+
+	offerID, err := s.UpsertDonateShopItem(ctx, domain.DonateShopItem{
+		ItemIndex: 12, Price: 70, Title: "X", Enabled: true,
+	}, mod)
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if _, err := s.BuyDonateItem(ctx, buyer, offerID); err != nil {
+		t.Fatalf("buy 1: %v", err)
+	}
+	if _, err := s.BuyDonateItem(ctx, buyer, offerID); err != nil {
+		t.Fatalf("buy 2: %v", err)
+	}
+	if _, err := s.CreditDonateBalance(ctx, buyer, 250, mod, "bonus"); err != nil {
+		t.Fatalf("credit: %v", err)
+	}
+
+	w := window(time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	got, err := s.DonateLedgerTotals(ctx, w, 0)
+	if err != nil {
+		t.Fatalf("totals: %v", err)
+	}
+	if got.ShopPurchases != 2 || got.CreditsSpent != 140 {
+		t.Errorf("purchases = (%d, %d credits), want (2, 140)", got.ShopPurchases, got.CreditsSpent)
+	}
+	if got.ManualCredits != 1 || got.CreditsGranted != 250 {
+		t.Errorf("manual credits = (%d, %d credits), want (1, 250)", got.ManualCredits, got.CreditsGranted)
+	}
+}
+
+// --- account search ---
+
+// TestSearchAccountsByNamePrefix covers the prefix match and the LIKE escaping.
+func TestSearchAccountsByNamePrefix(t *testing.T) {
+	ctx, pool, s := revenueFixture(t)
+	seedAccount(t, ctx, pool, "zarco_one", "1@x.c", "player", 5)
+	seedAccount(t, ctx, pool, "zarco_two", "2@x.c", "admin", 0)
+	seedAccount(t, ctx, pool, "outro", "3@x.c", "player", 0)
+
+	got, err := s.SearchAccountsByNamePrefix(ctx, "zarco", 20)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d accounts, want 2: %+v", len(got), got)
+	}
+	if got[0].Name != "zarco_one" || got[0].DonateBalance != 5 {
+		t.Errorf("first = %+v, want zarco_one with balance 5", got[0])
+	}
+	if got[1].Role != "admin" {
+		t.Errorf("second role = %q, want admin", got[1].Role)
+	}
+
+	// A literal '%' must be escaped, not treated as a wildcard.
+	got, err = s.SearchAccountsByNamePrefix(ctx, "%", 20)
+	if err != nil {
+		t.Fatalf("wildcard search: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("prefix %%%% matched %d accounts, want 0 — the metacharacter must be escaped", len(got))
+	}
+}

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -33,6 +33,10 @@ func testPool(t *testing.T) *pgxpool.Pool {
 	return pool
 }
 
+// resetTestSchema drops every table any migration creates, so a re-run starts
+// from an empty database. It must list them ALL: `DROP TABLE account CASCADE`
+// drops dependent *constraints*, not dependent *tables*, so a table omitted here
+// survives and the next Migrate fails with 42P07 (relation already exists).
 func resetTestSchema(ctx context.Context, pool *pgxpool.Pool) {
 	_, _ = pool.Exec(ctx, `
 		DROP TABLE IF EXISTS
@@ -50,6 +54,14 @@ func resetTestSchema(ctx context.Context, pool *pgxpool.Pool) {
 			item,
 			character_pvp_stats,
 			character,
+			castle_quest_state,
+			guild_tower_state,
+			guild_zone,
+			guild_relation,
+			guild_member,
+			guild,
+			donate_topup_order,
+			donate_payer_profile,
 			account,
 			donate_shop_audit,
 			donate_shop_item,

--- a/webserver/cmd/webserver/main.go
+++ b/webserver/cmd/webserver/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/attributemap"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/characters"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/dailyreward"
+	"github.com/jeanluca/w2pp-openwyd/webserver/internal/donaterevenue"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/donateshop"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/donatetopup"
 	"github.com/jeanluca/w2pp-openwyd/webserver/internal/droptool"
@@ -90,6 +91,7 @@ func run(logger *slog.Logger) error {
 	donate := donateshop.New(st)
 	dailyRwd := dailyreward.New(st)
 	topup := donatetopup.New(st)
+	revenue := donaterevenue.New(st)
 	attrMap := attributemap.New(st, *contentDir)
 	worldEvents := worldevent.New(st)
 	if *contentDir != "" {
@@ -143,6 +145,7 @@ func run(logger *slog.Logger) error {
 	webv1.RegisterDailyRewardAdminServiceServer(srv, grpcsrv.NewDailyRewardAdmin(dailyRwd))
 	webv1.RegisterDailyRewardServiceServer(srv, grpcsrv.NewDailyReward(dailyRwd))
 	webv1.RegisterDonateTopupServiceServer(srv, grpcsrv.NewDonateTopup(topup))
+	webv1.RegisterDonateRevenueAdminServiceServer(srv, grpcsrv.NewDonateRevenue(revenue))
 	webv1.RegisterWorldEventAdminServiceServer(srv, grpcsrv.NewWorldEventAdmin(worldEvents))
 
 	ln, err := net.Listen("tcp", *addr)

--- a/webserver/internal/donaterevenue/service.go
+++ b/webserver/internal/donaterevenue/service.go
@@ -1,0 +1,256 @@
+// Package donaterevenue holds the read-only revenue reporting logic behind the
+// painel de faturamento: how much money came in over a period, who paid, and
+// where the donate credits went. It reads donate_topup_order (real money),
+// donate_shop_audit (wallet movements), account and donate_payer_profile.
+//
+// It is NOT bin.v1.BillingService — that is the login entitlement gate, which
+// web-platform-plan.md explicitly separates from the cash wallet.
+//
+// Every operation is moderator-gated exactly like donateshop, and every
+// operation is a READ: this package writes nothing at all, not even an audit
+// row, so it never interacts with the tmServer's single-owner loop.
+//
+// Two units flow through here and never mix: *Cents is real BRL in integer
+// cents, *Credits is the in-game donate wallet unit. Revenue is recognized on
+// confirmed_at, never created_at — the store enforces that; see
+// internal/store/donate_revenue.go.
+package donaterevenue
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+	"github.com/jeanluca/w2pp-openwyd/internal/store"
+)
+
+// Store is the persistence surface the service needs (satisfied by *store.Store).
+type Store interface {
+	AccountRole(ctx context.Context, id int64) (string, error)
+	RevenueTotals(ctx context.Context, w store.RevenueWindow, accountID int64) (domain.RevenueTotals, error)
+	RevenueByMethod(ctx context.Context, w store.RevenueWindow, accountID int64) ([]domain.RevenueByMethod, error)
+	RevenueSeries(ctx context.Context, w store.RevenueWindow, bucket string, accountID int64) ([]domain.RevenuePoint, error)
+	DonateLedgerTotals(ctx context.Context, w store.RevenueWindow, accountID int64) (domain.DonateLedgerTotals, error)
+	ListTopupOrders(ctx context.Context, w store.RevenueWindow, f store.TopupOrderFilter, limit, offset int) ([]domain.TopupOrderRow, int, error)
+	ListTopBuyers(ctx context.Context, w store.RevenueWindow, limit, offset int) ([]domain.TopBuyer, int, error)
+	ListDonateLedger(ctx context.Context, w store.RevenueWindow, actions []string, accountID int64, limit, offset int) ([]domain.DonateLedgerEntry, int, error)
+	SearchAccountsByNamePrefix(ctx context.Context, prefix string, limit int) ([]domain.AccountSummary, error)
+}
+
+// Result is the business outcome of an operation, mirroring donateshop.Result
+// and carried in the response's AdminResult. Only infra failures are returned
+// as errors.
+type Result int
+
+const (
+	// OK means the operation succeeded.
+	OK Result = iota
+	// Forbidden means the caller is not a moderator/admin.
+	Forbidden
+	// Invalid means the request failed validation.
+	Invalid
+	// NotFound means the target does not exist. Reserved for contract symmetry:
+	// no read here returns it, because an empty window is a legitimate result.
+	NotFound
+)
+
+// Bucket is the requested series granularity, mirroring webv1.RevenueBucket.
+type Bucket int
+
+const (
+	// BucketUnspecified skips the series entirely.
+	BucketUnspecified Bucket = iota
+	// BucketDay buckets per calendar day.
+	BucketDay
+	// BucketWeek buckets per ISO week (starts Monday).
+	BucketWeek
+	// BucketMonth buckets per calendar month.
+	BucketMonth
+)
+
+// LedgerAction filters the donate ledger, mirroring webv1.DonateLedgerAction.
+type LedgerAction int
+
+const (
+	// LedgerAny returns both movement kinds.
+	LedgerAny LedgerAction = iota
+	// LedgerPurchase returns only shop purchases (wallet debits).
+	LedgerPurchase
+	// LedgerCredit returns only moderator credits (wallet credits).
+	LedgerCredit
+)
+
+// Summary bundles everything the KPI header needs in one round trip.
+type Summary struct {
+	Totals   domain.RevenueTotals
+	Ledger   domain.DonateLedgerTotals
+	ByMethod []domain.RevenueByMethod
+	Series   []domain.RevenuePoint
+	Window   Window
+}
+
+// Service implements the revenue reporting operations.
+type Service struct {
+	store Store
+}
+
+// New builds the service over the given store.
+func New(s Store) *Service { return &Service{store: s} }
+
+// Summary returns the KPI header, the per-gateway split and, when bucket is not
+// Unspecified, the gap-filled time series. accountID 0 means all accounts.
+func (s *Service) Summary(ctx context.Context, moderatorID, fromUnix, toUnix int64, bucket Bucket, accountID int64) (Result, Summary, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, Summary{}, err
+	}
+	if accountID < 0 {
+		return Invalid, Summary{}, nil
+	}
+	w, echo, ok := normalizeWindow(fromUnix, toUnix)
+	if !ok {
+		return Invalid, Summary{}, nil
+	}
+
+	// Four independent reads over the same window. They stay sequential: no
+	// other webserver service fans out, and the saving would be a few
+	// milliseconds against a pool that also serves every other RPC.
+	out := Summary{Window: echo}
+	var err error
+	if out.Totals, err = s.store.RevenueTotals(ctx, w, accountID); err != nil {
+		return Invalid, Summary{}, fmt.Errorf("donaterevenue: revenue totals: %w", err)
+	}
+	if out.Ledger, err = s.store.DonateLedgerTotals(ctx, w, accountID); err != nil {
+		return Invalid, Summary{}, fmt.Errorf("donaterevenue: ledger totals: %w", err)
+	}
+	if out.ByMethod, err = s.store.RevenueByMethod(ctx, w, accountID); err != nil {
+		return Invalid, Summary{}, fmt.Errorf("donaterevenue: revenue by method: %w", err)
+	}
+	if keyword, want := bucketKeyword(bucket); want {
+		if out.Series, err = s.store.RevenueSeries(ctx, w, keyword, accountID); err != nil {
+			return Invalid, Summary{}, fmt.Errorf("donaterevenue: revenue series: %w", err)
+		}
+	}
+	return OK, out, nil
+}
+
+// Orders returns one page of the order table. The CPF of every row is masked
+// here; the raw digits never leave this function.
+func (s *Service) Orders(ctx context.Context, moderatorID, fromUnix, toUnix int64, status, method int16, accountID int64, limit, offset int) (Result, []domain.TopupOrderRow, int, Window, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, nil, 0, Window{}, err
+	}
+	if accountID < 0 || status < 0 || method < 0 {
+		return Invalid, nil, 0, Window{}, nil
+	}
+	w, echo, ok := normalizeWindow(fromUnix, toUnix)
+	if !ok {
+		return Invalid, nil, 0, Window{}, nil
+	}
+	limit, offset = normalizePage(limit, offset)
+
+	rows, total, err := s.store.ListTopupOrders(ctx, w,
+		store.TopupOrderFilter{Status: status, PaymentMethod: method, AccountID: accountID}, limit, offset)
+	if err != nil {
+		return Invalid, nil, 0, Window{}, fmt.Errorf("donaterevenue: list topup orders: %w", err)
+	}
+	for i := range rows {
+		rows[i].PayerCPF = maskCPF(rows[i].PayerCPF)
+	}
+	return OK, rows, total, echo, nil
+}
+
+// TopBuyers ranks accounts by revenue inside the window, with their all-time
+// aggregate alongside.
+func (s *Service) TopBuyers(ctx context.Context, moderatorID, fromUnix, toUnix int64, limit, offset int) (Result, []domain.TopBuyer, int, Window, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, nil, 0, Window{}, err
+	}
+	w, echo, ok := normalizeWindow(fromUnix, toUnix)
+	if !ok {
+		return Invalid, nil, 0, Window{}, nil
+	}
+	limit, offset = normalizePage(limit, offset)
+
+	rows, total, err := s.store.ListTopBuyers(ctx, w, limit, offset)
+	if err != nil {
+		return Invalid, nil, 0, Window{}, fmt.Errorf("donaterevenue: list top buyers: %w", err)
+	}
+	return OK, rows, total, echo, nil
+}
+
+// Spend returns one page of the donate wallet ledger. accountID matches the
+// SUBJECT of each movement (whose wallet moved), never the raw audit column —
+// see store.ledgerSubjectExpr for why those differ.
+func (s *Service) Spend(ctx context.Context, moderatorID, fromUnix, toUnix int64, action LedgerAction, accountID int64, limit, offset int) (Result, []domain.DonateLedgerEntry, int, Window, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, nil, 0, Window{}, err
+	}
+	if accountID < 0 {
+		return Invalid, nil, 0, Window{}, nil
+	}
+	w, echo, ok := normalizeWindow(fromUnix, toUnix)
+	if !ok {
+		return Invalid, nil, 0, Window{}, nil
+	}
+	limit, offset = normalizePage(limit, offset)
+
+	rows, total, err := s.store.ListDonateLedger(ctx, w, ledgerActions(action), accountID, limit, offset)
+	if err != nil {
+		return Invalid, nil, 0, Window{}, fmt.Errorf("donaterevenue: list donate ledger: %w", err)
+	}
+	return OK, rows, total, echo, nil
+}
+
+// SearchAccounts resolves a typed login prefix to account identities so the
+// panel can build an account_id filter.
+func (s *Service) SearchAccounts(ctx context.Context, moderatorID int64, prefix string, limit int) (Result, []domain.AccountSummary, error) {
+	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
+		return r, nil, err
+	}
+	p, ok := normalizePrefix(prefix)
+	if !ok {
+		return Invalid, nil, nil
+	}
+	rows, err := s.store.SearchAccountsByNamePrefix(ctx, p, normalizeSearchLimit(limit))
+	if err != nil {
+		return Invalid, nil, fmt.Errorf("donaterevenue: search accounts: %w", err)
+	}
+	return OK, rows, nil
+}
+
+// --- helpers ---
+
+// ledgerActions maps the filter enum to the store's action keywords. LedgerAny
+// yields nil, which the store reads as "both movement kinds".
+func ledgerActions(a LedgerAction) []string {
+	switch a {
+	case LedgerPurchase:
+		return []string{store.LedgerActionPurchase}
+	case LedgerCredit:
+		return []string{store.LedgerActionCredit}
+	default:
+		return nil
+	}
+}
+
+// authorize checks the caller has a moderator/admin role. A missing account or a
+// plain-player role yields Forbidden (never leaks whether the account exists).
+// Mirrors donateshop.authorize — the panel is gated no differently from the rest
+// of the admin surface.
+func (s *Service) authorize(ctx context.Context, moderatorID int64) (Result, error) {
+	if moderatorID <= 0 {
+		return Forbidden, nil
+	}
+	role, err := s.store.AccountRole(ctx, moderatorID)
+	if errors.Is(err, store.ErrNotFound) {
+		return Forbidden, nil
+	}
+	if err != nil {
+		return Invalid, fmt.Errorf("donaterevenue: role lookup %d: %w", moderatorID, err)
+	}
+	if role != "moderator" && role != "admin" {
+		return Forbidden, nil
+	}
+	return OK, nil
+}

--- a/webserver/internal/donaterevenue/service_test.go
+++ b/webserver/internal/donaterevenue/service_test.go
@@ -1,0 +1,458 @@
+package donaterevenue
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+	"github.com/jeanluca/w2pp-openwyd/internal/store"
+)
+
+// fakeStore records what the service asked for and returns scripted data, so the
+// tests pin authorization, validation and masking without a database.
+type fakeStore struct {
+	roles map[int64]string
+	err   error // when set, every read returns it
+
+	orders []domain.TopupOrderRow
+	buyers []domain.TopBuyer
+	ledger []domain.DonateLedgerEntry
+	accts  []domain.AccountSummary
+
+	// recorded arguments from the last call
+	gotWindow  store.RevenueWindow
+	gotFilter  store.TopupOrderFilter
+	gotBucket  string
+	gotActions []string
+	gotAccount int64
+	gotLimit   int
+	gotOffset  int
+	gotPrefix  string
+
+	seriesCalls int
+	readCalls   int
+}
+
+func (f *fakeStore) AccountRole(_ context.Context, id int64) (string, error) {
+	r, ok := f.roles[id]
+	if !ok {
+		return "", store.ErrNotFound
+	}
+	return r, nil
+}
+
+func (f *fakeStore) RevenueTotals(_ context.Context, w store.RevenueWindow, accountID int64) (domain.RevenueTotals, error) {
+	f.readCalls++
+	f.gotWindow, f.gotAccount = w, accountID
+	if f.err != nil {
+		return domain.RevenueTotals{}, f.err
+	}
+	return domain.RevenueTotals{PaidOrders: 3, GrossCents: 4500}, nil
+}
+
+func (f *fakeStore) RevenueByMethod(_ context.Context, _ store.RevenueWindow, _ int64) ([]domain.RevenueByMethod, error) {
+	f.readCalls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return []domain.RevenueByMethod{{PaymentMethod: 1, PaidOrders: 3, GrossCents: 4500}}, nil
+}
+
+func (f *fakeStore) RevenueSeries(_ context.Context, _ store.RevenueWindow, bucket string, _ int64) ([]domain.RevenuePoint, error) {
+	f.readCalls++
+	f.seriesCalls++
+	f.gotBucket = bucket
+	if f.err != nil {
+		return nil, f.err
+	}
+	return []domain.RevenuePoint{{GrossCents: 4500}}, nil
+}
+
+func (f *fakeStore) DonateLedgerTotals(_ context.Context, _ store.RevenueWindow, _ int64) (domain.DonateLedgerTotals, error) {
+	f.readCalls++
+	if f.err != nil {
+		return domain.DonateLedgerTotals{}, f.err
+	}
+	return domain.DonateLedgerTotals{ShopPurchases: 2, CreditsSpent: 80}, nil
+}
+
+func (f *fakeStore) ListTopupOrders(_ context.Context, w store.RevenueWindow, fl store.TopupOrderFilter, limit, offset int) ([]domain.TopupOrderRow, int, error) {
+	f.readCalls++
+	f.gotWindow, f.gotFilter, f.gotLimit, f.gotOffset = w, fl, limit, offset
+	if f.err != nil {
+		return nil, 0, f.err
+	}
+	return f.orders, len(f.orders), nil
+}
+
+func (f *fakeStore) ListTopBuyers(_ context.Context, w store.RevenueWindow, limit, offset int) ([]domain.TopBuyer, int, error) {
+	f.readCalls++
+	f.gotWindow, f.gotLimit, f.gotOffset = w, limit, offset
+	if f.err != nil {
+		return nil, 0, f.err
+	}
+	return f.buyers, len(f.buyers), nil
+}
+
+func (f *fakeStore) ListDonateLedger(_ context.Context, w store.RevenueWindow, actions []string, accountID int64, limit, offset int) ([]domain.DonateLedgerEntry, int, error) {
+	f.readCalls++
+	f.gotWindow, f.gotActions, f.gotAccount, f.gotLimit, f.gotOffset = w, actions, accountID, limit, offset
+	if f.err != nil {
+		return nil, 0, f.err
+	}
+	return f.ledger, len(f.ledger), nil
+}
+
+func (f *fakeStore) SearchAccountsByNamePrefix(_ context.Context, prefix string, limit int) ([]domain.AccountSummary, error) {
+	f.readCalls++
+	f.gotPrefix, f.gotLimit = prefix, limit
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.accts, nil
+}
+
+func newFake() *fakeStore {
+	return &fakeStore{roles: map[int64]string{
+		1: "player", 2: "moderator", 3: "admin",
+	}}
+}
+
+// --- authorization ---
+
+func TestSummaryForbiddenForPlayer(t *testing.T) {
+	f := newFake()
+	got, _, err := New(f).Summary(context.Background(), 1, 0, 0, BucketUnspecified, 0)
+	if err != nil || got != Forbidden {
+		t.Fatalf("Summary(player) = (%v, %v), want (Forbidden, nil)", got, err)
+	}
+	if f.readCalls != 0 {
+		t.Errorf("store was read %d times for a forbidden caller, want 0", f.readCalls)
+	}
+}
+
+func TestForbiddenForMissingAccount(t *testing.T) {
+	f := newFake()
+	got, _, err := New(f).Summary(context.Background(), 999, 0, 0, BucketUnspecified, 0)
+	if err != nil || got != Forbidden {
+		t.Fatalf("Summary(unknown account) = (%v, %v), want (Forbidden, nil) — never NotFound, which would leak existence", got, err)
+	}
+}
+
+func TestForbiddenForZeroModeratorID(t *testing.T) {
+	f := newFake()
+	for _, id := range []int64{0, -5} {
+		got, _, err := New(f).Summary(context.Background(), id, 0, 0, BucketUnspecified, 0)
+		if err != nil || got != Forbidden {
+			t.Errorf("Summary(moderatorID=%d) = (%v, %v), want (Forbidden, nil)", id, got, err)
+		}
+	}
+	if f.readCalls != 0 {
+		t.Errorf("store was read %d times, want 0 (short-circuit before any query)", f.readCalls)
+	}
+}
+
+func TestAdminRoleIsAllowed(t *testing.T) {
+	f := newFake()
+	got, _, err := New(f).Summary(context.Background(), 3, 0, 0, BucketUnspecified, 0)
+	if err != nil || got != OK {
+		t.Fatalf("Summary(admin) = (%v, %v), want (OK, nil)", got, err)
+	}
+}
+
+func TestAllMethodsAreGated(t *testing.T) {
+	svc := New(newFake())
+	ctx := context.Background()
+
+	if r, _, _, _, err := svc.Orders(ctx, 1, 0, 0, 0, 0, 0, 0, 0); r != Forbidden || err != nil {
+		t.Errorf("Orders(player) = %v, want Forbidden", r)
+	}
+	if r, _, _, _, err := svc.TopBuyers(ctx, 1, 0, 0, 0, 0); r != Forbidden || err != nil {
+		t.Errorf("TopBuyers(player) = %v, want Forbidden", r)
+	}
+	if r, _, _, _, err := svc.Spend(ctx, 1, 0, 0, LedgerAny, 0, 0, 0); r != Forbidden || err != nil {
+		t.Errorf("Spend(player) = %v, want Forbidden", r)
+	}
+	if r, _, err := svc.SearchAccounts(ctx, 1, "abc", 0); r != Forbidden || err != nil {
+		t.Errorf("SearchAccounts(player) = %v, want Forbidden", r)
+	}
+}
+
+// --- window validation ---
+
+func TestWindowDefaultsToLast30Days(t *testing.T) {
+	f := newFake()
+	before := time.Now().UTC()
+	got, sum, err := New(f).Summary(context.Background(), 2, 0, 0, BucketUnspecified, 0)
+	if err != nil || got != OK {
+		t.Fatalf("Summary = (%v, %v)", got, err)
+	}
+	span := f.gotWindow.To.Sub(f.gotWindow.From)
+	if span < 29*24*time.Hour || span > 31*24*time.Hour {
+		t.Errorf("default window span = %v, want ~30 days", span)
+	}
+	if f.gotWindow.To.Before(before.Add(-time.Minute)) {
+		t.Errorf("default window ends at %v, want ~now", f.gotWindow.To)
+	}
+	if sum.Window.FromUnix != f.gotWindow.From.Unix() || sum.Window.ToUnix != f.gotWindow.To.Unix() {
+		t.Errorf("echoed window %+v does not match what the store received", sum.Window)
+	}
+}
+
+func TestWindowInvalidWhenFromNotBeforeTo(t *testing.T) {
+	f := newFake()
+	svc := New(f)
+	cases := []struct {
+		name     string
+		from, to int64
+	}{
+		{"equal", 1_700_000_000, 1_700_000_000},
+		{"reversed", 1_700_000_100, 1_700_000_000},
+		{"negative", -1, 1_700_000_000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _, err := svc.Summary(context.Background(), 2, tc.from, tc.to, BucketUnspecified, 0)
+			if err != nil || got != Invalid {
+				t.Errorf("Summary(%d,%d) = (%v, %v), want (Invalid, nil)", tc.from, tc.to, got, err)
+			}
+		})
+	}
+	if f.readCalls != 0 {
+		t.Errorf("store was read %d times for invalid windows, want 0", f.readCalls)
+	}
+}
+
+func TestWindowInvalidWhenWiderThan366Days(t *testing.T) {
+	to := time.Now().UTC()
+	from := to.AddDate(0, 0, -400)
+	got, _, err := New(newFake()).Summary(context.Background(), 2, from.Unix(), to.Unix(), BucketUnspecified, 0)
+	if err != nil || got != Invalid {
+		t.Fatalf("400-day window = (%v, %v), want (Invalid, nil)", got, err)
+	}
+}
+
+func TestWindowAcceptsExactlyMaxSpan(t *testing.T) {
+	to := time.Now().UTC()
+	from := to.Add(-maxWindowDays * 24 * time.Hour)
+	got, _, err := New(newFake()).Summary(context.Background(), 2, from.Unix(), to.Unix(), BucketUnspecified, 0)
+	if err != nil || got != OK {
+		t.Fatalf("366-day window = (%v, %v), want (OK, nil)", got, err)
+	}
+}
+
+// --- pagination ---
+
+func TestPageLimitClampedAndDefaulted(t *testing.T) {
+	f := newFake()
+	svc := New(f)
+	ctx := context.Background()
+
+	cases := []struct {
+		inLimit, inOffset  int
+		wantLimit, wantOff int
+	}{
+		{0, 0, defaultLimit, 0},
+		{1000, 0, maxLimit, 0},
+		{10, -5, 10, 0},
+		{25, 50, 25, 50},
+	}
+	for _, tc := range cases {
+		if _, _, _, _, err := svc.Orders(ctx, 2, 0, 0, 0, 0, 0, tc.inLimit, tc.inOffset); err != nil {
+			t.Fatalf("Orders: %v", err)
+		}
+		if f.gotLimit != tc.wantLimit || f.gotOffset != tc.wantOff {
+			t.Errorf("Orders(limit=%d,offset=%d) -> store got (%d,%d), want (%d,%d)",
+				tc.inLimit, tc.inOffset, f.gotLimit, f.gotOffset, tc.wantLimit, tc.wantOff)
+		}
+	}
+}
+
+// --- CPF masking ---
+
+func TestCPFIsMaskedInOrderRows(t *testing.T) {
+	f := newFake()
+	f.orders = []domain.TopupOrderRow{{PayerCPF: "12345678909", PayerName: "Fulano"}}
+
+	_, rows, _, _, err := New(f).Orders(context.Background(), 2, 0, 0, 0, 0, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("Orders: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	if rows[0].PayerCPF != "***.456.789-**" {
+		t.Errorf("masked CPF = %q, want ***.456.789-**", rows[0].PayerCPF)
+	}
+	if strings.Contains(rows[0].PayerCPF, "123") || strings.Contains(rows[0].PayerCPF, "909") {
+		t.Errorf("raw CPF digits leaked into %q", rows[0].PayerCPF)
+	}
+}
+
+func TestCPFEmptyWhenProfileMissing(t *testing.T) {
+	f := newFake()
+	f.orders = []domain.TopupOrderRow{{PayerCPF: ""}}
+	_, rows, _, _, err := New(f).Orders(context.Background(), 2, 0, 0, 0, 0, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("Orders: %v", err)
+	}
+	if rows[0].PayerCPF != "" {
+		t.Errorf("masked empty CPF = %q, want empty", rows[0].PayerCPF)
+	}
+}
+
+// --- series bucketing ---
+
+func TestBucketUnspecifiedSkipsSeries(t *testing.T) {
+	f := newFake()
+	_, sum, err := New(f).Summary(context.Background(), 2, 0, 0, BucketUnspecified, 0)
+	if err != nil {
+		t.Fatalf("Summary: %v", err)
+	}
+	if f.seriesCalls != 0 {
+		t.Errorf("RevenueSeries called %d times for UNSPECIFIED, want 0", f.seriesCalls)
+	}
+	if len(sum.Series) != 0 {
+		t.Errorf("series = %v, want empty", sum.Series)
+	}
+}
+
+func TestBucketMapsToStoreKeyword(t *testing.T) {
+	cases := map[Bucket]string{
+		BucketDay:   store.BucketDay,
+		BucketWeek:  store.BucketWeek,
+		BucketMonth: store.BucketMonth,
+	}
+	for b, want := range cases {
+		f := newFake()
+		if _, _, err := New(f).Summary(context.Background(), 2, 0, 0, b, 0); err != nil {
+			t.Fatalf("Summary: %v", err)
+		}
+		if f.gotBucket != want {
+			t.Errorf("bucket %v -> %q, want %q", b, f.gotBucket, want)
+		}
+	}
+}
+
+func TestUnknownBucketDegradesToNoSeries(t *testing.T) {
+	f := newFake()
+	got, sum, err := New(f).Summary(context.Background(), 2, 0, 0, Bucket(99), 0)
+	if err != nil || got != OK {
+		t.Fatalf("Summary(unknown bucket) = (%v, %v), want (OK, nil) — a newer portal must not 400 an older server", got, err)
+	}
+	if f.seriesCalls != 0 || len(sum.Series) != 0 {
+		t.Errorf("unknown bucket produced a series, want none")
+	}
+}
+
+// --- ledger filter ---
+
+func TestLedgerActionMapsToStoreKeywords(t *testing.T) {
+	cases := []struct {
+		action LedgerAction
+		want   []string
+	}{
+		{LedgerAny, nil},
+		{LedgerPurchase, []string{store.LedgerActionPurchase}},
+		{LedgerCredit, []string{store.LedgerActionCredit}},
+	}
+	for _, tc := range cases {
+		f := newFake()
+		if _, _, _, _, err := New(f).Spend(context.Background(), 2, 0, 0, tc.action, 0, 0, 0); err != nil {
+			t.Fatalf("Spend: %v", err)
+		}
+		if len(f.gotActions) != len(tc.want) {
+			t.Fatalf("action %v -> %v, want %v", tc.action, f.gotActions, tc.want)
+		}
+		for i := range tc.want {
+			if f.gotActions[i] != tc.want[i] {
+				t.Errorf("action %v -> %v, want %v", tc.action, f.gotActions, tc.want)
+			}
+		}
+	}
+}
+
+// --- account search ---
+
+func TestSearchAccountsRejectsShortPrefix(t *testing.T) {
+	f := newFake()
+	svc := New(f)
+	got, _, err := svc.SearchAccounts(context.Background(), 2, "a", 0)
+	if err != nil || got != Invalid {
+		t.Fatalf("SearchAccounts(1 char) = (%v, %v), want (Invalid, nil)", got, err)
+	}
+	if f.readCalls != 0 {
+		t.Errorf("store was read for a too-short prefix")
+	}
+
+	got, _, err = svc.SearchAccounts(context.Background(), 2, "  AB  ", 0)
+	if err != nil || got != OK {
+		t.Fatalf("SearchAccounts(2 chars) = (%v, %v), want (OK, nil)", got, err)
+	}
+	if f.gotPrefix != "ab" {
+		t.Errorf("prefix reached the store as %q, want lowercased+trimmed %q", f.gotPrefix, "ab")
+	}
+	if f.gotLimit != defaultSearchLimit {
+		t.Errorf("search limit = %d, want %d", f.gotLimit, defaultSearchLimit)
+	}
+}
+
+func TestSearchLimitClamped(t *testing.T) {
+	f := newFake()
+	if _, _, err := New(f).SearchAccounts(context.Background(), 2, "abc", 500); err != nil {
+		t.Fatalf("SearchAccounts: %v", err)
+	}
+	if f.gotLimit != maxSearchLimit {
+		t.Errorf("search limit = %d, want clamped to %d", f.gotLimit, maxSearchLimit)
+	}
+}
+
+// --- error propagation ---
+
+func TestStoreErrorBecomesInvalidAndIsWrapped(t *testing.T) {
+	boom := errors.New("connection reset")
+	svc := New(&fakeStore{roles: map[int64]string{2: "moderator"}, err: boom})
+	ctx := context.Background()
+
+	got, _, err := svc.Summary(ctx, 2, 0, 0, BucketUnspecified, 0)
+	if got != Invalid {
+		t.Errorf("Summary result = %v, want Invalid", got)
+	}
+	if err == nil || !errors.Is(err, boom) {
+		t.Fatalf("Summary error = %v, want it to wrap the store error", err)
+	}
+	if !strings.Contains(err.Error(), "donaterevenue:") {
+		t.Errorf("error %q is missing the package prefix", err)
+	}
+
+	if _, _, _, _, err := svc.Orders(ctx, 2, 0, 0, 0, 0, 0, 0, 0); err == nil || !errors.Is(err, boom) {
+		t.Errorf("Orders error = %v, want the store error wrapped", err)
+	}
+	if _, _, _, _, err := svc.TopBuyers(ctx, 2, 0, 0, 0, 0); err == nil || !errors.Is(err, boom) {
+		t.Errorf("TopBuyers error = %v, want the store error wrapped", err)
+	}
+	if _, _, _, _, err := svc.Spend(ctx, 2, 0, 0, LedgerAny, 0, 0, 0); err == nil || !errors.Is(err, boom) {
+		t.Errorf("Spend error = %v, want the store error wrapped", err)
+	}
+	if _, _, err := svc.SearchAccounts(ctx, 2, "abc", 0); err == nil || !errors.Is(err, boom) {
+		t.Errorf("SearchAccounts error = %v, want the store error wrapped", err)
+	}
+}
+
+// TestNegativeAccountIDRejected guards the drill-down filter.
+func TestNegativeAccountIDRejected(t *testing.T) {
+	svc := New(newFake())
+	ctx := context.Background()
+	if r, _, err := svc.Summary(ctx, 2, 0, 0, BucketUnspecified, -1); r != Invalid || err != nil {
+		t.Errorf("Summary(accountID=-1) = %v, want Invalid", r)
+	}
+	if r, _, _, _, err := svc.Orders(ctx, 2, 0, 0, 0, 0, -1, 0, 0); r != Invalid || err != nil {
+		t.Errorf("Orders(accountID=-1) = %v, want Invalid", r)
+	}
+	if r, _, _, _, err := svc.Spend(ctx, 2, 0, 0, LedgerAny, -1, 0, 0); r != Invalid || err != nil {
+		t.Errorf("Spend(accountID=-1) = %v, want Invalid", r)
+	}
+}

--- a/webserver/internal/donaterevenue/window.go
+++ b/webserver/internal/donaterevenue/window.go
@@ -1,0 +1,139 @@
+package donaterevenue
+
+import (
+	"strings"
+	"time"
+
+	"github.com/jeanluca/w2pp-openwyd/internal/store"
+)
+
+// Validation bounds. The window cap is load-bearing three ways: it bounds the
+// series row count, it keeps the range scan selective, and it stops an
+// accidental "since 1970" query from scanning the whole order table.
+const (
+	defaultLimit       = 50
+	maxLimit           = 100
+	defaultSearchLimit = 20
+	maxSearchLimit     = 50
+	minPrefixLen       = 2
+	defaultWindowDays  = 30
+	maxWindowDays      = 366
+)
+
+// Window is the resolved [FromUnix, ToUnix) range a request was actually served
+// with. Every windowed method returns it so the caller can echo it back and the
+// UI labels the period truthfully rather than the one it asked for.
+type Window struct {
+	FromUnix int64
+	ToUnix   int64
+}
+
+// normalizeWindow resolves the caller's Unix-second bounds into a concrete
+// bounded range. Both 0 means the last defaultWindowDays ending now; only
+// toUnix 0 means "now". ok is false when the range is nonsensical or too wide,
+// which the caller turns into Invalid.
+//
+// The result is ALWAYS bounded, which is what lets every store predicate be a
+// plain sargable `>= $1 AND < $2` with no NULL-guarded date logic.
+func normalizeWindow(fromUnix, toUnix int64) (store.RevenueWindow, Window, bool) {
+	if fromUnix < 0 || toUnix < 0 {
+		return store.RevenueWindow{}, Window{}, false
+	}
+
+	to := time.Now().UTC()
+	if toUnix != 0 {
+		to = time.Unix(toUnix, 0).UTC()
+	}
+	from := to.AddDate(0, 0, -defaultWindowDays)
+	if fromUnix != 0 {
+		from = time.Unix(fromUnix, 0).UTC()
+	}
+
+	if !from.Before(to) {
+		return store.RevenueWindow{}, Window{}, false
+	}
+	if to.Sub(from) > maxWindowDays*24*time.Hour {
+		return store.RevenueWindow{}, Window{}, false
+	}
+	return store.RevenueWindow{From: from, To: to},
+		Window{FromUnix: from.Unix(), ToUnix: to.Unix()},
+		true
+}
+
+// normalizePage clamps the pager. Mirrors ranking.normalizePage; the duplication
+// is deliberate — hoisting it would mean a shared util-shaped package.
+func normalizePage(limit, offset int) (int, int) {
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+	if limit > maxLimit {
+		limit = maxLimit
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return limit, offset
+}
+
+// normalizeSearchLimit clamps the account picker's page size.
+func normalizeSearchLimit(limit int) int {
+	if limit <= 0 {
+		return defaultSearchLimit
+	}
+	if limit > maxSearchLimit {
+		return maxSearchLimit
+	}
+	return limit
+}
+
+// normalizePrefix canonicalizes a typed login to the lowercase form account.name
+// is stored in. ok is false for a prefix shorter than minPrefixLen, which would
+// return an unbounded slice of the account table.
+func normalizePrefix(prefix string) (string, bool) {
+	p := strings.ToLower(strings.TrimSpace(prefix))
+	if len(p) < minPrefixLen {
+		return "", false
+	}
+	return p, true
+}
+
+// maskCPF renders an 11-digit CPF as ***.456.789-** — enough for an operator to
+// eyeball-match a payer against a bank statement, not enough to reuse the
+// document.
+//
+// Masking lives here, in the service, rather than in the store or the BFF:
+// 'moderator' is a coarse role shared with the NPC and mob editors, so everyone
+// who can open the panel would otherwise see every payer's full CPF, and nothing
+// in a revenue report needs it — a chargeback is reconciled by
+// external_reference. There is deliberately no unmasked variant in the contract.
+//
+// Anything that is not exactly 11 digits renders as "" rather than leaking a
+// partially-parsed value.
+func maskCPF(digits string) string {
+	if len(digits) != 11 {
+		return ""
+	}
+	for i := 0; i < len(digits); i++ {
+		if digits[i] < '0' || digits[i] > '9' {
+			return ""
+		}
+	}
+	return "***." + digits[3:6] + "." + digits[6:9] + "-**"
+}
+
+// bucketKeyword maps the request enum to the store's bucket constant. ok is
+// false for Unspecified AND for any unrecognized value: an unknown bucket
+// degrades to "no series" instead of failing, so a newer portal cannot 400
+// against an older server.
+func bucketKeyword(b Bucket) (string, bool) {
+	switch b {
+	case BucketDay:
+		return store.BucketDay, true
+	case BucketWeek:
+		return store.BucketWeek, true
+	case BucketMonth:
+		return store.BucketMonth, true
+	default:
+		return "", false
+	}
+}

--- a/webserver/internal/donaterevenue/window_test.go
+++ b/webserver/internal/donaterevenue/window_test.go
@@ -1,0 +1,152 @@
+package donaterevenue
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMaskCPF(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"eleven digits", "12345678909", "***.456.789-**"},
+		{"all zeroes", "00000000000", "***.000.000-**"},
+		{"ten digits", "1234567890", ""},
+		{"twelve digits", "123456789012", ""},
+		{"empty", "", ""},
+		{"already formatted", "123.456.789-09", ""},
+		{"letters", "1234567890a", ""},
+		{"spaces", "123456789 9", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := maskCPF(tc.in); got != tc.want {
+				t.Errorf("maskCPF(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeWindow(t *testing.T) {
+	const day = 24 * time.Hour
+	base := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC).Unix()
+
+	t.Run("explicit range is preserved", func(t *testing.T) {
+		from, to := base, base+7*int64(day/time.Second)
+		w, echo, ok := normalizeWindow(from, to)
+		if !ok {
+			t.Fatal("normalizeWindow returned not-ok for a valid range")
+		}
+		if w.From.Unix() != from || w.To.Unix() != to {
+			t.Errorf("window = [%d,%d), want [%d,%d)", w.From.Unix(), w.To.Unix(), from, to)
+		}
+		if echo.FromUnix != from || echo.ToUnix != to {
+			t.Errorf("echo = %+v, want the same bounds", echo)
+		}
+	})
+
+	t.Run("zero to means now", func(t *testing.T) {
+		before := time.Now().UTC()
+		w, _, ok := normalizeWindow(base, 0)
+		if !ok {
+			t.Fatal("not ok")
+		}
+		if w.To.Before(before.Add(-time.Minute)) {
+			t.Errorf("To = %v, want ~now", w.To)
+		}
+	})
+
+	t.Run("both zero means last 30 days", func(t *testing.T) {
+		w, _, ok := normalizeWindow(0, 0)
+		if !ok {
+			t.Fatal("not ok")
+		}
+		span := w.To.Sub(w.From)
+		if span < 29*day || span > 31*day {
+			t.Errorf("span = %v, want ~30 days", span)
+		}
+	})
+
+	t.Run("rejects", func(t *testing.T) {
+		cases := []struct {
+			name     string
+			from, to int64
+		}{
+			{"from equals to", base, base},
+			{"from after to", base + 10, base},
+			{"negative from", -1, base},
+			{"negative to", base, -1},
+			{"wider than max", base, base + (maxWindowDays+1)*int64(day/time.Second)},
+		}
+		for _, tc := range cases {
+			if _, _, ok := normalizeWindow(tc.from, tc.to); ok {
+				t.Errorf("%s: normalizeWindow(%d,%d) accepted, want rejected", tc.name, tc.from, tc.to)
+			}
+		}
+	})
+
+	t.Run("accepts exactly max span", func(t *testing.T) {
+		to := base + maxWindowDays*int64(day/time.Second)
+		if _, _, ok := normalizeWindow(base, to); !ok {
+			t.Error("exactly maxWindowDays was rejected, want accepted")
+		}
+	})
+}
+
+func TestNormalizePage(t *testing.T) {
+	cases := []struct {
+		inLimit, inOffset     int
+		wantLimit, wantOffset int
+	}{
+		{0, 0, defaultLimit, 0},
+		{-1, 0, defaultLimit, 0},
+		{maxLimit + 1, 0, maxLimit, 0},
+		{10_000, 0, maxLimit, 0},
+		{10, -3, 10, 0},
+		{maxLimit, 20, maxLimit, 20},
+	}
+	for _, tc := range cases {
+		gotL, gotO := normalizePage(tc.inLimit, tc.inOffset)
+		if gotL != tc.wantLimit || gotO != tc.wantOffset {
+			t.Errorf("normalizePage(%d,%d) = (%d,%d), want (%d,%d)",
+				tc.inLimit, tc.inOffset, gotL, gotO, tc.wantLimit, tc.wantOffset)
+		}
+	}
+}
+
+func TestNormalizeSearchLimit(t *testing.T) {
+	cases := map[int]int{
+		0:                  defaultSearchLimit,
+		-1:                 defaultSearchLimit,
+		5:                  5,
+		maxSearchLimit:     maxSearchLimit,
+		maxSearchLimit + 1: maxSearchLimit,
+		1000:               maxSearchLimit,
+	}
+	for in, want := range cases {
+		if got := normalizeSearchLimit(in); got != want {
+			t.Errorf("normalizeSearchLimit(%d) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func TestNormalizePrefix(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   string
+		wantOK bool
+	}{
+		{"AB", "ab", true},
+		{"  Zarco  ", "zarco", true},
+		{"a", "", false},
+		{"", "", false},
+		{"   ", "", false},
+		{" x ", "", false},
+	}
+	for _, tc := range cases {
+		got, ok := normalizePrefix(tc.in)
+		if got != tc.want || ok != tc.wantOK {
+			t.Errorf("normalizePrefix(%q) = (%q,%v), want (%q,%v)", tc.in, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}

--- a/webserver/internal/grpcsrv/donaterevenue.go
+++ b/webserver/internal/grpcsrv/donaterevenue.go
@@ -1,0 +1,295 @@
+package grpcsrv
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	webv1 "github.com/jeanluca/w2pp-openwyd/api/web/v1"
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+	"github.com/jeanluca/w2pp-openwyd/webserver/internal/donaterevenue"
+)
+
+// DonateRevenue is the revenue reporting surface (satisfied by
+// *donaterevenue.Service). Kept as an interface so the server is unit-testable.
+type DonateRevenue interface {
+	Summary(ctx context.Context, moderatorID, fromUnix, toUnix int64, bucket donaterevenue.Bucket, accountID int64) (donaterevenue.Result, donaterevenue.Summary, error)
+	Orders(ctx context.Context, moderatorID, fromUnix, toUnix int64, status, method int16, accountID int64, limit, offset int) (donaterevenue.Result, []domain.TopupOrderRow, int, donaterevenue.Window, error)
+	TopBuyers(ctx context.Context, moderatorID, fromUnix, toUnix int64, limit, offset int) (donaterevenue.Result, []domain.TopBuyer, int, donaterevenue.Window, error)
+	Spend(ctx context.Context, moderatorID, fromUnix, toUnix int64, action donaterevenue.LedgerAction, accountID int64, limit, offset int) (donaterevenue.Result, []domain.DonateLedgerEntry, int, donaterevenue.Window, error)
+	SearchAccounts(ctx context.Context, moderatorID int64, prefix string, limit int) (donaterevenue.Result, []domain.AccountSummary, error)
+}
+
+// DonateRevenueServer implements webv1.DonateRevenueAdminServiceServer.
+type DonateRevenueServer struct {
+	webv1.UnimplementedDonateRevenueAdminServiceServer
+	revenue DonateRevenue
+}
+
+// NewDonateRevenue builds the DonateRevenueAdminService over the given logic.
+func NewDonateRevenue(r DonateRevenue) *DonateRevenueServer { return &DonateRevenueServer{revenue: r} }
+
+// GetRevenueSummary returns the KPI header, the per-gateway split and the series.
+func (s *DonateRevenueServer) GetRevenueSummary(ctx context.Context, req *webv1.GetRevenueSummaryRequest) (*webv1.GetRevenueSummaryResponse, error) {
+	res, sum, err := s.revenue.Summary(ctx, req.GetModeratorId(),
+		req.GetWindow().GetFromUnix(), req.GetWindow().GetToUnix(),
+		revenueBucketFromProto(req.GetBucket()), req.GetAccountId())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "revenue summary: %v", err)
+	}
+	out := &webv1.GetRevenueSummaryResponse{
+		Result:   revenueResultToProto(res),
+		FromUnix: sum.Window.FromUnix,
+		ToUnix:   sum.Window.ToUnix,
+	}
+	if res != donaterevenue.OK {
+		return out, nil
+	}
+	// The wire message flattens the money counters and the credit counters into
+	// one RevenueTotals; the service keeps them apart because they are different
+	// units read from different tables.
+	out.Totals = &webv1.RevenueTotals{
+		PaidOrders:     sum.Totals.PaidOrders,
+		GrossCents:     sum.Totals.GrossCents,
+		CreditsSold:    sum.Totals.CreditsSold,
+		DistinctBuyers: sum.Totals.DistinctBuyers,
+		CreatedOrders:  sum.Totals.CreatedOrders,
+		PendingOrders:  sum.Totals.PendingOrders,
+		PendingCents:   sum.Totals.PendingCents,
+		ShopPurchases:  sum.Ledger.ShopPurchases,
+		CreditsSpent:   sum.Ledger.CreditsSpent,
+		ManualCredits:  sum.Ledger.ManualCredits,
+		CreditsGranted: sum.Ledger.CreditsGranted,
+	}
+	out.ByMethod = make([]*webv1.RevenueByMethod, 0, len(sum.ByMethod))
+	for _, m := range sum.ByMethod {
+		out.ByMethod = append(out.ByMethod, &webv1.RevenueByMethod{
+			PaymentMethod: paymentMethodToProto(m.PaymentMethod),
+			PaidOrders:    m.PaidOrders,
+			GrossCents:    m.GrossCents,
+		})
+	}
+	out.Series = make([]*webv1.RevenuePoint, 0, len(sum.Series))
+	for _, p := range sum.Series {
+		out.Series = append(out.Series, &webv1.RevenuePoint{
+			BucketStartUnix: unixOrZero(p.BucketStart),
+			PaidOrders:      p.PaidOrders,
+			GrossCents:      p.GrossCents,
+			CreditsSold:     p.CreditsSold,
+			DistinctBuyers:  p.DistinctBuyers,
+		})
+	}
+	return out, nil
+}
+
+// ListTopupOrders returns one page of the order table.
+func (s *DonateRevenueServer) ListTopupOrders(ctx context.Context, req *webv1.ListTopupOrdersRequest) (*webv1.ListTopupOrdersResponse, error) {
+	res, rows, total, w, err := s.revenue.Orders(ctx, req.GetModeratorId(),
+		req.GetWindow().GetFromUnix(), req.GetWindow().GetToUnix(),
+		int16(req.GetStatus()), int16(req.GetPaymentMethod()), req.GetAccountId(),
+		int(req.GetLimit()), int(req.GetOffset()))
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list topup orders: %v", err)
+	}
+	out := &webv1.ListTopupOrdersResponse{
+		Result:     revenueResultToProto(res),
+		TotalCount: int32(total),
+		FromUnix:   w.FromUnix,
+		ToUnix:     w.ToUnix,
+		Orders:     make([]*webv1.TopupOrderRow, 0, len(rows)),
+	}
+	for _, r := range rows {
+		out.Orders = append(out.Orders, &webv1.TopupOrderRow{
+			Id:                r.ID,
+			ExternalReference: r.ExternalReference,
+			AccountId:         r.AccountID,
+			AccountName:       r.AccountName,
+			AccountEmail:      r.AccountEmail,
+			PayerName:         r.PayerName,
+			PayerCpfMasked:    r.PayerCPF, // already masked by the service
+			Credits:           r.Credits,
+			AmountCents:       r.AmountCents,
+			PaymentMethod:     paymentMethodToProto(r.PaymentMethod),
+			Provider:          r.Provider,
+			Status:            topupStatusToProto(r.Status),
+			CreatedAtUnix:     unixOrZero(r.CreatedAt),
+			ConfirmedAtUnix:   unixPtrOrZero(r.ConfirmedAt),
+		})
+	}
+	return out, nil
+}
+
+// ListTopBuyers ranks accounts by revenue in the window.
+func (s *DonateRevenueServer) ListTopBuyers(ctx context.Context, req *webv1.ListTopBuyersRequest) (*webv1.ListTopBuyersResponse, error) {
+	res, rows, total, w, err := s.revenue.TopBuyers(ctx, req.GetModeratorId(),
+		req.GetWindow().GetFromUnix(), req.GetWindow().GetToUnix(),
+		int(req.GetLimit()), int(req.GetOffset()))
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list top buyers: %v", err)
+	}
+	out := &webv1.ListTopBuyersResponse{
+		Result:     revenueResultToProto(res),
+		TotalCount: int32(total),
+		FromUnix:   w.FromUnix,
+		ToUnix:     w.ToUnix,
+		Buyers:     make([]*webv1.TopBuyerRow, 0, len(rows)),
+	}
+	for _, b := range rows {
+		out.Buyers = append(out.Buyers, &webv1.TopBuyerRow{
+			AccountId:          b.AccountID,
+			AccountName:        b.AccountName,
+			AccountEmail:       b.AccountEmail,
+			WindowPaidOrders:   b.WindowPaidOrders,
+			WindowGrossCents:   b.WindowGrossCents,
+			LifetimePaidOrders: b.LifetimePaidOrders,
+			LifetimeGrossCents: b.LifetimeGrossCents,
+			LifetimeCredits:    b.LifetimeCredits,
+			FirstPaidAtUnix:    unixOrZero(b.FirstPaidAt),
+			LastPaidAtUnix:     unixOrZero(b.LastPaidAt),
+			DonateBalance:      b.DonateBalance,
+		})
+	}
+	return out, nil
+}
+
+// ListDonateSpend returns one page of the donate wallet ledger.
+func (s *DonateRevenueServer) ListDonateSpend(ctx context.Context, req *webv1.ListDonateSpendRequest) (*webv1.ListDonateSpendResponse, error) {
+	res, rows, total, w, err := s.revenue.Spend(ctx, req.GetModeratorId(),
+		req.GetWindow().GetFromUnix(), req.GetWindow().GetToUnix(),
+		ledgerActionFromProto(req.GetAction()), req.GetAccountId(),
+		int(req.GetLimit()), int(req.GetOffset()))
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list donate spend: %v", err)
+	}
+	out := &webv1.ListDonateSpendResponse{
+		Result:     revenueResultToProto(res),
+		TotalCount: int32(total),
+		FromUnix:   w.FromUnix,
+		ToUnix:     w.ToUnix,
+		Entries:    make([]*webv1.DonateLedgerRow, 0, len(rows)),
+	}
+	for _, e := range rows {
+		out.Entries = append(out.Entries, &webv1.DonateLedgerRow{
+			Id:                 e.ID,
+			Action:             ledgerActionToProto(e.Action),
+			CreatedAtUnix:      unixOrZero(e.CreatedAt),
+			SubjectAccountId:   e.SubjectAccountID,
+			SubjectAccountName: e.SubjectAccountName,
+			ActorAccountId:     e.ActorAccountID,
+			ActorAccountName:   e.ActorAccountName,
+			CreditsDelta:       e.CreditsDelta,
+			BalanceAfter:       e.BalanceAfter,
+			ShopItemId:         e.ShopItemID,
+			ShopItemTitle:      e.ShopItemTitle,
+			Reason:             e.Reason,
+		})
+	}
+	return out, nil
+}
+
+// SearchAccounts resolves a login prefix to account identities.
+func (s *DonateRevenueServer) SearchAccounts(ctx context.Context, req *webv1.SearchAccountsRequest) (*webv1.SearchAccountsResponse, error) {
+	res, rows, err := s.revenue.SearchAccounts(ctx, req.GetModeratorId(), req.GetNamePrefix(), int(req.GetLimit()))
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "search accounts: %v", err)
+	}
+	out := &webv1.SearchAccountsResponse{
+		Result:   revenueResultToProto(res),
+		Accounts: make([]*webv1.AccountSummary, 0, len(rows)),
+	}
+	for _, a := range rows {
+		out.Accounts = append(out.Accounts, &webv1.AccountSummary{
+			Id:            a.ID,
+			Name:          a.Name,
+			Email:         a.Email,
+			DonateBalance: a.DonateBalance,
+			Role:          a.Role,
+			IsBlocked:     a.IsBlocked,
+		})
+	}
+	return out, nil
+}
+
+// --- mappers ---
+
+// revenueResultToProto maps the service outcome to the shared AdminResult.
+func revenueResultToProto(r donaterevenue.Result) webv1.AdminResult {
+	switch r {
+	case donaterevenue.OK:
+		return webv1.AdminResult_ADMIN_RESULT_OK
+	case donaterevenue.Forbidden:
+		return webv1.AdminResult_ADMIN_RESULT_FORBIDDEN
+	case donaterevenue.NotFound:
+		return webv1.AdminResult_ADMIN_RESULT_NOT_FOUND
+	default:
+		return webv1.AdminResult_ADMIN_RESULT_INVALID
+	}
+}
+
+func revenueBucketFromProto(b webv1.RevenueBucket) donaterevenue.Bucket {
+	switch b {
+	case webv1.RevenueBucket_REVENUE_BUCKET_DAY:
+		return donaterevenue.BucketDay
+	case webv1.RevenueBucket_REVENUE_BUCKET_WEEK:
+		return donaterevenue.BucketWeek
+	case webv1.RevenueBucket_REVENUE_BUCKET_MONTH:
+		return donaterevenue.BucketMonth
+	default:
+		return donaterevenue.BucketUnspecified
+	}
+}
+
+func ledgerActionFromProto(a webv1.DonateLedgerAction) donaterevenue.LedgerAction {
+	switch a {
+	case webv1.DonateLedgerAction_DONATE_LEDGER_ACTION_PURCHASE:
+		return donaterevenue.LedgerPurchase
+	case webv1.DonateLedgerAction_DONATE_LEDGER_ACTION_CREDIT:
+		return donaterevenue.LedgerCredit
+	default:
+		return donaterevenue.LedgerAny
+	}
+}
+
+// ledgerActionToProto maps the stored audit action keyword to the wire enum.
+func ledgerActionToProto(action string) webv1.DonateLedgerAction {
+	switch action {
+	case "purchase":
+		return webv1.DonateLedgerAction_DONATE_LEDGER_ACTION_PURCHASE
+	case "credit_balance":
+		return webv1.DonateLedgerAction_DONATE_LEDGER_ACTION_CREDIT
+	default:
+		return webv1.DonateLedgerAction_DONATE_LEDGER_ACTION_UNSPECIFIED
+	}
+}
+
+// paymentMethodToProto maps the stored method int (1=PIX, 2=CREDIT_CARD).
+func paymentMethodToProto(m int16) webv1.PaymentMethod {
+	switch m {
+	case 1:
+		return webv1.PaymentMethod_PAYMENT_METHOD_PIX
+	case 2:
+		return webv1.PaymentMethod_PAYMENT_METHOD_CREDIT_CARD
+	default:
+		return webv1.PaymentMethod_PAYMENT_METHOD_UNSPECIFIED
+	}
+}
+
+// unixOrZero renders an instant as Unix seconds, mapping the zero time to 0
+// rather than to the negative epoch that time.Time{}.Unix() would produce.
+func unixOrZero(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.Unix()
+}
+
+// unixPtrOrZero is unixOrZero for a nullable column (a PENDING order's
+// confirmed_at), which the wire represents as 0.
+func unixPtrOrZero(t *time.Time) int64 {
+	if t == nil {
+		return 0
+	}
+	return unixOrZero(*t)
+}

--- a/webserver/internal/grpcsrv/donaterevenue_test.go
+++ b/webserver/internal/grpcsrv/donaterevenue_test.go
@@ -1,0 +1,438 @@
+package grpcsrv
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	webv1 "github.com/jeanluca/w2pp-openwyd/api/web/v1"
+	"github.com/jeanluca/w2pp-openwyd/internal/domain"
+	"github.com/jeanluca/w2pp-openwyd/webserver/internal/donaterevenue"
+)
+
+// fakeRevenue is a scripted DonateRevenue for testing the gRPC mapping alone.
+type fakeRevenue struct {
+	res     donaterevenue.Result
+	err     error
+	summary donaterevenue.Summary
+	orders  []domain.TopupOrderRow
+	buyers  []domain.TopBuyer
+	entries []domain.DonateLedgerEntry
+	accts   []domain.AccountSummary
+	total   int
+	window  donaterevenue.Window
+
+	// recorded request arguments
+	gotModerator int64
+	gotFrom      int64
+	gotTo        int64
+	gotBucket    donaterevenue.Bucket
+	gotAction    donaterevenue.LedgerAction
+	gotStatus    int16
+	gotMethod    int16
+	gotAccount   int64
+	gotLimit     int
+	gotOffset    int
+	gotPrefix    string
+}
+
+func (f *fakeRevenue) Summary(_ context.Context, mod, from, to int64, b donaterevenue.Bucket, acct int64) (donaterevenue.Result, donaterevenue.Summary, error) {
+	f.gotModerator, f.gotFrom, f.gotTo, f.gotBucket, f.gotAccount = mod, from, to, b, acct
+	return f.res, f.summary, f.err
+}
+
+func (f *fakeRevenue) Orders(_ context.Context, mod, from, to int64, st, method int16, acct int64, limit, offset int) (donaterevenue.Result, []domain.TopupOrderRow, int, donaterevenue.Window, error) {
+	f.gotModerator, f.gotFrom, f.gotTo = mod, from, to
+	f.gotStatus, f.gotMethod, f.gotAccount, f.gotLimit, f.gotOffset = st, method, acct, limit, offset
+	return f.res, f.orders, f.total, f.window, f.err
+}
+
+func (f *fakeRevenue) TopBuyers(_ context.Context, mod, from, to int64, limit, offset int) (donaterevenue.Result, []domain.TopBuyer, int, donaterevenue.Window, error) {
+	f.gotModerator, f.gotFrom, f.gotTo, f.gotLimit, f.gotOffset = mod, from, to, limit, offset
+	return f.res, f.buyers, f.total, f.window, f.err
+}
+
+func (f *fakeRevenue) Spend(_ context.Context, mod, from, to int64, a donaterevenue.LedgerAction, acct int64, limit, offset int) (donaterevenue.Result, []domain.DonateLedgerEntry, int, donaterevenue.Window, error) {
+	f.gotModerator, f.gotFrom, f.gotTo = mod, from, to
+	f.gotAction, f.gotAccount, f.gotLimit, f.gotOffset = a, acct, limit, offset
+	return f.res, f.entries, f.total, f.window, f.err
+}
+
+func (f *fakeRevenue) SearchAccounts(_ context.Context, mod int64, prefix string, limit int) (donaterevenue.Result, []domain.AccountSummary, error) {
+	f.gotModerator, f.gotPrefix, f.gotLimit = mod, prefix, limit
+	return f.res, f.accts, f.err
+}
+
+func TestListTopupOrdersMapping(t *testing.T) {
+	created := time.Date(2026, 2, 1, 10, 0, 0, 0, time.UTC)
+	confirmed := time.Date(2026, 2, 2, 11, 0, 0, 0, time.UTC)
+	f := &fakeRevenue{
+		res:    donaterevenue.OK,
+		total:  7,
+		window: donaterevenue.Window{FromUnix: 100, ToUnix: 200},
+		orders: []domain.TopupOrderRow{
+			{
+				ID: 12, ExternalReference: "uuid-1", AccountID: 34,
+				AccountName: "zarco", AccountEmail: "z@x.c",
+				PayerName: "Fulano", PayerCPF: "***.456.789-**",
+				Credits: 50, AmountCents: 2500, PaymentMethod: 1,
+				Provider: "", Status: 2,
+				CreatedAt: created, ConfirmedAt: &confirmed,
+			},
+			{ID: 13, ExternalReference: "uuid-2", PaymentMethod: 2, Status: 1, CreatedAt: created},
+		},
+	}
+	srv := NewDonateRevenue(f)
+
+	got, err := srv.ListTopupOrders(context.Background(), &webv1.ListTopupOrdersRequest{
+		ModeratorId:   9,
+		Window:        &webv1.RevenueWindow{FromUnix: 100, ToUnix: 200},
+		Status:        webv1.TopupStatus_TOPUP_STATUS_PAID,
+		PaymentMethod: webv1.PaymentMethod_PAYMENT_METHOD_PIX,
+		Limit:         25,
+		Offset:        5,
+	})
+	if err != nil {
+		t.Fatalf("ListTopupOrders: %v", err)
+	}
+	if got.GetResult() != webv1.AdminResult_ADMIN_RESULT_OK {
+		t.Errorf("result = %v, want OK", got.GetResult())
+	}
+	if got.GetTotalCount() != 7 || got.GetFromUnix() != 100 || got.GetToUnix() != 200 {
+		t.Errorf("total/window = (%d,%d,%d), want (7,100,200)", got.GetTotalCount(), got.GetFromUnix(), got.GetToUnix())
+	}
+	if f.gotModerator != 9 || f.gotStatus != 2 || f.gotMethod != 1 || f.gotLimit != 25 || f.gotOffset != 5 {
+		t.Errorf("service got mod=%d status=%d method=%d limit=%d offset=%d",
+			f.gotModerator, f.gotStatus, f.gotMethod, f.gotLimit, f.gotOffset)
+	}
+
+	rows := got.GetOrders()
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
+	}
+	r := rows[0]
+	if r.GetId() != 12 || r.GetExternalReference() != "uuid-1" || r.GetAccountId() != 34 {
+		t.Errorf("identity = (%d,%q,%d)", r.GetId(), r.GetExternalReference(), r.GetAccountId())
+	}
+	if r.GetAccountName() != "zarco" || r.GetAccountEmail() != "z@x.c" || r.GetPayerName() != "Fulano" {
+		t.Errorf("buyer fields wrong: %+v", r)
+	}
+	if r.GetPayerCpfMasked() != "***.456.789-**" {
+		t.Errorf("cpf = %q, want the masked value passed through", r.GetPayerCpfMasked())
+	}
+	if r.GetCredits() != 50 || r.GetAmountCents() != 2500 {
+		t.Errorf("amounts = (%d,%d), want (50,2500)", r.GetCredits(), r.GetAmountCents())
+	}
+	if r.GetPaymentMethod() != webv1.PaymentMethod_PAYMENT_METHOD_PIX {
+		t.Errorf("method = %v, want PIX", r.GetPaymentMethod())
+	}
+	if r.GetStatus() != webv1.TopupStatus_TOPUP_STATUS_PAID {
+		t.Errorf("status = %v, want PAID", r.GetStatus())
+	}
+	if r.GetCreatedAtUnix() != created.Unix() || r.GetConfirmedAtUnix() != confirmed.Unix() {
+		t.Errorf("times = (%d,%d), want (%d,%d)", r.GetCreatedAtUnix(), r.GetConfirmedAtUnix(), created.Unix(), confirmed.Unix())
+	}
+
+	// A PENDING row has no confirmed_at at all.
+	if rows[1].GetConfirmedAtUnix() != 0 {
+		t.Errorf("pending confirmed_at_unix = %d, want 0", rows[1].GetConfirmedAtUnix())
+	}
+	if rows[1].GetPaymentMethod() != webv1.PaymentMethod_PAYMENT_METHOD_CREDIT_CARD {
+		t.Errorf("method = %v, want CREDIT_CARD", rows[1].GetPaymentMethod())
+	}
+}
+
+// TestZeroTimeMapsToZeroUnix guards against time.Time{}.Unix() leaking the
+// negative epoch (-62135596800) onto the wire.
+func TestZeroTimeMapsToZeroUnix(t *testing.T) {
+	if got := unixOrZero(time.Time{}); got != 0 {
+		t.Errorf("unixOrZero(zero) = %d, want 0", got)
+	}
+	if got := unixPtrOrZero(nil); got != 0 {
+		t.Errorf("unixPtrOrZero(nil) = %d, want 0", got)
+	}
+	var zero time.Time
+	if got := unixPtrOrZero(&zero); got != 0 {
+		t.Errorf("unixPtrOrZero(&zero) = %d, want 0", got)
+	}
+	now := time.Unix(1_700_000_000, 0)
+	if got := unixOrZero(now); got != 1_700_000_000 {
+		t.Errorf("unixOrZero(now) = %d, want 1700000000", got)
+	}
+}
+
+// TestTopBuyersZeroTimestamps: a buyer whose confirmed_at aggregates came back
+// NULL must not emit a negative epoch.
+func TestTopBuyersZeroTimestamps(t *testing.T) {
+	f := &fakeRevenue{
+		res:    donaterevenue.OK,
+		buyers: []domain.TopBuyer{{AccountID: 1, AccountName: "a", LifetimeGrossCents: 10}},
+	}
+	got, err := NewDonateRevenue(f).ListTopBuyers(context.Background(), &webv1.ListTopBuyersRequest{ModeratorId: 2})
+	if err != nil {
+		t.Fatalf("ListTopBuyers: %v", err)
+	}
+	b := got.GetBuyers()[0]
+	if b.GetFirstPaidAtUnix() != 0 || b.GetLastPaidAtUnix() != 0 {
+		t.Errorf("zero timestamps = (%d,%d), want (0,0)", b.GetFirstPaidAtUnix(), b.GetLastPaidAtUnix())
+	}
+}
+
+func TestForbiddenMapsToAdminResultForbidden(t *testing.T) {
+	f := &fakeRevenue{res: donaterevenue.Forbidden}
+	srv := NewDonateRevenue(f)
+	ctx := context.Background()
+
+	o, err := srv.ListTopupOrders(ctx, &webv1.ListTopupOrdersRequest{ModeratorId: 1})
+	if err != nil {
+		t.Fatalf("unexpected gRPC error: %v", err)
+	}
+	if o.GetResult() != webv1.AdminResult_ADMIN_RESULT_FORBIDDEN || len(o.GetOrders()) != 0 {
+		t.Errorf("orders = (%v, %d rows), want (FORBIDDEN, 0)", o.GetResult(), len(o.GetOrders()))
+	}
+
+	s, err := srv.GetRevenueSummary(ctx, &webv1.GetRevenueSummaryRequest{ModeratorId: 1})
+	if err != nil {
+		t.Fatalf("unexpected gRPC error: %v", err)
+	}
+	if s.GetResult() != webv1.AdminResult_ADMIN_RESULT_FORBIDDEN {
+		t.Errorf("summary result = %v, want FORBIDDEN", s.GetResult())
+	}
+	if s.GetTotals() != nil {
+		t.Errorf("forbidden summary carried totals %+v, want none", s.GetTotals())
+	}
+}
+
+func TestGetRevenueSummaryMapsTotalsAndSeries(t *testing.T) {
+	b1 := time.Date(2026, 3, 1, 3, 0, 0, 0, time.UTC)
+	b2 := time.Date(2026, 3, 2, 3, 0, 0, 0, time.UTC)
+	f := &fakeRevenue{
+		res:    donaterevenue.OK,
+		window: donaterevenue.Window{FromUnix: 11, ToUnix: 22},
+		summary: donaterevenue.Summary{
+			Window: donaterevenue.Window{FromUnix: 11, ToUnix: 22},
+			Totals: domain.RevenueTotals{
+				PaidOrders: 4, GrossCents: 8000, CreditsSold: 200, DistinctBuyers: 3,
+				CreatedOrders: 6, PendingOrders: 2, PendingCents: 1500,
+			},
+			Ledger: domain.DonateLedgerTotals{
+				ShopPurchases: 5, CreditsSpent: 350, ManualCredits: 1, CreditsGranted: 90,
+			},
+			ByMethod: []domain.RevenueByMethod{
+				{PaymentMethod: 1, PaidOrders: 3, GrossCents: 6000},
+				{PaymentMethod: 2, PaidOrders: 1, GrossCents: 2000},
+			},
+			Series: []domain.RevenuePoint{
+				{BucketStart: b1, PaidOrders: 1, GrossCents: 3000},
+				{BucketStart: b2, PaidOrders: 3, GrossCents: 5000},
+			},
+		},
+	}
+	got, err := NewDonateRevenue(f).GetRevenueSummary(context.Background(), &webv1.GetRevenueSummaryRequest{
+		ModeratorId: 2,
+		Window:      &webv1.RevenueWindow{FromUnix: 11, ToUnix: 22},
+		Bucket:      webv1.RevenueBucket_REVENUE_BUCKET_DAY,
+	})
+	if err != nil {
+		t.Fatalf("GetRevenueSummary: %v", err)
+	}
+	if f.gotBucket != donaterevenue.BucketDay {
+		t.Errorf("bucket reached the service as %v, want BucketDay", f.gotBucket)
+	}
+	if got.GetFromUnix() != 11 || got.GetToUnix() != 22 {
+		t.Errorf("echoed window = (%d,%d), want (11,22)", got.GetFromUnix(), got.GetToUnix())
+	}
+
+	tot := got.GetTotals()
+	if tot.GetPaidOrders() != 4 || tot.GetGrossCents() != 8000 || tot.GetDistinctBuyers() != 3 {
+		t.Errorf("money totals wrong: %+v", tot)
+	}
+	if tot.GetCreatedOrders() != 6 || tot.GetPendingOrders() != 2 || tot.GetPendingCents() != 1500 {
+		t.Errorf("funnel totals wrong: %+v", tot)
+	}
+	// The ledger counters are merged into the same flat message.
+	if tot.GetShopPurchases() != 5 || tot.GetCreditsSpent() != 350 ||
+		tot.GetManualCredits() != 1 || tot.GetCreditsGranted() != 90 {
+		t.Errorf("ledger totals were not merged into RevenueTotals: %+v", tot)
+	}
+
+	bm := got.GetByMethod()
+	if len(bm) != 2 || bm[0].GetPaymentMethod() != webv1.PaymentMethod_PAYMENT_METHOD_PIX ||
+		bm[1].GetPaymentMethod() != webv1.PaymentMethod_PAYMENT_METHOD_CREDIT_CARD {
+		t.Errorf("by_method mapping wrong: %+v", bm)
+	}
+
+	series := got.GetSeries()
+	if len(series) != 2 {
+		t.Fatalf("got %d series points, want 2", len(series))
+	}
+	if series[0].GetBucketStartUnix() != b1.Unix() || series[1].GetBucketStartUnix() != b2.Unix() {
+		t.Errorf("bucket order/values wrong: %d then %d", series[0].GetBucketStartUnix(), series[1].GetBucketStartUnix())
+	}
+	if series[0].GetGrossCents() != 3000 || series[1].GetGrossCents() != 5000 {
+		t.Errorf("series values wrong: %+v", series)
+	}
+}
+
+func TestListDonateSpendMapping(t *testing.T) {
+	at := time.Date(2026, 4, 5, 12, 0, 0, 0, time.UTC)
+	f := &fakeRevenue{
+		res:   donaterevenue.OK,
+		total: 2,
+		entries: []domain.DonateLedgerEntry{
+			{
+				ID: 1, Action: "credit_balance", CreatedAt: at,
+				SubjectAccountID: 10, SubjectAccountName: "player",
+				ActorAccountID: 20, ActorAccountName: "mod",
+				CreditsDelta: 100, BalanceAfter: 300, Reason: "cortesia",
+			},
+			{
+				ID: 2, Action: "purchase", CreatedAt: at,
+				SubjectAccountID: 10, SubjectAccountName: "player",
+				ActorAccountID: 10, ActorAccountName: "player",
+				CreditsDelta: -70, BalanceAfter: 230, ShopItemID: 5, ShopItemTitle: "Asa",
+			},
+		},
+	}
+	got, err := NewDonateRevenue(f).ListDonateSpend(context.Background(), &webv1.ListDonateSpendRequest{
+		ModeratorId: 2,
+		Action:      webv1.DonateLedgerAction_DONATE_LEDGER_ACTION_CREDIT,
+		AccountId:   10,
+	})
+	if err != nil {
+		t.Fatalf("ListDonateSpend: %v", err)
+	}
+	if f.gotAction != donaterevenue.LedgerCredit || f.gotAccount != 10 {
+		t.Errorf("service got action=%v account=%d, want (LedgerCredit, 10)", f.gotAction, f.gotAccount)
+	}
+
+	e := got.GetEntries()
+	if len(e) != 2 {
+		t.Fatalf("got %d entries, want 2", len(e))
+	}
+	if e[0].GetAction() != webv1.DonateLedgerAction_DONATE_LEDGER_ACTION_CREDIT {
+		t.Errorf("action[0] = %v, want CREDIT", e[0].GetAction())
+	}
+	// The asymmetry the whole ledger design exists for.
+	if e[0].GetSubjectAccountId() != 10 || e[0].GetActorAccountId() != 20 {
+		t.Errorf("credit subject/actor = (%d,%d), want (10,20)", e[0].GetSubjectAccountId(), e[0].GetActorAccountId())
+	}
+	if e[0].GetCreditsDelta() != 100 || e[0].GetReason() != "cortesia" {
+		t.Errorf("credit row wrong: %+v", e[0])
+	}
+	if e[1].GetAction() != webv1.DonateLedgerAction_DONATE_LEDGER_ACTION_PURCHASE {
+		t.Errorf("action[1] = %v, want PURCHASE", e[1].GetAction())
+	}
+	if e[1].GetCreditsDelta() != -70 {
+		t.Errorf("purchase delta = %d, want -70 (signed debit)", e[1].GetCreditsDelta())
+	}
+	if e[1].GetShopItemId() != 5 || e[1].GetShopItemTitle() != "Asa" {
+		t.Errorf("purchase offer = (%d,%q)", e[1].GetShopItemId(), e[1].GetShopItemTitle())
+	}
+}
+
+func TestSearchAccountsMapping(t *testing.T) {
+	f := &fakeRevenue{
+		res: donaterevenue.OK,
+		accts: []domain.AccountSummary{
+			{ID: 3, Name: "zarco", Email: "z@x.c", DonateBalance: 42, Role: "admin", IsBlocked: true},
+		},
+	}
+	got, err := NewDonateRevenue(f).SearchAccounts(context.Background(), &webv1.SearchAccountsRequest{
+		ModeratorId: 2, NamePrefix: "zar", Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("SearchAccounts: %v", err)
+	}
+	if f.gotPrefix != "zar" || f.gotLimit != 10 {
+		t.Errorf("service got prefix=%q limit=%d", f.gotPrefix, f.gotLimit)
+	}
+	a := got.GetAccounts()[0]
+	if a.GetId() != 3 || a.GetName() != "zarco" || a.GetEmail() != "z@x.c" ||
+		a.GetDonateBalance() != 42 || a.GetRole() != "admin" || !a.GetIsBlocked() {
+		t.Errorf("account mapping wrong: %+v", a)
+	}
+}
+
+// TestUnspecifiedEnumsForwardAsZero: UNSPECIFIED must reach the service as 0,
+// which every filter reads as "any".
+func TestUnspecifiedEnumsForwardAsZero(t *testing.T) {
+	f := &fakeRevenue{res: donaterevenue.OK}
+	_, err := NewDonateRevenue(f).ListTopupOrders(context.Background(), &webv1.ListTopupOrdersRequest{
+		ModeratorId:   2,
+		Status:        webv1.TopupStatus_TOPUP_STATUS_UNSPECIFIED,
+		PaymentMethod: webv1.PaymentMethod_PAYMENT_METHOD_UNSPECIFIED,
+	})
+	if err != nil {
+		t.Fatalf("ListTopupOrders: %v", err)
+	}
+	if f.gotStatus != 0 || f.gotMethod != 0 {
+		t.Errorf("unspecified enums reached the service as (%d,%d), want (0,0)", f.gotStatus, f.gotMethod)
+	}
+
+	f2 := &fakeRevenue{res: donaterevenue.OK}
+	if _, err := NewDonateRevenue(f2).ListDonateSpend(context.Background(), &webv1.ListDonateSpendRequest{
+		ModeratorId: 2, Action: webv1.DonateLedgerAction_DONATE_LEDGER_ACTION_UNSPECIFIED,
+	}); err != nil {
+		t.Fatalf("ListDonateSpend: %v", err)
+	}
+	if f2.gotAction != donaterevenue.LedgerAny {
+		t.Errorf("unspecified action = %v, want LedgerAny", f2.gotAction)
+	}
+}
+
+// TestNilWindowUsesZeroes: a request with no window block must forward (0,0),
+// which the service turns into the last-30-days default.
+func TestNilWindowUsesZeroes(t *testing.T) {
+	f := &fakeRevenue{res: donaterevenue.OK}
+	if _, err := NewDonateRevenue(f).GetRevenueSummary(context.Background(),
+		&webv1.GetRevenueSummaryRequest{ModeratorId: 2}); err != nil {
+		t.Fatalf("GetRevenueSummary: %v", err)
+	}
+	if f.gotFrom != 0 || f.gotTo != 0 {
+		t.Errorf("nil window forwarded as (%d,%d), want (0,0)", f.gotFrom, f.gotTo)
+	}
+}
+
+func TestInfraErrorBecomesInternalStatus(t *testing.T) {
+	f := &fakeRevenue{err: errors.New("db down")}
+	srv := NewDonateRevenue(f)
+	ctx := context.Background()
+
+	cases := map[string]func() error{
+		"summary": func() error {
+			_, err := srv.GetRevenueSummary(ctx, &webv1.GetRevenueSummaryRequest{ModeratorId: 2})
+			return err
+		},
+		"orders": func() error {
+			_, err := srv.ListTopupOrders(ctx, &webv1.ListTopupOrdersRequest{ModeratorId: 2})
+			return err
+		},
+		"buyers": func() error {
+			_, err := srv.ListTopBuyers(ctx, &webv1.ListTopBuyersRequest{ModeratorId: 2})
+			return err
+		},
+		"spend": func() error {
+			_, err := srv.ListDonateSpend(ctx, &webv1.ListDonateSpendRequest{ModeratorId: 2})
+			return err
+		},
+		"search": func() error {
+			_, err := srv.SearchAccounts(ctx, &webv1.SearchAccountsRequest{ModeratorId: 2, NamePrefix: "ab"})
+			return err
+		},
+	}
+	for name, call := range cases {
+		err := call()
+		if err == nil {
+			t.Errorf("%s: got nil error, want codes.Internal", name)
+			continue
+		}
+		if status.Code(err) != codes.Internal {
+			t.Errorf("%s: code = %v, want Internal", name, status.Code(err))
+		}
+	}
+}


### PR DESCRIPTION
## Contexto

O portal precisa de uma tela de faturamento: quanto entrou de donate no mês, quem comprou, com filtros e drill-down.

**Todo o dado já estava persistido** desde `0008_donate_shop` e `0010_donate_topup` — `donate_topup_order` guarda `amount_cents`, `credits`, `payment_method`, `status`, `created_at` e `confirmed_at`. O que não existia era **qualquer superfície de leitura**:

- `internal/store/donate_topup.go` tinha só as cinco funções do ciclo de escrita;
- `GetTopupOrder` é escopado ao dono (`AND account_id = $2`), logo inútil para um painel;
- `donate_shop_audit` era escrito e **nunca lido por ninguém**;
- nenhum RPC resolvia `account_id → nome`;
- nenhum índice em `created_at`/`confirmed_at`, então qualquer relatório por período faria seq scan.

Este repo não tem front-end — o portal Next.js é um projeto separado e o que mora aqui é o contrato gRPC mais os guias em `docs/integrations/`. O entregável é a superfície de backend + o guia de integração.

## O que foi feito

| Arquivo | O quê |
|---|---|
| `internal/store/donate_revenue.go` | 8 queries de leitura: totais, split por gateway, série preenchida, pedidos paginados com identidade do comprador via JOIN, top compradores com LTV, extrato de donate, totais do extrato, busca de conta. Reusa `fallbackTotal` (`ranking.go:59`). |
| `api/web/v1/web.proto` | `DonateRevenueAdminService`, 5 RPCs, gate `moderator`/`admin`. |
| `webserver/internal/donaterevenue/` + `grpcsrv/donaterevenue.go` | Service + adaptador, ligados no `main.go`. |
| `internal/migrations/0017_*` | Só índices — nenhuma mudança de schema. |
| `docs/integrations/faturamento-nextjs.md` | Guia no formato de `world-events-nextjs.md`. |

**Nomenclatura:** `DonateRevenue`, não `Billing`. `bin.v1.BillingService` é o portão de entitlement de login, que o `web-platform-plan.md` separa explicitamente da carteira de cash. Um símbolo `web.v1.…Billing…` tornaria `grep -rn Billing` ambíguo para sempre.

## Três decisões que valem revisão

**1. Receita é reconhecida em `confirmed_at`, nunca em `created_at`.** Um pedido criado em janeiro e pago em fevereiro é receita **de fevereiro**. `created_at` escopa só os contadores de funil.

**2. Buckets fecham em `America/Sao_Paulo`,** para o painel bater com o extrato bancário. Isso **diverge de propósito** do resto do servidor (a regra de dia da recompensa diária é UTC). Usa o `date_trunc` de 3 argumentos, e `TestRevenueSeriesMonthBoundaryBRT` força a sessão para UTC antes de asserir o corte de mês — provando que a fronteira não depende do ambiente.

**3. `donate_shop_audit` é assimétrico.** Em `action='purchase'` a coluna `account_id` é o comprador; em `action='credit_balance'` ela é o **moderador**, e a conta creditada só existe em `after->>'account_id'` (`donate.go:207`). Um `GROUP BY account_id` ingênuo atribuiria toda cortesia ao moderador que a concedeu. Por isso o extrato reporta `subject` e `actor` separados via `ledgerSubjectExpr`, com índice de expressão correspondente.

## Lacunas conhecidas (documentadas, não escondidas)

- **`provider` sempre vazio** — a coluna existe desde a `0010` mas `CreateTopupOrder` nunca a escreve. Exposta como sempre-vazia e documentada como "não construa UI em cima dela".
- **PENDING não expira** — não há status de reembolso nem varredura, então `paid_orders / created_orders` é um **piso** da conversão que decai, e `pending_cents` cresce para sempre. O guia manda rotular como histórico, nunca "a receber".
- **Passivo em circulação fora de escopo** por decisão.

## Bug pré-existente corrigido

`resetTestSchema` nunca dropava `donate_topup_order`, `donate_payer_profile`, as tabelas de guild nem `castle_quest_state` — `DROP TABLE account CASCADE` derruba *constraints* dependentes, não *tabelas* dependentes. A segunda rodada de qualquer teste de integração falhava na migração `0010` com `42P07`. Não relacionado à feature, mas bloqueava o trabalho.

## Verificação

- Suíte completa verde com `-race`; `go vet` limpo; os quatro binários compilam; `govulncheck` sem vulnerabilidades.
- **43 testes de integração** passam contra Postgres 17 (19 novos), incluindo o corte de mês em BRT e a assimetria subject/actor do `credit_balance`.
- `EXPLAIN` com 60k linhas confirma que `RevenueTotals` usa **`BitmapOr` sobre os dois índices novos** em vez de seq scan, com resultados idênticos (1440 = 1440 linhas).
- O `.proto` embutido no guia foi conferido programaticamente contra `web.proto` — bate campo a campo.

`api/db/v1` e `api/bin/v1` ficaram intocados: o `protoc` foi fixado na v21.12 do repo para o diff gerado ser puramente aditivo (`web_grpc.pb.go` é +339/−0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
