### PR TITLE
fix(tmserver): reconstruct base defense scores

### DIFF
--- a/tmserver/internal/dbclient/client.go
+++ b/tmserver/internal/dbclient/client.go
@@ -605,8 +605,11 @@ func castleQuestStateFromProto(st *dbv1.CastleQuestState) world.CastleQuestState
 //
 // UNVERIFIED: the contract (api/db/v1 Character) does not carry the world-entry
 // spawn tile (CharacterState.X/Y, distinct from the Gema Estelar SaveX/SaveY
-// below) or the derived combat scores (Damage/AC/Master), so those stay zero
-// until the full STRUCT_MOB snapshot is captured (PROGRESS Fase 4).
+// below) or Master, so those stay zero until the full STRUCT_MOB snapshot is
+// captured (PROGRESS Fase 4). Damage and AC are also absent from the contract,
+// but the tmServer no longer depends on them: handler.deriveBaseScore rebuilds
+// their BaseScore from the legacy creation/level-up rules instead of subtracting
+// the equipment from a score that was never stored (issue #232).
 func characterStateFromProto(c *dbv1.Character) world.CharacterState {
 	st := world.CharacterState{
 		Slot:         int(c.GetSlot()),

--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -256,7 +256,11 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 		e.MP, e.MaxMP = st.MP, st.MaxMP
 		// Critical is a save-side cache only: refreshScore below re-derives it from the
 		// equipment (Basedef.cpp:3209), so the stored value never survives login.
-		e.Damage, e.AC, e.Master, e.Critical = st.Damage, st.AC, st.Master, st.Critical
+		// Damage and AC are NOT read from the state at all: the DB contract carries
+		// neither, so st.Damage/st.AC are always 0 — deriveBaseScore reconstructs
+		// their base from the legacy rules and refreshScore fills the live fields
+		// (issue #232).
+		e.Master, e.Critical = st.Master, st.Critical
 		e.Level, e.Coin, e.Exp = int32(st.Level), st.Coin, st.Exp
 		e.Clan, e.Guild, e.GuildLevel, e.Citizen, e.ClassMaster, e.Soul = st.Clan, st.GuildID, st.GuildLevel, st.Citizen, st.ClassMaster, st.Soul
 		e.Fame = st.Fame

--- a/tmserver/internal/handler/chat_test.go
+++ b/tmserver/internal/handler/chat_test.go
@@ -523,7 +523,8 @@ func TestApplyBonusScore(t *testing.T) {
 	if !ok || ty != protocol.MsgUpdateScore {
 		t.Errorf("got %#x ok=%v, want UpdateScore second", ty, ok)
 	}
-	if dmg := scoreDamage(payload); dmg != 69 {
-		t.Errorf("UpdateScore Damage = %d, want 69 after +1 STR (11→12)", dmg)
+	want := baseDamageChar + 12/2 + 10/3 + 10
+	if dmg := scoreDamage(payload); dmg != int32(want) {
+		t.Errorf("UpdateScore Damage = %d, want %d after +1 STR (11→12)", dmg, want)
 	}
 }

--- a/tmserver/internal/handler/chat_test.go
+++ b/tmserver/internal/handler/chat_test.go
@@ -524,7 +524,7 @@ func TestApplyBonusScore(t *testing.T) {
 		t.Errorf("got %#x ok=%v, want UpdateScore second", ty, ok)
 	}
 	want := baseDamageChar + 12/2 + 10/3 + 10
-	if dmg := scoreDamage(payload); dmg != int32(want) {
+	if dmg := scoreDamage(payload); dmg != want {
 		t.Errorf("UpdateScore Damage = %d, want %d after +1 STR (11→12)", dmg, want)
 	}
 }

--- a/tmserver/internal/handler/combat_test.go
+++ b/tmserver/internal/handler/combat_test.go
@@ -63,8 +63,8 @@ func TestAttackHitExact(t *testing.T) {
 	if len(got.Dam) != 1 || got.Dam[0].TargetID != 2 {
 		t.Fatalf("Dam = %+v", got.Dam)
 	}
-	if got.Dam[0].Damage != 154 {
-		t.Errorf("server damage = %d, want 154 (exact LCG golden)", got.Dam[0].Damage)
+	if got.Dam[0].Damage != 7 {
+		t.Errorf("server damage = %d, want 7 (exact LCG golden)", got.Dam[0].Damage)
 	}
 }
 

--- a/tmserver/internal/handler/duel_test.go
+++ b/tmserver/internal/handler/duel_test.go
@@ -20,7 +20,7 @@ import (
 func duelDB() *fakeDB {
 	db := newDB()
 	db.loads = map[int64]world.CharacterState{
-		7:  {Slot: 0, Name: "Hero", X: 5, Y: 5, HP: 1000, MaxHP: 1000, Damage: 500, AC: 0},
+		7:  {Slot: 0, Name: "Hero", X: 5, Y: 5, HP: 1000, MaxHP: 1000, ClassMaster: classMasterMortal, Str: 1000},
 		11: {Slot: 0, Name: "HeroB", X: 5, Y: 5, HP: 50, MaxHP: 50, Damage: 0, AC: 0},
 	}
 	return db

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -1368,6 +1368,11 @@ func (d *Dispatcher) useIdealStone(w *world.World, s *world.Session, e *world.En
 	e.Level = 1
 	e.Exp = 0
 	e.CelLv40, e.CelLv90, e.CelCircle = 0, 0, 0
+	// BaseScore.Ac goes back to the Celestial baseline together with the level
+	// (_MSG_UseItem.cpp:3136) — without this the Arch's accumulated per-level AC
+	// would linger for the rest of the session and only snap back on the next
+	// login, when playerBaseAC re-derives it from the new tier and level.
+	e.BaseAC = playerBaseAC(e)
 	consumeOneItem(&e.Carry[src])
 	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
 	d.refreshScore(e)
@@ -1908,20 +1913,25 @@ func (d *Dispatcher) equipBonus(e *world.Entity) equipBonus {
 	return b
 }
 
-// deriveBaseScore captures the equipment-free BaseScore from the loaded
-// CurrentScore (called once on login): base = current − equipBonus − derived
-// combat bonuses (attribute/class-weapon damage, skill AC). WeaponDamage is not
-// in the loaded CurrentScore, so it is not subtracted. After this, refreshScore
-// reproduces the loaded CurrentScore exactly until gear changes.
+// deriveBaseScore captures the equipment-free BaseScore on login. Attributes,
+// MaxHP/MaxMP and Magic ARE persisted as the gear-inclusive CurrentScore, so
+// their base is recovered by subtracting the equipment back out; after this,
+// refreshScore reproduces the loaded CurrentScore exactly until gear changes.
+//
+// AC and Damage take the other route: the DB contract carries neither (api/db/v1
+// Character has no `ac`/`damage`), so the loaded CurrentScore is always 0 for
+// them and subtracting the equipment would yield a NEGATIVE base — that was
+// issue #232, defense reading ~0 while geared and going negative on unequip.
+// Both are reconstructed from the legacy's own rules instead: see playerBaseAC
+// and baseDamageChar.
 func (d *Dispatcher) deriveBaseScore(e *world.Entity) {
 	b := d.equipBonus(e)
 	e.BaseStr = e.Str - b.str
 	e.BaseInt = e.Int - b.intel
 	e.BaseDex = e.Dex - b.dex
 	e.BaseCon = e.Con - b.con
-	flatAC := invertSkillACBonus(e, e.AC-b.ac)
-	e.BaseAC = flatAC
-	e.BaseDamage = e.Damage - b.damage - d.derivedDamageTotal(e, false)
+	e.BaseAC = playerBaseAC(e)
+	e.BaseDamage = baseDamageChar
 	e.BaseMaxHP = e.MaxHP - b.maxHP
 	e.BaseMaxMP = e.MaxMP - b.maxMP
 	// Magic (mount bonus + ordinary equipment's EF_MAGIC/EF_MAGICADD): same subtraction

--- a/tmserver/internal/handler/item_test.go
+++ b/tmserver/internal/handler/item_test.go
@@ -1200,8 +1200,8 @@ func TestRefreshScoreSpecial(t *testing.T) {
 	if e.Str != 80 {
 		t.Errorf("Str = %d, want 80 (round-trip stable)", e.Str)
 	}
-	if e.AC != 120 {
-		t.Errorf("AC = %d, want 120 (round-trip stable)", e.AC)
+	if want := playerBaseAC(e); e.AC != want {
+		t.Errorf("AC = %d, want rebuilt base %d", e.AC, want)
 	}
 	if e.Special[1] != 15 {
 		t.Errorf("Special[1] = %d, want 15", e.Special[1])

--- a/tmserver/internal/handler/mobkilled.go
+++ b/tmserver/internal/handler/mobkilled.go
@@ -240,6 +240,9 @@ func (d *Dispatcher) applyLevelUps(w *world.World, s *world.Session, e *world.En
 		// equip).
 		e.BaseMaxHP = addClamp(e.BaseMaxHP, level.IncHP(e.Class), level.MaxHPCap)
 		e.BaseMaxMP = addClamp(e.BaseMaxMP, level.IncMP(e.Class), level.MaxMPCap)
+		// +1 AC per level for every tier (CMob.cpp:1133,1145,1150). This keeps the
+		// live value right for the rest of the session; playerBaseAC rebuilds the
+		// same total from the (now higher) level on the next login.
 		e.BaseAC++
 		// SkillBonus +3/level (+4 from 200) and SpecialBonus +2/level are Mortal/Arch
 		// grants only; Celestial tiers grant AC + attribute points and nothing else

--- a/tmserver/internal/handler/mount_test.go
+++ b/tmserver/internal/handler/mount_test.go
@@ -106,13 +106,14 @@ func TestMountEquipScore(t *testing.T) {
 // whatever a fresh Entity starts with, which is exactly what avoids the login zero-out.
 func TestMountScoreRoundTrip(t *testing.T) {
 	d := New(Config{})
-	e := &world.Entity{ID: 1, Level: 50, Damage: 955, Magic: 60}
+	e := &world.Entity{ID: 1, ClassMaster: classMasterMortal, Level: 50, Damage: 955, Magic: 60}
 	e.Equip[0] = world.Item{Index: 11}
 	e.Equip[mountEquipSlot] = world.Item{Index: 3987}
 	d.deriveBaseScore(e)
 	d.refreshScore(e)
-	if e.Damage != 955 || e.Magic != 60 || e.Parry != 80 {
-		t.Errorf("round-trip = Damage %d Magic %d Parry %d, want 955/60/80", e.Damage, e.Magic, e.Parry)
+	wantDamage := baseDamageChar + e.Level + 750
+	if e.Damage != wantDamage || e.Magic != 60 || e.Parry != 80 {
+		t.Errorf("derived = Damage %d Magic %d Parry %d, want %d/60/80", e.Damage, e.Magic, e.Parry, wantDamage)
 	}
 	for i := range e.Resist {
 		if e.Resist[i] != 32 {

--- a/tmserver/internal/handler/score_derive.go
+++ b/tmserver/internal/handler/score_derive.go
@@ -13,6 +13,45 @@ const (
 	classMasterSCelestial  = 5
 )
 
+// BaseScore.Ac/Damage of a freshly created character. The per-class BaseMob
+// templates shipped in Release/DBsrv/run/BaseMob/{TK,FM,BM,HT} all carry
+// BaseScore.Ac=4 / BaseScore.Damage=5 (STRUCT_MOB.BaseScore @44, .Ac @48,
+// .Damage @52), and MORTAL creation only memcpy's the template
+// (DBSrv/CFileDB.cpp:984-993). ARCH creation overwrites the AC with 230
+// (CFileDB.cpp:1577) and the Arch→Celestial turn does the same
+// (_MSG_UseItem.cpp:3136). BaseScore.Damage is never written by TMSrv/DBSrv at
+// all — only by the EDITAPPMOB tool — so it stays 5 for a character's whole life.
+const (
+	baseACMortal   int32 = 4
+	baseACArch     int32 = 230
+	baseDamageChar int32 = 5
+)
+
+// playerBaseAC reproduces BaseScore.Ac without persisting it. In the legacy the
+// field is only ever written on creation (the per-tier baseline above) and on
+// level-up, +1 per level for every tier (CMob.cpp:1133,1145,1150) — so it is a
+// pure function of (tier, level). The Celestial turn resets the level to 1
+// together with the baseline (_MSG_UseItem.cpp:3136 + handler.useIdealStone), so
+// the same "baseline + (level−1)" holds for all three creation paths.
+//
+// This derivation exists because the DB contract carries no AC: api/db/v1
+// Character has no `ac` field, so a login always reads CurrentScore.Ac == 0 and
+// the old "base = current − equipment" subtraction produced a NEGATIVE base —
+// defense read ~0 while geared and went negative on unequip (issue #232).
+//
+// CAUTION: if the Arch quest crystals (+30/+20 BaseScore.Ac,
+// _MSG_UseItem.cpp:3412-3421, not ported) are ever implemented, this stops being
+// sufficient and BaseScore.Ac has to become a persisted column.
+func playerBaseAC(e *world.Entity) int32 {
+	base := baseACArch
+	// ClassMaster == 0 means "never persisted" and is treated as MORTAL, the same
+	// convention completeCharacterLogin applies before this runs (character.go).
+	if e.ClassMaster == classMasterMortal || e.ClassMaster == 0 {
+		base = baseACMortal
+	}
+	return base + max(e.Level-1, 0)
+}
+
 type weaponCoef struct {
 	nUnique int
 	dexK    float64
@@ -174,18 +213,4 @@ func skillDerivedACBonus(e *world.Entity, flatAC int32) int32 {
 		bonus += int32(e.Special[3])/3 + 10
 	}
 	return bonus
-}
-
-func invertSkillACBonus(e *world.Entity, ac int32) int32 {
-	if e.Class == 0 && e.LearnedSkill&(1<<15) != 0 {
-		return ac * 10 / 11
-	}
-	if e.Class == 3 && e.LearnedSkill&(1<<23) != 0 {
-		return ac - (int32(e.Special[3])/3 + 10)
-	}
-	return ac
-}
-
-func (d *Dispatcher) derivedDamageTotal(e *world.Entity, withAffectSpecial bool) int32 {
-	return d.derivedDamageBeforeAffects(e) + attributeDamageBonus(e, withAffectSpecial)
 }

--- a/tmserver/internal/handler/score_derive_test.go
+++ b/tmserver/internal/handler/score_derive_test.go
@@ -2,8 +2,10 @@ package handler
 
 import (
 	"encoding/binary"
+	"log/slog"
 	"testing"
 
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/level"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
@@ -47,12 +49,11 @@ func TestAttributeDamageBonus(t *testing.T) {
 func TestRefreshScoreAttributeDamage(t *testing.T) {
 	d := New(Config{})
 	e := testPlayerEntity()
-	flat := int32(80)
-	e.Damage = flat + attributeDamageBonus(e, false)
+	e.Damage = 80 + attributeDamageBonus(e, false) // ignored: Damage is absent from persistence
 	d.deriveBaseScore(e)
 	d.refreshScore(e)
-	if e.Damage != flat+attributeDamageBonus(e, true) {
-		t.Fatalf("round-trip Damage = %d, want %d", e.Damage, flat+attributeDamageBonus(e, true))
+	if want := baseDamageChar + attributeDamageBonus(e, true); e.Damage != want {
+		t.Fatalf("derived Damage = %d, want %d", e.Damage, want)
 	}
 	dmgBefore := e.Damage
 	e.BaseStr += 10
@@ -85,10 +86,140 @@ func TestLevelUpBaseAC(t *testing.T) {
 	e := testPlayerEntity()
 	e.Damage = 100 + attributeDamageBonus(e, false)
 	d.deriveBaseScore(e)
+	want := playerBaseAC(e) + 1
 	e.BaseAC++
 	d.refreshScore(e)
-	if e.AC != 51 {
-		t.Errorf("AC after BaseAC++ = %d, want 51", e.AC)
+	if e.AC != want {
+		t.Errorf("AC after BaseAC++ = %d, want %d", e.AC, want)
+	}
+}
+
+// TestPlayerBaseAC pins the BaseScore.Ac reconstruction (issue #232): the per-tier
+// creation baseline plus +1 per level (CFileDB.cpp:984-993/1577, CMob.cpp:1133).
+func TestPlayerBaseAC(t *testing.T) {
+	tests := []struct {
+		name        string
+		classMaster uint8
+		level       int32
+		want        int32
+	}{
+		{"mortal level 1", classMasterMortal, 1, 4},
+		{"mortal level 100", classMasterMortal, 100, 103},
+		{"mortal at cap", classMasterMortal, level.MaxLevel, 4 + level.MaxLevel - 1},
+		{"arch level 1", classMasterArch, 1, 230},
+		{"arch level 100", classMasterArch, 100, 329},
+		{"celestial level 50", classMasterCelestial, 50, 279},
+		{"scelestial level 1", classMasterSCelestial, 1, 230},
+		// A row written before ClassMaster was persisted reads back 0; login treats
+		// that as MORTAL, so the baseline must agree.
+		{"unpersisted tier is mortal", 0, 10, 13},
+		// Defensive: a level below the creation level must not underflow the baseline.
+		{"level 0 floors at baseline", classMasterMortal, 0, 4},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &world.Entity{ClassMaster: tt.classMaster, Level: tt.level}
+			if got := playerBaseAC(e); got != tt.want {
+				t.Errorf("playerBaseAC = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDefenseSurvivesUnequip is the issue #232 regression. It builds the entity the
+// way the production loader really does — AC and Damage are absent from the DB
+// contract, so they arrive as 0 — then equips, unequips and checks the defense never
+// collapses to ~0 or goes negative.
+func TestDefenseSurvivesUnequip(t *testing.T) {
+	const acItem, armorSlot = 700, 1
+	d := New(Config{ItemEffects: map[int][]content.BaseEffect{
+		acItem: {{Eff: efAc, Val: 120}},
+	}})
+	e := testPlayerEntity()
+	e.AC, e.Damage = 0, 0 // characterStateFromProto never fills these
+	e.Equip[armorSlot] = world.Item{Index: acItem}
+
+	d.deriveBaseScore(e)
+	d.refreshScore(e)
+
+	naked := playerBaseAC(e)
+	if want := naked + 120; e.AC != want {
+		t.Fatalf("geared AC = %d, want %d", e.AC, want)
+	}
+
+	e.Equip[armorSlot] = world.Item{}
+	d.refreshScore(e)
+
+	if e.AC != naked {
+		t.Fatalf("AC after unequip = %d, want the equipment-free %d", e.AC, naked)
+	}
+	if e.AC <= 0 {
+		t.Fatalf("AC after unequip = %d, must never be negative or zero", e.AC)
+	}
+	if got := d.computeScore(e).Ac; got != naked {
+		t.Fatalf("UpdateScore Ac = %d, want %d", got, naked)
+	}
+}
+
+// TestPlayerBaseDamageIsConstant: BaseScore.Damage is the BaseMob template's 5 and
+// is never written by TMSrv/DBSrv, so it must not depend on the gear that was worn
+// when the character logged in (issue #232, same root cause as the AC).
+func TestPlayerBaseDamageIsConstant(t *testing.T) {
+	const dmgItem, armorSlot = 701, 1
+	d := New(Config{ItemEffects: map[int][]content.BaseEffect{
+		dmgItem: {{Eff: efDamage, Val: 90}},
+	}})
+	for _, withGear := range []bool{false, true} {
+		e := testPlayerEntity()
+		e.AC, e.Damage = 0, 0
+		if withGear {
+			e.Equip[armorSlot] = world.Item{Index: dmgItem}
+		}
+		d.deriveBaseScore(e)
+		if e.BaseDamage != baseDamageChar {
+			t.Errorf("withGear=%v: BaseDamage = %d, want %d", withGear, e.BaseDamage, baseDamageChar)
+		}
+	}
+}
+
+// TestRefreshScoreKeepsMobTemplateStats guards the other half of issue #232: a mob's
+// BaseScore has to be seeded at spawn, because refreshScore runs on mobs too (any
+// skill landing an affect on one recomputes its score) and rebuilds CurrentScore as
+// BaseScore + equipment. With a zero BaseScore that wiped the template's AC, damage
+// and attributes, and the MaxHP clamp dropped the mob's HP to 0 outright.
+func TestRefreshScoreKeepsMobTemplateStats(t *testing.T) {
+	d := New(Config{})
+	w := world.New(world.Config{GridDim: 16}, slog.New(slog.DiscardHandler), nil, nil)
+
+	tmpl := make([]byte, 816)
+	copy(tmpl[0:16], "Tanky")
+	const cs = 92                                    // CurrentScore offset within STRUCT_MOB
+	binary.LittleEndian.PutUint32(tmpl[cs+0:], 50)   // Level
+	binary.LittleEndian.PutUint32(tmpl[cs+4:], 300)  // Ac
+	binary.LittleEndian.PutUint32(tmpl[cs+8:], 500)  // Damage
+	binary.LittleEndian.PutUint32(tmpl[cs+16:], 800) // MaxHp
+	binary.LittleEndian.PutUint32(tmpl[cs+24:], 800) // Hp
+	binary.LittleEndian.PutUint16(tmpl[cs+32:], 40)  // Str
+
+	id := w.SpawnMob(tmpl, 5, 5)
+	if id < 0 {
+		t.Fatal("SpawnMob failed")
+	}
+	e := w.Entity(id)
+
+	d.refreshScore(e)
+
+	if e.AC != 300 {
+		t.Errorf("AC after refreshScore = %d, want the template's 300", e.AC)
+	}
+	if e.Damage != 500 {
+		t.Errorf("Damage after refreshScore = %d, want 500", e.Damage)
+	}
+	if e.MaxHP != 800 || e.HP != 800 {
+		t.Errorf("HP/MaxHP after refreshScore = %d/%d, want 800/800", e.HP, e.MaxHP)
+	}
+	if e.Str != 40 {
+		t.Errorf("Str after refreshScore = %d, want 40", e.Str)
 	}
 }
 
@@ -112,9 +243,6 @@ func TestHuntressShadowProtectionUsesTreeThree(t *testing.T) {
 
 	if got := skillDerivedACBonus(e, 100); got != 40 {
 		t.Fatalf("skillDerivedACBonus = %d, want Special[3]/3+10 = 40", got)
-	}
-	if got := invertSkillACBonus(e, 140); got != 100 {
-		t.Fatalf("invertSkillACBonus = %d, want 100", got)
 	}
 }
 
@@ -147,7 +275,7 @@ func TestApplyBonusScoreIncreasesDamage(t *testing.T) {
 		t.Fatalf("got %#x ok=%v, want UpdateScore second", ty, ok)
 	}
 	dmg := scoreDamage(payload)
-	minWant := flat + attributeDamageBonus(&world.Entity{
+	minWant := baseDamageChar + attributeDamageBonus(&world.Entity{
 		ID: 1, Class: 0, ClassMaster: classMasterMortal,
 		Level: 10, Str: 21, Dex: 15,
 		Equip: [world.MaxEquip]world.Item{{Index: 11}},

--- a/tmserver/internal/handler/starter_equip_test.go
+++ b/tmserver/internal/handler/starter_equip_test.go
@@ -73,38 +73,39 @@ func TestEquipScoreRoundTrip(t *testing.T) {
 	}})
 	// Loaded CurrentScore (with the chest already equipped: AC/Con include it).
 	e := &world.Entity{
-		ID:    world.MaxUser + 1,
-		Level: 50, AC: 150, Damage: 200, MaxHP: 1000, HP: 1000, MaxMP: 300, MP: 300,
+		ID:          1,
+		ClassMaster: classMasterMortal,
+		Level:       50, AC: 150, Damage: 200, MaxHP: 1000, HP: 1000, MaxMP: 300, MP: 300,
 		Str: 60, Int: 10, Dex: 20, Con: 35,
 	}
 	e.Equip[0] = world.Item{Index: 700} // chest
 	d.deriveBaseScore(e)
 	// Base = current − chest: AC 150−50=100, Con 35−5=30.
-	if e.BaseAC != 100 || e.BaseCon != 30 {
-		t.Fatalf("derived base AC=%d Con=%d, want 100/30", e.BaseAC, e.BaseCon)
+	if e.BaseAC != 53 || e.BaseCon != 30 {
+		t.Fatalf("derived base AC=%d Con=%d, want 53/30", e.BaseAC, e.BaseCon)
 	}
 	// refreshScore reproduces the loaded current exactly (gear unchanged).
 	d.refreshScore(e)
-	if e.AC != 150 || e.Con != 35 {
-		t.Fatalf("refresh reproduced AC=%d Con=%d, want 150/35", e.AC, e.Con)
+	if e.AC != 103 || e.Con != 35 {
+		t.Fatalf("refresh produced AC=%d Con=%d, want 103/35", e.AC, e.Con)
 	}
 
 	// Unequip the chest → AC/Con drop to base.
 	e.Equip[0] = world.Item{}
 	d.refreshScore(e)
-	if e.AC != 100 || e.Con != 30 {
-		t.Fatalf("after unequip AC=%d Con=%d, want 100/30", e.AC, e.Con)
+	if e.AC != 53 || e.Con != 30 {
+		t.Fatalf("after unequip AC=%d Con=%d, want 53/30", e.AC, e.Con)
 	}
 
 	// Equip the sword (right hand): weapon damage is separate, so e.Damage is
 	// unchanged but the shown/combat damage includes it.
 	e.Equip[weaponSlotR] = world.Item{Index: 861}
 	d.refreshScore(e)
-	if e.Damage != 200 {
-		t.Errorf("e.Damage = %d, want 200 (weapon damage is separate)", e.Damage)
+	if e.Damage != 91 {
+		t.Errorf("e.Damage = %d, want 91 (weapon damage is separate)", e.Damage)
 	}
-	if sc := d.computeScore(e); sc.Damage != 230 {
-		t.Errorf("computeScore Damage = %d, want 230 (200 + weapon 30)", sc.Damage)
+	if sc := d.computeScore(e); sc.Damage != 121 {
+		t.Errorf("computeScore Damage = %d, want 121 (91 + weapon 30)", sc.Damage)
 	}
 }
 

--- a/tmserver/internal/world/api.go
+++ b/tmserver/internal/world/api.go
@@ -108,6 +108,16 @@ func (w *World) SpawnMobAt(sp MobSpawn) int {
 		AttackRun: b.AttackRun,
 		X:         x, Y: y, SpawnX: x, SpawnY: y, Level: b.Level, AC: b.Ac, Damage: b.Damage, Exp: b.Exp,
 		MaxHP: b.MaxHp, HP: b.Hp, Str: b.Str, Int: b.Int, Dex: b.Dex, Con: b.Con,
+		// A mob's BaseScore must be seeded too, not just the CurrentScore above:
+		// handler.refreshScore runs on mobs as well (any skill that lands an affect
+		// on one recomputes its score) and rebuilds CurrentScore as BaseScore +
+		// equipment — with a zero BaseScore that wipes the template's AC, damage,
+		// attributes and MaxHP, and the MaxHP clamp then drops the mob's HP to 0.
+		// The template's score IS the equipment-free base: EDITAPPMOB writes
+		// CurrentScore = BaseScore on save (see internal/domain.MobTemplateStat), and
+		// BASE_GetCurrentScore adds the equipment on top at runtime (CMob.cpp:709).
+		BaseAC: b.Ac, BaseDamage: b.Damage, BaseMaxHP: b.MaxHp,
+		BaseStr: b.Str, BaseInt: b.Int, BaseDex: b.Dex, BaseCon: b.Con,
 		Template:  template, // retained for runtime respawn (world/respawn.go)
 		RouteType: sp.RouteType, SegListX: sp.SegX, SegListY: sp.SegY, SegWait: sp.SegWait,
 		GenIndex: sp.GenIndex,


### PR DESCRIPTION
## Summary
- reconstruct player BaseScore AC from the legacy tier and level rules instead of subtracting equipment from an unstored score
- reconstruct player base damage and keep mob template BaseScore fields intact during score refreshes
- keep base AC synchronized across level-ups and the Celestial reset
- add regressions for unequipping defense gear, player damage derivation, and mob score refreshes

Fixes #232

## Testing
- `go test ./tmserver/... -count=1`
- `go test ./... -count=1`
- `git diff --check`