### PR TITLE
Add Magic Trumpet shout command

### DIFF
--- a/docs/game.md
+++ b/docs/game.md
@@ -25,6 +25,7 @@
 ✅ /buffs: Remove todos os buffs do personagem <br/>
 ✅ /cp: mostra os pontos de caos atuais do personagem <br/>
 ✅ /nick \<jogador\>: mostra nick, guild (nome/fama, se registrada — `world/guild.go`), cidadania e fama do jogador alvo <br/>
+✅ /gritar \<mensagem\>: grito global — consome 1 Trombeta Mágica (item 3330) e envia `[Nome]> mensagem` a todos os jogadores online, em verde (`_MSG_MagicTrumpet`). Alias legado: `/spk`. Sem trombeta, avisa e não grita; o alcance é o deste canal (o fan-out entre canais do legado passava pelo DBSrv e não foi portado) <br/>
 
 > Bônus já implementados (existem na fonte legada, fora da lista acima): `/selados`,
 > `/amagos`, `/agua` (teleportes).

--- a/tmserver/internal/handler/chat.go
+++ b/tmserver/internal/handler/chat.go
@@ -166,6 +166,10 @@ func (d *Dispatcher) runCommand(w *world.World, s *world.Session, name string, a
 		d.showChaosPoints(w, s)
 		return true
 	}
+	if cmd == "gritar" || cmd == "spk" {
+		d.magicTrumpet(w, s, args)
+		return true
+	}
 	if cmd == "gm" {
 		// GM/moderation command bus (issue #122). args is the whisper's String — the
 		// rest of the typed line (e.g. "/gm kick foo" → args = "kick foo").
@@ -335,6 +339,59 @@ func (d *Dispatcher) showChaosPoints(w *world.World, s *world.Session) {
 	chaos := int(pkPoint(e)) - 75
 	msg := fmt.Sprintf("Pontos Caos atual: %d", chaos)
 	d.sendChatText(w, s, msg)
+}
+
+// itemMagicTrumpet is the Trombeta Mágica (ItemList.csv:5031 —
+// "3330,Trombeta_Mágica,…,EF_VOLATILE,0,EF_GRID,0"): a stackable consumable with
+// no use-effect of its own; it exists only to pay for /gritar.
+const itemMagicTrumpet = 3330
+
+// magicTrumpet handles /gritar (legacy alias /spk): it burns one Trombeta Mágica
+// and shouts "[Nome]> texto" to every player online
+// (_MSG_MessageWhisper.cpp:114-162, issue #258).
+//
+// Deviations from the legacy, all deliberate:
+//   - The legacy relayed MSG_MagicTrumpet through the DBSrv so every channel
+//     received it (DBSrv/CFileDB.cpp:1616, TMSrv/ProcessDBMessage.cpp:136). The Go
+//     stack has one tmServer per channel and the dbServer has no announce RPC, so
+//     the shout reaches this server's players only. Cross-channel fan-out is future
+//     work.
+//   - Without a trumpet the legacy returned silently (:139); here the player is
+//     told why nothing happened.
+//   - An empty message is refused instead of shouting "[Nome]> " and eating a
+//     trumpet anyway.
+//   - The MuteChat gate (:118) has no counterpart — muting is not modeled yet.
+func (d *Dispatcher) magicTrumpet(w *world.World, s *world.Session, args []byte) {
+	e := w.Entity(s.Conn)
+	if e == nil {
+		return
+	}
+	text := strings.TrimSpace(cstr(args))
+	if text == "" {
+		return
+	}
+	slot := -1
+	for i, limit := 0, activeCarryLimit(e); i < limit; i++ {
+		if e.Carry[i].Index == itemMagicTrumpet {
+			slot = i
+			break
+		}
+	}
+	if slot < 0 {
+		d.sendChatText(w, s, "Você precisa de uma Trombeta Mágica para gritar.")
+		return
+	}
+	consumeOneItem(&e.Carry[slot])
+	d.sendSlot(w, s, world.ItemPlaceCarry, slot, e.Carry[slot])
+
+	// HEADER.ID = 0 like the legacy (sm_mt.ID = 0): the shout carries its speaker
+	// inside the text, not in the header. Nobody is excluded — the shouter sees it
+	// too, as SyncMulticast(0, …) did.
+	payload := protocol.EncodeMagicTrumpetBody(fmt.Sprintf("[%s]> %s", e.Name, text))
+	w.ForEachPlaying(-1, func(vs *world.Session, _ *world.Entity) {
+		w.SendTo(vs, protocol.Header{Type: protocol.MsgMagicTrumpet, ID: 0}, payload)
+	})
+	d.log.Info("magic trumpet", "conn", s.Conn, "account", s.AccountName, "name", e.Name, "text", text)
 }
 
 // sendChatText sends a raw MsgMessageChat line to s only — the SendClientMessage

--- a/tmserver/internal/handler/chat_test.go
+++ b/tmserver/internal/handler/chat_test.go
@@ -257,6 +257,121 @@ func TestCommandChaosPoints(t *testing.T) {
 	}
 }
 
