### PR TITLE
test(tmserver): validar eventos de mundo E2E no cliente

### DIFF
--- a/docs/migration/worldevents-e2e-report.md
+++ b/docs/migration/worldevents-e2e-report.md
@@ -1,0 +1,162 @@
+# Validação E2E dos eventos de mundo (issue #116)
+
+Este documento registra o que foi **validado ponta a ponta contra uma stack viva** dos eventos de
+mundo, o que **não é alcançável sem o cliente real** e por quê, e o checklist manual que sobra para
+quem tem o `WYD.exe` na mão.
+
+Artefatos:
+
+- `tmserver/internal/world/worldevents_e2e_test.go` — cliente CPSock headless + os casos de teste.
+- `scripts/e2e-worldevents.sh` — sobe o que falta, abre a janela do calendário e roda a suíte.
+
+## 1. Por que um cliente headless
+
+O contrato observável de um evento de mundo é **o frame S→C**. Um servidor que calcula o estado
+certo e manda o pacote errado é indistinguível de um servidor quebrado num teste unitário — é a
+lição registrada no `SESSION-PRIMER.md` §5.1 ("servidor-correto ≠ cliente-correto"). Os testes aqui
+abrem um socket de verdade, fazem o handshake INITCODE, `MSG_AccountLogin`, `MSG_CreateCharacter` e
+`MSG_CharacterLogin` como o `WYD.exe` faz, entram em `USER_PLAY` e **conferem os bytes na rede**.
+
+O que isso cobre: a metade servidor de "o que o cliente veria". O que isso **não** cobre: a
+renderização (céu, barra de vida, painel de aviso). Essa metade continua exigindo uma pessoa no
+cliente real — ver §5.
+
+## 2. Resultado
+
+Stack: `docker compose` completo (PostgreSQL + dbServer + binServer + tmServer), conteúdo
+`Release/` montado, 12.824 mobs gerados, conta `test` promovida a `admin`.
+
+| Evento (fase da issue #116) | Frame S→C | Status |
+| --- | --- | --- |
+| Clima — broadcast de mudança | `MSG_UpdateWeather` (0x018B) | ✅ validado |
+| Clima — guarda de idempotência | (ausência de frame) | ✅ validado |
+| Clima — rejeição de valor inválido | `MSG_MessageChat` | ✅ validado |
+| Clima — snapshot no login | `MSG_CNFCharacterLogin` @1032 | ✅ validado |
+| Newbie — handicap de HP no spawn | `MSG_CreateMob` (Hp/MaxHp) | ✅ validado |
+| Newbie — recarga via config do portal | (efeito no spawn seguinte) | ✅ validado |
+| Torre — aviso e início da guerra | `MSG_MessageChat` | ✅ validado |
+| Reino (RvR) — muro e dano de área | `MSG_EnvEffect` + dano | ❌ inalcançável (§3) |
+| Reino — morte do rei | `MSG_MessageChat` por área | ❌ inalcançável (§3) |
+| Castelo/Zakum — abertura da quest | `MSG_StartTime` (0x03A1) | ❌ inalcançável (§3) |
+| Evento de item (config do portal) | slot + `MSG_MessageChat` | ❌ inalcançável (§3) |
+
+### 2.1 Clima (fase 1)
+
+Quatro casos, todos passando:
+
+- **Broadcast.** `/gm weather 1|2|0` produz exatamente um `MSG_UpdateWeather` por sessão em jogo,
+  corpo de 4 bytes com o valor em `int32`, e `HEADER.ID = ESCENE_FIELD (30000)`. O `HEADER.ID`
+  importa tanto quanto o `Type`: é ele que roteia o pacote para o handler de cena do cliente
+  (`SendFunc.cpp:1669-1696`).
+- **Idempotência.** Reforçar o clima que já está ativo **não** coloca um segundo pacote na rede —
+  a guarda `ForceWeather != CurrentWeather` do legado. Um pacote redundante reinicia a transição de
+  céu no cliente, então a guarda é visível.
+- **Validação.** `/gm weather 9` responde com a linha de erro e **não** transmite. Divergência
+  deliberada do legado, que mandava qualquer `int` direto para o cliente (`imple.cpp:1122-1129`).
+- **Snapshot de login.** Um cliente que entra **depois** da mudança aprende o valor pelo
+  `MSG_CNFCharacterLogin` (offset 1032 do corpo), não por um broadcast que ele nunca viu. Sem isso,
+  quem faz relog no meio de uma tempestade renderiza céu limpo.
+
+### 2.2 Newbie (fase 2)
+
+O único efeito **visível ao cliente** dessa fase é o handicap de spawn: com `NewbieEventServer`
+ligado, monstro abaixo do nível 120 nasce com 3/4 do HP e `MaxHp` intacto
+(`Server.cpp:3326-3327` → `world.applyNewbieHandicap`). Isso chega ao cliente dentro do
+`MSG_CreateMob`, e é o que faz a barra de vida do monstro nascer em três quartos.
+
+Medido na rede, com o mesmo template (`/gm spawn 1`, mob nível 4):
+
+- evento desligado → `100/100 HP`
+- evento ligado → `75/100 HP`
+
+O caminho exercitado é o **real**: a flag vem da config do portal (`world_event_config`), o
+`world_event_meta.version` é incrementado, e o `pollWorldEventConfig` (a cada 15 ticks) recarrega no
+servidor **em execução** — confirmado no log com `world event config reloaded version=1`.
+
+O bônus de EXP da mesma flag **não tem frame próprio** e não é observável de um cliente; ele
+continua coberto pelos testes unitários de `internal/level`.
+
+### 2.3 Torre (fase 4)
+
+A janela é "dia útil, hora 20, minuto ≤ 5, com `NewbieEventServer` ligado"
+(`CWarTower.cpp:203` → `handler/towerwar.go`). O evento lê `time.Now()`, ou seja, **a hora local do
+container** — então a janela é alcançável sem esperar uma terça à noite e **sem mockar relógio em
+código de produção**: `scripts/e2e-worldevents.sh` procura um fuso em que agora sejam 20:0x, sobe um
+segundo tmServer nele e conecta o cliente headless.
+
+<!-- RESULTADO-TORRE -->
+
+Resultado observado na stack viva: o aviso `"[Torre] A guerra da torre comecara em breve."` e,
+273,75 segundos depois, o início `"[Torre] A guerra da torre comecou."` chegaram ao cliente
+headless como `MSG_MessageChat`. O runner preserva e restaura o valor anterior de
+`newbie_event_enabled`, mantendo-o ligado durante toda a execução para que a recarga periódica de
+configuração não feche a janela antes da transição do minuto 6.
+
+## 3. O que não é alcançável de um cliente headless
+
+Não são falhas: são eventos cujo gatilho exige estado que nenhum comando disponível produz. Listar
+isso explicitamente é o ponto — o risco real é um evento passar por "validado" porque o teste
+simplesmente não conseguiu dispará-lo.
+
+- **Muro do reino (RvR).** O pulso de `MSG_EnvEffect` + dano só ocorre com um jogador **dentro** das
+  caixas `{1050,2108,1098,2146}` (azul) e `{1204,1947,1245,1988}` (vermelha). Não existe comando de
+  GM de teleporte por coordenada (`gm.go` tem `goto <jogador>` e `summon <jogador>`, ambos relativos
+  a alguém online), e nenhum `/cidade` do `teleportCmds` cai lá dentro. Andar até lá seriam ~1000
+  tiles de pacotes de movimento com colisão real.
+- **Morte do rei.** `kingdomKingKilled` depende de matar os geradores 8/9 (Harabard/Glantuar). Dá
+  para **spawnar** o rei com `/gm spawn`, mas matá-lo exige um laço de combate real.
+- **Castelo/Zakum (fase 5).** `openCastleQuest` só é chamado por `gate.go` quando o jogador abre um
+  portão com `EF_KEYID == 10` **carregando uma chave cujo `EF_QUEST` nomeia o nível da quest**.
+  `/gm item` entrega item **sem efeitos** (`gm.go:178`, "by index, no effects"), então `itemQuestID`
+  devolve -1 e o portão nunca abre quest. A chave legítima vem de `castleKeyDrop`, que por sua vez
+  exige uma quest já ativa — circular.
+- **Drop do evento de item.** `tryWorldEventDrop` é chamado de `mobkilled.go:75`; exige matar um mob.
+
+Todos os quatro se destravam com a mesma peça: **um caminho de combate no cliente headless** (mirar
++ atacar até a morte) e **um `/gm item` que aceite efeitos**. Ficam registrados como próximo passo,
+não como cobertura existente.
+
+## 4. Observação operacional: `-newbie-event` perde para o banco
+
+`w.SetNewbieEvent(*newbieEvent)` roda no boot (`main.go:311`) e é **sobrescrito poucos
+milissegundos depois** por `ApplyWorldEventConfigBoot` (`main.go:345`), que aplica
+`world_event_config.newbie_event_enabled`. O comentário em `main.go:307-310` diz que isso é
+intencional (o portal é a autoridade), mas o efeito prático merece registro:
+
+> Com `-dbserver` ligado — que é a topologia normal — a flag `-newbie-event` **não tem efeito
+> algum**, porque a linha de config nasce com `newbie_event_enabled = false`. Ligar o evento newbie
+> (e, por tabela, a guerra da torre, que depende dele) é feito **no banco/portal**, não na linha de
+> comando.
+
+Foi exatamente isso que fez a primeira tentativa da janela da torre não disparar. Não é bug de
+código; é uma pegadinha de operação que vale estar escrita.
+
+## 5. Checklist manual no `WYD.exe`
+
+O que os testes acima **não** conseguem afirmar é o lado da renderização. Com a stack de pé
+(`./scripts/run-local.sh`) e uma conta promovida a `admin`:
+
+1. **Clima.** `/gm weather 1`, depois `2`, depois `0`. O céu deve mudar em cada um e **não** piscar
+   ao repetir o mesmo valor. Confirmar que `/gm weather 9` não muda nada.
+2. **Clima no relog.** Com o clima em 2, sair para a seleção de personagem e entrar de novo: o céu
+   deve **já** estar no clima 2 ao entrar, sem um frame de céu limpo antes.
+3. **Newbie.** Com `newbie_event_enabled = true`, spawnar um monstro abaixo do nível 120 e conferir
+   que a barra de vida nasce em três quartos.
+4. **Torre.** Dentro da janela (§2.3), confirmar que os avisos `[Torre]` aparecem no painel de chat
+   e que a torre aparece no terreno em `{2445,1850}-{2546,1920}`.
+5. **Reino e Castelo.** Sem cobertura automatizada (§3) — validar inteiramente à mão.
+
+## 6. Como reproduzir
+
+```bash
+./scripts/run-local.sh
+docker compose exec db psql -U postgres -c "UPDATE account SET role='admin' WHERE name='test'"
+docker compose run --rm dbserver seed-account -name test2 -pass test123   # snapshot de login
+
+./scripts/e2e-worldevents.sh weather
+./scripts/e2e-worldevents.sh newbie
+./scripts/e2e-worldevents.sh tower      # espera a janela abrir (até ~30 min)
+./scripts/e2e-worldevents.sh probe      # "a janela da torre está aberta agora?"
+```
+
+Os testes ficam atrás da tag de build `e2e`, então `go test ./...` normal não os enxerga.

--- a/scripts/e2e-worldevents.sh
+++ b/scripts/e2e-worldevents.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Drive the world-event E2E suite (tmserver/internal/world/worldevents_e2e_test.go)
+# against a live stack, including the calendar-gated Tower War.
+#
+# The tower window is "a weekday, hour 20, minute <= 5, NewbieEventServer on"
+# (CWarTower.cpp:203 → handler/towerwar.go). The event reads time.Now(), i.e. the
+# CONTAINER's local time, so the gate is reachable without waiting for a real
+# Tuesday evening: this script finds a timezone in which it is currently 20:0x
+# and boots a second tmserver in it. No production code is time-mocked.
+#
+# Windows exist roughly twice an hour (at UTC :00-:05 via a whole-hour zone, and
+# at UTC :30-:35 via a :30 zone), so the wait is at most ~30 minutes.
+#
+# Usage:
+#   ./scripts/e2e-worldevents.sh              # weather now, tower when the window opens
+#   ./scripts/e2e-worldevents.sh weather      # weather only, no waiting
+#   ./scripts/e2e-worldevents.sh tower        # tower only
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Git Bash on Windows rewrites POSIX-looking arguments into Windows paths, which
+# turns container-side paths (/src, /Release) into C:\Program Files\Git\... .
+# No-op everywhere else.
+export MSYS_NO_PATHCONV=1
+
+MODE=${1:-all}
+# Compose derives the project name from the directory: lowercased, with the
+# characters it rejects (dots included) stripped, dashes kept.
+PROJECT=${W2PP_E2E_PROJECT:-$(basename "$PWD" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]-')}
+NETWORK=${W2PP_E2E_NETWORK:-${PROJECT}_default}
+GOIMAGE=${W2PP_E2E_GOIMAGE:-golang:1.26-alpine}
+TMIMAGE=${W2PP_E2E_TMIMAGE:-${PROJECT}-tmserver}
+TOWER_CONTAINER=w2pp-e2e-tower
+TOWER_PORT=8281
+
+# Only DST-free zones: a zone that shifts would make the offset table lie.
+# "<offset-in-minutes> <zone>", the offset being local = UTC + offset.
+ZONES="
+-720 Etc/GMT+12
+-660 Etc/GMT+11
+-600 Etc/GMT+10
+-570 Pacific/Marquesas
+-540 Etc/GMT+9
+-480 Etc/GMT+8
+-420 Etc/GMT+7
+-360 Etc/GMT+6
+-300 Etc/GMT+5
+-240 Etc/GMT+4
+-180 Etc/GMT+3
+-120 Etc/GMT+2
+-60 Etc/GMT+1
+0 UTC
+60 Etc/GMT-1
+120 Etc/GMT-2
+180 Etc/GMT-3
+210 Asia/Tehran
+240 Etc/GMT-4
+270 Asia/Kabul
+300 Etc/GMT-5
+330 Asia/Kolkata
+345 Asia/Kathmandu
+360 Etc/GMT-6
+390 Asia/Yangon
+420 Etc/GMT-7
+480 Etc/GMT-8
+525 Australia/Eucla
+540 Etc/GMT-9
+570 Australia/Darwin
+600 Etc/GMT-10
+660 Etc/GMT-11
+720 Etc/GMT-12
+780 Etc/GMT-13
+840 Etc/GMT-14
+"
+
+# find_window prints "<zone> <weekday>" for a zone where it is now hour 20,
+# minute <= 3 (margin: the server needs ~40s to boot before its first minute
+# tick) and the weekday is Mon-Fri. Prints nothing when no zone qualifies.
+find_window() {
+	local utc_h utc_m utc_dow now_min off zone local_min local_h local_dow
+	utc_h=$(date -u +%H); utc_m=$(date -u +%M); utc_dow=$(date -u +%u)
+	# Strip leading zeros so arithmetic does not read them as octal.
+	now_min=$(( 10#$utc_h * 60 + 10#$utc_m ))
+	while read -r off zone; do
+		[ -n "${off:-}" ] || continue
+		local_min=$(( now_min + off ))
+		local_dow=$(( 10#$utc_dow ))
+		if [ "$local_min" -lt 0 ]; then
+			local_min=$(( local_min + 1440 )); local_dow=$(( local_dow - 1 ))
+		elif [ "$local_min" -ge 1440 ]; then
+			local_min=$(( local_min - 1440 )); local_dow=$(( local_dow + 1 ))
+		fi
+		[ "$local_dow" -lt 1 ] && local_dow=7
+		[ "$local_dow" -gt 7 ] && local_dow=1
+		# Saturday/Sunday are excluded by the event itself.
+		[ "$local_dow" -ge 6 ] && continue
+		local_h=$(( local_min / 60 ))
+		[ "$local_h" -eq 20 ] || continue
+		[ $(( local_min % 60 )) -le 3 ] || continue
+		echo "$zone"
+		return 0
+	done <<-EOF
+	$ZONES
+	EOF
+	return 1
+}
+
+run_go_test() {
+	local pattern=$1; shift
+	docker run --rm \
+		-v "$PWD":/src -v w2pp-gocache:/go/pkg/mod -w /src \
+		--network "$NETWORK" \
+		-e W2PP_E2E_ADDR="${W2PP_E2E_ADDR:-tmserver:8281}" \
+		-e W2PP_E2E_ACCOUNT="${W2PP_E2E_ACCOUNT:-test}" \
+		-e W2PP_E2E_PASSWORD="${W2PP_E2E_PASSWORD:-test123}" \
+		-e W2PP_E2E_ACCOUNT2="${W2PP_E2E_ACCOUNT2:-}" \
+		-e W2PP_E2E_PASSWORD2="${W2PP_E2E_PASSWORD2:-test123}" \
+		-e W2PP_E2E_VERSION="${W2PP_E2E_VERSION:-12000}" \
+		-e W2PP_E2E_TOWER_ADDR="${W2PP_E2E_TOWER_ADDR:-}" \
+		-e W2PP_E2E_NEWBIE_EXPECT="${W2PP_E2E_NEWBIE_EXPECT:-}" \
+		-e W2PP_E2E_SUMMON_TEMPLATE="${W2PP_E2E_SUMMON_TEMPLATE:-}" \
+		"$GOIMAGE" \
+		go test -tags=e2e -count=1 -timeout 20m -run "$pattern" ./tmserver/internal/world/ -v "$@"
+}
+
+# "probe" answers "is a tower window open right now?" without touching Docker —
+# useful when deciding whether the ~30 minute wait below is worth starting.
+if [ "$MODE" = "probe" ]; then
+	date -u
+	if zone=$(find_window); then
+		echo "window OPEN in ${zone}"
+	else
+		echo "no window right now"
+	fi
+	exit 0
+fi
+
+docker volume create w2pp-gocache >/dev/null
+
+if [ "$MODE" = "all" ] || [ "$MODE" = "weather" ]; then
+	echo "==> Weather / login-snapshot suite"
+	run_go_test 'TestE2EWorldEventWeather'
+fi
+
+if [ "$MODE" = "all" ] || [ "$MODE" = "newbie" ]; then
+	echo "==> Newbie event (mob spawn handicap), driven through the portal config"
+	# The DB row wins over the -newbie-event boot flag (ApplyWorldEventConfigBoot →
+	# setNewbieEvent), so the flag is toggled here. The version bump is what makes
+	# the RUNNING tmserver reload: pollWorldEventConfig compares versions.
+	set_newbie() {
+		docker compose exec -T db psql -U postgres -q \
+			-c "UPDATE world_event_config SET newbie_event_enabled = $1 WHERE id = TRUE" \
+			-c "UPDATE world_event_meta SET version = version + 1 WHERE id = TRUE" >/dev/null
+		echo "    newbie_event_enabled := $1 (waiting for the 15-tick config poll)"
+		sleep 25
+	}
+	set_newbie FALSE
+	export W2PP_E2E_NEWBIE_EXPECT=full
+	run_go_test 'TestE2EWorldEventNewbieMobHandicap'
+	set_newbie TRUE
+	export W2PP_E2E_NEWBIE_EXPECT=handicap
+	run_go_test 'TestE2EWorldEventNewbieMobHandicap'
+	unset W2PP_E2E_NEWBIE_EXPECT
+fi
+
+if [ "$MODE" = "all" ] || [ "$MODE" = "tower" ]; then
+	echo "==> Waiting for a tower window (weekday 20:00-20:03 in some zone)…"
+	ZONE=""
+	while [ -z "$ZONE" ]; do
+		if ZONE=$(find_window); then
+			break
+		fi
+		ZONE=""
+		echo "    $(date -u +%H:%M:%SZ) — no zone in the window, retrying in 20s"
+		sleep 20
+	done
+	echo "==> Window open in ${ZONE}; enabling NewbieEventServer and booting ${TOWER_CONTAINER}"
+
+	# ApplyWorldEventConfigBoot makes the portal row authoritative over the CLI
+	# flag. Keep it enabled for the whole run because the live-config poll would
+	# otherwise turn the tower gate off again before minute 6.
+	ORIGINAL_NEWBIE=$(docker compose exec -T db psql -U postgres -Atq \
+		-c "SELECT newbie_event_enabled FROM world_event_config WHERE id = TRUE")
+	docker compose exec -T db psql -U postgres -q \
+		-c "UPDATE world_event_config SET newbie_event_enabled = TRUE WHERE id = TRUE" \
+		-c "UPDATE world_event_meta SET version = version + 1 WHERE id = TRUE" >/dev/null
+
+	cleanup_tower() {
+		docker rm -f "$TOWER_CONTAINER" >/dev/null 2>&1 || true
+		if [ -n "${ORIGINAL_NEWBIE:-}" ]; then
+			docker compose exec -T db psql -U postgres -q \
+				-c "UPDATE world_event_config SET newbie_event_enabled = ${ORIGINAL_NEWBIE} WHERE id = TRUE" \
+				-c "UPDATE world_event_meta SET version = version + 1 WHERE id = TRUE" >/dev/null || true
+		fi
+	}
+	trap cleanup_tower EXIT
+
+	docker rm -f "$TOWER_CONTAINER" >/dev/null 2>&1 || true
+	docker run -d --name "$TOWER_CONTAINER" --network "$NETWORK" \
+		-e TZ="$ZONE" \
+		-v "$PWD/Release":/Release:ro \
+		"$TMIMAGE" \
+		-addr ":${TOWER_PORT}" -dbserver dbserver:7514 -binserver binserver:3000 \
+		-content /Release -status-addr :80 -client-version 12000 -newbie-event >/dev/null
+
+	echo "==> Waiting for the tower tmserver to accept connections…"
+	for _ in $(seq 1 60); do
+		if docker logs "$TOWER_CONTAINER" 2>&1 | grep -q "world loop started"; then break; fi
+		sleep 2
+	done
+	docker logs "$TOWER_CONTAINER" 2>&1 | tail -3
+
+	W2PP_E2E_TOWER_ADDR="${TOWER_CONTAINER}:${TOWER_PORT}" run_go_test 'TestE2EWorldEventTowerWar' || TOWER_FAILED=1
+	echo "==> tower tmserver log (event lines):"
+	docker logs "$TOWER_CONTAINER" 2>&1 | grep -iE "torre|tower|weather changed" || echo "    (none)"
+	[ -z "${TOWER_FAILED:-}" ] || exit 1
+fi

--- a/tmserver/internal/world/worldevents_e2e_test.go
+++ b/tmserver/internal/world/worldevents_e2e_test.go
@@ -1,0 +1,580 @@
+//go:build e2e
+
+// End-to-end validation of the WORLD EVENTS (issue #116) against a LIVE stack,
+// driven by a headless CPSock client that speaks exactly what WYD.exe speaks.
+//
+// Why this exists: the world events are timer-driven and their only observable
+// contract is the S→C frame the client receives — a server that computes the
+// right state but ships the wrong packet is indistinguishable from a broken one
+// at the unit-test level (SESSION-PRIMER §5.1, "servidor-correto ≠ cliente-correto").
+// These tests assert the bytes on the wire, from a real socket, against a real
+// tmServer → dbServer → PostgreSQL chain.
+//
+// The client here is deliberately dumb: it performs the INITCODE handshake, a
+// real MSG_AccountLogin, MSG_CreateCharacter and MSG_CharacterLogin, then reads
+// frames. It renders nothing, so it validates the SERVER half of "what WYD.exe
+// would see" — the rendering half still needs a human at the real client, and
+// the events that have no S→C frame at all are listed in
+// docs/migration/worldevents-e2e-report.md rather than silently skipped.
+//
+// Run against a stack brought up by scripts/run-local.sh:
+//
+//	W2PP_E2E_ADDR=127.0.0.1:8281 W2PP_E2E_ACCOUNT=test W2PP_E2E_PASSWORD=test123 \
+//	  W2PP_E2E_VERSION=12000 go test -tags=e2e -run TestE2EWorldEvent ./tmserver/internal/world/ -v
+//
+// The GM-driven cases need the account promoted to a moderator/admin role:
+//
+//	docker compose exec db psql -U postgres -c "UPDATE account SET role='admin' WHERE name='test'"
+package world
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+)
+
+// clientKeyWord seeds the C→S obfuscation. Any value works (the server reads it
+// out of byte 2); 7 is what the smoke test uses.
+const clientKeyWord = 7
+
+// cnfCharLoginWeatherOffset is where CurrentWeather rides the login snapshot:
+// MSG_CNFCharacterLogin body @1032, an unsigned short (protocol/mob.go
+// EncodeCNFCharacterLoginRaw, legacy sm.Weather at ProcessDBMessage.cpp:834).
+// Weather is NOT sent as its own packet at login — if this offset is wrong the
+// client shows the wrong sky until the next broadcast.
+const cnfCharLoginWeatherOffset = 1032
+
+// liveClient is a headless stand-in for WYD.exe: one CPSock connection plus a
+// backlog of frames already pulled off the socket.
+//
+// The backlog matters. Entering the world triggers a burst of unrelated frames
+// (CreateMob for every visible entity, affects, item slots), and a world-event
+// frame arrives interleaved with them. Every wait therefore scans forward and
+// keeps what it did not want, so a later wait can still find it.
+type liveClient struct {
+	t       *testing.T
+	conn    net.Conn
+	account string
+	backlog []protocol.Frame
+	connID  uint16
+	// snapshot is the MSG_CNFCharacterLogin this client entered the world with.
+	// Weather rides it, so tests read it instead of re-deriving state.
+	snapshot protocol.Frame
+}
+
+// dialLive opens a connection and completes the INITCODE handshake.
+func dialLive(t *testing.T, addr, account string) *liveClient {
+	t.Helper()
+	return &liveClient{t: t, conn: liveDial(t, addr), account: account}
+}
+
+func (c *liveClient) close() {
+	if c.conn != nil {
+		_ = c.conn.Close()
+	}
+}
+
+// send encodes and writes one C→S frame.
+func (c *liveClient) send(typ protocol.Type, id uint16, body []byte) {
+	c.t.Helper()
+	wire, err := protocol.Encode(protocol.Header{Type: typ, ID: id}, body, clientKeyWord)
+	if err != nil {
+		c.t.Fatalf("encode %#x: %v", typ, err)
+	}
+	if _, err := c.conn.Write(wire); err != nil {
+		c.t.Fatalf("write %#x: %v", typ, err)
+	}
+}
+
+// readFrame pulls exactly one frame off the socket, honouring deadline.
+func (c *liveClient) readFrame(deadline time.Time) (protocol.Frame, error) {
+	if err := c.conn.SetReadDeadline(deadline); err != nil {
+		return protocol.Frame{}, err
+	}
+	var sz [2]byte
+	if _, err := io.ReadFull(c.conn, sz[:]); err != nil {
+		return protocol.Frame{}, err
+	}
+	size := int(binary.LittleEndian.Uint16(sz[:]))
+	if size < protocol.HeaderSize {
+		return protocol.Frame{}, fmt.Errorf("frame size %d below header size", size)
+	}
+	buf := make([]byte, size)
+	copy(buf, sz[:])
+	if _, err := io.ReadFull(c.conn, buf[2:]); err != nil {
+		return protocol.Frame{}, err
+	}
+	h, payload, _, err := protocol.Decode(buf)
+	if err != nil {
+		return protocol.Frame{}, err
+	}
+	return protocol.Frame{Header: h, Payload: payload}, nil
+}
+
+// waitFor scans the backlog and then the socket for the first frame of type typ.
+// Frames of other types are retained in the backlog, never dropped.
+func (c *liveClient) waitFor(typ protocol.Type, within time.Duration) (protocol.Frame, bool) {
+	c.t.Helper()
+	for i, f := range c.backlog {
+		if f.Header.Type == typ {
+			c.backlog = append(c.backlog[:i], c.backlog[i+1:]...)
+			return f, true
+		}
+	}
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		f, err := c.readFrame(deadline)
+		if err != nil {
+			return protocol.Frame{}, false
+		}
+		if f.Header.Type == typ {
+			return f, true
+		}
+		c.backlog = append(c.backlog, f)
+	}
+	return protocol.Frame{}, false
+}
+
+// waitForAny is waitFor over a set of types, for the branches where the server
+// legitimately answers one of several frames. Waiting for them one at a time
+// would burn a full timeout on the branch that did not happen.
+func (c *liveClient) waitForAny(types []protocol.Type, within time.Duration) (protocol.Frame, bool) {
+	c.t.Helper()
+	match := func(t protocol.Type) bool {
+		for _, want := range types {
+			if t == want {
+				return true
+			}
+		}
+		return false
+	}
+	for i, f := range c.backlog {
+		if match(f.Header.Type) {
+			c.backlog = append(c.backlog[:i], c.backlog[i+1:]...)
+			return f, true
+		}
+	}
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		f, err := c.readFrame(deadline)
+		if err != nil {
+			return protocol.Frame{}, false
+		}
+		if match(f.Header.Type) {
+			return f, true
+		}
+		c.backlog = append(c.backlog, f)
+	}
+	return protocol.Frame{}, false
+}
+
+// waitForChat scans for a MSG_MessageChat whose text contains substr. World
+// event announcements (tower, castle, event drops) all ride this frame.
+func (c *liveClient) waitForChat(substr string, within time.Duration) (string, bool) {
+	c.t.Helper()
+	deadline := time.Now().Add(within)
+	// Backlog first, then the socket, with the same matching rule.
+	for i := 0; i < len(c.backlog); i++ {
+		if text, ok := chatText(c.backlog[i]); ok && strings.Contains(text, substr) {
+			c.backlog = append(c.backlog[:i], c.backlog[i+1:]...)
+			return text, true
+		}
+	}
+	for time.Now().Before(deadline) {
+		f, err := c.readFrame(deadline)
+		if err != nil {
+			return "", false
+		}
+		if text, ok := chatText(f); ok && strings.Contains(text, substr) {
+			return text, true
+		}
+		c.backlog = append(c.backlog, f)
+	}
+	return "", false
+}
+
+// chatText extracts the NUL-terminated text of a MSG_MessageChat frame.
+func chatText(f protocol.Frame) (string, bool) {
+	if f.Header.Type != protocol.MsgMessageChat {
+		return "", false
+	}
+	return cstring(f.Payload), true
+}
+
+// cstring reads a NUL-terminated string from b.
+func cstring(b []byte) string {
+	if i := bytes.IndexByte(b, 0); i >= 0 {
+		b = b[:i]
+	}
+	return string(b)
+}
+
+// quiet drains whatever the server pushes for d, so a later waitFor cannot match
+// a frame the PREVIOUS step caused. Retains nothing: callers use it as a barrier.
+func (c *liveClient) quiet(d time.Duration) {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if _, err := c.readFrame(deadline); err != nil {
+			return
+		}
+	}
+}
+
+// login performs MSG_AccountLogin and waits for the character-selection reply.
+func (c *liveClient) login(password string) {
+	c.t.Helper()
+	if _, err := c.conn.Write(loginFrame(c.account, password)); err != nil {
+		c.t.Fatalf("write login: %v", err)
+	}
+	f, ok := c.waitFor(protocol.MsgCNFAccountLogin, 10*time.Second)
+	if !ok {
+		c.t.Fatalf("account %q: no CNFAccountLogin (backlog: %s)", c.account, c.backlogTypes())
+	}
+	c.connID = f.Header.ID
+}
+
+// enterWorld creates the character if it does not exist yet and selects slot 0,
+// leaving the session in USER_PLAY. Returns the CNFCharacterLogin snapshot.
+//
+// Creation is attempted unconditionally: on a re-run the name is taken and the
+// server answers MSG_NewCharacterFail, which is the same "slot 0 is ready"
+// state. That keeps the test idempotent without a delete/recreate cycle.
+func (c *liveClient) enterWorld(charName string, class int32) protocol.Frame {
+	c.t.Helper()
+	create := protocol.MsgCreateCharacterBody{Slot: 0, MobClass: class}
+	copy(create.MobName[:], charName)
+	c.send(protocol.MsgCreateCharacter, 0, create.Encode())
+	// Either outcome is fine; both mean slot 0 is settled.
+	if _, ok := c.waitForAny([]protocol.Type{protocol.MsgCNFNewCharacter, protocol.MsgNewCharacterFail},
+		8*time.Second); !ok {
+		c.t.Fatalf("create char %q: neither CNFNewCharacter nor NewCharacterFail", charName)
+	}
+
+	login := protocol.MsgCharacterLoginBody{Slot: 0}
+	c.send(protocol.MsgCharacterLogin, 0, login.Encode())
+	f, ok := c.waitFor(protocol.MsgCNFCharacterLogin, 15*time.Second)
+	if !ok {
+		c.t.Fatalf("char login: no CNFCharacterLogin (backlog: %s)", c.backlogTypes())
+	}
+	if len(f.Payload) < cnfCharLoginWeatherOffset+2 {
+		c.t.Fatalf("CNFCharacterLogin body too short: %d bytes", len(f.Payload))
+	}
+	c.snapshot = f
+	return f
+}
+
+// gm sends a "/gm <line>" command. The client encodes slash commands as a
+// whisper whose TARGET NAME is the keyword ("gm") and whose text is the rest of
+// the line — the legacy _MSG_MessageWhisper quirk (handler/chat.go runCommand).
+func (c *liveClient) gm(line string) {
+	c.t.Helper()
+	body := protocol.MsgWhisperBody{String: append([]byte(line), 0)}
+	copy(body.MobName[:], "gm")
+	c.send(protocol.MsgMessageWhisper, c.connID, body.Encode())
+}
+
+func (c *liveClient) backlogTypes() string {
+	var b strings.Builder
+	for i, f := range c.backlog {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(&b, "%#x", f.Header.Type)
+	}
+	if b.Len() == 0 {
+		return "(empty)"
+	}
+	return b.String()
+}
+
+// snapshotWeather reads CurrentWeather out of a CNFCharacterLogin body.
+func snapshotWeather(f protocol.Frame) int32 {
+	return int32(binary.LittleEndian.Uint16(f.Payload[cnfCharLoginWeatherOffset:]))
+}
+
+// newPlayer is the common arrangement: connect, log in, enter the world.
+func newPlayer(t *testing.T, account, password, charName string) *liveClient {
+	t.Helper()
+	c := dialLive(t, env("W2PP_E2E_ADDR", "127.0.0.1:8281"), account)
+	t.Cleanup(c.close)
+	c.login(password)
+	c.enterWorld(charName, 0) // class 0 = TransKnight
+	return c
+}
+
+// gmPlayer is newPlayer for the privileged account under test.
+func gmPlayer(t *testing.T) *liveClient {
+	t.Helper()
+	return newPlayer(t,
+		env("W2PP_E2E_ACCOUNT", "test"),
+		env("W2PP_E2E_PASSWORD", "test123"),
+		env("W2PP_E2E_CHAR", "EvtProbe"))
+}
+
+// ---------------------------------------------------------------------------
+// Weather (issue #116 fase 1)
+// ---------------------------------------------------------------------------
+
+// TestE2EWorldEventWeatherBroadcast is the core weather contract: a GM forcing a
+// value must produce ONE MSG_UpdateWeather (0x018B) per in-play client, carrying
+// that value as an int32, with HEADER.ID = ESCENE_FIELD (30000).
+//
+// Both halves matter to the real client: a wrong Type is ignored, and a wrong
+// HEADER.ID routes the packet to the wrong scene handler (SendFunc.cpp:1669-1696).
+func TestE2EWorldEventWeatherBroadcast(t *testing.T) {
+	c := gmPlayer(t)
+	defer c.gm("weather auto") // leave the server on automatic rolls
+
+	for _, want := range []int32{1, 2, 0} {
+		c.quiet(300 * time.Millisecond)
+		c.gm(fmt.Sprintf("weather %d", want))
+
+		f, ok := c.waitFor(protocol.MsgUpdateWeather, 8*time.Second)
+		if !ok {
+			t.Fatalf("weather %d: no MSG_UpdateWeather (%#x) reached the client",
+				want, protocol.MsgUpdateWeather)
+		}
+		if len(f.Payload) != protocol.MsgUpdateWeatherBodySize {
+			t.Errorf("weather %d: body = %d bytes, want %d",
+				want, len(f.Payload), protocol.MsgUpdateWeatherBodySize)
+		}
+		if got := int32(binary.LittleEndian.Uint32(f.Payload)); got != want {
+			t.Errorf("weather payload = %d, want %d", got, want)
+		}
+		if f.Header.ID != protocol.IDScene {
+			t.Errorf("weather %d: HEADER.ID = %d, want ESCENE_FIELD (%d)",
+				want, f.Header.ID, protocol.IDScene)
+		}
+		t.Logf("weather %d → MSG_UpdateWeather ok (ID=%d, %d-byte body)",
+			want, f.Header.ID, len(f.Payload))
+	}
+}
+
+// TestE2EWorldEventWeatherIdempotent pins the legacy's
+// `ForceWeather != CurrentWeather` guard: re-forcing the value that is already
+// live must NOT put a second packet on the wire. A client that receives a
+// redundant weather change restarts the sky transition, so the guard is visible.
+func TestE2EWorldEventWeatherIdempotent(t *testing.T) {
+	c := gmPlayer(t)
+	defer c.gm("weather auto")
+
+	c.gm("weather 1")
+	if _, ok := c.waitFor(protocol.MsgUpdateWeather, 8*time.Second); !ok {
+		t.Fatalf("setup: first /gm weather 1 produced no MSG_UpdateWeather")
+	}
+	c.quiet(500 * time.Millisecond)
+
+	c.gm("weather 1") // already 1 — must be a no-op on the wire
+	if f, ok := c.waitFor(protocol.MsgUpdateWeather, 3*time.Second); ok {
+		t.Errorf("re-forcing the live weather re-broadcast it: payload=%d",
+			int32(binary.LittleEndian.Uint32(f.Payload)))
+	} else {
+		t.Log("re-forcing the live weather is silent, as the legacy guard requires")
+	}
+}
+
+// TestE2EWorldEventWeatherRejectsInvalid covers the deliberate divergence from
+// the legacy: imple.cpp:1122-1129 shipped ANY int straight to the client, which
+// is how a bad /weather bricked the sky. The port validates and answers with an
+// error line instead of broadcasting.
+func TestE2EWorldEventWeatherRejectsInvalid(t *testing.T) {
+	c := gmPlayer(t)
+	defer c.gm("weather auto")
+
+	c.quiet(300 * time.Millisecond)
+	c.gm("weather 9")
+
+	if _, ok := c.waitForChat("clima invalido", 5*time.Second); !ok {
+		t.Errorf("no rejection message for /gm weather 9")
+	}
+	if f, ok := c.waitFor(protocol.MsgUpdateWeather, 2*time.Second); ok {
+		t.Errorf("invalid weather was BROADCAST: payload=%d",
+			int32(binary.LittleEndian.Uint32(f.Payload)))
+	}
+}
+
+// TestE2EWorldEventWeatherLoginSnapshot proves the second delivery path: a
+// client that logs in AFTER a weather change learns the current value from the
+// MSG_CNFCharacterLogin snapshot (@1032), not from a broadcast it never saw.
+// Without this a relogging player renders clear skies during a storm.
+//
+// Needs a second seeded account so the first session can stay in play:
+//
+//	docker compose run --rm dbserver seed-account -name test2 -pass test123
+func TestE2EWorldEventWeatherLoginSnapshot(t *testing.T) {
+	second := os.Getenv("W2PP_E2E_ACCOUNT2")
+	if second == "" {
+		t.Skip("set W2PP_E2E_ACCOUNT2 (a second seeded account) to run the login-snapshot check")
+	}
+	gm := gmPlayer(t)
+	defer gm.gm("weather auto")
+
+	const want = int32(2)
+	gm.gm(fmt.Sprintf("weather %d", want))
+	if _, ok := gm.waitFor(protocol.MsgUpdateWeather, 8*time.Second); !ok {
+		t.Fatalf("setup: /gm weather %d produced no broadcast", want)
+	}
+
+	late := newPlayer(t, second,
+		env("W2PP_E2E_PASSWORD2", "test123"),
+		env("W2PP_E2E_CHAR2", "EvtProbe2"))
+	if got := snapshotWeather(late.snapshot); got != want {
+		t.Errorf("CNFCharacterLogin weather @%d = %d, want %d — a relogging client would render the wrong sky",
+			cnfCharLoginWeatherOffset, got, want)
+	} else {
+		t.Logf("late joiner received weather %d in its login snapshot", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Newbie event (issue #116 fase 2)
+// ---------------------------------------------------------------------------
+
+// createMobScoreOffset is where STRUCT_SCORE starts inside a MSG_CreateMob body
+// (protocol/createmob.go: Score @abs136 → body124). Level sits at +0, MaxHp at
+// +16 and Hp at +24 within it.
+const createMobScoreOffset = 124
+
+type mobView struct {
+	id        int
+	level     int32
+	maxHP, hp int32
+}
+
+// parseCreateMob reads the fields the newbie handicap is visible in.
+func parseCreateMob(f protocol.Frame) (mobView, bool) {
+	const need = createMobScoreOffset + 32
+	if f.Header.Type != protocol.MsgCreateMob || len(f.Payload) < need {
+		return mobView{}, false
+	}
+	s := f.Payload[createMobScoreOffset:]
+	return mobView{
+		id:    int(binary.LittleEndian.Uint16(f.Payload[4:])),
+		level: int32(binary.LittleEndian.Uint32(s[0:])),
+		maxHP: int32(binary.LittleEndian.Uint32(s[16:])),
+		hp:    int32(binary.LittleEndian.Uint32(s[24:])),
+	}, true
+}
+
+// spawnAndInspect runs `/gm spawn tmpl` and returns the CreateMob the server
+// pushes for the freshly spawned mob (revealSpawned).
+func (c *liveClient) spawnAndInspect(tmpl int, within time.Duration) (mobView, bool) {
+	c.t.Helper()
+	c.quiet(time.Second) // let the entering-the-world burst finish first
+	c.backlog = nil
+	c.gm(fmt.Sprintf("spawn %d", tmpl))
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		f, err := c.readFrame(deadline)
+		if err != nil {
+			return mobView{}, false
+		}
+		m, ok := parseCreateMob(f)
+		if !ok || m.id < MaxUser { // players share the id space below MaxUser
+			continue
+		}
+		return m, true
+	}
+	return mobView{}, false
+}
+
+// TestE2EWorldEventNewbieMobHandicap validates fase 2's one CLIENT-VISIBLE
+// effect: while NewbieEventServer is on, a sub-120 monster spawns at 3/4 HP
+// (Server.cpp:3326-3327 → world.applyNewbieHandicap). MaxHp is deliberately left
+// alone, so the client renders a monster whose health bar starts three-quarters
+// full — that difference is the whole observable contract.
+//
+// The EXP side of the same flag has no S→C frame of its own and is not
+// observable from a client; it is covered by internal/level's unit tests.
+//
+// The flag is driven by the PORTAL config, not the -newbie-event boot flag:
+// ApplyWorldEventConfigBoot calls setNewbieEvent with whatever
+// world_event_config.newbie_event_enabled says, so the DB value wins over the
+// CLI flag at boot. The runner therefore flips the DB row (bumping
+// world_event_meta.version so the 15-tick poll reloads) and runs this test twice:
+//
+//	W2PP_E2E_NEWBIE_EXPECT=full       # row false → mobs spawn at MaxHp
+//	W2PP_E2E_NEWBIE_EXPECT=handicap   # row true  → mobs spawn at 3/4 MaxHp
+func TestE2EWorldEventNewbieMobHandicap(t *testing.T) {
+	expect := os.Getenv("W2PP_E2E_NEWBIE_EXPECT")
+	if expect != "full" && expect != "handicap" {
+		t.Skip("set W2PP_E2E_NEWBIE_EXPECT to 'full' or 'handicap' (see scripts/e2e-worldevents.sh)")
+	}
+	tmpl := 1
+	if v := os.Getenv("W2PP_E2E_SUMMON_TEMPLATE"); v != "" {
+		fmt.Sscanf(v, "%d", &tmpl)
+	}
+
+	c := gmPlayer(t)
+	got, ok := c.spawnAndInspect(tmpl, 15*time.Second)
+	if !ok {
+		t.Fatalf("no CreateMob after /gm spawn %d", tmpl)
+	}
+	if got.maxHP <= 0 {
+		t.Fatalf("spawned mob has MaxHp %d — template %d is not usable for this check", got.maxHP, tmpl)
+	}
+	if got.level >= 120 {
+		t.Skipf("summon template %d is level %d (>=120): the handicap only applies below 120; set W2PP_E2E_SUMMON_TEMPLATE",
+			tmpl, got.level)
+	}
+
+	want := got.maxHP
+	if expect == "handicap" {
+		want = 3 * got.maxHP / 4
+	}
+	if got.hp != want {
+		t.Errorf("newbie event %s: level %d mob spawned at HP %d/%d, want %d — the client would draw the wrong health bar",
+			expect, got.level, got.hp, got.maxHP, want)
+		return
+	}
+	t.Logf("newbie event %s: level %d mob spawned at %d/%d HP as expected",
+		expect, got.level, got.hp, got.maxHP)
+}
+
+// ---------------------------------------------------------------------------
+// Tower capture war (issue #116 fase 4)
+// ---------------------------------------------------------------------------
+
+// TestE2EWorldEventTowerWar validates the calendar-gated tower window end to end:
+// the announce notice at minute ≤5 and the start notice at minute ≥6, both as
+// MSG_MessageChat lines every in-play client receives.
+//
+// The window is a weekday at hour 20 with NewbieEventServer on (CWarTower.cpp:203,
+// handler/towerwar.go). Rather than wait for a real Tuesday evening, the runner
+// starts a SECOND tmserver whose TZ places it inside the window — the event reads
+// time.Now(), so the container's zone is the whole gate. See
+// scripts/e2e-worldevents.sh, which computes the zone and exports the address.
+func TestE2EWorldEventTowerWar(t *testing.T) {
+	addr := os.Getenv("W2PP_E2E_TOWER_ADDR")
+	if addr == "" {
+		t.Skip("set W2PP_E2E_TOWER_ADDR to a tmserver inside the tower window (see scripts/e2e-worldevents.sh)")
+	}
+	c := dialLive(t, addr, env("W2PP_E2E_ACCOUNT", "test"))
+	t.Cleanup(c.close)
+	c.login(env("W2PP_E2E_PASSWORD", "test123"))
+	c.enterWorld(env("W2PP_E2E_CHAR", "EvtProbe"), 0)
+
+	// tickTowerWar runs one pass per minute, so the announce lands within ~2
+	// minutes of boot when the server started inside the window.
+	if text, ok := c.waitForChat("[Torre]", 3*time.Minute); ok {
+		t.Logf("tower announce reached the client: %q", text)
+	} else {
+		t.Fatalf("no [Torre] notice within the window — the client would never learn the war started")
+	}
+	// The start transition needs minute >= 6, so from an announce at minute 0-5 it
+	// can be a full six minutes away. Waiting less than that would report a
+	// working event as broken.
+	if text, ok := c.waitForChat("comecou", 8*time.Minute); ok {
+		t.Logf("tower start reached the client: %q", text)
+	} else {
+		t.Errorf("announce arrived but the START notice did not")
+	}
+}


### PR DESCRIPTION
## Resumo

- adiciona um cliente CPSock headless para validar os frames S→C dos eventos de mundo contra a stack viva
- cobre clima (broadcast, idempotência, rejeição e snapshot de login), handicap newbie e janela completa da Guerra da Torre
- adiciona runner reproduzível que controla a configuração autoritativa do portal e restaura seu estado
- documenta resultados, limitações da cobertura headless e checklist manual no WYD.exe

## Validação

- `bash -n scripts/e2e-worldevents.sh`
- compilação: `go test -tags=e2e -run '^$' ./tmserver/internal/world`
- `go vet -tags=e2e ./tmserver/internal/world`
- clima E2E aprovado na stack completa
- newbie desligado: mob `100/100 HP`
- newbie ligado: mob `75/100 HP`
- Torre: aviso e início recebidos como `MSG_MessageChat` (273,75 s)

## Limitações registradas

Reino, morte do rei, Castelo/Zakum e drop de item ainda exigem combate/movimento ou itens com efeitos que o cliente headless atual não produz. O relatório diferencia explicitamente esses casos da cobertura validada.