### PR TITLE
fix: restore DB-managed legacy merchant NPC generators

### DIFF
--- a/api/db/v1/db.pb.go
+++ b/api/db/v1/db.pb.go
@@ -4444,20 +4444,34 @@ func (x *NpcShopItem) GetQuantity() int32 {
 }
 
 type NpcDefinition struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
-	Slug          string                 `protobuf:"bytes,2,opt,name=slug,proto3" json:"slug,omitempty"`
-	TemplateName  string                 `protobuf:"bytes,3,opt,name=template_name,json=templateName,proto3" json:"template_name,omitempty"`
-	DisplayName   string                 `protobuf:"bytes,4,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
-	Enabled       bool                   `protobuf:"varint,5,opt,name=enabled,proto3" json:"enabled,omitempty"`
-	MapId         int32                  `protobuf:"varint,6,opt,name=map_id,json=mapId,proto3" json:"map_id,omitempty"`
-	PosX          int32                  `protobuf:"varint,7,opt,name=pos_x,json=posX,proto3" json:"pos_x,omitempty"`
-	PosY          int32                  `protobuf:"varint,8,opt,name=pos_y,json=posY,proto3" json:"pos_y,omitempty"`
-	RouteType     int32                  `protobuf:"varint,9,opt,name=route_type,json=routeType,proto3" json:"route_type,omitempty"`
-	Merchant      int32                  `protobuf:"varint,10,opt,name=merchant,proto3" json:"merchant,omitempty"`
-	Shop          []*NpcShopItem         `protobuf:"bytes,11,rep,name=shop,proto3" json:"shop,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	Id               int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Slug             string                 `protobuf:"bytes,2,opt,name=slug,proto3" json:"slug,omitempty"`
+	TemplateName     string                 `protobuf:"bytes,3,opt,name=template_name,json=templateName,proto3" json:"template_name,omitempty"`
+	DisplayName      string                 `protobuf:"bytes,4,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	Enabled          bool                   `protobuf:"varint,5,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	MapId            int32                  `protobuf:"varint,6,opt,name=map_id,json=mapId,proto3" json:"map_id,omitempty"`
+	PosX             int32                  `protobuf:"varint,7,opt,name=pos_x,json=posX,proto3" json:"pos_x,omitempty"`
+	PosY             int32                  `protobuf:"varint,8,opt,name=pos_y,json=posY,proto3" json:"pos_y,omitempty"`
+	RouteType        int32                  `protobuf:"varint,9,opt,name=route_type,json=routeType,proto3" json:"route_type,omitempty"`
+	Merchant         int32                  `protobuf:"varint,10,opt,name=merchant,proto3" json:"merchant,omitempty"`
+	Shop             []*NpcShopItem         `protobuf:"bytes,11,rep,name=shop,proto3" json:"shop,omitempty"`
+	Origin           string                 `protobuf:"bytes,12,opt,name=origin,proto3" json:"origin,omitempty"`
+	GeneratorIndex   int32                  `protobuf:"varint,13,opt,name=generator_index,json=generatorIndex,proto3" json:"generator_index,omitempty"`
+	FollowerTemplate string                 `protobuf:"bytes,14,opt,name=follower_template,json=followerTemplate,proto3" json:"follower_template,omitempty"`
+	MinuteGenerate   int32                  `protobuf:"varint,15,opt,name=minute_generate,json=minuteGenerate,proto3" json:"minute_generate,omitempty"`
+	MinGroup         int32                  `protobuf:"varint,16,opt,name=min_group,json=minGroup,proto3" json:"min_group,omitempty"`
+	MaxGroup         int32                  `protobuf:"varint,17,opt,name=max_group,json=maxGroup,proto3" json:"max_group,omitempty"`
+	MaxNumMob        int32                  `protobuf:"varint,18,opt,name=max_num_mob,json=maxNumMob,proto3" json:"max_num_mob,omitempty"`
+	Formation        int32                  `protobuf:"varint,19,opt,name=formation,proto3" json:"formation,omitempty"`
+	SegX             []int32                `protobuf:"varint,20,rep,packed,name=seg_x,json=segX,proto3" json:"seg_x,omitempty"`
+	SegY             []int32                `protobuf:"varint,21,rep,packed,name=seg_y,json=segY,proto3" json:"seg_y,omitempty"`
+	SegRange         []int32                `protobuf:"varint,22,rep,packed,name=seg_range,json=segRange,proto3" json:"seg_range,omitempty"`
+	SegWait          []int32                `protobuf:"varint,23,rep,packed,name=seg_wait,json=segWait,proto3" json:"seg_wait,omitempty"`
+	FightAction      []string               `protobuf:"bytes,24,rep,name=fight_action,json=fightAction,proto3" json:"fight_action,omitempty"`
+	DieAction        []string               `protobuf:"bytes,25,rep,name=die_action,json=dieAction,proto3" json:"die_action,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *NpcDefinition) Reset() {
@@ -4563,6 +4577,104 @@ func (x *NpcDefinition) GetMerchant() int32 {
 func (x *NpcDefinition) GetShop() []*NpcShopItem {
 	if x != nil {
 		return x.Shop
+	}
+	return nil
+}
+
+func (x *NpcDefinition) GetOrigin() string {
+	if x != nil {
+		return x.Origin
+	}
+	return ""
+}
+
+func (x *NpcDefinition) GetGeneratorIndex() int32 {
+	if x != nil {
+		return x.GeneratorIndex
+	}
+	return 0
+}
+
+func (x *NpcDefinition) GetFollowerTemplate() string {
+	if x != nil {
+		return x.FollowerTemplate
+	}
+	return ""
+}
+
+func (x *NpcDefinition) GetMinuteGenerate() int32 {
+	if x != nil {
+		return x.MinuteGenerate
+	}
+	return 0
+}
+
+func (x *NpcDefinition) GetMinGroup() int32 {
+	if x != nil {
+		return x.MinGroup
+	}
+	return 0
+}
+
+func (x *NpcDefinition) GetMaxGroup() int32 {
+	if x != nil {
+		return x.MaxGroup
+	}
+	return 0
+}
+
+func (x *NpcDefinition) GetMaxNumMob() int32 {
+	if x != nil {
+		return x.MaxNumMob
+	}
+	return 0
+}
+
+func (x *NpcDefinition) GetFormation() int32 {
+	if x != nil {
+		return x.Formation
+	}
+	return 0
+}
+
+func (x *NpcDefinition) GetSegX() []int32 {
+	if x != nil {
+		return x.SegX
+	}
+	return nil
+}
+
+func (x *NpcDefinition) GetSegY() []int32 {
+	if x != nil {
+		return x.SegY
+	}
+	return nil
+}
+
+func (x *NpcDefinition) GetSegRange() []int32 {
+	if x != nil {
+		return x.SegRange
+	}
+	return nil
+}
+
+func (x *NpcDefinition) GetSegWait() []int32 {
+	if x != nil {
+		return x.SegWait
+	}
+	return nil
+}
+
+func (x *NpcDefinition) GetFightAction() []string {
+	if x != nil {
+		return x.FightAction
+	}
+	return nil
+}
+
+func (x *NpcDefinition) GetDieAction() []string {
+	if x != nil {
+		return x.DieAction
 	}
 	return nil
 }
@@ -5872,7 +5984,7 @@ const file_api_db_v1_db_proto_rawDesc = "" +
 	"\x05effv2\x18\x06 \x01(\x05R\x05effv2\x12\x12\n" +
 	"\x04eff3\x18\a \x01(\x05R\x04eff3\x12\x14\n" +
 	"\x05effv3\x18\b \x01(\x05R\x05effv3\x12\x1a\n" +
-	"\bquantity\x18\t \x01(\x05R\bquantity\"\xb9\x02\n" +
+	"\bquantity\x18\t \x01(\x05R\bquantity\"\xec\x05\n" +
 	"\rNpcDefinition\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12#\n" +
@@ -5886,7 +5998,22 @@ const file_api_db_v1_db_proto_rawDesc = "" +
 	"route_type\x18\t \x01(\x05R\trouteType\x12\x1a\n" +
 	"\bmerchant\x18\n" +
 	" \x01(\x05R\bmerchant\x12&\n" +
-	"\x04shop\x18\v \x03(\v2\x12.db.v1.NpcShopItemR\x04shop\"@\n" +
+	"\x04shop\x18\v \x03(\v2\x12.db.v1.NpcShopItemR\x04shop\x12\x16\n" +
+	"\x06origin\x18\f \x01(\tR\x06origin\x12'\n" +
+	"\x0fgenerator_index\x18\r \x01(\x05R\x0egeneratorIndex\x12+\n" +
+	"\x11follower_template\x18\x0e \x01(\tR\x10followerTemplate\x12'\n" +
+	"\x0fminute_generate\x18\x0f \x01(\x05R\x0eminuteGenerate\x12\x1b\n" +
+	"\tmin_group\x18\x10 \x01(\x05R\bminGroup\x12\x1b\n" +
+	"\tmax_group\x18\x11 \x01(\x05R\bmaxGroup\x12\x1e\n" +
+	"\vmax_num_mob\x18\x12 \x01(\x05R\tmaxNumMob\x12\x1c\n" +
+	"\tformation\x18\x13 \x01(\x05R\tformation\x12\x13\n" +
+	"\x05seg_x\x18\x14 \x03(\x05R\x04segX\x12\x13\n" +
+	"\x05seg_y\x18\x15 \x03(\x05R\x04segY\x12\x1b\n" +
+	"\tseg_range\x18\x16 \x03(\x05R\bsegRange\x12\x19\n" +
+	"\bseg_wait\x18\x17 \x03(\x05R\asegWait\x12!\n" +
+	"\ffight_action\x18\x18 \x03(\tR\vfightAction\x12\x1d\n" +
+	"\n" +
+	"die_action\x18\x19 \x03(\tR\tdieAction\"@\n" +
 	"\tItemPrice\x12\x1d\n" +
 	"\n" +
 	"item_index\x18\x01 \x01(\x05R\titemIndex\x12\x14\n" +

--- a/api/db/v1/db.proto
+++ b/api/db/v1/db.proto
@@ -493,6 +493,20 @@ message NpcDefinition {
   int32 route_type = 9;
   int32 merchant = 10;
   repeated NpcShopItem shop = 11;
+  string origin = 12;
+  int32 generator_index = 13;
+  string follower_template = 14;
+  int32 minute_generate = 15;
+  int32 min_group = 16;
+  int32 max_group = 17;
+  int32 max_num_mob = 18;
+  int32 formation = 19;
+  repeated int32 seg_x = 20;
+  repeated int32 seg_y = 21;
+  repeated int32 seg_range = 22;
+  repeated int32 seg_wait = 23;
+  repeated string fight_action = 24;
+  repeated string die_action = 25;
 }
 
 message ItemPrice {

--- a/api/web/v1/web.pb.go
+++ b/api/web/v1/web.pb.go
@@ -90,11 +90,12 @@ func (CreateResult) EnumDescriptor() ([]byte, []int) {
 type AdminResult int32
 
 const (
-	AdminResult_ADMIN_RESULT_UNSPECIFIED AdminResult = 0
-	AdminResult_ADMIN_RESULT_OK          AdminResult = 1
-	AdminResult_ADMIN_RESULT_FORBIDDEN   AdminResult = 2 // caller is not a moderator/admin
-	AdminResult_ADMIN_RESULT_INVALID     AdminResult = 3 // validation failed (bad slot, unknown target, …)
-	AdminResult_ADMIN_RESULT_NOT_FOUND   AdminResult = 4 // target definition does not exist
+	AdminResult_ADMIN_RESULT_UNSPECIFIED   AdminResult = 0
+	AdminResult_ADMIN_RESULT_OK            AdminResult = 1
+	AdminResult_ADMIN_RESULT_FORBIDDEN     AdminResult = 2 // caller is not a moderator/admin
+	AdminResult_ADMIN_RESULT_INVALID       AdminResult = 3 // validation failed (bad slot, unknown target, …)
+	AdminResult_ADMIN_RESULT_NOT_FOUND     AdminResult = 4 // target definition does not exist
+	AdminResult_ADMIN_RESULT_CONTENT_OWNED AdminResult = 5 // content definitions must be hidden, not deleted
 )
 
 // Enum value maps for AdminResult.
@@ -105,13 +106,15 @@ var (
 		2: "ADMIN_RESULT_FORBIDDEN",
 		3: "ADMIN_RESULT_INVALID",
 		4: "ADMIN_RESULT_NOT_FOUND",
+		5: "ADMIN_RESULT_CONTENT_OWNED",
 	}
 	AdminResult_value = map[string]int32{
-		"ADMIN_RESULT_UNSPECIFIED": 0,
-		"ADMIN_RESULT_OK":          1,
-		"ADMIN_RESULT_FORBIDDEN":   2,
-		"ADMIN_RESULT_INVALID":     3,
-		"ADMIN_RESULT_NOT_FOUND":   4,
+		"ADMIN_RESULT_UNSPECIFIED":   0,
+		"ADMIN_RESULT_OK":            1,
+		"ADMIN_RESULT_FORBIDDEN":     2,
+		"ADMIN_RESULT_INVALID":       3,
+		"ADMIN_RESULT_NOT_FOUND":     4,
+		"ADMIN_RESULT_CONTENT_OWNED": 5,
 	}
 )
 
@@ -1606,20 +1609,22 @@ func (x *AdminNpcShopItem) GetQuantity() int32 {
 }
 
 type AdminNpc struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
-	Slug          string                 `protobuf:"bytes,2,opt,name=slug,proto3" json:"slug,omitempty"`
-	TemplateName  string                 `protobuf:"bytes,3,opt,name=template_name,json=templateName,proto3" json:"template_name,omitempty"`
-	DisplayName   string                 `protobuf:"bytes,4,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
-	Enabled       bool                   `protobuf:"varint,5,opt,name=enabled,proto3" json:"enabled,omitempty"`
-	MapId         int32                  `protobuf:"varint,6,opt,name=map_id,json=mapId,proto3" json:"map_id,omitempty"`
-	PosX          int32                  `protobuf:"varint,7,opt,name=pos_x,json=posX,proto3" json:"pos_x,omitempty"`
-	PosY          int32                  `protobuf:"varint,8,opt,name=pos_y,json=posY,proto3" json:"pos_y,omitempty"`
-	RouteType     int32                  `protobuf:"varint,9,opt,name=route_type,json=routeType,proto3" json:"route_type,omitempty"`
-	Merchant      int32                  `protobuf:"varint,10,opt,name=merchant,proto3" json:"merchant,omitempty"`
-	Shop          []*AdminNpcShopItem    `protobuf:"bytes,11,rep,name=shop,proto3" json:"shop,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Id             int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Slug           string                 `protobuf:"bytes,2,opt,name=slug,proto3" json:"slug,omitempty"`
+	TemplateName   string                 `protobuf:"bytes,3,opt,name=template_name,json=templateName,proto3" json:"template_name,omitempty"`
+	DisplayName    string                 `protobuf:"bytes,4,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	Enabled        bool                   `protobuf:"varint,5,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	MapId          int32                  `protobuf:"varint,6,opt,name=map_id,json=mapId,proto3" json:"map_id,omitempty"`
+	PosX           int32                  `protobuf:"varint,7,opt,name=pos_x,json=posX,proto3" json:"pos_x,omitempty"`
+	PosY           int32                  `protobuf:"varint,8,opt,name=pos_y,json=posY,proto3" json:"pos_y,omitempty"`
+	RouteType      int32                  `protobuf:"varint,9,opt,name=route_type,json=routeType,proto3" json:"route_type,omitempty"`
+	Merchant       int32                  `protobuf:"varint,10,opt,name=merchant,proto3" json:"merchant,omitempty"`
+	Shop           []*AdminNpcShopItem    `protobuf:"bytes,11,rep,name=shop,proto3" json:"shop,omitempty"`
+	Origin         string                 `protobuf:"bytes,12,opt,name=origin,proto3" json:"origin,omitempty"`
+	GeneratorIndex int32                  `protobuf:"varint,13,opt,name=generator_index,json=generatorIndex,proto3" json:"generator_index,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *AdminNpc) Reset() {
@@ -1727,6 +1732,20 @@ func (x *AdminNpc) GetShop() []*AdminNpcShopItem {
 		return x.Shop
 	}
 	return nil
+}
+
+func (x *AdminNpc) GetOrigin() string {
+	if x != nil {
+		return x.Origin
+	}
+	return ""
+}
+
+func (x *AdminNpc) GetGeneratorIndex() int32 {
+	if x != nil {
+		return x.GeneratorIndex
+	}
+	return 0
 }
 
 type ListNpcsRequest struct {
@@ -9060,7 +9079,7 @@ const file_api_web_v1_web_proto_rawDesc = "" +
 	"\x05effv2\x18\x06 \x01(\x05R\x05effv2\x12\x12\n" +
 	"\x04eff3\x18\a \x01(\x05R\x04eff3\x12\x14\n" +
 	"\x05effv3\x18\b \x01(\x05R\x05effv3\x12\x1a\n" +
-	"\bquantity\x18\t \x01(\x05R\bquantity\"\xba\x02\n" +
+	"\bquantity\x18\t \x01(\x05R\bquantity\"\xfb\x02\n" +
 	"\bAdminNpc\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12#\n" +
@@ -9074,7 +9093,9 @@ const file_api_web_v1_web_proto_rawDesc = "" +
 	"route_type\x18\t \x01(\x05R\trouteType\x12\x1a\n" +
 	"\bmerchant\x18\n" +
 	" \x01(\x05R\bmerchant\x12,\n" +
-	"\x04shop\x18\v \x03(\v2\x18.web.v1.AdminNpcShopItemR\x04shop\"4\n" +
+	"\x04shop\x18\v \x03(\v2\x18.web.v1.AdminNpcShopItemR\x04shop\x12\x16\n" +
+	"\x06origin\x18\f \x01(\tR\x06origin\x12'\n" +
+	"\x0fgenerator_index\x18\r \x01(\x05R\x0egeneratorIndex\"4\n" +
 	"\x0fListNpcsRequest\x12!\n" +
 	"\fmoderator_id\x18\x01 \x01(\x03R\vmoderatorId\"e\n" +
 	"\x10ListNpcsResponse\x12+\n" +
@@ -9661,13 +9682,14 @@ const file_api_web_v1_web_proto_rawDesc = "" +
 	"\x19CREATE_RESULT_UNSPECIFIED\x10\x00\x12\x14\n" +
 	"\x10CREATE_RESULT_OK\x10\x01\x12\x1c\n" +
 	"\x18CREATE_RESULT_NAME_TAKEN\x10\x02\x12\x19\n" +
-	"\x15CREATE_RESULT_INVALID\x10\x03*\x92\x01\n" +
+	"\x15CREATE_RESULT_INVALID\x10\x03*\xb2\x01\n" +
 	"\vAdminResult\x12\x1c\n" +
 	"\x18ADMIN_RESULT_UNSPECIFIED\x10\x00\x12\x13\n" +
 	"\x0fADMIN_RESULT_OK\x10\x01\x12\x1a\n" +
 	"\x16ADMIN_RESULT_FORBIDDEN\x10\x02\x12\x18\n" +
 	"\x14ADMIN_RESULT_INVALID\x10\x03\x12\x1a\n" +
-	"\x16ADMIN_RESULT_NOT_FOUND\x10\x04*\xdc\x02\n" +
+	"\x16ADMIN_RESULT_NOT_FOUND\x10\x04\x12\x1e\n" +
+	"\x1aADMIN_RESULT_CONTENT_OWNED\x10\x05*\xdc\x02\n" +
 	"\x1eAttributeMapTransformOperation\x121\n" +
 	"-ATTRIBUTE_MAP_TRANSFORM_OPERATION_UNSPECIFIED\x10\x00\x12>\n" +
 	":ATTRIBUTE_MAP_TRANSFORM_OPERATION_LEGACY_MARK_PVP_EXP_LOSS\x10\x01\x122\n" +

--- a/api/web/v1/web.proto
+++ b/api/web/v1/web.proto
@@ -202,6 +202,7 @@ enum AdminResult {
   ADMIN_RESULT_FORBIDDEN = 2;  // caller is not a moderator/admin
   ADMIN_RESULT_INVALID = 3;    // validation failed (bad slot, unknown target, …)
   ADMIN_RESULT_NOT_FOUND = 4;  // target definition does not exist
+  ADMIN_RESULT_CONTENT_OWNED = 5; // content definitions must be hidden, not deleted
 }
 
 message AdminAck { AdminResult result = 1; }
@@ -230,6 +231,8 @@ message AdminNpc {
   int32 route_type = 9;
   int32 merchant = 10;
   repeated AdminNpcShopItem shop = 11;
+  string origin = 12;
+  int32 generator_index = 13;
 }
 
 message ListNpcsRequest { int64 moderator_id = 1; }

--- a/dbserver/cmd/dbserver/main.go
+++ b/dbserver/cmd/dbserver/main.go
@@ -188,15 +188,25 @@ func buildNPCDefinitions(contentDir string, logger *slog.Logger) ([]domain.NPCDe
 			continue // missing template, or a monster / non-shop NPC (stays in NPCGener.txt)
 		}
 		def := domain.NPCDefinition{
-			Slug:         fmt.Sprintf("%s-%d", b.leader, i),
-			TemplateName: tmpl.name,
-			DisplayName:  cString(mob.Name[:]),
-			Enabled:      true,
-			PosX:         int32(b.startX),
-			PosY:         int32(b.startY),
-			RouteType:    int16(b.routeType),
-			Merchant:     int16(mob.CurrentScore.Merchant),
+			Slug:             fmt.Sprintf("%s-%d", b.leader, i),
+			TemplateName:     tmpl.name,
+			DisplayName:      cString(mob.Name[:]),
+			Enabled:          true,
+			PosX:             int32(b.startX),
+			PosY:             int32(b.startY),
+			RouteType:        int16(b.routeType),
+			Merchant:         int16(mob.CurrentScore.Merchant),
+			Origin:           "content",
+			GeneratorIndex:   int32(i),
+			FollowerTemplate: b.follower,
+			MinuteGenerate:   int32(b.minuteGenerate), MinGroup: int32(b.minGroup),
+			MaxGroup: int32(b.maxGroup), MaxNumMob: int32(b.maxNumMob), Formation: int16(b.formation),
 		}
+		for j := 0; j < 5; j++ {
+			def.SegX[j], def.SegY[j] = int32(b.segX[j]), int32(b.segY[j])
+			def.SegRange[j], def.SegWait[j] = int32(b.segRange[j]), int32(b.segWait[j])
+		}
+		def.FightAction, def.DieAction = b.fightAction, b.dieAction
 		// Slot is the MSG_ShopList display index (0..26); it maps to the real Carry
 		// slot via shopCarrySlot (3 tabs of 9). Reading Carry directly would miss
 		// tabs 2/3 (Carry[27..35],[54..62]) — the same mapping the tmServer writes
@@ -244,9 +254,12 @@ func shopQuantity(effects *[3]savefmt.Effect) int16 {
 // npcGenerBlock is the subset of an NPCGener.txt spawn block the importer needs:
 // the leader template name, the Start waypoint (spawn point) and the route type.
 type npcGenerBlock struct {
-	leader         string
-	startX, startY int
-	routeType      int
+	leader, follower                                         string
+	startX, startY                                           int
+	routeType                                                int
+	minuteGenerate, minGroup, maxGroup, maxNumMob, formation int
+	segX, segY, segRange, segWait                            [5]int
+	fightAction, dieAction                                   [4]string
 }
 
 // parseNPCGener reads NPCGener.txt. Blocks begin with '#'; lines are "Key:\tvalue";
@@ -276,7 +289,7 @@ func parseNPCGener(path string) ([]npcGenerBlock, error) {
 		}
 		if strings.HasPrefix(line, "#") {
 			flush()
-			cur = &npcGenerBlock{}
+			cur = &npcGenerBlock{minGroup: 1}
 			continue
 		}
 		if cur == nil {
@@ -290,12 +303,58 @@ func parseNPCGener(path string) ([]npcGenerBlock, error) {
 		switch key {
 		case "Leader":
 			cur.leader = val
+		case "Follower":
+			if val != "0" {
+				cur.follower = val
+			}
+		case "MinuteGenerate":
+			cur.minuteGenerate = atoiSafe(val)
+		case "MinGroup":
+			cur.minGroup = atoiSafe(val)
+		case "MaxGroup":
+			cur.maxGroup = atoiSafe(val)
+		case "MaxNumMob":
+			cur.maxNumMob = atoiSafe(val)
+		case "Formation":
+			cur.formation = atoiSafe(val)
 		case "StartX":
 			cur.startX = atoiSafe(val)
+			cur.segX[0] = cur.startX
 		case "StartY":
 			cur.startY = atoiSafe(val)
+			cur.segY[0] = cur.startY
+		case "StartRange":
+			cur.segRange[0] = atoiSafe(val)
+		case "StartWait":
+			cur.segWait[0] = atoiSafe(val)
+		case "DestX":
+			cur.segX[4] = atoiSafe(val)
+		case "DestY":
+			cur.segY[4] = atoiSafe(val)
+		case "DestRange":
+			cur.segRange[4] = atoiSafe(val)
+		case "DestWait":
+			cur.segWait[4] = atoiSafe(val)
 		case "RouteType":
 			cur.routeType = atoiSafe(val)
+		case "FightAction":
+			addGeneratorAction(&cur.fightAction, val)
+		case "DieAction":
+			addGeneratorAction(&cur.dieAction, val)
+		default:
+			for n := 1; n <= 3; n++ {
+				prefix := "Segment" + strconv.Itoa(n)
+				switch key {
+				case prefix + "X":
+					cur.segX[n] = atoiSafe(val)
+				case prefix + "Y":
+					cur.segY[n] = atoiSafe(val)
+				case prefix + "Range":
+					cur.segRange[n] = atoiSafe(val)
+				case prefix + "Wait":
+					cur.segWait[n] = atoiSafe(val)
+				}
+			}
 		}
 	}
 	flush()
@@ -303,6 +362,15 @@ func parseNPCGener(path string) ([]npcGenerBlock, error) {
 		return nil, fmt.Errorf("import-npcs: scan NPCGener: %w", err)
 	}
 	return out, nil
+}
+
+func addGeneratorAction(dst *[4]string, value string) {
+	for i := range dst {
+		if dst[i] == "" {
+			dst[i] = value
+			return
+		}
+	}
 }
 
 // cString trims a fixed-size C string field at its first NUL.
@@ -381,6 +449,7 @@ func runServe(args []string, logger *slog.Logger) error {
 	tlsCert := fs.String("tls-cert", os.Getenv("W2PP_TLS_CERT"), "server certificate (PEM)")
 	tlsKey := fs.String("tls-key", os.Getenv("W2PP_TLS_KEY"), "server private key (PEM)")
 	tlsCA := fs.String("tls-ca", os.Getenv("W2PP_TLS_CA"), "client CA (PEM) for mTLS")
+	contentDir := fs.String("content", envOr("W2PP_CONTENT", "/Release"), "content root used to reconcile the complete NPC generator catalog")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -398,6 +467,20 @@ func runServe(args []string, logger *slog.Logger) error {
 	defer pool.Close()
 	if err := store.Migrate(ctx, pool); err != nil {
 		return err
+	}
+	if *contentDir != "" {
+		defs, buildErr := buildNPCDefinitions(*contentDir, logger)
+		if buildErr != nil {
+			return fmt.Errorf("build NPC generator catalog: %w", buildErr)
+		}
+		if len(defs) == 0 {
+			return fmt.Errorf("NPC generator catalog is empty")
+		}
+		seeded, seedErr := store.New(pool).SeedNPCDefinitions(ctx, defs)
+		if seedErr != nil {
+			return fmt.Errorf("reconcile NPC generator catalog: %w", seedErr)
+		}
+		logger.Info("NPC generator catalog reconciled", "expected", len(defs), "processed", seeded)
 	}
 
 	creds, err := secure.ServerCreds(secure.Config{CertFile: *tlsCert, KeyFile: *tlsKey, CAFile: *tlsCA})

--- a/dbserver/cmd/dbserver/main_test.go
+++ b/dbserver/cmd/dbserver/main_test.go
@@ -10,6 +10,41 @@ import (
 	"github.com/jeanluca/w2pp-openwyd/internal/savefmt"
 )
 
+func TestBuildNPCDefinitionsRealCatalog(t *testing.T) {
+	contentDir := filepath.Join("..", "..", "..", "Release")
+	if _, err := os.Stat(contentDir); err != nil {
+		t.Skip("Release content unavailable")
+	}
+	defs, err := buildNPCDefinitions(contentDir, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(defs) != 548 {
+		t.Fatalf("merchant generator definitions = %d, want 548", len(defs))
+	}
+	want := map[string]struct {
+		index    int32
+		merchant int16
+		x, y     int32
+	}{
+		"Jeffi-290": {290, 12, 1112, 290}, "Jeffi-987": {987, 12, 2517, 1727},
+		"Kibita-3811": {3811, 74, 2135, 2104},
+	}
+	for _, d := range defs {
+		w, ok := want[d.Slug]
+		if !ok {
+			continue
+		}
+		if d.GeneratorIndex != w.index || d.Merchant != w.merchant || d.PosX != w.x || d.PosY != w.y {
+			t.Errorf("%s = index %d merchant %d (%d,%d), want %+v", d.Slug, d.GeneratorIndex, d.Merchant, d.PosX, d.PosY, w)
+		}
+		delete(want, d.Slug)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing expected definitions: %v", want)
+	}
+}
+
 func TestBuildNPCDefinitionsNormalizesLegacyTemplateNames(t *testing.T) {
 	dir := t.TempDir()
 	runDir := filepath.Join(dir, "TMsrv", "run")

--- a/dbserver/internal/grpcsrv/npcconfig.go
+++ b/dbserver/internal/grpcsrv/npcconfig.go
@@ -80,6 +80,11 @@ func npcDefinitionsToProto(defs []domain.NPCDefinition) []*dbv1.NpcDefinition {
 			Id: d.ID, Slug: d.Slug, TemplateName: d.TemplateName, DisplayName: d.DisplayName,
 			Enabled: d.Enabled, MapId: d.MapID, PosX: d.PosX, PosY: d.PosY,
 			RouteType: int32(d.RouteType), Merchant: int32(d.Merchant), Shop: shop,
+			Origin: d.Origin, GeneratorIndex: d.GeneratorIndex, FollowerTemplate: d.FollowerTemplate,
+			MinuteGenerate: d.MinuteGenerate, MinGroup: d.MinGroup, MaxGroup: d.MaxGroup,
+			MaxNumMob: d.MaxNumMob, Formation: int32(d.Formation),
+			SegX: d.SegX[:], SegY: d.SegY[:], SegRange: d.SegRange[:], SegWait: d.SegWait[:],
+			FightAction: d.FightAction[:], DieAction: d.DieAction[:],
 		})
 	}
 	return out

--- a/docs/migration/npc-generator-inventory.md
+++ b/docs/migration/npc-generator-inventory.md
@@ -1,0 +1,29 @@
+# Inventário dos generators com `Merchant != 0`
+
+Fonte reproduzível: `dbserver import-npcs -content ./Release` usa o mesmo parser e
+codec do seed de produção. O catálogo atual contém **548 blocos** em 6099 slots;
+produção possuía apenas 84 antes da migration do catálogo integral.
+
+O byte `Merchant` é sobrecarregado pelo legado: além de lojas, identifica quests,
+montarias e atores de eventos. Por isso cada registro preserva a receita completa
+do `NPCGener.txt` e o `generator_index`, em vez de virar um spawn simples.
+
+Principais grupos que estavam integral ou parcialmente ausentes:
+
+| Merchant | Blocos | Exemplos | Classificação |
+|---:|---:|---|---|
+| 1 | 88 | lojas regionais e equipamentos | loja |
+| 12 | 4 | Jeffi, Torre_Real | quest pendente |
+| 16 | 64 | montarias e criaturas associadas | montaria/evento |
+| 23/24 | 2 | Mestre_Grifo, Alquimista_Odin | quest/combine |
+| 32 | 65 | guardas e cavaleiros | evento/combate |
+| 64 | 178 | Zakum, arqueiros, lanceiros | evento/combate |
+| 74 | 2 | Kibita, Lindy | quest/combine parcial |
+| 78 | 2 | BlueOracle, RedOracle | quest |
+| 96 | 43 | guardas, soldados e Lanceiro | evento/combate |
+| 100 | 26 | cadeia Quest 256 e tutoriais | quest parcial |
+| 111 | 2 | Rei_Glantuar, Rei_Harabard | quest |
+
+Casos não classificados com paridade comprovada permanecem `UNVERIFIED` e são
+acompanhados pela issue guarda-chuva. A presença no mundo não implica que a
+interação específica já esteja implementada.

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -195,17 +195,25 @@ type Affect struct {
 // tmServer's single-owner loop — never the reverse. Slug is the stable id;
 // TemplateName points at the 816-byte STRUCT_MOB in Release/TMsrv/run/npc/.
 type NPCDefinition struct {
-	ID           int64
-	Slug         string
-	TemplateName string
-	DisplayName  string
-	Enabled      bool
-	MapID        int32
-	PosX         int32
-	PosY         int32
-	RouteType    int16
-	Merchant     int16
-	Shop         []NPCShopItem // merchant stock; overlays the template Carry[]
+	ID                            int64
+	Slug                          string
+	TemplateName                  string
+	DisplayName                   string
+	Enabled                       bool
+	MapID                         int32
+	PosX                          int32
+	PosY                          int32
+	RouteType                     int16
+	Merchant                      int16
+	Origin                        string
+	GeneratorIndex                int32
+	FollowerTemplate              string
+	MinuteGenerate                int32
+	MinGroup, MaxGroup, MaxNumMob int32
+	Formation                     int16
+	SegX, SegY, SegRange, SegWait [5]int32
+	FightAction, DieAction        [4]string
+	Shop                          []NPCShopItem // merchant stock; overlays the template Carry[]
 }
 
 // NPCShopItem is one shop slot of a merchant NPC. Prices are NOT stored here —

--- a/internal/migrations/0018_npc_generator_catalog.down.sql
+++ b/internal/migrations/0018_npc_generator_catalog.down.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS npc_definition_generator_index_idx;
+ALTER TABLE npc_definition DROP COLUMN IF EXISTS generator_data;
+ALTER TABLE npc_definition DROP COLUMN IF EXISTS formation;
+ALTER TABLE npc_definition DROP COLUMN IF EXISTS max_num_mob;
+ALTER TABLE npc_definition DROP COLUMN IF EXISTS max_group;
+ALTER TABLE npc_definition DROP COLUMN IF EXISTS min_group;
+ALTER TABLE npc_definition DROP COLUMN IF EXISTS minute_generate;
+ALTER TABLE npc_definition DROP COLUMN IF EXISTS follower_template;
+ALTER TABLE npc_definition DROP COLUMN IF EXISTS generator_index;
+ALTER TABLE npc_definition DROP COLUMN IF EXISTS origin;

--- a/internal/migrations/0018_npc_generator_catalog.up.sql
+++ b/internal/migrations/0018_npc_generator_catalog.up.sql
@@ -1,0 +1,17 @@
+-- Persist the complete NPCGener recipe for content-owned merchant blocks.
+ALTER TABLE npc_definition ADD COLUMN origin TEXT NOT NULL DEFAULT 'custom'
+    CHECK (origin IN ('content', 'custom'));
+ALTER TABLE npc_definition ADD COLUMN generator_index INTEGER;
+ALTER TABLE npc_definition ADD COLUMN follower_template TEXT NOT NULL DEFAULT '';
+ALTER TABLE npc_definition ADD COLUMN minute_generate INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE npc_definition ADD COLUMN min_group INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE npc_definition ADD COLUMN max_group INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE npc_definition ADD COLUMN max_num_mob INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE npc_definition ADD COLUMN formation SMALLINT NOT NULL DEFAULT 0;
+ALTER TABLE npc_definition ADD COLUMN generator_data JSONB NOT NULL DEFAULT '{}';
+CREATE UNIQUE INDEX npc_definition_generator_index_idx
+    ON npc_definition(generator_index) WHERE generator_index IS NOT NULL;
+
+-- Definitions shipped by the old curated seed are content, not moderator-created.
+UPDATE npc_definition SET origin = 'content'
+WHERE slug IN (SELECT slug FROM npc_definition WHERE updated_by IS NULL);

--- a/internal/store/npc.go
+++ b/internal/store/npc.go
@@ -35,7 +35,9 @@ func (s *Store) NPCConfigVersion(ctx context.Context) (int64, error) {
 // id. This is the full snapshot the tmServer materializes into live entities.
 func (s *Store) ListNPCDefinitions(ctx context.Context) ([]domain.NPCDefinition, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT id, slug, template_name, display_name, enabled, map_id, pos_x, pos_y, route_type, merchant
+		SELECT id, slug, template_name, display_name, enabled, map_id, pos_x, pos_y, route_type, merchant,
+		       origin, COALESCE(generator_index,-1), follower_template, minute_generate,
+		       min_group, max_group, max_num_mob, formation, generator_data
 		FROM npc_definition ORDER BY id`)
 	if err != nil {
 		return nil, fmt.Errorf("store: list npc definitions: %w", err)
@@ -46,9 +48,20 @@ func (s *Store) ListNPCDefinitions(ctx context.Context) ([]domain.NPCDefinition,
 	var out []domain.NPCDefinition
 	for rows.Next() {
 		var d domain.NPCDefinition
+		var generatorData []byte
 		if err := rows.Scan(&d.ID, &d.Slug, &d.TemplateName, &d.DisplayName, &d.Enabled,
-			&d.MapID, &d.PosX, &d.PosY, &d.RouteType, &d.Merchant); err != nil {
+			&d.MapID, &d.PosX, &d.PosY, &d.RouteType, &d.Merchant, &d.Origin,
+			&d.GeneratorIndex, &d.FollowerTemplate, &d.MinuteGenerate, &d.MinGroup,
+			&d.MaxGroup, &d.MaxNumMob, &d.Formation, &generatorData); err != nil {
 			return nil, fmt.Errorf("store: scan npc definition: %w", err)
+		}
+		if len(generatorData) > 0 {
+			var gd generatorJSON
+			if err := json.Unmarshal(generatorData, &gd); err != nil {
+				return nil, fmt.Errorf("store: decode generator %q: %w", d.Slug, err)
+			}
+			d.SegX, d.SegY, d.SegRange, d.SegWait = gd.SegX, gd.SegY, gd.SegRange, gd.SegWait
+			d.FightAction, d.DieAction = gd.FightAction, gd.DieAction
 		}
 		byID[d.ID] = len(out)
 		out = append(out, d)
@@ -87,10 +100,11 @@ func (s *Store) ListNPCDefinitions(ctx context.Context) ([]domain.NPCDefinition,
 func (s *Store) GetNPCDefinition(ctx context.Context, id int64) (domain.NPCDefinition, error) {
 	var d domain.NPCDefinition
 	err := s.pool.QueryRow(ctx, `
-		SELECT id, slug, template_name, display_name, enabled, map_id, pos_x, pos_y, route_type, merchant
+		SELECT id, slug, template_name, display_name, enabled, map_id, pos_x, pos_y, route_type, merchant,
+		       origin, COALESCE(generator_index,-1)
 		FROM npc_definition WHERE id = $1`, id).
 		Scan(&d.ID, &d.Slug, &d.TemplateName, &d.DisplayName, &d.Enabled,
-			&d.MapID, &d.PosX, &d.PosY, &d.RouteType, &d.Merchant)
+			&d.MapID, &d.PosX, &d.PosY, &d.RouteType, &d.Merchant, &d.Origin, &d.GeneratorIndex)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return domain.NPCDefinition{}, ErrNotFound
 	}
@@ -250,6 +264,17 @@ func (s *Store) SetItemPrice(ctx context.Context, itemIndex int32, price int64, 
 // ErrNotFound if absent.
 func (s *Store) DeleteNPCDefinition(ctx context.Context, npcID int64, moderatorID int64) error {
 	return s.inTx(ctx, func(tx pgx.Tx) error {
+		var origin string
+		err := tx.QueryRow(ctx, `SELECT origin FROM npc_definition WHERE id = $1`, npcID).Scan(&origin)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("store: read npc definition origin: %w", err)
+		}
+		if origin == "content" {
+			return ErrContentOwned
+		}
 		before, err := fetchDefJSONByID(ctx, tx, npcID)
 		if err != nil {
 			return err
@@ -271,20 +296,37 @@ func (s *Store) DeleteNPCDefinition(ctx context.Context, npcID int64, moderatorI
 // definitions actually inserted.
 func (s *Store) SeedNPCDefinitions(ctx context.Context, defs []domain.NPCDefinition) (int, error) {
 	inserted := 0
+	indices := make(map[int32]string, len(defs))
+	for _, d := range defs {
+		if previous, exists := indices[d.GeneratorIndex]; exists {
+			return 0, fmt.Errorf("store: duplicate content generator index %d for %q and %q", d.GeneratorIndex, previous, d.Slug)
+		}
+		indices[d.GeneratorIndex] = d.Slug
+	}
 	err := s.inTx(ctx, func(tx pgx.Tx) error {
 		for _, d := range defs {
+			gd, marshalErr := json.Marshal(generatorJSON{
+				SegX: d.SegX, SegY: d.SegY, SegRange: d.SegRange, SegWait: d.SegWait,
+				FightAction: d.FightAction, DieAction: d.DieAction,
+			})
+			if marshalErr != nil {
+				return fmt.Errorf("store: encode generator %q: %w", d.Slug, marshalErr)
+			}
 			var id int64
+			var created bool
 			err := tx.QueryRow(ctx, `
 				INSERT INTO npc_definition
-					(slug, template_name, display_name, enabled, map_id, pos_x, pos_y, route_type, merchant)
-				VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
-				ON CONFLICT (slug) DO NOTHING
-				RETURNING id`,
+					(slug, template_name, display_name, enabled, map_id, pos_x, pos_y, route_type, merchant,
+					 origin, generator_index, follower_template, minute_generate, min_group, max_group, max_num_mob, formation, generator_data)
+				VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,'content',$10,$11,$12,$13,$14,$15,$16,$17)
+				ON CONFLICT (slug) DO UPDATE SET origin='content', generator_index=EXCLUDED.generator_index,
+				 follower_template=EXCLUDED.follower_template, minute_generate=EXCLUDED.minute_generate,
+				 min_group=EXCLUDED.min_group, max_group=EXCLUDED.max_group,
+				 max_num_mob=EXCLUDED.max_num_mob, formation=EXCLUDED.formation, generator_data=EXCLUDED.generator_data
+				RETURNING id, (xmax = 0)`,
 				d.Slug, d.TemplateName, d.DisplayName, d.Enabled, d.MapID, d.PosX, d.PosY, d.RouteType, d.Merchant,
-			).Scan(&id)
-			if errors.Is(err, pgx.ErrNoRows) {
-				continue // slug already present — leave it untouched
-			}
+				d.GeneratorIndex, d.FollowerTemplate, d.MinuteGenerate, d.MinGroup, d.MaxGroup, d.MaxNumMob, d.Formation, gd,
+			).Scan(&id, &created)
 			if err != nil {
 				return fmt.Errorf("store: seed npc definition %q: %w", d.Slug, err)
 			}
@@ -292,16 +334,19 @@ func (s *Store) SeedNPCDefinitions(ctx context.Context, defs []domain.NPCDefinit
 				normalizeShopQuantity(&it)
 				if _, err := tx.Exec(ctx, `
 					INSERT INTO npc_shop_item (npc_id, slot, item_index, quantity, eff1, effv1, eff2, effv2, eff3, effv3)
-					VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+					VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+					ON CONFLICT (npc_id, slot) DO NOTHING`,
 					id, it.Slot, it.ItemIndex, normalizedQuantity(it.Quantity),
 					it.Eff1, it.EffV1, it.Eff2, it.EffV2, it.Eff3, it.EffV3,
 				); err != nil {
 					return fmt.Errorf("store: seed shop item (%q slot %d): %w", d.Slug, it.Slot, err)
 				}
 			}
-			inserted++
+			if created {
+				inserted++
+			}
 		}
-		if inserted > 0 {
+		if len(defs) > 0 {
 			if _, err := tx.Exec(ctx, `UPDATE npc_config_meta SET version = version + 1 WHERE id = TRUE`); err != nil {
 				return fmt.Errorf("store: bump npc config version: %w", err)
 			}
@@ -309,6 +354,15 @@ func (s *Store) SeedNPCDefinitions(ctx context.Context, defs []domain.NPCDefinit
 		return nil
 	})
 	return inserted, err
+}
+
+type generatorJSON struct {
+	SegX        [5]int32  `json:"seg_x"`
+	SegY        [5]int32  `json:"seg_y"`
+	SegRange    [5]int32  `json:"seg_range"`
+	SegWait     [5]int32  `json:"seg_wait"`
+	FightAction [4]string `json:"fight_action"`
+	DieAction   [4]string `json:"die_action"`
 }
 
 // --- helpers ---

--- a/internal/store/npc_integration_test.go
+++ b/internal/store/npc_integration_test.go
@@ -116,9 +116,9 @@ func TestSeedNPCDefinitionsIdempotent(t *testing.T) {
 
 	s := New(pool)
 	defs := []domain.NPCDefinition{
-		{Slug: "seed-int-1", TemplateName: "A", Enabled: true, Merchant: 1,
+		{Slug: "seed-int-1", TemplateName: "A", Enabled: true, Merchant: 1, GeneratorIndex: 1,
 			Shop: []domain.NPCShopItem{{Slot: 0, ItemIndex: 10, Quantity: 2}}},
-		{Slug: "seed-int-2", TemplateName: "B", Enabled: true, Merchant: 1},
+		{Slug: "seed-int-2", TemplateName: "B", Enabled: true, Merchant: 1, GeneratorIndex: 2},
 	}
 	n, err := s.SeedNPCDefinitions(ctx, defs)
 	if err != nil {

--- a/internal/store/store_live.go
+++ b/internal/store/store_live.go
@@ -14,6 +14,9 @@ import (
 // ErrNotFound is returned when a queried account or character does not exist.
 var ErrNotFound = errors.New("store: not found")
 
+// ErrContentOwned prevents deleting versioned world content; moderators hide it instead.
+var ErrContentOwned = errors.New("store: content-owned definition")
+
 // ErrNoFreeSlot is returned when an account already has all character slots in use.
 var ErrNoFreeSlot = errors.New("store: no free character slot")
 

--- a/tmserver/cmd/tmserver/main.go
+++ b/tmserver/cmd/tmserver/main.go
@@ -343,7 +343,9 @@ func run(logger *slog.Logger) error {
 		seedWorldItems(w, *contentDir, logger)
 	}
 	if npcConfig != nil {
-		dispatch.ApplyNPCConfigBoot(w)
+		if err := dispatch.ApplyNPCConfigBoot(w); err != nil {
+			return err
+		}
 	}
 	if worldEvents != nil {
 		dispatch.ApplyWorldEventConfigBoot(w)
@@ -427,6 +429,7 @@ func spawnNPCs(w *world.World, dir string, skipMerchants bool, mobStatOverrides 
 	}
 
 	wgens := make([]*world.Generator, len(gens))
+	dbOwned := make([]bool, len(gens))
 	skipped := 0
 	missingLeaderBlocks, missingFollowerBlocks := 0, 0
 	missingLeaderNames := make(map[string]struct{})
@@ -448,7 +451,7 @@ func spawnNPCs(w *world.World, dir string, skipMerchants bool, mobStatOverrides 
 		// and "owned by npc_definition".
 		if skipMerchants && leader.rawMerchant != 0 {
 			skipped++
-			continue
+			dbOwned[i] = true
 		}
 		follower := load(g.Follower)
 		if g.Follower != "" && follower.bytes == nil {
@@ -456,6 +459,7 @@ func spawnNPCs(w *world.World, dir string, skipMerchants bool, mobStatOverrides 
 			missingFollowerNames[g.Follower] = struct{}{}
 		}
 		wg := &world.Generator{
+			DBManaged:      dbOwned[i],
 			MinuteGenerate: g.MinuteGenerate,
 			MinGroup:       g.MinGroup,
 			MaxGroup:       g.MaxGroup,
@@ -474,12 +478,16 @@ func spawnNPCs(w *world.World, dir string, skipMerchants bool, mobStatOverrides 
 			wg.SegWait[s] = int16(g.SegWait[s])
 		}
 		wgens[i] = wg
+		if dbOwned[i] {
+			wg.LeaderTmpl = nil
+			wg.FollowerTmpl = nil
+		}
 	}
 	w.RegisterGenerators(wgens)
 
 	total := 0
 	for i := range wgens {
-		if wgens[i] != nil {
+		if wgens[i] != nil && !dbOwned[i] {
 			total += len(w.GenerateMob(i))
 		}
 	}

--- a/tmserver/internal/dbclient/npcconfig.go
+++ b/tmserver/internal/dbclient/npcconfig.go
@@ -78,7 +78,33 @@ func (c *NpcConfig) Snapshot(ctx context.Context) (npccfg.Snapshot, error) {
 			Y:           int16(d.GetPosY()),
 			RouteType:   uint8(d.GetRouteType()),
 			Merchant:    uint8(d.GetMerchant()),
+			Origin:      d.GetOrigin(), GeneratorIndex: int(d.GetGeneratorIndex()),
+			MinuteGenerate: int(d.GetMinuteGenerate()), MinGroup: int(d.GetMinGroup()),
+			MaxGroup: int(d.GetMaxGroup()), MaxNumMob: int(d.GetMaxNumMob()), Formation: int(d.GetFormation()),
 		}
+		if name := d.GetFollowerTemplate(); name != "" {
+			if b, lerr := c.template(name); lerr != nil {
+				c.log.Warn("npc follower template resolve failed", "template", name, "slug", d.GetSlug(), "err", lerr)
+			} else {
+				def.FollowerTemplate = b
+			}
+		}
+		for i := 0; i < 5; i++ {
+			if i < len(d.GetSegX()) {
+				def.SegX[i] = int16(d.GetSegX()[i])
+			}
+			if i < len(d.GetSegY()) {
+				def.SegY[i] = int16(d.GetSegY()[i])
+			}
+			if i < len(d.GetSegRange()) {
+				def.SegRange[i] = int16(d.GetSegRange()[i])
+			}
+			if i < len(d.GetSegWait()) {
+				def.SegWait[i] = int16(d.GetSegWait()[i])
+			}
+		}
+		copy(def.FightAction[:], d.GetFightAction())
+		copy(def.DieAction[:], d.GetDieAction())
 		for _, it := range d.GetShop() {
 			def.Shop = append(def.Shop, npccfg.ShopItem{
 				Slot:     int(it.GetSlot()),

--- a/tmserver/internal/handler/npcconfig.go
+++ b/tmserver/internal/handler/npcconfig.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -30,21 +31,39 @@ const (
 
 // ApplyNPCConfigBoot fetches the definition snapshot synchronously and applies it
 // once at boot (no reveal — no players are connected yet). It runs before the
-// loop starts, so it is single-threaded like spawnNPCs. A fetch error is logged
-// and left for the periodic poll to retry once the loop is running.
-func (d *Dispatcher) ApplyNPCConfigBoot(w *world.World) {
+// loop starts, so it is single-threaded like spawnNPCs. Loading is fail-closed:
+// starting with an incomplete content catalog would silently remove legacy NPCs.
+func (d *Dispatcher) ApplyNPCConfigBoot(w *world.World) error {
 	if d.npcSource == nil {
-		return
+		return nil
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), npcFetchTimeout)
 	defer cancel()
 	snap, err := d.npcSource.Snapshot(ctx)
 	if err != nil {
-		d.log.Warn("npc config boot load failed (will retry via poll)", "err", err)
-		return
+		return fmt.Errorf("npc config boot load: %w", err)
+	}
+	expected := w.DBManagedGeneratorCount()
+	seen := make(map[int]struct{}, expected)
+	for _, def := range snap.Defs {
+		if def.Origin != "content" || def.GeneratorIndex < 0 {
+			continue
+		}
+		if _, exists := seen[def.GeneratorIndex]; exists {
+			return fmt.Errorf("npc config duplicate generator index %d", def.GeneratorIndex)
+		}
+		g := w.GeneratorAt(def.GeneratorIndex)
+		if g == nil || !g.DBManaged {
+			return fmt.Errorf("npc config content generator index %d is not DB-managed", def.GeneratorIndex)
+		}
+		seen[def.GeneratorIndex] = struct{}{}
+	}
+	if len(seen) != expected {
+		return fmt.Errorf("npc config incomplete: content generators=%d expected=%d", len(seen), expected)
 	}
 	d.applyNPCConfig(w, snap, false)
 	d.log.Info("npc config applied at boot", "version", snap.Version, "npcs", len(d.managedNPCs))
+	return nil
 }
 
 // pollNPCConfig checks the config version off the loop each npcPollPeriod ticks
@@ -97,6 +116,42 @@ func (d *Dispatcher) applyNPCConfig(w *world.World, snap npccfg.Snapshot, reveal
 	}
 
 	for _, def := range snap.Defs {
+		if def.Origin == "content" && def.GeneratorIndex >= 0 {
+			g := w.GeneratorAt(def.GeneratorIndex)
+			if g == nil || !g.DBManaged {
+				d.log.Warn("npc content generator index is not DB-managed", "slug", def.Slug, "index", def.GeneratorIndex)
+				continue
+			}
+			w.ClearGenerator(def.GeneratorIndex)
+			if !def.Enabled {
+				g.LeaderTmpl = nil
+				g.FollowerTmpl = nil
+				continue
+			}
+			if def.Template == nil {
+				d.log.Warn("npc definition has no template — skipped", "slug", def.Slug)
+				continue
+			}
+			g.MinuteGenerate, g.MinGroup, g.MaxGroup, g.MaxNumMob = def.MinuteGenerate, def.MinGroup, def.MaxGroup, def.MaxNumMob
+			g.RouteType, g.Formation = def.RouteType, def.Formation
+			g.SegX, g.SegY, g.SegRange, g.SegWait = def.SegX, def.SegY, def.SegRange, def.SegWait
+			g.FightAction, g.DieAction = def.FightAction, def.DieAction
+			g.LeaderTmpl = npcTemplateWithDisplayName(def.Template, def.DisplayName)
+			g.FollowerTmpl = def.FollowerTemplate
+			ids := w.GenerateMob(def.GeneratorIndex)
+			if len(ids) == 0 {
+				d.log.Warn("npc content generator produced no entities", "slug", def.Slug, "index", def.GeneratorIndex)
+				continue
+			}
+			if def.Merchant != 0 {
+				applyShop(w.Entity(ids[0]), def.Shop)
+			}
+			d.managedNPCs[def.Slug] = ids[0]
+			if reveal {
+				d.revealSpawned(w, ids)
+			}
+			continue
+		}
 		if !def.Enabled {
 			continue
 		}

--- a/tmserver/internal/npccfg/npccfg.go
+++ b/tmserver/internal/npccfg/npccfg.go
@@ -22,14 +22,20 @@ type ShopItem struct {
 // Template is nil when the referenced file could not be loaded — such a
 // definition is skipped by the applier.
 type Definition struct {
-	Slug        string
-	Template    []byte
-	DisplayName string
-	Enabled     bool
-	X, Y        int16
-	RouteType   uint8
-	Merchant    uint8
-	Shop        []ShopItem // nil = use the template's own Carry[] as the shop
+	Slug                                                     string
+	Template                                                 []byte
+	DisplayName                                              string
+	Enabled                                                  bool
+	X, Y                                                     int16
+	RouteType                                                uint8
+	Merchant                                                 uint8
+	Origin                                                   string
+	GeneratorIndex                                           int
+	FollowerTemplate                                         []byte
+	MinuteGenerate, MinGroup, MaxGroup, MaxNumMob, Formation int
+	SegX, SegY, SegRange, SegWait                            [5]int16
+	FightAction, DieAction                                   [4]string
+	Shop                                                     []ShopItem // nil = use the template's own Carry[] as the shop
 }
 
 // Snapshot is the full config at a given version: the definition set plus the

--- a/tmserver/internal/world/generator.go
+++ b/tmserver/internal/world/generator.go
@@ -10,8 +10,9 @@ package world
 // Generator is the runtime state of one NPCGener.txt block (NPCGENLIST,
 // CNPCGene.h:29-51): the spawn recipe plus the live population counter.
 type Generator struct {
-	MinuteGenerate int // respawn period in minutes; <=0 = the timer never regenerates
-	MinGroup       int // follower count rolled as MinGroup + rand()%(MaxGroup-MinGroup+1)
+	DBManaged      bool // content merchant recipe must be supplied by npc_definition
+	MinuteGenerate int  // respawn period in minutes; <=0 = the timer never regenerates
+	MinGroup       int  // follower count rolled as MinGroup + rand()%(MaxGroup-MinGroup+1)
 	MaxGroup       int
 	MaxNumMob      int // population cap (leader and followers both count toward it)
 	RouteType      uint8
@@ -59,6 +60,40 @@ func (w *World) GeneratorAt(idx int) *Generator {
 		return nil
 	}
 	return w.generators[idx]
+}
+
+// DBManagedGeneratorCount reports how many content slots require DB recipes.
+func (w *World) DBManagedGeneratorCount() int {
+	n := 0
+	for _, g := range w.generators {
+		if g != nil && g.DBManaged {
+			n++
+		}
+	}
+	return n
+}
+
+// ClearGenerator removes every live entity and queued respawn owned by one
+// generator slot before a DB snapshot replaces its recipe. Loop-only.
+func (w *World) ClearGenerator(idx int) {
+	if idx < 0 || idx >= len(w.generators) {
+		return
+	}
+	for id := MaxUser; id < MaxMob; id++ {
+		if e := w.entities[id]; e != nil && int(e.GenIndex) == idx {
+			w.DespawnMob(id, 0)
+		}
+	}
+	kept := w.respawnQueue[:0]
+	for _, entry := range w.respawnQueue {
+		if int(entry.spawn.GenIndex) != idx {
+			kept = append(kept, entry)
+		}
+	}
+	w.respawnQueue = kept
+	if g := w.generators[idx]; g != nil {
+		g.CurrentNumMob = 0
+	}
 }
 
 // SpawnGeneratorLeader spawns exactly one generator leader at its first

--- a/tmserver/internal/world/generator_test.go
+++ b/tmserver/internal/world/generator_test.go
@@ -23,6 +23,31 @@ func genMerchantTemplate(merchant uint8) []byte {
 	return b
 }
 
+func TestClearGeneratorRemovesWholeGroup(t *testing.T) {
+	w := New(Config{GridDim: 64}, slogDiscard(), nil, nil)
+	g := &Generator{
+		DBManaged: true, MinGroup: 2, MaxGroup: 2, MaxNumMob: 3,
+		SegX: [5]int16{20}, SegY: [5]int16{20},
+		LeaderTmpl: genMerchantTemplate(12), FollowerTmpl: genMobTemplate(0),
+	}
+	w.RegisterGenerators([]*Generator{g})
+	ids := w.GenerateMob(0)
+	if len(ids) != 3 {
+		t.Fatalf("GenerateMob spawned %d entities, want 3", len(ids))
+	}
+
+	w.ClearGenerator(0)
+
+	if g.CurrentNumMob != 0 {
+		t.Fatalf("CurrentNumMob = %d, want 0", g.CurrentNumMob)
+	}
+	for _, id := range ids {
+		if w.Entity(id) != nil {
+			t.Errorf("entity %d survived generator clear", id)
+		}
+	}
+}
+
 // TestGenerateMobGroup covers the GenerateMob port (Server.cpp:3442-3810):
 // group size, leader/follower linking, per-block population accounting
 // (including the leader-not-counted-in-the-clamp quirk) and the cap.

--- a/webserver/internal/grpcsrv/npcadmin.go
+++ b/webserver/internal/grpcsrv/npcadmin.go
@@ -274,6 +274,7 @@ func adminNpcToProto(d domain.NPCDefinition) *webv1.AdminNpc {
 		Id: d.ID, Slug: d.Slug, TemplateName: d.TemplateName, DisplayName: d.DisplayName,
 		Enabled: d.Enabled, MapId: d.MapID, PosX: d.PosX, PosY: d.PosY,
 		RouteType: int32(d.RouteType), Merchant: int32(d.Merchant), Shop: shop,
+		Origin: d.Origin, GeneratorIndex: d.GeneratorIndex,
 	}
 }
 
@@ -301,6 +302,8 @@ func resultToProto(r npcadmin.Result) webv1.AdminResult {
 		return webv1.AdminResult_ADMIN_RESULT_FORBIDDEN
 	case npcadmin.NotFound:
 		return webv1.AdminResult_ADMIN_RESULT_NOT_FOUND
+	case npcadmin.ContentOwned:
+		return webv1.AdminResult_ADMIN_RESULT_CONTENT_OWNED
 	default:
 		return webv1.AdminResult_ADMIN_RESULT_INVALID
 	}

--- a/webserver/internal/npcadmin/service.go
+++ b/webserver/internal/npcadmin/service.go
@@ -44,6 +44,8 @@ const (
 	Invalid
 	// NotFound means the target definition does not exist.
 	NotFound
+	// ContentOwned means versioned content must be hidden rather than deleted.
+	ContentOwned
 )
 
 // Shop slots mirror MSG_ShopList's 27 entries; a merchant NPC's stock lives in
@@ -277,6 +279,8 @@ func classifyWrite(err error, op string) (Result, error) {
 		return OK, nil
 	case errors.Is(err, store.ErrNotFound):
 		return NotFound, nil
+	case errors.Is(err, store.ErrContentOwned):
+		return ContentOwned, nil
 	default:
 		return Invalid, fmt.Errorf("npcadmin: %s: %w", op, err)
 	}
@@ -287,10 +291,5 @@ func classifyWrite(err error, op string) (Result, error) {
 // quest NPC), and 111 (canonical King templates). Others are rejected until
 // confirmed by capture (npc-editing-plan.md §9.4).
 func validMerchant(m int16) bool {
-	switch m {
-	case 0, 1, 2, 19, 100, 111:
-		return true
-	default:
-		return false
-	}
+	return m >= 0 && m <= 255
 }

--- a/webserver/internal/npcadmin/service_test.go
+++ b/webserver/internal/npcadmin/service_test.go
@@ -127,8 +127,9 @@ func TestUpsertValidation(t *testing.T) {
 		{"king ok", domain.NPCDefinition{Slug: "king", TemplateName: "Rei_Harabard", Merchant: 111}, OK},
 		{"empty slug", domain.NPCDefinition{TemplateName: "t"}, Invalid},
 		{"empty template", domain.NPCDefinition{Slug: "s"}, Invalid},
-		{"bad merchant", domain.NPCDefinition{Slug: "s", TemplateName: "t", Merchant: 7}, Invalid},
-		{"unsupported king variant merchant", domain.NPCDefinition{Slug: "s", TemplateName: "t", Merchant: 96}, Invalid},
+		{"legacy quest merchant", domain.NPCDefinition{Slug: "s", TemplateName: "t", Merchant: 7}, OK},
+		{"legacy event merchant", domain.NPCDefinition{Slug: "s", TemplateName: "t", Merchant: 96}, OK},
+		{"merchant outside byte range", domain.NPCDefinition{Slug: "s", TemplateName: "t", Merchant: 256}, Invalid},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- import and reconcile all 548 merchant-tagged NPCGener recipes at dbserver startup
- preserve generator indices, followers, formations, routes, respawn settings, actions, waypoints, shops, and single-owner world-loop behavior
- restore Jeffi and Kibita while protecting content-owned definitions from deletion
- fail closed when the database catalog is incomplete, duplicated, or mapped to the wrong generator slots
- document the affected NPC inventory and merchant-code distribution

## Validation
- Docker: go test ./...
- Docker: go vet ./...
- Docker: go build ./...
- PostgreSQL 17 Docker integration tests for migrations and idempotent catalog seeding

Closes #249
Closes #250
Closes #251