### PR TITLE
feat(tmserver): mostrar EXP ganho ao matar mobs

### DIFF
--- a/tmserver/internal/handler/mobkilled.go
+++ b/tmserver/internal/handler/mobkilled.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"fmt"
+
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/level"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/loot"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
@@ -9,6 +11,10 @@ import (
 
 // coinCap is the total-gold overflow guard (game-rules.md §7, MobKilled.cpp:2715).
 const coinCap = 2_000_000_000
+
+// expPanelDefaultColor is TNColor::Default from Basedef.h. The alpha byte is
+// required by the unmodified client; RGB alone leaves the panel text invisible.
+const expPanelDefaultColor uint32 = 0xFFCCAAFF
 
 // Level-up effect (captura-wyd-levelup.md §7): MSG_Motion with these values is the
 // client-side level-up animation/sound.
@@ -201,9 +207,14 @@ func (d *Dispatcher) grantExp(w *world.World, ks *world.Session, killer, mob *wo
 	if gain <= 0 {
 		return
 	}
+	previousExp := killer.Exp
 	killer.Exp += gain
 	if killer.Exp > level.MaxExp {
 		killer.Exp = level.MaxExp
+	}
+	if applied := killer.Exp - previousExp; applied > 0 && ks != nil {
+		body := protocol.EncodeExpPanelBody(fmt.Sprintf("+%d de EXP", applied), expPanelDefaultColor)
+		w.Send(ks, protocol.MsgExpPanel, body)
 	}
 
 	d.applyLevelUps(w, ks, killer)

--- a/tmserver/internal/protocol/messages_test.go
+++ b/tmserver/internal/protocol/messages_test.go
@@ -6,6 +6,22 @@ import (
 	"testing"
 )
 
+func TestEncodeExpPanelBody(t *testing.T) {
+	body := EncodeExpPanelBody("+425 de EXP", 0xFFCCAAFF)
+	if len(body) != MsgExpPanelBodySize {
+		t.Fatalf("len = %d, want %d", len(body), MsgExpPanelBodySize)
+	}
+	if got := string(body[:11]); got != "+425 de EXP" {
+		t.Fatalf("text = %q, want %q", got, "+425 de EXP")
+	}
+	if body[11] != 0 {
+		t.Fatalf("text is not NUL terminated: byte[11] = %#x", body[11])
+	}
+	if got := binary.LittleEndian.Uint32(body[MessageLength:]); got != 0xFFCCAAFF {
+		t.Fatalf("color = %#x, want %#x", got, uint32(0xFFCCAAFF))
+	}
+}
+
 func TestMessageBodySizes(t *testing.T) {
 	// Body size + HeaderSize must equal the documented total packet size
 	// (protocol-spec.md §3.5).

--- a/tmserver/internal/protocol/types.go
+++ b/tmserver/internal/protocol/types.go
@@ -1,5 +1,7 @@
 package protocol
 
+import "encoding/binary"
+
 // Type is the 2-byte HEADER.Type field: a message base OR'd with direction
 // flags (protocol-spec.md §2, Basedef.h:1212-1221). The dispatcher compares the
 // full wire value (base + flags) directly, so a constant with multiple flags
@@ -28,6 +30,19 @@ const (
 func EncodeMessageChatBody(text string) []byte {
 	body := make([]byte, MessageLength)
 	copy(body, text)
+	return body
+}
+
+// MsgExpPanelBodySize is the packed body of MSG_Exp_Msg_Panel_: Msg[96]
+// followed by its 32-bit ARGB text color.
+const MsgExpPanelBodySize = MessageLength + 4
+
+// EncodeExpPanelBody builds the fixed-width body shown in the client's EXP
+// notification panel. Text longer than the legacy C string is truncated.
+func EncodeExpPanelBody(text string, color uint32) []byte {
+	body := make([]byte, MsgExpPanelBodySize)
+	copy(body[:MessageLength], text)
+	binary.LittleEndian.PutUint32(body[MessageLength:], color)
 	return body
 }
 
@@ -157,4 +172,5 @@ const (
 	// the pose is driven by this Type (0x0363), NOT by a CreateType value.
 	MsgCreateMobTrade Type = 0x0363 // 867  S→C spawn a shop-owner in view (MSG_CreateMobTrade)
 	MsgItemSold       Type = 0x039B // 923  S→C an item left a shop (MSG_STANDARDPARM2, Parm1=seller Parm2=pos)
+	MsgExpPanel       Type = 0x5000 // S→C MSG_Exp_Msg_Panel_ (custom EXP notification panel)
 )


### PR DESCRIPTION
## Resumo

- implementa o pacote legado `MSG_Exp_Msg_Panel_` (`0x5000`)
- mostra `+N de EXP` no painel ao conceder experiência por morte de mob
- exibe somente o ganho efetivamente aplicado, respeitando o teto de EXP
- adiciona teste do layout binário e da cor ARGB

## Testes

- `go test ./tmserver/internal/protocol ./tmserver/internal/handler`
- `git diff --check`

Closes #260