+// trumpetDB is chatDB with "Hero" (account 7) carrying a stack of Trombetas
+// Mágicas in slot 0. amount == 0 means no trumpet at all.
+func trumpetDB(amount uint8) *fakeDB {
+	db := chatDB()
+	hero := db.loads[7]
+	if amount > 0 {
+		hero.Carry[0] = amountItem(itemMagicTrumpet, amount)
+	}
+	db.loads[7] = hero
+	return db
+}
+
+// TestCommandGritar verifies /gritar burns one Trombeta Mágica and shouts to
+// every player online, the shouter included (_MSG_MessageWhisper.cpp:114).
+func TestCommandGritar(t *testing.T) {
+	addr, stop, _ := startServerClock(t, trumpetDB(3))
+	defer stop()
+	a := enterWorldAs(t, addr, "tester")
+	defer a.Close()
+	b := enterWorldAs(t, addr, "tradeb")
+	defer b.Close()
+
+	whisperFrame(t, a, "gritar", "ola mundo")
+
+	// The shouter's own slot is re-synced first: 3 → 2.
+	_, slot, index, amount := sendItemSlotAmount(expect(t, a, protocol.MsgSendItem))
+	if slot != 0 || index != itemMagicTrumpet || amount != 2 {
+		t.Errorf("slot sync = (slot %d, index %d, amount %d), want (0, %d, 2)", slot, index, amount, itemMagicTrumpet)
+	}
+
+	want := "[Hero]> ola mundo"
+	for _, tc := range []struct {
+		name string
+		c    net.Conn
+	}{{"shouter", a}, {"other", b}} {
+		payload := expect(t, tc.c, protocol.MsgMagicTrumpet)
+		if len(payload) != protocol.MagicTrumpetBodySize {
+			t.Errorf("%s: body = %d bytes, want %d", tc.name, len(payload), protocol.MagicTrumpetBodySize)
+			continue
+		}
+		if got := cstr(payload); got != want {
+			t.Errorf("%s: shout = %q, want %q", tc.name, got, want)
+		}
+		if payload[94] != 1 {
+			t.Errorf("%s: String[94] = %d, want 1 (legacy marker byte)", tc.name, payload[94])
+		}
+	}
+}
+
+// TestCommandGritarLastTrumpet verifies the slot is cleared, not decremented,
+// when the last unit is spent (BASE_ClearItem, _MSG_MessageWhisper.cpp:135).
+func TestCommandGritarLastTrumpet(t *testing.T) {
+	addr, stop, _ := startServerClock(t, trumpetDB(1))
+	defer stop()
+	a := enterWorldAs(t, addr, "tester")
+	defer a.Close()
+
+	whisperFrame(t, a, "gritar", "adeus")
+	_, slot, index, _ := sendItemSlotAmount(expect(t, a, protocol.MsgSendItem))
+	if slot != 0 || index != 0 {
+		t.Errorf("slot sync = (slot %d, index %d), want (0, 0) — an empty slot", slot, index)
+	}
+}
+
+// TestCommandGritarNoTrumpet verifies the command refuses without the item: the
+// caller is told why (a deliberate deviation — the legacy returned silently at
+// _MSG_MessageWhisper.cpp:139) and nobody else hears anything.
+func TestCommandGritarNoTrumpet(t *testing.T) {
+	addr, stop, _ := startServerClock(t, trumpetDB(0))
+	defer stop()
+	a := enterWorldAs(t, addr, "tester")
+	defer a.Close()
+	b := enterWorldAs(t, addr, "tradeb")
+	defer b.Close()
+
+	whisperFrame(t, a, "gritar", "ola mundo")
+	ty, payload, ok := readMaybe(t, a)
+	if !ok || ty != protocol.MsgMessageChat {
+		t.Fatalf("got %#x ok=%v, want MessageChat", ty, ok)
+	}
+	if got := cstr(payload); got != "Você precisa de uma Trombeta Mágica para gritar." {
+		t.Errorf("refusal = %q", got)
+	}
+	if ty, _, ok := readMaybe(t, b); ok && ty == protocol.MsgMagicTrumpet {
+		t.Error("the shout reached other players without a trumpet being spent")
+	}
+}
+
+// TestCommandGritarEmpty verifies a bare /gritar is a no-op: no shout and, above
+// all, no trumpet burned (the legacy shouted "[Nome]> " and charged for it).
+func TestCommandGritarEmpty(t *testing.T) {
+	addr, stop, _ := startServerClock(t, trumpetDB(3))
+	defer stop()
+	a := enterWorldAs(t, addr, "tester")
+	defer a.Close()
+
+	whisperFrame(t, a, "gritar", "   ")
+	if ty, _, ok := readMaybe(t, a); ok {
+		t.Errorf("empty shout produced %#x, want silence", ty)
+	}
+}
+
+// TestCommandSpkAlias verifies /spk, the legacy alias, routes to the same command.
+func TestCommandSpkAlias(t *testing.T) {
+	addr, stop, _ := startServerClock(t, trumpetDB(2))
+	defer stop()
+	a := enterWorldAs(t, addr, "tester")
+	defer a.Close()
+
+	whisperFrame(t, a, "spk", "oi")
+	if got := cstr(expect(t, a, protocol.MsgMagicTrumpet)); got != "[Hero]> oi" {
+		t.Errorf("shout = %q, want %q", got, "[Hero]> oi")
+	}
+}
+
 func TestChatPublicBroadcast(t *testing.T) {
 	addr, stop, _ := startServerClock(t, chatDB())
 	defer stop()

--- a/tmserver/internal/protocol/messages.go
+++ b/tmserver/internal/protocol/messages.go
@@ -497,6 +497,31 @@ func (m *MsgWhisperBody) Encode() []byte {
 	return b
 }
 
+// MagicTrumpetBodySize is MSG_MagicTrumpet minus the header (Basedef.h:1739-1745):
+// char String[MESSAGE_LENGTH] followed by int Color — 100 bytes, so the frame on
+// the wire is 112.
+const MagicTrumpetBodySize = MessageLength + 4
+
+// magicTrumpetMarker is the offset of the byte the legacy stamps to 1 right after
+// copying the text (_MSG_MessageWhisper.cpp:154, "sm_mt.String[94] = 1").
+const magicTrumpetMarker = 94
+
+// EncodeMagicTrumpetBody returns the MSG_MagicTrumpet body carrying text (already
+// formatted as "[Nome]> mensagem" by the caller).
+//
+// Parity notes: text is truncated to magicTrumpetMarker-1 bytes so the C string
+// always terminates before the marker byte — the legacy strncpy(String, temp, 96)
+// could ship an unterminated string and then overwrite byte 94 mid-text. Color
+// stays 0: the legacy only memset the first sizeof(MSG_STANDARDPARM) bytes of the
+// struct, so it shipped uninitialized stack garbage there, and the patched client
+// picks the colour itself (ClientPatch_v7662/Functions.cpp:51).
+func EncodeMagicTrumpetBody(text string) []byte {
+	b := make([]byte, MagicTrumpetBodySize)
+	copy(b[:magicTrumpetMarker-1], text)
+	b[magicTrumpetMarker] = 1
+	return b
+}
+
 // MsgSendReqPartyBody is MSG_SendReqParty (C↔S, 0x037F): PartyID is the leader
 // and Unk carries the invited player on the client request. This struct is
 // outside the legacy pack(1) blocks, so the int field keeps the MSVC x86 padding

--- a/tmserver/internal/protocol/messages_test.go
+++ b/tmserver/internal/protocol/messages_test.go
@@ -241,3 +241,38 @@ func TestEncodeStandardParm(t *testing.T) {
 		t.Fatalf("round-trip = %d ok=%v, want -2", parm, ok)
 	}
 }
