### PR TITLE
fix(tmserver): Classe A-E items reroll inventory gear again (issue #228)

### DIFF
--- a/tmserver/internal/handler/classe.go
+++ b/tmserver/internal/handler/classe.go
@@ -20,24 +20,33 @@ func classeTier(idx int16) int {
 }
 
 // useClasseItem is the Classe A-E path of _MSG_UseItem (Vol==190,
-// _MSG_UseItem.cpp:4958-5012): dragging a Classe item onto an equipped piece
-// of gear at the matching EF_ITEMLEVEL grade rerolls its sanc (capped at +6)
-// and its two bonus stats (SetItemBonus2). The Classe item is always consumed
-// on a successful match; a gate failure resyncs the dragged slot instead.
+// _MSG_UseItem.cpp:4958-5012): dragging a Classe item onto a piece of gear
+// sitting in the INVENTORY at the matching EF_ITEMLEVEL grade rerolls its sanc
+// (capped at +6) and its two bonus stats (SetItemBonus2). The Classe item is
+// consumed on a successful reroll; a gate failure resyncs the dragged slot.
 //
-// Deviates from Source in exactly one place: the DestType gate below is
-// `!= Equip` here, not the literal `!m->DestType` (which rejects DestType==0
-// == ITEM_PLACE_EQUIP, i.e. every legitimate target — the feature could never
-// fire as literally written). Every analogous gate elsewhere in this same
-// file (_MSG_UseItem.cpp:3779,3901,3979,4057) uses the correct polarity;
-// reproduced as a corrected typo, not a literal port.
+// The target must NOT be equipped (issue #228). The legacy gate reads
+// `if (!m->DestType || m->DestPos >= 60)` (:4970) — it rejects
+// DestType==ITEM_PLACE_EQUIP(0) and bounds DestPos to the carry range. Two
+// things confirm that polarity is intentional rather than the typo an earlier
+// port took it for: the bound is 60 (maxUnlockedCarry), not 16 (MaxEquip) as in
+// the genuinely equip-only gates at :3779/:3901/:3979/:4057; and SetItemBonus2
+// is followed by SendItem alone, with no score recompute (:4997-5000), which is
+// only safe because the rerolled item is not worn.
 func (d *Dispatcher) useClasseItem(w *world.World, s *world.Session, e *world.Entity, body protocol.MsgUseItemBody, src int) {
 	dst := d.itemSlot(w, s, e, int(body.DestType), int(body.DestPos))
 	if dst == nil || dst.Empty() {
 		return // no such target slot — the legacy just logs and drops the message
 	}
 
-	if int(body.DestType) != world.ItemPlaceEquip {
+	// The legacy's companion `m->DestPos >= 60` bound needs no explicit port:
+	// itemSlot routes carry through carrySlotAccessible, which already caps at
+	// activeCarryLimit(e) <= maxUnlockedCarry == 60 and yields nil above it —
+	// caught by the dst == nil return above.
+	if int(body.DestType) == world.ItemPlaceEquip {
+		// _NN_Only_To_Equips is the string Source sends here (:4972). It reads
+		// backwards for this gate — one of the legacy's many misfiled message
+		// ids — but the client shows it, so it is kept for parity.
 		d.notify(w, s, NoticeOnlyToEquips)
 		d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
 		return
@@ -55,7 +64,15 @@ func (d *Dispatcher) useClasseItem(w *world.World, s *world.Session, e *world.En
 		return
 	}
 
-	refine.ClasseBonus(dst, d.itemPos[int(dst.Index)], func(n int) int { return w.Rand().Intn(n) }, d.itemAbility)
+	// Deliberate deviation from SetItemBonus2 (Server.cpp:2719-2861), which has
+	// no branch for an nPos outside helm/chest/legs/glove/boot and so falls
+	// through to consume the Classe item for no effect — the known legacy bug
+	// recorded in "Source/Lista de bugs.txt:6". Refuse and resync instead of
+	// destroying the item.
+	if !refine.ClasseBonus(dst, d.itemPos[int(dst.Index)], func(n int) int { return w.Rand().Intn(n) }, d.itemAbility) {
+		d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
+		return
+	}
 
 	d.sendSlot(w, s, int(body.DestType), int(body.DestPos), *dst)
 	d.log.Info("classe item bonus reroll", "conn", s.Conn, "item", dst.Index, "effects", dst.Effects)

--- a/tmserver/internal/handler/classe_test.go
+++ b/tmserver/internal/handler/classe_test.go
@@ -15,17 +15,21 @@ const (
 	itemClasseA  = 4016 // tier 1
 	itemClasseE  = 4020 // tier 5
 	itemClasseAP = 4021 // tier 1, "(P)" variant
+	itemClasseD  = 4019 // tier 4 (ItemList.csv:5665)
+	itemClasseDP = 4024 // tier 4, "(P)" variant (ItemList.csv:5675)
 
 	itemHelmT1   = 6001 // nPos 2
 	itemChestT1  = 6002 // nPos 4
 	itemGloveT1  = 6003 // nPos 16
 	itemBootT1   = 6004 // nPos 32
 	itemWeaponT1 = 6005 // nPos 1 (uncovered by SetItemBonus2)
+	itemChestT4  = 6006 // nPos 4, EF_ITEMLEVEL 4 — stands in for Armadura_Aeon (1479)
 )
 
 func classeCatalog() (map[int]int, map[int][]content.BaseEffect) {
 	pos := map[int]int{
-		itemHelmT1: nPosHelmForTest, itemChestT1: 4, itemGloveT1: 16, itemBootT1: 32, itemWeaponT1: 1,
+		itemHelmT1: nPosHelmForTest, itemChestT1: 4, itemGloveT1: 16, itemBootT1: 32,
+		itemWeaponT1: 1, itemChestT4: 4,
 	}
 	effects := map[int][]content.BaseEffect{
 		itemHelmT1:   {{Eff: efItemLevel, Val: 1}},
@@ -33,6 +37,7 @@ func classeCatalog() (map[int]int, map[int][]content.BaseEffect) {
 		itemGloveT1:  {{Eff: efItemLevel, Val: 1}},
 		itemBootT1:   {{Eff: efItemLevel, Val: 1}},
 		itemWeaponT1: {{Eff: efItemLevel, Val: 1}},
+		itemChestT4:  {{Eff: efItemLevel, Val: 4}},
 	}
 	return pos, effects
 }
@@ -53,6 +58,7 @@ func newClasseFixture(t *testing.T, pos map[int]int, effects map[int][]content.B
 		Log: slog.New(slog.DiscardHandler),
 		ItemVolatiles: map[int]int{
 			itemClasseA: volClasses, itemClasseE: volClasses, itemClasseAP: volClasses,
+			itemClasseD: volClasses, itemClasseDP: volClasses,
 		},
 		ItemPos:     pos,
 		ItemEffects: effects,
@@ -65,17 +71,18 @@ func newClasseFixture(t *testing.T, pos map[int]int, effects map[int][]content.B
 	}
 }
 
-// use drags the classe item in carry slot 0 onto the item in carry slot 1.
+// use drags the classe item in carry slot 0 onto the item in carry slot 1 —
+// the only destination the legacy accepts (_MSG_UseItem.cpp:4970).
 func (f *classeFixture) use(classe int16) {
 	f.e.Carry[0] = world.Item{Index: classe}
 	body := protocol.MsgUseItemBody{
 		SourType: world.ItemPlaceCarry, SourPos: 0,
-		DestType: world.ItemPlaceEquip, DestPos: 1,
+		DestType: world.ItemPlaceCarry, DestPos: 1,
 	}
 	f.d.useClasseItem(f.w, f.s, f.e, body, 0)
 }
 
-func (f *classeFixture) target() world.Item { return f.e.Equip[1] }
+func (f *classeFixture) target() world.Item { return f.e.Carry[1] }
 
 func TestClasseTier(t *testing.T) {
 	cases := []struct {
@@ -95,7 +102,7 @@ func TestClasseTier(t *testing.T) {
 func TestClasseBonusHelmRerollsSancAndEffects(t *testing.T) {
 	pos, effects := classeCatalog()
 	f := newClasseFixture(t, pos, effects)
-	f.e.Equip[1] = world.Item{Index: itemHelmT1}
+	f.e.Carry[1] = world.Item{Index: itemHelmT1}
 
 	f.use(itemClasseA)
 
@@ -117,16 +124,54 @@ func TestClasseBonusHelmRerollsSancAndEffects(t *testing.T) {
 // classeSancCapForTest avoids importing the unexported refine.classeSancCap.
 const classeSancCapForTest = 6
 
-func TestClasseUncoveredSlotConsumesButDoesNothing(t *testing.T) {
+// TestClasseDRerollsTier4Set is the issue #228 regression: a Classe D (plain and
+// "(P)") applied to a tier-4 set piece in the inventory must reroll it.
+func TestClasseDRerollsTier4Set(t *testing.T) {
+	for _, c := range []struct {
+		name   string
+		classe int16
+	}{
+		{"Classe_D", itemClasseD},
+		{"Classe_D(P)", itemClasseDP},
+	} {
+		classe := c.classe
+		t.Run(c.name, func(t *testing.T) {
+			pos, effects := classeCatalog()
+			f := newClasseFixture(t, pos, effects)
+			f.e.Carry[1] = world.Item{Index: itemChestT4}
+
+			f.use(classe)
+
+			if !f.e.Carry[0].Empty() {
+				t.Errorf("classe %d not consumed: %+v", classe, f.e.Carry[0])
+			}
+			got := f.target()
+			if got.Index != itemChestT4 {
+				t.Fatalf("target replaced: %+v", got)
+			}
+			if got.Effects[0].Effect != efSanc {
+				t.Errorf("Effects[0] = %+v, want EF_SANC", got.Effects[0])
+			}
+			if got.Effects[1].Effect == 0 || got.Effects[2].Effect == 0 {
+				t.Errorf("bonus adds not rolled: %+v", got.Effects)
+			}
+		})
+	}
+}
+
+// TestClasseUncoveredSlotRefusesAndKeepsItem covers the deliberate deviation
+// from SetItemBonus2 (Lista de bugs.txt:6): an nPos the reroll tables don't
+// cover must not silently eat the Classe item.
+func TestClasseUncoveredSlotRefusesAndKeepsItem(t *testing.T) {
 	pos, effects := classeCatalog()
 	f := newClasseFixture(t, pos, effects)
-	f.e.Equip[1] = world.Item{Index: itemWeaponT1}
+	f.e.Carry[1] = world.Item{Index: itemWeaponT1}
 	before := f.target()
 
 	f.use(itemClasseA)
 
-	if !f.e.Carry[0].Empty() {
-		t.Errorf("classe item not consumed: %+v", f.e.Carry[0])
+	if f.e.Carry[0].Empty() {
+		t.Error("classe item consumed on an uncovered nPos")
 	}
 	if got := f.target(); got != before {
 		t.Errorf("uncovered nPos was mutated: %+v -> %+v", before, got)
@@ -142,38 +187,40 @@ func TestClasseGates(t *testing.T) {
 	mobTypeGated[itemChestT1] = append(append([]content.BaseEffect{}, effects[itemChestT1]...), content.BaseEffect{Eff: efMobType, Val: 1})
 
 	cases := []struct {
-		name     string
-		classe   int16
-		target   world.Item
-		effects  map[int][]content.BaseEffect
-		wantSame bool // target unchanged, item still consumed
+		name    string
+		classe  int16
+		target  world.Item
+		effects map[int][]content.BaseEffect
 	}{
 		{
-			name:     "tier mismatch is rejected",
-			classe:   itemClasseE,                    // tier 5
-			target:   world.Item{Index: itemChestT1}, // catalog tier 1
-			effects:  effects,
-			wantSame: true,
+			name:    "tier mismatch is rejected",
+			classe:  itemClasseE,                    // tier 5
+			target:  world.Item{Index: itemChestT1}, // catalog tier 1
+			effects: effects,
 		},
 		{
-			name:     "sanc >= +10 is rejected",
-			classe:   itemClasseA,
-			target:   world.Item{Index: itemChestT1, Effects: [3]world.Effect{{Effect: efSanc, Value: 230}}}, // level 10
-			effects:  effects,
-			wantSame: true,
+			name:    "Classe A on a tier-4 piece is rejected",
+			classe:  itemClasseA,                    // tier 1
+			target:  world.Item{Index: itemChestT4}, // catalog tier 4
+			effects: effects,
 		},
 		{
-			name:     "EF_MOBTYPE outside {0,2} is rejected",
-			classe:   itemClasseA,
-			target:   world.Item{Index: itemChestT1},
-			effects:  mobTypeGated,
-			wantSame: true,
+			name:    "sanc >= +10 is rejected",
+			classe:  itemClasseA,
+			target:  world.Item{Index: itemChestT1, Effects: [3]world.Effect{{Effect: efSanc, Value: 230}}}, // level 10
+			effects: effects,
+		},
+		{
+			name:    "EF_MOBTYPE outside {0,2} is rejected",
+			classe:  itemClasseA,
+			target:  world.Item{Index: itemChestT1},
+			effects: mobTypeGated,
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			f := newClasseFixture(t, pos, c.effects)
-			f.e.Equip[1] = c.target
+			f.e.Carry[1] = c.target
 			f.use(c.classe)
 			if got := f.target(); got != c.target {
 				t.Errorf("target mutated on a gate failure: %+v -> %+v", c.target, got)
@@ -187,23 +234,25 @@ func TestClasseGates(t *testing.T) {
 	}
 }
 
-func TestClasseRejectsCarryDestination(t *testing.T) {
+// TestClasseRejectsEquipDestination pins the legacy polarity: the target has to
+// be in the inventory, never worn (_MSG_UseItem.cpp:4970, issue #228).
+func TestClasseRejectsEquipDestination(t *testing.T) {
 	pos, effects := classeCatalog()
 	f := newClasseFixture(t, pos, effects)
-	f.e.Carry[1] = world.Item{Index: itemChestT1}
+	f.e.Equip[1] = world.Item{Index: itemChestT1}
 	f.e.Carry[0] = world.Item{Index: itemClasseA}
 
 	body := protocol.MsgUseItemBody{
 		SourType: world.ItemPlaceCarry, SourPos: 0,
-		DestType: world.ItemPlaceCarry, DestPos: 1,
+		DestType: world.ItemPlaceEquip, DestPos: 1,
 	}
 	f.d.useClasseItem(f.w, f.s, f.e, body, 0)
 
 	if f.e.Carry[0].Empty() {
-		t.Error("classe item consumed despite a non-Equip destination")
+		t.Error("classe item consumed despite an equipped destination")
 	}
-	if f.e.Carry[1].Index != itemChestT1 {
-		t.Errorf("carry target mutated: %+v", f.e.Carry[1])
+	if f.e.Equip[1] != (world.Item{Index: itemChestT1}) {
+		t.Errorf("equipped target mutated: %+v", f.e.Equip[1])
 	}
 }
 
@@ -218,7 +267,7 @@ func TestClasseBootDamageClamp(t *testing.T) {
 	clamped[itemBootT1] = append(append([]content.BaseEffect{}, effects[itemBootT1]...), content.BaseEffect{Eff: efDamage, Val: 20})
 
 	f := newClasseFixture(t, pos, clamped)
-	f.e.Equip[1] = world.Item{Index: itemBootT1}
+	f.e.Carry[1] = world.Item{Index: itemBootT1}
 
 	f.use(itemClasseA)
 
@@ -237,12 +286,12 @@ func TestClasseBootDamageClamp(t *testing.T) {
 func TestClasseConsumesOneUnitFromStack(t *testing.T) {
 	pos, effects := classeCatalog()
 	f := newClasseFixture(t, pos, effects)
-	f.e.Equip[1] = world.Item{Index: itemChestT1}
+	f.e.Carry[1] = world.Item{Index: itemChestT1}
 	f.e.Carry[0] = world.Item{Index: itemClasseA, Effects: [3]world.Effect{{Effect: efAmount, Value: 3}}}
 
 	body := protocol.MsgUseItemBody{
 		SourType: world.ItemPlaceCarry, SourPos: 0,
-		DestType: world.ItemPlaceEquip, DestPos: 1,
+		DestType: world.ItemPlaceCarry, DestPos: 1,
 	}
 	f.d.useClasseItem(f.w, f.s, f.e, body, 0)
 

--- a/tmserver/internal/refine/classebonus.go
+++ b/tmserver/internal/refine/classebonus.go
@@ -103,6 +103,12 @@ func ClasseBonus(dest *world.Item, nPos int, roll func(int) int, itemAbility fun
 		return false
 	}
 
+	// The table index is drawn BEFORE any sanc roll: every branch of
+	// SetItemBonus2 opens with `int _rand = rand()%N;` and only then touches
+	// stEffect[0] (Server.cpp:2723-2726 and its three siblings). Keeping that
+	// order is what makes a captured rand() sequence reproduce byte-for-byte.
+	row := table[roll(len(table))]
+
 	if dest.Effects[0].Effect == classeSancEffect {
 		lvl := Level(*dest)
 		if lvl < classeSancCap {
@@ -116,7 +122,6 @@ func ClasseBonus(dest *world.Item, nPos int, roll func(int) int, itemAbility fun
 		dest.Effects[0] = world.Effect{Effect: classeSancEffect, Value: uint8(roll(2))}
 	}
 
-	row := table[roll(len(table))]
 	dest.Effects[1] = world.Effect{Effect: uint8(row[0]), Value: uint8(row[1])}
 	dest.Effects[2] = world.Effect{Effect: uint8(row[2]), Value: uint8(row[3])}
 

--- a/tmserver/internal/refine/classebonus_test.go
+++ b/tmserver/internal/refine/classebonus_test.go
@@ -1,0 +1,201 @@
+package refine
+
+import (
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// scriptedRoll returns a roll func that hands back vals in order (repeating the
+// last one if it runs out) and records the modulus of every call, so a test can
+// assert both the values consumed and the ORDER they were drawn in.
+func scriptedRoll(vals ...int) (func(int) int, *[]int) {
+	var mods []int
+	i := 0
+	return func(n int) int {
+		mods = append(mods, n)
+		v := vals[len(vals)-1]
+		if i < len(vals) {
+			v = vals[i]
+		}
+		i++
+		return v % n
+	}, &mods
+}
+
+// noAbility stands in for BASE_GetItemAbility on the non-boot paths, where
+// ClasseBonus never consults it.
+func noAbility(world.Item, uint8) int { return 0 }
+
+// TestClasseBonusDrawsTableIndexFirst pins the legacy RNG call order: every
+// branch of SetItemBonus2 opens with `int _rand = rand()%N;` and only then rolls
+// the sanc (Server.cpp:2723-2726). Swapping the two would silently desync a
+// captured rand() sequence.
+func TestClasseBonusDrawsTableIndexFirst(t *testing.T) {
+	dest := world.Item{Index: 100, Effects: [3]world.Effect{{Effect: efSanc, Value: 0}}}
+	roll, mods := scriptedRoll(3, 1)
+
+	if !ClasseBonus(&dest, nPosHelm, roll, noAbility) {
+		t.Fatal("ClasseBonus reported an uncovered nPos for a helm")
+	}
+
+	if len(*mods) != 2 || (*mods)[0] != len(bonusValue3) || (*mods)[1] != 2 {
+		t.Fatalf("roll moduli = %v, want [%d 2] (table index drawn first)", *mods, len(bonusValue3))
+	}
+	want := bonusValue3[3]
+	if dest.Effects[1] != (world.Effect{Effect: uint8(want[0]), Value: uint8(want[1])}) ||
+		dest.Effects[2] != (world.Effect{Effect: uint8(want[2]), Value: uint8(want[3])}) {
+		t.Errorf("effects = %+v, want row %v", dest.Effects, want)
+	}
+	if got := Level(dest); got != 1 {
+		t.Errorf("sanc level = %d, want 1 (0 + roll(2)=1)", got)
+	}
+}
+
+func TestClasseBonusTablePerSlot(t *testing.T) {
+	cases := []struct {
+		name string
+		nPos int
+		size int
+	}{
+		{"helm", nPosHelm, len(bonusValue3)},
+		{"chest", nPosChest, len(bonusValue2)},
+		{"legs", nPosLegs, len(bonusValue2)},
+		{"glove", nPosGlove, len(bonusValue4)},
+		{"boot", nPosBoot, len(bonusValue5)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dest := world.Item{Index: 100, Effects: [3]world.Effect{{Effect: efSanc, Value: 0}}}
+			roll, mods := scriptedRoll(0)
+			if !ClasseBonus(&dest, c.nPos, roll, noAbility) {
+				t.Fatalf("nPos %d reported as uncovered", c.nPos)
+			}
+			if (*mods)[0] != c.size {
+				t.Errorf("table modulus = %d, want %d", (*mods)[0], c.size)
+			}
+		})
+	}
+}
+
+func TestClasseBonusSanc(t *testing.T) {
+	cases := []struct {
+		name      string
+		effect0   world.Effect
+		roll      int // value fed to the sanc roll(2)
+		wantLevel int
+		wantRolls int
+	}{
+		{
+			name:      "unrefined item steps to +1",
+			effect0:   world.Effect{Effect: efSanc, Value: encode(0, 0)},
+			roll:      1,
+			wantLevel: 1,
+			wantRolls: 2,
+		},
+		{
+			name:      "roll of 0 leaves the level alone",
+			effect0:   world.Effect{Effect: efSanc, Value: encode(3, 0)},
+			roll:      0,
+			wantLevel: 3,
+			wantRolls: 2,
+		},
+		{
+			name:      "+5 clamps at the +6 ceiling",
+			effect0:   world.Effect{Effect: efSanc, Value: encode(5, 0)},
+			roll:      1,
+			wantLevel: classeSancCap,
+			wantRolls: 2,
+		},
+		{
+			name:      "at the cap no sanc roll is drawn at all",
+			effect0:   world.Effect{Effect: efSanc, Value: encode(classeSancCap, 0)},
+			roll:      1,
+			wantLevel: classeSancCap,
+			wantRolls: 1,
+		},
+		{
+			name:      "a non-sanc slot 0 is overwritten with a fresh EF_SANC",
+			effect0:   world.Effect{Effect: 71, Value: 50},
+			roll:      1,
+			wantLevel: 1,
+			wantRolls: 2,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dest := world.Item{Index: 100, Effects: [3]world.Effect{c.effect0}}
+			roll, mods := scriptedRoll(0, c.roll)
+
+			ClasseBonus(&dest, nPosChest, roll, noAbility)
+
+			if dest.Effects[0].Effect != efSanc {
+				t.Errorf("Effects[0] = %+v, want EF_SANC", dest.Effects[0])
+			}
+			if got := Level(dest); got != c.wantLevel {
+				t.Errorf("level = %d, want %d", got, c.wantLevel)
+			}
+			if len(*mods) != c.wantRolls {
+				t.Errorf("roll calls = %d (%v), want %d", len(*mods), *mods, c.wantRolls)
+			}
+		})
+	}
+}
+
+// TestClasseBonusUncoveredSlot: SetItemBonus2 has no branch for weapons, capes
+// or accessories, so the item must come back untouched — the caller
+// (useClasseItem) relies on the false return to refuse instead of consuming the
+// Classe item (Lista de bugs.txt:6).
+func TestClasseBonusUncoveredSlot(t *testing.T) {
+	for _, nPos := range []int{1, 64, 128, 192, 512, 2048, -32768} {
+		before := world.Item{Index: 100, Effects: [3]world.Effect{{Effect: efSanc, Value: 3}}}
+		dest := before
+		roll, mods := scriptedRoll(0)
+
+		if ClasseBonus(&dest, nPos, roll, noAbility) {
+			t.Errorf("nPos %d reported as covered", nPos)
+		}
+		if dest != before {
+			t.Errorf("nPos %d mutated the item: %+v -> %+v", nPos, before, dest)
+		}
+		if len(*mods) != 0 {
+			t.Errorf("nPos %d drew %d rolls, want 0", nPos, len(*mods))
+		}
+	}
+}
+
+// TestClasseBonusBootDamageClamp: a rolled EF_DAMAGE bonus is trimmed so the
+// item's total damage ability stays at 30 (Server.cpp:2845-2861). Row 0 of
+// bonusValue5 rolls {EF_DAMAGE 30}, which on top of a base 20 lands at 50.
+func TestClasseBonusBootDamageClamp(t *testing.T) {
+	const catalogDamage = 20
+	ability := func(it world.Item, id uint8) int {
+		if id != efDamageBonus {
+			return 0
+		}
+		total := catalogDamage
+		for _, ef := range it.Effects {
+			if ef.Effect == id {
+				total += int(ef.Value)
+			}
+		}
+		return total
+	}
+
+	dest := world.Item{Index: 100, Effects: [3]world.Effect{{Effect: efSanc, Value: 0}}}
+	roll, _ := scriptedRoll(0)
+
+	if !ClasseBonus(&dest, nPosBoot, roll, ability) {
+		t.Fatal("boot reported as uncovered")
+	}
+
+	if row := bonusValue5[0]; row[0] != efDamageBonus {
+		t.Fatalf("fixture assumption broken: bonusValue5[0] = %v, want EF_DAMAGE first", row)
+	}
+	if got := ability(dest, efDamageBonus); got != bootDamageCap {
+		t.Errorf("total EF_DAMAGE ability = %d, want %d", got, bootDamageCap)
+	}
+	if got := dest.Effects[1].Value; got != bootDamageCap-catalogDamage {
+		t.Errorf("rolled EF_DAMAGE value = %d, want %d", got, bootDamageCap-catalogDamage)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #228 — "O item classe D não refina, e não joga add no set de forma aleatoria".

Using a Classe item on a set piece did nothing: no `+N` bump, no random add reroll, the item just bounced back. Both symptoms come from `SetItemBonus2`, so a single gate rejection explained the whole report. It affected all of Classe A–E, not just D.

## Root cause

`handler/classe.go` had the destination gate inverted. The legacy reads:

```c
if (!m->DestType || m->DestPos >= 60)   // _MSG_UseItem.cpp:4970
```

which rejects `ITEM_PLACE_EQUIP` (0) — a Classe item only applies to gear sitting in the **inventory**. An earlier port took this for a typo and wrote `!= Equip`, so the server rejected exactly the drag players make.

Two things show the legacy polarity was deliberate:

- The bound is **60** (`maxUnlockedCarry`), not 16 (`MaxEquip`) as in the genuinely equip-only gates at `:3779/:3901/:3979/:4057`.
- `SetItemBonus2` is followed by `SendItem` alone, with **no score recompute** (`:4997-5000`) — only safe because the rerolled item is not worn.

## Changes

- **Gate polarity restored** (`handler/classe.go`), with the doc comment rewritten to record the evidence so it isn't "re-fixed" later. The `DestPos >= 60` bound needs no explicit port: `itemSlot` → `carrySlotAccessible` already caps at `maxUnlockedCarry == 60`.
- **`ClasseBonus`'s return is now honoured.** Dropping a Classe on a weapon/cape/accessory used to consume a 200k-gold item for zero effect — the known legacy bug in `Source/Lista de bugs.txt:6`. It now refuses and resyncs. Deliberate, documented deviation from `Server.cpp:2719-2861`.
- **RNG call order restored** (`refine/classebonus.go`): the table index is drawn before the sanc roll, matching `Server.cpp:2723-2726`. The port had them swapped, which silently broke replay against a captured `rand()` sequence.

Tier / sanc / MobType gates stay silent, exactly as Source does.

## Tests

- `handler/classe_test.go`: fixture retargeted to carry, so every existing case now exercises the real path. `TestClasseRejectsCarryDestination` → `TestClasseRejectsEquipDestination`. The uncovered-nPos test asserts the item survives. New `TestClasseDRerollsTier4Set` is the #228 regression — 4019 and 4024 on an `EF_ITEMLEVEL 4` piece, where every prior case used tier 1.
- New `refine/classebonus_test.go`: `refine.ClasseBonus` had no direct unit test. Pins call order, the +6 cap, per-slot table selection, uncovered nPos, and the boot `EF_DAMAGE` clamp.

## Verification

Go isn't installed locally, so the toolchain ran in a `golang:1.25` container against the repo:

- `go vet ./...` — clean
- `go test -race -cover ./...` — all packages pass; `handler` 74.7%, `refine` 92.8% (up from ~85%)
- `golangci-lint v2.6.2` — the only hits are `gofmt`, all line-ending noise from a Windows checkout (`core.autocrlf=true`); untouched files like `handler/area.go` are flagged identically, and stripping CRLF makes every file gofmt-clean.

Not yet exercised against a real client (`make run-local` + a tier-4 piece and a Classe D in the inventory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
