### PR TITLE
fix: corrigir a corrida de boot entre tmserver e dbserver

### DIFF
--- a/internal/store/npc.go
+++ b/internal/store/npc.go
@@ -295,7 +295,6 @@ func (s *Store) DeleteNPCDefinition(ctx context.Context, npcID int64, moderatorI
 // audit (this is a system import, not moderator activity). Returns the number of
 // definitions actually inserted.
 func (s *Store) SeedNPCDefinitions(ctx context.Context, defs []domain.NPCDefinition) (int, error) {
-	inserted := 0
 	indices := make(map[int32]string, len(defs))
 	for _, d := range defs {
 		if previous, exists := indices[d.GeneratorIndex]; exists {
@@ -303,18 +302,63 @@ func (s *Store) SeedNPCDefinitions(ctx context.Context, defs []domain.NPCDefinit
 		}
 		indices[d.GeneratorIndex] = d.Slug
 	}
+	inserted := 0
 	err := s.inTx(ctx, func(tx pgx.Tx) error {
-		for _, d := range defs {
+		ids, created, err := seedNPCRows(ctx, tx, defs)
+		if err != nil {
+			return err
+		}
+		if err := seedNPCShopRows(ctx, tx, defs, ids); err != nil {
+			return err
+		}
+		for _, isNew := range created {
+			if isNew {
+				inserted++
+			}
+		}
+		if len(defs) > 0 {
+			if _, err := tx.Exec(ctx, `UPDATE npc_config_meta SET version = version + 1 WHERE id = TRUE`); err != nil {
+				return fmt.Errorf("store: bump npc config version: %w", err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return inserted, nil
+}
+
+// seedBatchChunk bounds how many statements are pipelined per round trip. The
+// content catalog is ~550 definitions plus several thousand shop items, so
+// chunking keeps the client-side buffer bounded without giving up the
+// pipelining. See seedNPCRows for why the pipelining matters.
+const seedBatchChunk = 1000
+
+// seedNPCRows upserts every definition and returns, positionally, each row's id
+// and whether THIS call created it (`xmax = 0` distinguishes a fresh insert from
+// a conflict update — that is what SeedNPCDefinitions counts).
+//
+// The statements are pipelined with pgx.Batch rather than issued one at a time.
+// A round trip per row cost ~56s against the production database, and because
+// dbServer reconciles the catalog BEFORE it listens (dbserver/cmd/dbserver/main.go),
+// that time was spent with port 7514 closed — long enough for the tmServer to
+// exhaust its restart budget and crash-loop the deploy.
+func seedNPCRows(ctx context.Context, tx pgx.Tx, defs []domain.NPCDefinition) ([]int64, []bool, error) {
+	ids := make([]int64, len(defs))
+	created := make([]bool, len(defs))
+	for start := 0; start < len(defs); start += seedBatchChunk {
+		end := min(start+seedBatchChunk, len(defs))
+		batch := &pgx.Batch{}
+		for _, d := range defs[start:end] {
 			gd, marshalErr := json.Marshal(generatorJSON{
 				SegX: d.SegX, SegY: d.SegY, SegRange: d.SegRange, SegWait: d.SegWait,
 				FightAction: d.FightAction, DieAction: d.DieAction,
 			})
 			if marshalErr != nil {
-				return fmt.Errorf("store: encode generator %q: %w", d.Slug, marshalErr)
+				return nil, nil, fmt.Errorf("store: encode generator %q: %w", d.Slug, marshalErr)
 			}
-			var id int64
-			var created bool
-			err := tx.QueryRow(ctx, `
+			batch.Queue(`
 				INSERT INTO npc_definition
 					(slug, template_name, display_name, enabled, map_id, pos_x, pos_y, route_type, merchant,
 					 origin, generator_index, follower_template, minute_generate, min_group, max_group, max_num_mob, formation, generator_data)
@@ -326,34 +370,71 @@ func (s *Store) SeedNPCDefinitions(ctx context.Context, defs []domain.NPCDefinit
 				RETURNING id, (xmax = 0)`,
 				d.Slug, d.TemplateName, d.DisplayName, d.Enabled, d.MapID, d.PosX, d.PosY, d.RouteType, d.Merchant,
 				d.GeneratorIndex, d.FollowerTemplate, d.MinuteGenerate, d.MinGroup, d.MaxGroup, d.MaxNumMob, d.Formation, gd,
-			).Scan(&id, &created)
-			if err != nil {
-				return fmt.Errorf("store: seed npc definition %q: %w", d.Slug, err)
-			}
-			for _, it := range d.Shop {
-				normalizeShopQuantity(&it)
-				if _, err := tx.Exec(ctx, `
-					INSERT INTO npc_shop_item (npc_id, slot, item_index, quantity, eff1, effv1, eff2, effv2, eff3, effv3)
-					VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
-					ON CONFLICT (npc_id, slot) DO NOTHING`,
-					id, it.Slot, it.ItemIndex, normalizedQuantity(it.Quantity),
-					it.Eff1, it.EffV1, it.Eff2, it.EffV2, it.Eff3, it.EffV3,
-				); err != nil {
-					return fmt.Errorf("store: seed shop item (%q slot %d): %w", d.Slug, it.Slot, err)
-				}
-			}
-			if created {
-				inserted++
+			)
+		}
+		// Every queued result must be consumed and the batch closed before the
+		// next statement runs on this tx, so keep only the first error and drain.
+		res := tx.SendBatch(ctx, batch)
+		var batchErr error
+		for i := start; i < end; i++ {
+			if err := res.QueryRow().Scan(&ids[i], &created[i]); err != nil && batchErr == nil {
+				batchErr = fmt.Errorf("store: seed npc definition %q: %w", defs[i].Slug, err)
 			}
 		}
-		if len(defs) > 0 {
-			if _, err := tx.Exec(ctx, `UPDATE npc_config_meta SET version = version + 1 WHERE id = TRUE`); err != nil {
-				return fmt.Errorf("store: bump npc config version: %w", err)
+		if err := res.Close(); err != nil && batchErr == nil {
+			batchErr = fmt.Errorf("store: seed npc definitions: %w", err)
+		}
+		if batchErr != nil {
+			return nil, nil, batchErr
+		}
+	}
+	return ids, created, nil
+}
+
+// seedNPCShopRows inserts the shop items of every definition, pipelined the same
+// way as seedNPCRows. ids is positional against defs (from seedNPCRows).
+func seedNPCShopRows(ctx context.Context, tx pgx.Tx, defs []domain.NPCDefinition, ids []int64) error {
+	// Flatten first so the chunking is over shop items, not over definitions —
+	// a merchant carries up to 27 slots, so the row count is several thousand.
+	type shopRow struct {
+		npcID int64
+		slug  string
+		item  domain.NPCShopItem
+	}
+	var rows []shopRow
+	for i, d := range defs {
+		for _, it := range d.Shop {
+			normalizeShopQuantity(&it)
+			rows = append(rows, shopRow{npcID: ids[i], slug: d.Slug, item: it})
+		}
+	}
+	for start := 0; start < len(rows); start += seedBatchChunk {
+		end := min(start+seedBatchChunk, len(rows))
+		batch := &pgx.Batch{}
+		for _, r := range rows[start:end] {
+			batch.Queue(`
+				INSERT INTO npc_shop_item (npc_id, slot, item_index, quantity, eff1, effv1, eff2, effv2, eff3, effv3)
+				VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+				ON CONFLICT (npc_id, slot) DO NOTHING`,
+				r.npcID, r.item.Slot, r.item.ItemIndex, normalizedQuantity(r.item.Quantity),
+				r.item.Eff1, r.item.EffV1, r.item.Eff2, r.item.EffV2, r.item.Eff3, r.item.EffV3,
+			)
+		}
+		res := tx.SendBatch(ctx, batch)
+		var batchErr error
+		for _, r := range rows[start:end] {
+			if _, err := res.Exec(); err != nil && batchErr == nil {
+				batchErr = fmt.Errorf("store: seed shop item (%q slot %d): %w", r.slug, r.item.Slot, err)
 			}
 		}
-		return nil
-	})
-	return inserted, err
+		if err := res.Close(); err != nil && batchErr == nil {
+			batchErr = fmt.Errorf("store: seed shop items: %w", err)
+		}
+		if batchErr != nil {
+			return batchErr
+		}
+	}
+	return nil
 }
 
 type generatorJSON struct {

--- a/internal/store/npc_integration_test.go
+++ b/internal/store/npc_integration_test.go
@@ -8,6 +8,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/jeanluca/w2pp-openwyd/internal/domain"
@@ -133,5 +134,69 @@ func TestSeedNPCDefinitionsIdempotent(t *testing.T) {
 	}
 	if n != 0 {
 		t.Errorf("second seed inserted %d, want 0 (idempotent)", n)
+	}
+	// The shop items are re-queued on every pass and deduped by
+	// ON CONFLICT (npc_id, slot) DO NOTHING — assert the second pass did not
+	// double them, which the pipelined seed could otherwise hide.
+	var shopRows int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM npc_shop_item si
+		JOIN npc_definition d ON d.id = si.npc_id
+		WHERE d.slug = 'seed-int-1'`).Scan(&shopRows); err != nil {
+		t.Fatalf("count shop items: %v", err)
+	}
+	if shopRows != 1 {
+		t.Errorf("shop items for seed-int-1 = %d, want 1", shopRows)
+	}
+}
+
+// chunkGenBase keeps TestSeedNPCDefinitionsSpansBatchChunks' generator indices
+// clear of the ones the other tests in this package use.
+const chunkGenBase = 100000
+
+// TestSeedNPCDefinitionsSpansBatchChunks covers the chunk boundary of the
+// pipelined seed. Definition ids come back positionally per chunk and the shop
+// items are keyed off them, so an off-by-one at a chunk split would silently
+// attach a merchant's stock to the wrong NPC.
+func TestSeedNPCDefinitionsSpansBatchChunks(t *testing.T) {
+	ctx := context.Background()
+	pool := testPool(t)
+	if err := Migrate(ctx, pool); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	_, _ = pool.Exec(ctx, `DELETE FROM npc_shop_item; DELETE FROM npc_definition WHERE slug LIKE 'seed-chunk-%'`)
+
+	s := New(pool)
+	total := seedBatchChunk + 5
+	defs := make([]domain.NPCDefinition, total)
+	for i := range defs {
+		defs[i] = domain.NPCDefinition{
+			Slug: fmt.Sprintf("seed-chunk-%d", i), TemplateName: "A", Enabled: true,
+			// generator_index is globally unique, so offset well clear of any
+			// rows the other tests in this package leave behind.
+			Merchant: 1, GeneratorIndex: int32(chunkGenBase + i),
+			// item_index encodes the slug's ordinal so the pairing is checkable.
+			Shop: []domain.NPCShopItem{{Slot: 0, ItemIndex: int32(1000 + i), Quantity: 1}},
+		}
+	}
+
+	n, err := s.SeedNPCDefinitions(ctx, defs)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if n != total {
+		t.Fatalf("seed inserted %d, want %d", n, total)
+	}
+
+	var mismatched int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM npc_shop_item si
+		JOIN npc_definition d ON d.id = si.npc_id
+		WHERE d.slug LIKE 'seed-chunk-%'
+		  AND si.item_index <> 1000 + split_part(d.slug, '-', 3)::int`).Scan(&mismatched); err != nil {
+		t.Fatalf("check shop pairing: %v", err)
+	}
+	if mismatched != 0 {
+		t.Errorf("%d shop items landed on the wrong definition across the chunk split", mismatched)
 	}
 }

--- a/tmserver/cmd/tmserver/main.go
+++ b/tmserver/cmd/tmserver/main.go
@@ -355,7 +355,9 @@ func run(logger *slog.Logger) error {
 		seedWorldItems(w, *contentDir, logger)
 	}
 	if npcConfig != nil {
-		if err := dispatch.ApplyNPCConfigBoot(w); err != nil {
+		// Retries while the dbServer is still coming up; ctx aborts the wait on
+		// SIGTERM instead of holding the process for the whole retry budget.
+		if err := dispatch.ApplyNPCConfigBoot(ctx, w); err != nil {
 			return err
 		}
 	}

--- a/tmserver/internal/handler/npcconfig.go
+++ b/tmserver/internal/handler/npcconfig.go
@@ -29,19 +29,64 @@ const (
 	npcFetchTimeout = 5 * time.Second
 )
 
+// Boot retry budget. Vars, not consts, so tests can shrink them.
+var (
+	// npcBootRetryBudget bounds how long boot waits for the dbServer to become
+	// reachable and finish reconciling the content catalog. Both services are
+	// deployed together and the dbServer seeds the catalog BEFORE it listens, so
+	// the tmServer legitimately wins the race; without this wait the deploy
+	// crash-loops (production incident, 2026-08-13).
+	npcBootRetryBudget = 90 * time.Second
+	// npcBootRetryInitial and npcBootRetryMax bracket the exponential backoff.
+	npcBootRetryInitial = 1 * time.Second
+	npcBootRetryMax     = 5 * time.Second
+)
+
 // ApplyNPCConfigBoot fetches the definition snapshot synchronously and applies it
 // once at boot (no reveal — no players are connected yet). It runs before the
 // loop starts, so it is single-threaded like spawnNPCs. Loading is fail-closed:
 // starting with an incomplete content catalog would silently remove legacy NPCs.
-func (d *Dispatcher) ApplyNPCConfigBoot(w *world.World) error {
+// Transient failures are retried until npcBootRetryBudget expires — the dbServer
+// may still be unreachable, or still mid-seed and answering with a short catalog.
+// Structural failures (duplicate or non-DB-managed generator index) never heal on
+// their own, so they fail immediately instead of burning the budget.
+func (d *Dispatcher) ApplyNPCConfigBoot(ctx context.Context, w *world.World) error {
 	if d.npcSource == nil {
 		return nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), npcFetchTimeout)
+	deadline := time.Now().Add(npcBootRetryBudget)
+	delay := npcBootRetryInitial
+	for attempt := 1; ; attempt++ {
+		retriable, err := d.loadNPCConfigBoot(ctx, w)
+		if err == nil {
+			return nil
+		}
+		if !retriable {
+			return err
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("gave up after %d attempts in %s: %w", attempt, npcBootRetryBudget, err)
+		}
+		d.log.Warn("npc config boot load failed, retrying", "attempt", attempt, "retry_in", delay, "err", err)
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("npc config boot load: %w", ctx.Err())
+		case <-timer.C:
+		}
+		delay = min(delay*2, npcBootRetryMax)
+	}
+}
+
+// loadNPCConfigBoot runs one boot-load attempt. retriable reports whether the
+// failure is the kind that clears once the dbServer finishes coming up.
+func (d *Dispatcher) loadNPCConfigBoot(ctx context.Context, w *world.World) (retriable bool, err error) {
+	fetchCtx, cancel := context.WithTimeout(ctx, npcFetchTimeout)
 	defer cancel()
-	snap, err := d.npcSource.Snapshot(ctx)
+	snap, err := d.npcSource.Snapshot(fetchCtx)
 	if err != nil {
-		return fmt.Errorf("npc config boot load: %w", err)
+		return true, fmt.Errorf("npc config boot load: %w", err)
 	}
 	expected := w.DBManagedGeneratorCount()
 	seen := make(map[int]struct{}, expected)
@@ -50,20 +95,22 @@ func (d *Dispatcher) ApplyNPCConfigBoot(w *world.World) error {
 			continue
 		}
 		if _, exists := seen[def.GeneratorIndex]; exists {
-			return fmt.Errorf("npc config duplicate generator index %d", def.GeneratorIndex)
+			return false, fmt.Errorf("npc config duplicate generator index %d", def.GeneratorIndex)
 		}
 		g := w.GeneratorAt(def.GeneratorIndex)
 		if g == nil || !g.DBManaged {
-			return fmt.Errorf("npc config content generator index %d is not DB-managed", def.GeneratorIndex)
+			return false, fmt.Errorf("npc config content generator index %d is not DB-managed", def.GeneratorIndex)
 		}
 		seen[def.GeneratorIndex] = struct{}{}
 	}
 	if len(seen) != expected {
-		return fmt.Errorf("npc config incomplete: content generators=%d expected=%d", len(seen), expected)
+		// The dbServer seeds the whole catalog in one transaction, so a short
+		// count means we read before it committed — not that content is broken.
+		return true, fmt.Errorf("npc config incomplete: content generators=%d expected=%d", len(seen), expected)
 	}
 	d.applyNPCConfig(w, snap, false)
 	d.log.Info("npc config applied at boot", "version", snap.Version, "npcs", len(d.managedNPCs))
-	return nil
+	return false, nil
 }
 
 // pollNPCConfig checks the config version off the loop each npcPollPeriod ticks

--- a/tmserver/internal/handler/npcconfig_test.go
+++ b/tmserver/internal/handler/npcconfig_test.go
@@ -3,9 +3,12 @@ package handler
 import (
 	"context"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/npccfg"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
@@ -183,4 +186,190 @@ func TestApplyNPCConfigSkipsInvalid(t *testing.T) {
 		t.Errorf("managed = %d, want 0 (both invalid)", len(d.managedNPCs))
 	}
 	_ = w
+}
+
+// --- boot load retry ---
+//
+// Production incident 2026-08-13: tmServer and dbServer deploy together, and the
+// dbServer reconciles the content catalog BEFORE it listens, so the tmServer
+// routinely wins the race. Boot must wait it out instead of exiting and burning
+// the platform's restart budget — while still failing fast on config that will
+// never become valid.
+
+// bootStep is one scripted answer from fakeBootSource.
+type bootStep struct {
+	snap npccfg.Snapshot
+	err  error
+}
+
+// fakeBootSource replays scripted Snapshot answers, one per call, repeating the
+// last step once the script runs out. Unlike staticSource it counts calls, which
+// is how the tests tell a retry from a fail-fast.
+type fakeBootSource struct {
+	steps []bootStep
+	calls int
+}
+
+func (f *fakeBootSource) Version(context.Context) (int64, error) { return 0, nil }
+
+func (f *fakeBootSource) Snapshot(ctx context.Context) (npccfg.Snapshot, error) {
+	f.calls++
+	// The real dbclient fails this way on a cancelled/expired boot context.
+	if err := ctx.Err(); err != nil {
+		return npccfg.Snapshot{}, err
+	}
+	step := f.steps[min(f.calls-1, len(f.steps)-1)]
+	return step.snap, step.err
+}
+
+// shrinkBootRetry collapses the retry budget so the tests finish in
+// milliseconds. Package vars, restored on cleanup; no t.Parallel here.
+func shrinkBootRetry(t *testing.T) {
+	t.Helper()
+	budget, lo, hi := npcBootRetryBudget, npcBootRetryInitial, npcBootRetryMax
+	npcBootRetryBudget, npcBootRetryInitial, npcBootRetryMax = 150*time.Millisecond, time.Millisecond, 2*time.Millisecond
+	t.Cleanup(func() {
+		npcBootRetryBudget, npcBootRetryInitial, npcBootRetryMax = budget, lo, hi
+	})
+}
+
+// newBootDispatcher wires a Dispatcher to src over a world holding managed
+// DB-managed generator slots — the shape ApplyNPCConfigBoot validates against.
+func newBootDispatcher(src npccfg.Source, managed int) (*Dispatcher, *world.World) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := New(Config{Log: log, NpcConfig: src})
+	w := world.New(world.Config{GridDim: 32}, log, world.NopPersistence{}, d.Handle)
+	gens := make([]*world.Generator, managed)
+	for i := range gens {
+		gens[i] = &world.Generator{DBManaged: true}
+	}
+	w.RegisterGenerators(gens)
+	return d, w
+}
+
+// bootSnapshot covers the first n DB-managed generator slots. The definitions are
+// left disabled: they still count toward the completeness check, which keeps
+// these tests on the boot-load path rather than the spawn path already covered
+// by TestApplyNPCConfigSpawnsMerchant.
+func bootSnapshot(version int64, n int) npccfg.Snapshot {
+	snap := npccfg.Snapshot{Version: version}
+	for i := 0; i < n; i++ {
+		snap.Defs = append(snap.Defs, npccfg.Definition{
+			Slug:           fmt.Sprintf("merchant-%d", i),
+			Origin:         "content",
+			GeneratorIndex: i,
+		})
+	}
+	return snap
+}
+
+func TestApplyNPCConfigBootRetries(t *testing.T) {
+	const managed = 3
+	unavailable := errors.New("connection refused")
+
+	tests := []struct {
+		name  string
+		steps []bootStep
+		// wantCalls is exact; 0 means "only require that it retried".
+		wantCalls int
+		wantErr   bool
+	}{
+		{
+			// The nine transport failures of the production crash-loop.
+			name: "transport failure clears once dbServer listens",
+			steps: []bootStep{
+				{err: unavailable},
+				{err: unavailable},
+				{snap: bootSnapshot(7, managed)},
+			},
+			wantCalls: 3,
+		},
+		{
+			// The other production signature: dbServer answered mid-seed, so the
+			// catalog was short rather than the connection refused.
+			name: "short catalog clears once the seed commits",
+			steps: []bootStep{
+				{snap: bootSnapshot(7, managed-1)},
+				{snap: bootSnapshot(7, managed)},
+			},
+			wantCalls: 2,
+		},
+		{
+			name:      "succeeds on the first attempt",
+			steps:     []bootStep{{snap: bootSnapshot(7, managed)}},
+			wantCalls: 1,
+		},
+		{
+			// Duplicate generator index is corrupt data — waiting cannot fix it,
+			// so boot must not spend the budget before reporting it.
+			name: "duplicate generator index fails without retrying",
+			steps: []bootStep{{snap: npccfg.Snapshot{Defs: []npccfg.Definition{
+				{Slug: "a", Origin: "content", GeneratorIndex: 0},
+				{Slug: "b", Origin: "content", GeneratorIndex: 0},
+			}}}},
+			wantCalls: 1,
+			wantErr:   true,
+		},
+		{
+			name:      "generator outside the DB-managed set fails without retrying",
+			steps:     []bootStep{{snap: bootSnapshot(7, managed+1)}},
+			wantCalls: 1,
+			wantErr:   true,
+		},
+		{
+			// Fail-closed is preserved: a dbServer that never comes back still
+			// stops the boot rather than starting on an empty catalog.
+			name:    "permanent failure still fails closed",
+			steps:   []bootStep{{err: unavailable}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shrinkBootRetry(t)
+			src := &fakeBootSource{steps: tt.steps}
+			d, w := newBootDispatcher(src, managed)
+
+			err := d.ApplyNPCConfigBoot(context.Background(), w)
+
+			if tt.wantErr && err == nil {
+				t.Fatal("ApplyNPCConfigBoot succeeded, want error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("ApplyNPCConfigBoot: %v", err)
+			}
+			switch {
+			case tt.wantCalls > 0 && src.calls != tt.wantCalls:
+				t.Errorf("Snapshot called %d times, want %d", src.calls, tt.wantCalls)
+			case tt.wantCalls == 0 && src.calls < 2:
+				t.Errorf("Snapshot called %d times, want more than one attempt", src.calls)
+			}
+			if !tt.wantErr && d.npcVersion != 7 {
+				t.Errorf("npcVersion = %d, want the applied snapshot version 7", d.npcVersion)
+			}
+		})
+	}
+}
+
+// TestApplyNPCConfigBootHonoursContext proves SIGTERM during boot aborts the wait
+// instead of holding the process for the whole retry budget. The budget is left
+// at full size on purpose: cancellation, not the budget, must end the wait.
+func TestApplyNPCConfigBootHonoursContext(t *testing.T) {
+	src := &fakeBootSource{steps: []bootStep{{err: errors.New("connection refused")}}}
+	d, w := newBootDispatcher(src, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	err := d.ApplyNPCConfigBoot(ctx, w)
+	if err == nil {
+		t.Fatal("ApplyNPCConfigBoot succeeded on a cancelled context, want error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want it to wrap context.Canceled", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("returned after %s, want it to abort promptly", elapsed)
+	}
 }


### PR DESCRIPTION
## Problema

O tm-server caiu em produção em **dois deploys seguidos** no dia 13/08 (deployments `36078b8b` às 18:01 UTC e `beef3330` às 19:10 UTC), sempre com o mesmo erro repetido 11 vezes antes do Railway desistir:

```
npc config boot load: dbclient: list npc definitions: rpc error: code = Unavailable
... dial tcp [...]:7514: connect: connection refused
```

Não é bug de gameplay — é uma **corrida de inicialização**. Os dois serviços sobem juntos e:

- O **dbServer** reconcilia o catálogo de NPCs **antes** de chamar `net.Listen`, e o seed fazia um round-trip por linha: ~548 definições **mais** os shop items de cada mercador (até 27 por NPC). Medido em produção: **~56 segundos com a porta 7514 fechada**. No `beef3330` o log foi `expected=548 processed=0` — 56 segundos sem inserir uma única linha nova.
- O **tmServer** sobe em ~1s e `ApplyNPCConfigBoot` era fail-closed, timeout de 5s e **sem retry**. Falhava, saía, e o orçamento de restart da plataforma se esgotava.

No `beef3330` o tmServer morreu de vez às 19:10:32; o dbServer só abriu a porta às **19:10:48** — 16 segundos tarde demais.

## O que muda

**dbServer** (`internal/store/npc.go`) — o seed passa a ser pipelinado com `pgx.Batch` em duas fases (definições, depois shop items), em blocos de 1000. A **ordem continua a mesma** (catálogo completo antes de escutar) porque é esse invariante que permite ao tmServer confiar no fail-closed; o que muda é o número de round-trips, de **~6000 para ~8**. Os ids voltam posicionalmente por bloco e os shop items são chaveados por eles.

**tmServer** (`tmserver/internal/handler/npcconfig.go`) — `ApplyNPCConfigBoot` passa a receber `context.Context` e a tentar de novo com backoff exponencial (1s→5s) até um orçamento de 90s. A classificação importa:

| erro | retriable |
|---|---|
| falha de transporte (dbServer ainda subindo) | sim |
| `npc config incomplete` (dbServer no meio do seed) | sim |
| índice de gerador duplicado | **não** |
| índice fora do conjunto DB-managed | **não** |

Os dois primeiros são exatamente os que apareceram em produção. Os dois últimos nunca se curam sozinhos, então falham na primeira tentativa e preservam o diagnóstico.

O **fail-closed original é preservado**: esgotado o orçamento, o boot ainda para em vez de subir com catálogo vazio. E o `ctx` cancelado por sinal aborta a espera, então SIGTERM durante o boot não segura o processo por 90s.

## Testes

- `tmserver/internal/handler/npcconfig_test.go` — os 4 testes que já existiam continuam intactos; acrescentei `TestApplyNPCConfigBootRetries` (6 casos, incluindo as duas assinaturas de falha vistas em produção e os dois casos de fail-fast) e `TestApplyNPCConfigBootHonoursContext`.
- `internal/store/npc_integration_test.go` — `TestSeedNPCDefinitionsIdempotent` ganhou asserção de que os shop items não duplicam na segunda passada, e adicionei `TestSeedNPCDefinitionsSpansBatchChunks`, que semeia 1005 definições para cobrir a fronteira dos blocos e verificar via SQL que cada shop item ficou pareado com a sua própria definição (um off-by-one no split de bloco colaria o estoque de um mercador no NPC errado).

Verificado com Docker (`golang:1.25`):

- `go build ./...`, `go vet ./...` e `go vet -tags=integration ./internal/store/...` — limpos
- `go test -race ./...` — exit 0, sem falhas
- Testes de integração rodados contra um Postgres 16 real: `TestNPCConfigCRUD`, `TestSeedNPCDefinitionsIdempotent` e `TestSeedNPCDefinitionsSpansBatchChunks` passam (1005 definições + 1005 shop items em 0,49s)
- `golangci-lint run` nos pacotes alterados — limpo. Sobram 3 findings de `gofmt` em `internal/store/{dailyreward,donate,donate_revenue}.go`, que **já existiam na main** e não estão neste diff.

## Fora do escopo

- **Backoff de restart no Railway.** 11 tentativas em ~16s dá margem quase nenhuma. É configuração de dashboard, não código.
- **Bump de versão a cada boot.** `SeedNPCDefinitions` bumpa `npc_config_meta.version` incondicionalmente, então todo restart do dbServer com um tmServer no ar dispara um reconcile completo dos mercadores no próximo poll. Limpeza natural, mas independente desta correção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