+
+// TestEncodeMagicTrumpetBody pins the MSG_MagicTrumpet body (Basedef.h:1739):
+// String[96] + int Color, with the legacy marker byte at String[94] and the text
+// always NUL-terminated before it.
+func TestEncodeMagicTrumpetBody(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{"short", "[Hero]> ola", "[Hero]> ola"},
+		{"empty", "", ""},
+		{"truncated", strings.Repeat("x", 200), strings.Repeat("x", magicTrumpetMarker-1)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := EncodeMagicTrumpetBody(tt.text)
+			if len(b) != MagicTrumpetBodySize || MagicTrumpetBodySize+HeaderSize != 112 {
+				t.Fatalf("body = %d bytes (packet %d), want %d (112)", len(b), MagicTrumpetBodySize+HeaderSize, MagicTrumpetBodySize)
+			}
+			if got := cTrimNUL(b[:MessageLength]); got != tt.want {
+				t.Errorf("text = %q, want %q", got, tt.want)
+			}
+			if b[magicTrumpetMarker] != 1 {
+				t.Errorf("String[%d] = %d, want 1", magicTrumpetMarker, b[magicTrumpetMarker])
+			}
+			if b[magicTrumpetMarker-1] != 0 {
+				t.Errorf("String[%d] = %d, want a NUL terminating the text before the marker", magicTrumpetMarker-1, b[magicTrumpetMarker-1])
+			}
+			if binary.LittleEndian.Uint32(b[MessageLength:]) != 0 {
+				t.Error("Color must ship as 0 — the patched client picks the colour itself")
+			}
+		})
+	}
+}

