### PR TITLE
fix(tmserver): remover evocações órfãs ao sair do grupo (#234)

### DIFF
--- a/docs/migration/handlers/lote2-party-guilda-guerra.md
+++ b/docs/migration/handlers/lote2-party-guilda-guerra.md
@@ -33,6 +33,19 @@
 - **Efeitos:** se eu sou líder (`Leader`) → `RemoveParty(conn)` (dissolve/saída do líder); senão
   `RemoveParty(target)`.
 - **Risco:** semântica líder-vs-membro embutida; documentar `RemoveParty` (em `Server.cpp`).
+- **Limpeza de summons (issue #234):** `RemoveParty` **deleta os pets** que ocupam slots da
+  `PartyList` — os do membro que sai (`Server.cpp:8185-8190`) e os do líder ao dissolver
+  (`Server.cpp:8237-8243`). O Go faz isso em `despawnSummonsOf` (`handler/summon.go`), chamado pelos
+  três caminhos de `party.go`. Sem isso o pet sobrevive fora de qualquer lista e a próxima evocação
+  empilha um conjunto novo. Ao dissolver, o Go mata os pets de **todos** os membros — divergência
+  deliberada, ver `docs/migration/skills/beastmaster.md` (ciclo de vida do pet).
+  Um **BM solo com pets tem `Leader == 0`**, então o botão de sair cai no caminho do líder: é a
+  reprodução mais curta do bug.
+- **Logout/desconexão:** o legado chama `RemoveParty(conn)` também em `_MSG_CharacterLogout.cpp:23`
+  e em `CloseUser` (`Server.cpp:7654`). No Go isso é `Dispatcher.SessionEnd`, chamado por
+  `characterLogout` e registrado em `world.SetSessionEndHandler` (rodado por `removeSession` antes de
+  liberar o slot). Faltando isso, quem saía ficava fantasma na `PartyList` do líder, e o líder virava
+  "já em party" para sempre (`isInParty`) — além de um slot de conn reutilizado herdar as linhas.
 
 ## `_MSG_InviteGuild` (0x03D5) — convidar para guilda
 - **Gatilho/struct:** `MSG_STANDARDPARM2` (`Parm1=TargetID`, `Parm2=InviteType` 0..3).

--- a/docs/migration/skills/beastmaster.md
+++ b/docs/migration/skills/beastmaster.md
@@ -40,6 +40,38 @@ Evidencia usa os codigos definidos em `README.md`.
 - Dano BM usa a mesma formula de caster da Foema: `Int/30 + Int/3 + Level + base + 2*Special`, Magic multiplier e 5/4.
 - Summons usam `InstanceType 11`, `InstanceValue 1..8`, `pSummonBonus` local, `Special[2]` para quantidade/escalonamento, `PartyList` para limite e `MSG_CNFAddParty` para UI.
 - Transformacoes usam affect type 16, valores 1..5, `pTransBonus`, learned bits 17/19/21 para flat adds de Lobo/Urso/Astaroth, mesh 22/23/24/25/32, critical e attack/run speed.
+
+### Ciclo de vida do pet (issue #234)
+
+O `PartyList` do lider **e** o unico registro de pets: `generateSummon` conta por ele e
+`commandSummons` acha os pets por ele. Logo todo caminho que zera slot de party tem de matar o pet
+que estava ali, senao ele sobrevive fora de qualquer lista — e a proxima evocacao conta zero e
+empilha um novo conjunto (o bug relatado em #234).
+
+Quem remove pet, e por que:
+
+| Gatilho | Onde | Evidencia |
+|---|---|---|
+| membro sai / e expulso | `handler/party.go` `leaveParty`/`kickPartyMember` → `despawnSummonsOf(leader, conn)` | `Server.cpp:8185-8190` |
+| lider sai (party dissolvida) e **BM solo** clicando sair | `leaderLeaveParty` → `despawnSummonsOf(leader, 0)` | `Server.cpp:8237-8243` |
+| logout / desconexao | `Dispatcher.SessionEnd` (`characterLogout` + `world.SetSessionEndHandler`) | `_MSG_CharacterLogout.cpp:23`, `Server.cpp:7654` |
+| dono morto / fora de `USER_PLAY` | `summonTick` | `ProcessSecMinTimer.cpp:2381` |
+| pet fora do `PartyList` do seu lider (rede de seguranca) | `summonTick` + `petIsListed` | `CMob.cpp:118-124` |
+| fim do affect type 24 | `summonTick` | `Server.cpp:5843` |
+| montaria bebe desequipada/morta | `removeBabyMountSummons` | `Server.cpp:4650-4665` |
+
+Duas notas de paridade:
+
+- **Divergencia deliberada:** ao dissolver a party o Go mata os pets de **todos** os membros. O
+  legado deleta apenas os do lider e so zera `Summoner` nos demais (`Server.cpp:8242`), contando com
+  a varredura global do affect 24 (`Server.cpp:5843`) para recolher o resto. Aqui a contagem de vida
+  roda dentro de `summonTick`, que exige `Summoner != 0` (`mobai.go:61`), entao copiar essa linha
+  vazaria mobs sem dono para sempre.
+- `DespawnMob` so envia `MSG_RemoveMob`; a linha de party do pet precisa de `MSG_RemoveParty`
+  explicito (no legado vem de graca via `DeleteMob → RemoveParty`, `Server.cpp:7840`).
+
+O orcamento de pets e **da party inteira**, nao por jogador: `generateSummon` conta todo pet no
+`PartyList` do lider, de quem for (`Server.cpp:2991-2997`).
 - O score derivado de transform fica em caches de affect/read-time, nao no score persistido.
 
 ## Lacunas e riscos
@@ -53,4 +85,7 @@ Evidencia usa os codigos definidos em `README.md`.
 - `TestEtherealFlameBurnsPlayerMP`, `TestBeastAuraTickUsesSkill52`.
 - `TestSummonCount`, `TestEvocationSpawnsScaledSummons`, `TestEvocationSendsAddPartyForSummon`, `TestEvocationDoesNotDuplicateExistingSummon`.
 - `TestSummonExpires`, `TestSummonGoneAfterRelogin`, `TestSummonAssistsAgainstMob`.
+- Issue #234: `TestSoloSummonDespawnsOnRemoveParty`, `TestEvocationAfterLeavingPartyStaysCapped`,
+  `TestSummonDespawnsWhenOwnerLeavesParty`, `TestSummonDespawnsWhenKicked`,
+  `TestSummonDespawnsOnPartyDisband`, `TestSummonPartySlotClearedOnDespawn`.
 - `TestApplyTransformScore`, `TestTransformCastBroadcastsMesh`, `TestTransformExpiryRevertsMesh`.

--- a/tmserver/cmd/tmserver/main.go
+++ b/tmserver/cmd/tmserver/main.go
@@ -304,6 +304,9 @@ func run(logger *slog.Logger) error {
 	}, logger, persist, dispatch.Handle)
 	// Mob-AI pulse: monsters acquire/chase/melee nearby players each tick (mobai.go).
 	w.SetTickHandler(world.DefaultMobTick, dispatch.Tick)
+	// Party teardown on disconnect: unlink the party bond and reap the summons
+	// before the slot is freed (party.go SessionEnd).
+	w.SetSessionEndHandler(dispatch.SessionEnd)
 	// The newbie flag has two owners: the dispatcher's ExpEvents (the EXP bonus)
 	// and the world (the sub-120 spawn HP handicap). Set here, BEFORE spawnNPCs
 	// below, so the boot population is handicapped too — the portal config may

--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -578,6 +578,11 @@ func (d *Dispatcher) characterLogout(w *world.World, s *world.Session, _ protoco
 	if s.Mode != world.UserPlay {
 		return
 	}
+	// Leave the party (and reap this character's summons) first, while the session
+	// is still UserPlay — sendRemoveParty/sendAddParty only reach UserPlay
+	// recipients (_MSG_CharacterLogout.cpp:23 calls RemoveParty for the same
+	// reason). The disconnect-time hook is a no-op after this.
+	d.SessionEnd(w, s)
 	// Despawn this entity for in-view players (back to character selection).
 	body := protocol.EncodeRemoveMobBody(2)
 	w.ForEachInView(s.Conn, func(vs *world.Session, _ *world.Entity) {

--- a/tmserver/internal/handler/movement_test.go
+++ b/tmserver/internal/handler/movement_test.go
@@ -30,6 +30,7 @@ func startServerClock(t *testing.T, persist world.Persistence) (string, func(), 
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	d := New(Config{Log: log, Now: func() time.Time { return time.Unix(0, 0) }})
 	w := world.New(world.Config{GridDim: 16, Now: clock.Load}, log, persist, d.Handle)
+	w.SetSessionEndHandler(d.SessionEnd) // party unlink on disconnect, as in main.go
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() { _ = w.Serve(ctx, ln); close(done) }()

--- a/tmserver/internal/handler/party.go
+++ b/tmserver/internal/handler/party.go
@@ -122,6 +122,27 @@ func (d *Dispatcher) removeParty(w *world.World, s *world.Session, _ protocol.He
 	d.kickPartyMember(w, s.Conn, target)
 }
 
+// SessionEnd unlinks a leaving connection from its party. It ports the
+// RemoveParty(conn) the legacy runs on logout and on socket teardown
+// (_MSG_CharacterLogout.cpp:23, CloseUser → Server.cpp:7654), which the port
+// was missing: the leaver stayed a ghost in the leader's PartyList, so that
+// leader read as "already partied" forever (isInParty) and a reused conn slot
+// inherited the rows. Registered with world.SetSessionEndHandler and also called
+// from characterLogout. Idempotent — the second run finds an empty party.
+func (d *Dispatcher) SessionEnd(w *world.World, s *world.Session) {
+	e := w.Entity(s.Conn)
+	if e == nil || !isInParty(e) {
+		return // nothing to unlink; don't push a party packet at a partyless client
+	}
+	if e.Leader != 0 {
+		d.leaveParty(w, s.Conn)
+		return
+	}
+	// Leaders (and solo pet holders) dissolve; leaderLeaveParty promotes the next
+	// member and resyncs, like the synthetic AcceptParty at Server.cpp:8246-8260.
+	d.leaderLeaveParty(w, s.Conn)
+}
+
 func (d *Dispatcher) reqPartyBody(e *world.Entity, partyID int) protocol.MsgSendReqPartyBody {
 	body := protocol.MsgSendReqPartyBody{
 		Class:    e.Class,
@@ -163,6 +184,11 @@ func (d *Dispatcher) leaveParty(w *world.World, conn int) {
 		return
 	}
 	leaderConn := e.Leader
+	// A member's summons occupy slots in the LEADER's PartyList (summon.go:205),
+	// so cutting the bond without reaping them leaves them alive and untracked —
+	// the next evocation then counts zero pets and spawns a whole new set (#234).
+	d.despawnSummonsOf(w, leaderConn, conn)
+	d.despawnSummonsOf(w, conn, 0)
 	e.Leader = 0
 	e.PartyList = [world.MaxParty]int{}
 	d.sendRemoveParty(w, conn, 0)
@@ -184,6 +210,8 @@ func (d *Dispatcher) kickPartyMember(w *world.World, leaderConn, conn int) {
 	if e == nil || le == nil || e.Leader != leaderConn {
 		return
 	}
+	d.despawnSummonsOf(w, leaderConn, conn) // same reaping as leaveParty (#234)
+	d.despawnSummonsOf(w, conn, 0)
 	e.Leader = 0
 	e.PartyList = [world.MaxParty]int{}
 	removeMember(le, conn)
@@ -201,6 +229,13 @@ func (d *Dispatcher) leaderLeaveParty(w *world.World, leaderConn int) {
 	if le == nil {
 		return
 	}
+	// Every summon in the list goes, whoever evoked it. The legacy only deletes
+	// the leaver's own and merely zeroes Summoner on the rest (Server.cpp:8237-8243),
+	// relying on its global Type-24 sweep to reap them; here the lifespan ticks
+	// inside summonTick, which is gated on Summoner != 0 (mobai.go:61), so copying
+	// that would leak permanent ownerless mobs. This branch is also the solo-BM
+	// path — a pet holder has Leader == 0, so RemoveParty lands here (#234).
+	d.despawnSummonsOf(w, leaderConn, 0)
 	members := partyMembers(le)
 	le.PartyList = [world.MaxParty]int{}
 	for _, memberID := range members {

--- a/tmserver/internal/handler/party_test.go
+++ b/tmserver/internal/handler/party_test.go
@@ -216,6 +216,36 @@ func TestPartyLeaderLeavePromotesNextMember(t *testing.T) {
 	}
 }
 
+// TestPartyMemberLogoutLeavesParty: the port never ran the legacy
+// RemoveParty(conn) on logout (_MSG_CharacterLogout.cpp:23), so the leaver stayed
+// a ghost slot in the leader's PartyList — which made the leader read as "already
+// partied" forever and unable to accept any later invite (isInParty).
+func TestPartyMemberLogoutLeavesParty(t *testing.T) {
+	addr, stop, _ := startServerClock(t, partyDB())
+	defer stop()
+	a := enterWorldAs(t, addr, "tester")
+	defer a.Close()
+	b := enterWorldAs(t, addr, "tradeb")
+	defer b.Close()
+	c := enterWorldAs(t, addr, "third")
+	defer c.Close()
+
+	reqPartyFrame(t, a, 1, 2)
+	expectPartyFrame(t, b, protocol.MsgSendReqParty)
+	acceptPartyFrame(t, b, 1, "Hero")
+	drainRaw(t, a)
+	drainRaw(t, b)
+
+	send(t, b, protocol.MsgCharacterLogout, nil)
+	expectRemoveParty(t, a, 2)
+
+	// The ex-leader is party-free again, so a fresh invite reaches it.
+	drainRaw(t, a)
+	drainRaw(t, c)
+	reqPartyFrame(t, c, 3, 1)
+	expectPartyFrame(t, a, protocol.MsgSendReqParty)
+}
+
 func TestGuildInvite(t *testing.T) {
 	addr, stop, _ := startServerClock(t, guildDB())
 	defer stop()

--- a/tmserver/internal/handler/summon.go
+++ b/tmserver/internal/handler/summon.go
@@ -244,21 +244,55 @@ func (d *Dispatcher) removeBabyMountSummons(w *world.World, ownerID int, owner *
 	if leaderID == 0 {
 		leaderID = ownerID
 	}
+	d.despawnSummons(w, leaderID, func(pet *world.Entity) bool {
+		return pet.Summoner == ownerID &&
+			pet.EquipVisual[0] >= babyMountFaceLo && pet.EquipVisual[0] < babyMountFaceHi
+	})
+}
+
+// despawnSummonsOf removes every summon parked in leaderID's PartyList that
+// belongs to ownerID; ownerID == 0 means all of them (the party dissolved).
+// This is the DeleteMob sweep inside RemoveParty (Server.cpp:8185-8190 when a
+// member leaves, Server.cpp:8237-8243 when the leader does) — without it the
+// pets outlive the party bond that held them (issue #234).
+func (d *Dispatcher) despawnSummonsOf(w *world.World, leaderID, ownerID int) {
+	d.despawnSummons(w, leaderID, func(pet *world.Entity) bool {
+		// Summoner 0 is a stray mob sitting in a player's party slot; the legacy
+		// reaps those on any leave too (Server.cpp:8188-8190).
+		return ownerID == 0 || pet.Summoner == ownerID || pet.Summoner == 0
+	})
+}
+
+// despawnSummons is the shared walk of a leader's pet slots: match selects which
+// pets go. The ids and the packet recipients are snapshotted first because
+// DespawnMob frees the slot as it goes (world/api.go:215-223).
+func (d *Dispatcher) despawnSummons(w *world.World, leaderID int, match func(*world.Entity) bool) {
 	leader := w.Entity(leaderID)
 	if leader == nil {
 		return
 	}
+	var doomed []int
+	recipients := []int{leaderID}
 	for _, memberID := range leader.PartyList {
-		if memberID < world.MaxUser {
+		if memberID <= 0 {
 			continue
 		}
-		pet := w.Entity(memberID)
-		if pet == nil || pet.Summoner != ownerID {
+		if world.IsPlayer(memberID) {
+			recipients = append(recipients, memberID)
 			continue
 		}
-		if pet.EquipVisual[0] >= babyMountFaceLo && pet.EquipVisual[0] < babyMountFaceHi {
-			w.DespawnMob(memberID, 3)
+		if pet := w.Entity(memberID); pet != nil && match(pet) {
+			doomed = append(doomed, memberID)
 		}
+	}
+	for _, id := range doomed {
+		// DespawnMob only sends MsgRemoveMob, so the party row has to be dropped
+		// explicitly or the client keeps the pet slot (legacy gets this from
+		// DeleteMob → RemoveParty, Server.cpp:7840).
+		for _, recipientID := range recipients {
+			d.sendRemoveParty(w, recipientID, id)
+		}
+		w.DespawnMob(id, 3)
 	}
 }
 
@@ -348,6 +382,16 @@ func (d *Dispatcher) sendSummonPartySlot(w *world.World, leaderID, summonID, slo
 	}
 }
 
+// petIsListed reports whether the pet still holds a slot in its leader's
+// PartyList — the only registry summons have (generateSummon, commandSummons).
+func petIsListed(w *world.World, id int, e *world.Entity) bool {
+	leader := w.Entity(e.Leader)
+	if leader == nil {
+		return false
+	}
+	return hasMember(leader, id)
+}
+
 // summonTick replaces the regular mob AI for a summoned pet (the RouteType-5
 // branch of StandingByProcessor, CMob.cpp:84-152): despawn when the owner is
 // gone, tick the lifespan, fight the owner's fight within the leash, otherwise
@@ -359,6 +403,13 @@ func (d *Dispatcher) summonTick(w *world.World, id int, e *world.Entity) {
 		if m, ok := w.SessionMode(e.Summoner); !ok || m != world.UserPlay {
 			ownerGone = true // logout / back to char select / disconnect
 		}
+	}
+	if !ownerGone && !petIsListed(w, id, e) {
+		// Belt and braces: a pet whose party slot is gone has no owner bond left,
+		// and nothing else would ever reap it (its lifespan ticks right here). The
+		// legacy bails the same way when a summon's leader is cleared
+		// (CMob.cpp:118-124). Keeps any future PartyList reset from leaking pets.
+		ownerGone = true
 	}
 	if ownerGone {
 		// The legacy clears summons via its timers on death/logout

--- a/tmserver/internal/handler/summon_test.go
+++ b/tmserver/internal/handler/summon_test.go
@@ -81,6 +81,13 @@ func startServerSummon(t *testing.T, db world.Persistence, mob []byte, mobX, mob
 }
 
 func startServerSummonWith(t *testing.T, db world.Persistence, spells *content.SkillData, summonMobs [][]byte, mob []byte, mobX, mobY int16) (string, func(), *atomic.Uint32) {
+	return startServerSummonTick(t, db, spells, summonMobs, mob, mobX, mobY, 10*time.Millisecond)
+}
+
+// startServerSummonTick is startServerSummonWith with the AI-tick period exposed:
+// the summon lifespan is 20 ticks of affectTickPeriod, so a slow tick keeps a pet
+// alive for the whole test and isolates what the handlers do from what expiry does.
+func startServerSummonTick(t *testing.T, db world.Persistence, spells *content.SkillData, summonMobs [][]byte, mob []byte, mobX, mobY int16, tick time.Duration) (string, func(), *atomic.Uint32) {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -94,7 +101,8 @@ func startServerSummonWith(t *testing.T, db world.Persistence, spells *content.S
 	if mob != nil {
 		w.SpawnMobAt(world.MobSpawn{Template: mob, X: mobX, Y: mobY, GenIndex: -1})
 	}
-	w.SetTickHandler(10*time.Millisecond, d.Tick)
+	w.SetTickHandler(tick, d.Tick)
+	w.SetSessionEndHandler(d.SessionEnd)
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() { _ = w.Serve(ctx, ln); close(done) }()
@@ -182,7 +190,7 @@ func expectPetRemove(t *testing.T, c net.Conn, petID int) {
 			return
 		}
 	}
-	t.Fatalf("no RemoveMob for baby mount pet %d", petID)
+	t.Fatalf("no RemoveMob for pet %d", petID)
 }
 
 func TestBabyMountSpawnsOnEquip(t *testing.T) {
@@ -574,6 +582,210 @@ func TestSummonGoneAfterRelogin(t *testing.T) {
 	if pets := collectPets(t, c, 500*time.Millisecond); len(pets) != 0 {
 		t.Fatalf("pets after relogin = %d, want 0 (owner-gone cleanup)", len(pets))
 	}
+}
+
+// --- issue #234: summons must not outlive the party bond that holds them ---
+
+// trackPets folds the pet lifecycle frames arriving over timeout into live: a pet
+// CreateMob adds an id, a RemoveMob (HEADER.ID) drops it. What remains in live is
+// what the client still has on screen.
+func trackPets(t *testing.T, c net.Conn, timeout time.Duration, live map[int]bool) map[int]bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		h, payload, ok := readMaybeHeaderRaw(t, c)
+		if !ok {
+			continue
+		}
+		switch h.Type {
+		case protocol.MsgCreateMob:
+			if id, name, _, _, _ := petFromCreateMob(payload); strings.HasSuffix(name, "^") {
+				live[id] = true
+			}
+		case protocol.MsgRemoveMob:
+			delete(live, int(h.ID))
+		}
+	}
+	return live
+}
+
+// summonPartySrv is a summon-capable server whose AI tick is slower than any
+// assert window, so a pet can only vanish because a party handler removed it
+// synchronously — never through the lifespan countdown or summonTick's orphan
+// reaper, which would otherwise mask a missing sweep.
+func summonPartySrv(t *testing.T, db world.Persistence) (string, func()) {
+	t.Helper()
+	addr, stop, _ := startServerSummonTick(t, db, evokeSpell(),
+		[][]byte{summonTemplate("Condor")}, nil, 0, 0, 5*time.Second)
+	return addr, stop
+}
+
+// summonPartyDB gives the leader (account 7) Evocação 30 → 1 pet and the member
+// (account 11) 60 → 2. The pet budget is shared party-wide — generateSummon counts
+// EVERY pet in the leader's PartyList, whoever evoked it (Server.cpp:2991-2997) —
+// so the member needs the larger allowance to fit one pet of its own alongside
+// the leader's.
+func summonPartyDB() *fakeDB {
+	db := summonDB(30)
+	member := db.loadResult
+	member.BaseSpecial[2] = 60
+	db.loads = map[int64]world.CharacterState{7: db.loadResult, 11: member}
+	return db
+}
+
+// evokeOne casts Evocar Condor from conn and returns the single pet's id.
+func evokeOne(t *testing.T, c net.Conn, conn int) int {
+	t.Helper()
+	skillAttackFrame(t, c, serverTime, conn, 56, damSkill)
+	pets := collectPets(t, c, 400*time.Millisecond)
+	if len(pets) != 1 {
+		t.Fatalf("conn %d evoked %d pets, want 1", conn, len(pets))
+	}
+	for id := range pets {
+		return id
+	}
+	return 0
+}
+
+// TestSoloSummonDespawnsOnRemoveParty is the issue-234 repro. A BM holding pets
+// has Leader == 0 with the pets in its OWN PartyList, so the leave button routes
+// to leaderLeaveParty — which used to zero the list and orphan them.
+func TestSoloSummonDespawnsOnRemoveParty(t *testing.T) {
+	addr, stop := summonPartySrv(t, summonDB(30))
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	pet := evokeOne(t, c, 1)
+	removePartyFrame(t, c, 1)
+	// The 5s tick puts expiry (20 decrements, one per 8 ticks) ~13min out, so this
+	// RemoveMob can only be the leave.
+	expectPetRemove(t, c, pet)
+}
+
+// TestEvocationAfterLeavingPartyStaysCapped is the second half of the report
+// ("...e fazer novas evocações"): the orphans used to be invisible to
+// generateSummon's head count, so a re-cast stacked a whole new set on top.
+func TestEvocationAfterLeavingPartyStaysCapped(t *testing.T) {
+	addr, stop := summonPartySrv(t, summonDB(30))
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	live := map[int]bool{evokeOne(t, c, 1): true}
+	removePartyFrame(t, c, 1)
+	trackPets(t, c, 400*time.Millisecond, live)
+	if len(live) != 0 {
+		t.Fatalf("pets alive after leaving = %v, want none", live)
+	}
+	skillAttackFrame(t, c, serverTime+1000, 1, 56, damSkill)
+	trackPets(t, c, 400*time.Millisecond, live)
+	if len(live) != 1 {
+		t.Fatalf("pets alive after re-evoking = %d (%v), want 1 — evocations stacked", len(live), live)
+	}
+}
+
+// partyWithPets: A (conn 1) leads, B (conn 2) joins, each evokes one pet. The
+// returned ids are both visible to A, whose stream the asserts read.
+func partyWithPets(t *testing.T, addr string) (a, b net.Conn, petA, petB int) {
+	t.Helper()
+	a = enterWorldAs(t, addr, "tester")
+	b = enterWorldAs(t, addr, "tradeb")
+	reqPartyFrame(t, a, 1, 2)
+	expectPartyFrame(t, b, protocol.MsgSendReqParty)
+	acceptPartyFrame(t, b, 1, "Beast")
+	drainRaw(t, a)
+	drainRaw(t, b)
+
+	petA = evokeOne(t, a, 1)
+	drainRaw(t, b)
+	skillAttackFrame(t, b, serverTime, 2, 56, damSkill)
+	pets := collectPets(t, a, 400*time.Millisecond) // A sees the member's pet appear
+	if len(pets) != 1 {
+		t.Fatalf("member evoked %d pets as seen by the leader, want 1", len(pets))
+	}
+	for id := range pets {
+		petB = id
+	}
+	drainRaw(t, b)
+	return a, b, petA, petB
+}
+
+// TestSummonDespawnsWhenOwnerLeavesParty: a member's pets sit in the LEADER's
+// PartyList, so leaving must take them along — and only them (Server.cpp:8185).
+func TestSummonDespawnsWhenOwnerLeavesParty(t *testing.T) {
+	addr, stop := summonPartySrv(t, summonPartyDB())
+	defer stop()
+	a, b, petA, petB := partyWithPets(t, addr)
+	defer a.Close()
+	defer b.Close()
+
+	removePartyFrame(t, b, 2)
+	live := trackPets(t, a, 600*time.Millisecond, map[int]bool{petA: true, petB: true})
+	if live[petB] {
+		t.Errorf("leaver's pet %d survived the party leave", petB)
+	}
+	if !live[petA] {
+		t.Errorf("leader's own pet %d was removed; only the leaver's should go", petA)
+	}
+}
+
+// TestSummonDespawnsWhenKicked is the kick side of the same sweep.
+func TestSummonDespawnsWhenKicked(t *testing.T) {
+	addr, stop := summonPartySrv(t, summonPartyDB())
+	defer stop()
+	a, b, petA, petB := partyWithPets(t, addr)
+	defer a.Close()
+	defer b.Close()
+
+	removePartyFrame(t, a, 2) // leader kicks the member
+	live := trackPets(t, a, 600*time.Millisecond, map[int]bool{petA: true, petB: true})
+	if live[petB] {
+		t.Errorf("kicked member's pet %d survived", petB)
+	}
+	if !live[petA] {
+		t.Errorf("leader's own pet %d was removed by the kick", petA)
+	}
+}
+
+// TestSummonDespawnsOnPartyDisband: dissolving takes every pet in the list, not
+// just the leader's — the deliberate divergence from Server.cpp:8242, which only
+// zeroes Summoner and would leak ownerless mobs here (party.go leaderLeaveParty).
+func TestSummonDespawnsOnPartyDisband(t *testing.T) {
+	addr, stop := summonPartySrv(t, summonPartyDB())
+	defer stop()
+	a, b, petA, petB := partyWithPets(t, addr)
+	defer a.Close()
+	defer b.Close()
+
+	removePartyFrame(t, a, 1) // leader leaves → party dissolves
+	live := trackPets(t, a, 600*time.Millisecond, map[int]bool{petA: true, petB: true})
+	if len(live) != 0 {
+		t.Fatalf("pets alive after the party dissolved = %v, want none", live)
+	}
+}
+
+// TestSummonPartySlotClearedOnDespawn: DespawnMob only sends RemoveMob, so the
+// sweep has to drop the pet's party row too or the client keeps the slot.
+func TestSummonPartySlotClearedOnDespawn(t *testing.T) {
+	addr, stop := summonPartySrv(t, summonDB(30))
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	pet := evokeOne(t, c, 1)
+	removePartyFrame(t, c, 1)
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		h, payload, ok := readMaybeHeaderRaw(t, c)
+		if !ok {
+			continue
+		}
+		if h.Type == protocol.MsgRemoveParty && int(protocolLe16(payload[0:2])) == pet {
+			return
+		}
+	}
+	t.Fatalf("no RemoveParty row for pet %d; the client keeps a ghost party slot", pet)
 }
 
 // TestSummonAssistsAgainstMob: a monster fight near the owner pulls the pet in

--- a/tmserver/internal/world/event.go
+++ b/tmserver/internal/world/event.go
@@ -138,11 +138,22 @@ func (e disconnectEvent) apply(w *World) {
 	w.removeSession(e.s)
 }
 
+// SetSessionEndHandler registers the session-teardown hook (party unlink). Like
+// the tick handler it runs INSIDE the loop goroutine and may mutate world state
+// directly; it sees the session and its entity still live. Call before Run.
+func (w *World) SetSessionEndHandler(fn func(*World, *Session)) { w.onSessionEnd = fn }
+
 // removeSession tears down a session and frees its slot. It only acts if the
 // slot still holds this exact session (guards against a reused slot). Loop-only.
 func (w *World) removeSession(s *Session) {
 	if s == nil || w.sessions[s.Conn] != s {
 		return
+	}
+	// Shared-state teardown (the party bond and its summons) while the session and
+	// its entity are still addressable — the legacy calls RemoveParty from CloseUser
+	// for the same reason (Server.cpp:7654).
+	if w.onSessionEnd != nil {
+		w.onSessionEnd(w, s)
 	}
 	// S→C post-mortem first, while the slot still identifies the session: what
 	// the client was sent last is the key evidence for a client-side freeze

--- a/tmserver/internal/world/event_test.go
+++ b/tmserver/internal/world/event_test.go
@@ -1,0 +1,45 @@
+package world
+
+import "testing"
+
+// TestSessionEndHandlerPlumbing verifies the teardown hook wiring: removeSession
+// runs it while the session AND its entity are still addressable (the party
+// unlink reads Leader/PartyList off the entity), exactly once per slot, and a nil
+// hook stays a safe no-op.
+func TestSessionEndHandlerPlumbing(t *testing.T) {
+	w := New(Config{GridDim: 16}, slogDiscard(), nil, nil)
+	const conn = 3
+	s := &Session{Conn: conn, Mode: UserPlay, out: make(chan outFrame, 4), closeCh: make(chan struct{})}
+	w.sessions[conn] = s
+	w.entities[conn] = &Entity{ID: conn, Mode: MobUser, HP: 100, Leader: 7}
+
+	calls, sawLeader := 0, 0
+	w.SetSessionEndHandler(func(hw *World, hs *Session) {
+		calls++
+		if e := hw.Entity(hs.Conn); e != nil {
+			sawLeader = e.Leader
+		}
+	})
+	w.removeSession(s)
+	if calls != 1 {
+		t.Fatalf("onSessionEnd called %d times, want 1", calls)
+	}
+	if sawLeader != 7 {
+		t.Fatalf("hook saw Leader %d, want 7 (the entity must still be live)", sawLeader)
+	}
+	if w.sessions[conn] != nil || w.entities[conn] != nil {
+		t.Fatal("removeSession did not free the slot")
+	}
+	// Tearing the same (already freed) session down again must not re-run the hook.
+	w.removeSession(s)
+	if calls != 1 {
+		t.Fatalf("onSessionEnd ran again for a freed slot (calls = %d)", calls)
+	}
+
+	// A nil handler is a safe no-op (e.g. transport-only tests).
+	w2 := New(Config{GridDim: 16}, slogDiscard(), nil, nil)
+	s2 := &Session{Conn: 1, Mode: UserPlay, out: make(chan outFrame, 4), closeCh: make(chan struct{})}
+	w2.sessions[1] = s2
+	w2.entities[1] = &Entity{ID: 1, Mode: MobUser, HP: 100}
+	w2.removeSession(s2) // must not panic
+}

--- a/tmserver/internal/world/world.go
+++ b/tmserver/internal/world/world.go
@@ -165,6 +165,10 @@ type World struct {
 	onTick       func(*World)
 	tickInterval time.Duration
 
+	// onSessionEnd is the teardown hook (party unlink), run inside the loop just
+	// before a session's slot is freed; see event.go. nil disables it.
+	onSessionEnd func(*World, *Session)
+
 	// respawnQueue holds dead monsters awaiting respawn, drained by SpawnDueRespawns
 	// from the tick (world/respawn.go). Loop-owned.
 	respawnQueue []respawnEntry


### PR DESCRIPTION
Fixes #234

> As evocações do BM continuam no lugar depois de sair do grupo e fazer novas evocações.

## Causa

Os pets do BM não têm registro próprio: eles ocupam **slots reais no `PartyList` do líder** (`summon.go:205`). Essa lista *é* o registro — `generateSummon` conta por ela e `commandSummons` acha os pets por ela.

Os três caminhos de saída de party (`handler/party.go`) zeravam esses slots **sem matar os pets**, então eles continuavam vivos fora de qualquer lista, e a evocação seguinte contava zero e empilhava um conjunto novo.

O bug se reproduz **sozinho, sem party nenhuma**: um BM com pets tem `Leader == 0`, então `_MSG_RemoveParty` cai em `leaderLeaveParty`, que zerava o `PartyList` inteiro. É a reprodução mais curta.

O legado faz essa limpeza dentro de `RemoveParty` (`Server.cpp:8185-8190` e `8237-8243`), chamado também de `_MSG_CharacterLogout.cpp:23` e de `CloseUser` (`Server.cpp:7654`) — nenhum dos dois estava portado.

## O que mudou

| Arquivo | Mudança |
|---|---|
| `handler/summon.go` | `despawnSummonsOf` + varredura compartilhada `despawnSummons`; `removeBabyMountSummons` refatorado por cima; rede de segurança `petIsListed` em `summonTick` |
| `handler/party.go` | varredura nos 3 caminhos de saída + `SessionEnd` |
| `handler/character.go` | `characterLogout` chama `SessionEnd` ainda em `UserPlay` |
| `world/event.go`, `world/world.go` | `SetSessionEndHandler`, rodado por `removeSession` antes de liberar o slot |
| `cmd/tmserver/main.go` | uma linha de wiring ao lado de `SetTickHandler` |

Dois detalhes:

- A varredura envia `MSG_RemoveParty` da linha do pet **antes** do `DespawnMob`, porque `DespawnMob` só manda `MSG_RemoveMob` — sem isso o cliente mantém o slot de pet fantasma. No legado isso vem de graça via `DeleteMob → RemoveParty` (`Server.cpp:7840`).
- `SessionEnd` sai cedo para quem não está em party, então logout não empurra mais um `RemoveParty(0)` inútil.

## Divergência deliberada

Ao dissolver a party o Go mata os pets de **todos** os membros. O legado deleta só os do líder e apenas zera `Summoner` nos demais (`Server.cpp:8242`), contando com a varredura global do affect 24 (`Server.cpp:5843`) para recolher o resto. Aqui a contagem de vida roda dentro de `summonTick`, que exige `Summoner != 0` (`mobai.go:61`) — copiar essa linha vazaria mobs sem dono para sempre. Documentado em `docs/migration/skills/beastmaster.md` e no doc de handlers de party.

## Verificação

- `go build ./...`, `go vet ./...` — limpos
- `go test -race -cover ./...` — **37 pacotes ok**, sem falhas e sem data race (`handler` 74.8%, `world` 59.9%)
- `golangci-lint run ./tmserver/...` — limpo em todo arquivo tocado (as 3 queixas de gofmt são pré-existentes em `cmd/exptool`, `internal/npccfg` e `internal/worldcfg`, intocados aqui)
- Os 6 testes novos de summon **falham** com a varredura desativada e passam com ela — verificado. Os testes de party rodam com tick de 5s para provar o caminho síncrono, não o reaper (com o tick de 10ms original, três deles passavam mesmo sem a correção, mascarados pelo reaper).

**Não validado:** o passo com cliente 7662 real (`make run-local`). Os testes cobrem a sequência de pacotes; ver o pet desaparecer na tela ainda vale antes do merge.

## Achado adjacente (fora de escopo)

`d.castleParty` (`handler/castle.go:49-51`) copia `leader.PartyList` e nunca é invalidado: quem sai ou faz logout mantém acesso à sala do castelo e ainda recebe o prêmio da party. Merece issue própria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