--- a/tmserver/internal/protocol/types.go
+++ b/tmserver/internal/protocol/types.go
@@ -153,6 +153,15 @@ const (
 	MsgEnvEffect          Type = 0x03A2 // 930  S→C area effect box (MSG_EnvEffect, Basedef.h:2529)
 	MsgUpdateWeather      Type = 0x018B // 395  S→C global weather change (MSG_UpdateWeather, Basedef.h:2167)
 
+	// MsgMagicTrumpet is _MSG_MagicTrumpet (Basedef.h:1738, protocol-spec.md:685):
+	// 29 | DB2Game | Game2DB | Game2Client. The Trombeta Mágica shout — a
+	// server-wide chat line. The legacy relayed it through the DBSrv so every
+	// channel saw it; here it is emitted straight to the players of this tmServer.
+	// The ClientPatch paints it green on arrival (ClientPatch_v7662/Functions.cpp:51
+	// writes TNColor::Speak 0xFF00CD00 to 0x4A016A), which is why the shout does not
+	// reuse MsgMessageChat.
+	MsgMagicTrumpet Type = 0x0D1D // 3357 S→C global shout (MSG_MagicTrumpet)
+
 	// Personal shop / autotrade S→C (issue #115). CreateMobTrade is the shop pose:
 	// the pose is driven by this Type (0x0363), NOT by a CreateType value.
 	MsgCreateMobTrade Type = 0x0363 // 867  S→C spawn a shop-owner in view (MSG_CreateMobTrade)


### PR DESCRIPTION
## Problem
Players could not use the Trombeta Mágica item to send a global shout with `/gritar`.

## Solution
Add `/gritar` and the legacy `/spk` alias. The command spends 1 Trombeta Mágica item, sends `[Nome]> mensagem` to online players on the current server using `MSG_MagicTrumpet`, and tells the player when they do not have the item.

Details:
- Added Magic Trumpet protocol encoding and message type.
- Added item consumption and slot sync after a shout.
- Refuses empty shouts without spending the item.
- Documented the command and current single-channel behavior.
- Added tests for spending, last-item clearing, missing item, empty message, alias behavior, and packet encoding.

Testing:
- Added handler and protocol unit tests in `chat_test.go` and `messages_test.go`.

Fixes #258