### PR TITLE
Plano de viabilidade: imagens dos itens para o front-end

### DIFF
--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -27,6 +27,7 @@
 | — | [client-patch-hooks.md](client-patch-hooks.md) | **COMPLETO** | mapa dos hooks/patches da `ClientPatch_v7662.dll` por endereço (checksum off, força-gráficos, SkillDelay, título); 4 pontos de extensão p/ customizar o cliente fechado (ReadMessage/SendChat/UI/SendPack) |
 | — | [web-platform-plan.md](web-platform-plan.md) | **PLANO** | integração da plataforma web (contas, cash, recompensas, loja-web, ranking); web-api + `delivery_queue` (mailbox) preservando o single-owner |
 | — | [npc-editing-plan.md](npc-editing-plan.md) | **PLANO** | edição de NPCs por moderadores via web (aparece/não, posição, itens/preços da loja); overlay em Postgres + hot-reload no loop single-owner |
+| — | [item-icons-plan.md](item-icons-plan.md) | **PLANO** | viabilidade das imagens de item no front-end; a imagem é função de `(IndexMesh, IndexTexture, nPos)` → 1055 `icon_key` p/ 3220 itens; decodificação do `ItemList.bin` (XOR 0x5A, 6500×140 B); fallback procedural + pacote de ícones fora do repo |
 
 ---
 

--- a/docs/migration/data-formats.md
+++ b/docs/migration/data-formats.md
@@ -457,6 +457,18 @@ documentar na Fase 4/5 ao detalhar `CItem`/`CReadFiles`.
 > **`ItemCSum.h`** (`Release/TMsrv/` e `DBsrv/`) é um header de checksum da `ItemList` — provável
 > anti-tamper para garantir que TMSrv e DBSrv usam a mesma lista. Confirmar uso.
 
+**Layout do `.bin` (CONFIRMADO):** `Release/DBsrv/run/ItemList.bin` = **6500 registros × 140 bytes,
+ofuscados com XOR 0x5A plano, sem cabeçalho** (sobram 4 bytes no fim; 910 004 = 6500×140 + 4). Os
+comentários de offset da struct (`Price // 92`) são de uma versão antiga com nome curto — com
+`ITEMNAME_LENGTH=64` (`Basedef.h:203`) o layout real é `Name[64] + 8×short (mesh, texture, vfx,
+ReqLvl/Str/Int/Dex/Con) + 12×(short sEffect, short sValue) + int Price + 4×short (nUnique, nPos,
+Extra, Grade) = 140`. `nPos` é um **bitmask sobre `STRUCT_MOB.Equip[16]`** (bit *i* = slot *i*;
+`64|128` = arma de duas mãos; `0` = não equipável), e `IndexVisualEffect` é 0 em todas as linhas.
+O `.bin` está **desatualizado** em relação ao `.csv`: 23 dos 3216 itens divergem em mesh — o `.csv`
+é a fonte de verdade (é o que os serviços Go carregam). Decodificador de referência:
+`scripts/item-icon-manifest.py --check-bin`; consumo desses campos pelo front em
+[item-icons-plan.md](item-icons-plan.md).
+
 ### 3.2. `SkillData.csv` → `STRUCT_SPELL` (`Basedef.h:1110-...`)
 
 `MAX_SKILL`/`MAX_SPELL` entradas. Campos por skill: `SkillPoint, TargetType, ManaSpent, Delay,

--- a/docs/migration/item-icons-plan.md
+++ b/docs/migration/item-icons-plan.md
@@ -1,0 +1,213 @@
+# Plano de viabilidade — Imagens dos itens para o front-end
+
+> Status: **PLANO** (nada implementado além do script de levantamento
+> `scripts/item-icon-manifest.py`). Pergunta que este doc responde: *dá para mostrar a imagem de
+> cada item no portal web, e por qual caminho?* Resposta curta: **dá, mas a imagem não vem do
+> servidor** — o repositório não tem nenhum pixel de item. O que o servidor tem, e que ninguém
+> estava usando, é a **chave** que identifica a imagem. O plano é publicar essa chave num contrato
+> estável agora e plugar o pacote de imagens depois, como conteúdo.
+
+---
+
+## 1. Por que isso importa
+
+O front-end (Next.js BFF, `docs/migration/web-platform-plan.md`) já manipula item em várias telas:
+inventário/equipamento em `my-characters`, loja de doação (`donate-shop-frontend.md`), recompensa
+diária (`daily-reward-frontend.md`), DropTool (`docs/integrations/drop-tool-nextjs.md`), editor de
+loja de NPC (`npc-admin-nextjs.md`) e templates de mob (`mob-template-editing-frontend.md`). Hoje
+todas mostram `item_index` + `name` cru (`Botas_Douradas(N)`). Ícone é o que transforma essas telas
+em algo usável.
+
+---
+
+## 2. Levantamento: o que existe no repositório
+
+| Recurso | Onde | Serve para imagem? |
+|---|---|---|
+| `Release/Common/ItemList.csv` | catálogo editável, 6439 linhas / **3220 itens nomeados** | **sim — é a chave**, não a imagem |
+| `Release/DBsrv/run/ItemList.bin` | forma compilada, 910 004 B | idem (mesmos campos) |
+| `images/sv.bmp` | 3 MB, splash da lista de servidores | não |
+| `Release/**` restante | mapas, drops, NPCs, rates | não |
+
+**Não há nenhuma imagem de item no repositório, e não haverá:** o cliente (`WYD.exe` 7662) não faz
+parte do repo e não tem fonte aberta — ver `docs/agents/CLIENT-RESEARCH-2026-06-27.md` §1 ("não
+existe cliente gráfico 3D de WYD com código-fonte aberto"). Os assets gráficos vivem só dentro da
+pasta do cliente oficial.
+
+### 2.1. O que o catálogo carrega de visual
+
+`STRUCT_ITEMLIST` (`Source/Code/Basedef.h:1162-1185`, parse em `Source/Code/Basedef.cpp:5717-5772`):
+
+| Campo | Origem no CSV | Papel visual |
+|---|---|---|
+| `IndexMesh` | col. 3 antes do ponto (`10.0` → 10) | modelo/aparência (o "set") |
+| `IndexTexture` | col. 3 depois do ponto | variante de cor do modelo |
+| `IndexVisualEffect` | — (o servidor zera; **0 em 100% do `.bin`**) | efeito/brilho |
+| `nPos` | col. 7 | bitmask de `Equip[16]` — a peça (elmo, botas, arma…) |
+| `Grade` | col. 9 | 1=Normal 2=Místico 3=Arcano 4=Lendário… |
+| `EF_GRID` | par `EF_*` | tamanho na grade — **0 em todo o catálogo atual** |
+
+Decodificação do `nPos` (bit *i* = `STRUCT_MOB.Equip[i]`), confirmada cruzando com os nomes reais:
+
+```
+bit0 face/corpo(233)  bit1 elmo(191)   bit2 armadura(191)  bit3 calça(189)
+bit4 luvas(188)       bit5 botas(190)  bit6 arma(494)      bit7 escudo(19)
+bit8 acessório(28)    bit9 amuleto(20) bit10 orb(15)       bit11 gema(33)
+bit12 medalha(55)     bit13 fada(55)   bit14 montaria(146) bit15 manto(36)
+64|128 = 192 → arma de duas mãos (238 itens)      nPos = 0 → não equipável (890 itens)
+```
+(bit13 = fada bate com `Source/Code/TMSrv/CMob.cpp:712` lendo `Equip[13]` para os ids 39xx;
+bit14 = montaria bate com `mountEquipSlot = 14` em `tmserver/internal/handler/character.go:662`.)
+
+### 2.2. A conclusão que destrava o plano
+
+O cliente **lê o mesmo `ItemList.bin`** que o servidor. Logo, na hora de desenhar um item ele não
+tem nada além desses campos — ou seja:
+
+> **A imagem do item é função de `(IndexMesh, IndexTexture, nPos)`, não do `item_index`.**
+
+Isso muda a escala do problema: os 3220 itens nomeados colapsam em **1055 chaves visuais
+distintas** (614 meshes, 889 pares mesh.texture). Um pacote de ícones precisa cobrir ~1k imagens,
+não 6,5k. É por isso que armadura/calça/luva/bota de um mesmo set compartilham `IndexMesh` (o set
+"Malha" inteiro é mesh 4) e se diferenciam pelo `nPos`.
+
+> **UNVERIFIED:** a *fórmula exata* que o cliente usa para ir de `(mesh, texture, pos)` ao bitmap
+> (atlas? arquivo por mesh? tabela intermediária tipo `meshlist.bin`?) não foi confirmada — exige o
+> cliente em mãos. §7 descreve o experimento que confirma ou derruba isso. Se cair, o plano não
+> muda de forma: só a função que gera `icon_key` muda.
+
+### 2.3. Bônus do levantamento: o `.bin` foi decodificado
+
+`Release/DBsrv/run/ItemList.bin` = **6500 registros × 140 bytes, ofuscado com XOR 0x5A plano, sem
+cabeçalho** (sobram 4 bytes no fim). Os comentários de offset no header (`Price // 92`) são de uma
+versão antiga da struct com nome curto; com `ITEMNAME_LENGTH=64` (`Basedef.h:203`) o layout real é
+`Name[64] + 8 shorts + 12×(short,short) + int Price + 4 shorts = 140`. Isso não estava documentado
+em `data-formats.md` §3.1 e deveria ser incorporado lá.
+
+Cruzando `.csv` × `.bin`: **3193 de 3216 itens batem**; 23 divergem em mesh (Dríade Selado,
+Sephirot, Pedra/Cupom da Imortalidade). O `.bin` está **desatualizado** em relação ao `.csv` — o
+`.csv` é a fonte de verdade porque é ele que os serviços Go carregam
+(`tmserver/internal/content/catalog.go`). Vale um check no CI.
+
+---
+
+## 3. Onde estão as imagens de verdade (pesquisa externa)
+
+| Fonte | O que é | Avaliação |
+|---|---|---|
+| Cliente oficial 7662 | ícones dentro dos recursos do cliente (`.wys` + `.msh/.msa`; interface na pasta `UI/`) | fidelidade máxima; exige o cliente e um unpacker |
+| Pack comunitário de ícones | "praticamente todos os ícones", **PNG 35×35 com fundo preto** ([WebCheats](https://www.webcheats.com.br/topic/2271954-%C3%ADcones-itens-wyd/)) | caminho mais rápido; resolução baixa, fundo preto, procedência incerta |
+| Sites de droplist (ex.: [wydmisc](https://wydmisc.raidhut.com.br/droplist/global/index.html?type=item)) | já servem ícone por item | só como *referência* de que o mapeamento existe — hotlink está fora de cogitação |
+| Ferramentas da comunidade ([WYD-ItemList-Editor](https://github.com/Rechdan/WYD-ItemList-Editor), [WYD-Tools](https://github.com/davirs/WYD-Tools)) | editores de `ItemList.bin` e outros formatos | úteis para conferir o layout e talvez o formato dos recursos |
+
+> Nota de ambiente: `webcheats.com.br` e `wydmisc.raidhut.com.br` estão **bloqueados pelo proxy de
+> egress** desta sessão (403 no CONNECT). As duas primeiras linhas da tabela precisam ser
+> verificadas manualmente por um humano antes da Fase 2.
+
+---
+
+## 4. Opções avaliadas
+
+| # | Abordagem | Fidelidade | Esforço | Risco | Veredito |
+|---|---|---|---|---|---|
+| A | Extrair do cliente oficial (unpack dos recursos) | alta | médio-alto | jurídico (assets HanbitSoft/JoyImpact) + formato desconhecido | **fonte alvo** |
+| B | Pack comunitário PNG 35×35 | média-baixa (fundo preto, 35 px) | baixo | licença/procedência incertas; precisa remapear as chaves | **atalho da Fase 2** |
+| C | Renderizar os meshes 3D em qualquer resolução | alta | alto (parser `.msh` + pipeline de render) | depende do cliente do mesmo jeito | Fase 3 opcional |
+| D | Fallback procedural (SVG/CSS por `slot` + `grade` + classe) | baixa (não é o ícone real) | muito baixo | nenhum | **entrega já, e é a rede de segurança permanente** |
+| E | Gerar com IA | inconsistente entre itens | médio | visual incoerente com o jogo | descartado |
+| F | Hotlink de sites de terceiros | — | baixo | quebra, latência, uso indevido | descartado |
+
+**Recomendação: D agora, A (ou B) como camada de conteúdo por cima**, com o contrato de §5 no meio.
+O front-end integra uma vez e não muda quando a fonte da imagem mudar.
+
+---
+
+## 5. Arquitetura proposta
+
+```
+ItemList.csv ──(build)──> items.json (manifesto)  ──> Next.js: item_index → icon_key
+                                                            │
+                          item-icons/ (pacote separado) ────┘ icon_key → <img src>
+                                                            │ 404
+                                                            └─> fallback SVG por slot+grade
+```
+
+1. **`icon_key` derivado do catálogo.** Formato `m<mesh>_t<texture>_p<pos>` (ex.: `m10_t0_p32` =
+   Botas Douradas). Estável, ~1055 valores, calculável offline e no servidor.
+2. **Manifesto `items.json`** gerado no build a partir do `.csv`: `index, name, display_name,
+   icon_key, slots, grade, class_mask, req_level, price`. ~1 MB cru, ~120 KB gzip. O catálogo é
+   **imutável em runtime** — pode ser servido como estático com cache longo, sem RPC por item.
+3. **Pacote de imagens em repositório/bucket separado** (`item-icons/`), *não* neste repo:
+   `icons/<icon_key>.webp` (64 e 128 px, fundo transparente) + `manifest.json` com hash. Manter
+   fora do repo do servidor isola a questão de licença (§6) e não infla o clone.
+4. **Fallback obrigatório no front:** `icon_key` sem arquivo → SVG por `slot` (arma, elmo, poção…)
+   colorido por `grade`. Nenhuma tela quebra por ícone faltando; a Fase 1 entrega já com 100% de
+   fallback.
+5. **Decoração fica no front, não na imagem:** refino (`+1..+9`), aura por `grade`, quantidade
+   (`EF_AMOUNT`), marca de "selado". Assar isso no PNG multiplicaria o pacote por 10.
+6. **Contrato gRPC:** estender `ItemCatalogEntry` (`api/web/v1/web.proto:312`) com
+   `icon_key`, `slot_mask`, `grade`, `mesh`, `texture` — a implementação já tem tudo em mãos
+   (`webserver/internal/grpcsrv/npcadmin.go:160`). Como `ListItemCatalog` hoje exige
+   `moderator_id`, criar um `ItemCatalogService.ListItems` público (leitura pura do catálogo) para
+   as telas de jogador, **ou** simplesmente publicar o `items.json` estático e não gastar RPC. A
+   segunda opção é a recomendada: menos superfície, cacheável em CDN.
+
+### 5.1. O que já existe para apoiar
+
+`scripts/item-icon-manifest.py` (neste commit) lê o `.csv`, emite o manifesto e opcionalmente faz o
+diff contra o `.bin`:
+
+```bash
+./scripts/item-icon-manifest.py -o items.json --check-bin
+# items: 3220  distinct icon_key: 1055
+# bin rows: 3216  visual drift csv!=bin: 23  only in bin: 0
+```
+
+---
+
+## 6. Riscos
+
+| Risco | Impacto | Mitigação |
+|---|---|---|
+| **Jurídico** — ícones são assets da HanbitSoft/JoyImpact | distribuir num CDN público é exposição real | pacote de imagens fora deste repo; default é o fallback procedural (D); decisão consciente do dono do projeto antes da Fase 2 |
+| Chave `(mesh, texture, pos)` pode não ser o que o cliente usa | refaz o gerador de `icon_key` | experimento §7 **antes** de produzir o pacote; o contrato (`icon_key` opaco) absorve a mudança |
+| `.bin` divergente do `.csv` (23 itens) | ícone errado em itens específicos | `.csv` como fonte única + check no CI com `--check-bin` |
+| Pack comunitário 35×35 com fundo preto | visual ruim em tema claro | remoção de fundo em lote + upscale, ou pular direto para A/C |
+| Nomes em Latin-1 com `_` | `Botas_Douradas(N)` na UI | `display_name` já sai normalizado no manifesto |
+| Itens novos do servidor (não-originais) | sem imagem no pack | fallback cobre; arte própria depois |
+
+---
+
+## 7. Experimento que decide a Fase 2 (meio dia)
+
+1. Obter uma cópia do cliente 7662 e listar os arquivos de recurso (`.wys`, pasta `UI/`).
+2. Extrair/abrir o container e localizar o conjunto de ícones de inventário.
+3. Verificar como cada ícone é endereçado: por `IndexMesh`? por posição num atlas? por uma tabela
+   auxiliar tipo `meshlist.bin`?
+4. Conferir 20 itens conhecidos e diversos — `Botas_Douradas(N)` (m10/p32), `Garra` (m837/p64),
+   `Cupom_da_Sorte` (m2711/p0), set Malha inteiro (m4, cinco `nPos`), um item com `texture=1`
+   (Dríade Selado) e uma montaria (m943/p16384).
+5. Saída: ou o gerador de `icon_key` está certo (segue Fase 2 direto), ou sai dali a regra correta.
+
+---
+
+## 8. Faseamento e esforço
+
+| Fase | Entrega | Esforço | Depende de |
+|---|---|---|---|
+| 0 | Manifesto + relatório de cobertura (`scripts/item-icon-manifest.py`) | **feito** | — |
+| 1 | `icon_key`/`slot`/`grade` no contrato + fallback SVG no front | ~1-2 dias | nada |
+| 2 | Pacote de ícones reais (A ou B), WebP 64/128, publicado | ~2-4 dias | experimento §7 + decisão de licença |
+| 3 | Render 3D dos meshes p/ alta resolução, ou arte própria nas lacunas | ~1 semana | opcional |
+
+Fase 1 já resolve a dor descrita no pedido (telas usáveis, item reconhecível por slot/raridade) sem
+depender de nada externo. Fase 2 é o "bonito", e é a única que carrega risco jurídico.
+
+---
+
+## 9. Decisões que precisam de um humano
+
+1. **Distribuir assets extraídos do cliente oficial?** (Fase 2 A/B). Se a resposta for não, o plano
+   para na Fase 1 + Fase 3 com arte própria.
+2. **Manifesto estático ou RPC pública?** Recomendado estático (§5.6).
+3. **Onde hospedar o pacote de imagens** — repo separado + CDN, ou bucket do próprio portal.

--- a/scripts/item-icon-manifest.py
+++ b/scripts/item-icon-manifest.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Generate the item-icon manifest the web front-end needs from the item catalog.
+
+Reads the editable catalog (Release/Common/ItemList.csv — the same file the
+tmServer/webServer load) and emits one JSON row per item with the fields a UI
+needs to pick and decorate an icon: the equip slot, the grade, the inventory
+grid size, and an `icon_key`.
+
+`icon_key` is the important part. The client never sees the item index when it
+draws an item: it reads the very same catalog (STRUCT_ITEMLIST) and the only
+visual fields there are IndexMesh, IndexTexture and nPos (Basedef.h:1162-1185,
+parsed at Basedef.cpp:5757-5772). So the image is a function of that triple,
+which collapses ~3.2k named items into ~1k distinct icons — that triple is what
+an icon pack should be keyed by, not the item index.
+
+Optionally cross-checks the compiled Release/DBsrv/run/ItemList.bin, which is
+6500 records of 140 bytes each, obfuscated with a flat XOR 0x5A (no header; the
+file has 4 trailing bytes). Divergences mean the .bin is stale relative to the
+.csv — the .csv wins, since that is what the Go services parse.
+
+Usage:
+  ./scripts/item-icon-manifest.py                       # manifest to stdout
+  ./scripts/item-icon-manifest.py -o web/items.json     # manifest to a file
+  ./scripts/item-icon-manifest.py --check-bin           # also diff csv vs bin
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import struct
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+CSV = REPO / "Release" / "Common" / "ItemList.csv"
+BIN = REPO / "Release" / "DBsrv" / "run" / "ItemList.bin"
+
+BIN_RECORD = 140  # Name[64] + 8 shorts + 12*(short,short) + int Price + 4 shorts
+BIN_COUNT = 6500  # MAX_ITEMLIST (Basedef.h:199)
+BIN_XOR = 0x5A
+
+# nPos is a bitmask over STRUCT_MOB.Equip[16]: bit i means "goes in Equip[i]".
+# 0 means "not equippable" (potions, quest items, coupons…). Bit 6|7 (192) is a
+# two-handed weapon, which takes the shield slot too. Slot 13 is the fairy
+# (CMob.cpp:712 keys off Equip[13] for the 39xx fairies) and 14 the mount
+# (handler/character.go:662 mountEquipSlot).
+SLOTS = {
+    1 << 0: "face",
+    1 << 1: "helmet",
+    1 << 2: "armor",
+    1 << 3: "pants",
+    1 << 4: "gloves",
+    1 << 5: "boots",
+    1 << 6: "weapon",
+    1 << 7: "shield",
+    1 << 8: "accessory",
+    1 << 9: "amulet",
+    1 << 10: "orb",
+    1 << 11: "gem",
+    1 << 12: "medal",
+    1 << 13: "fairy",
+    1 << 14: "mount",
+    1 << 15: "cape",
+}
+
+
+def slot_names(pos: int) -> list[str]:
+    """Decode the nPos bitmask into slot names (empty list when pos == 0).
+
+    nPos is a signed short, so capes (bit 15) show up as -32768 in the CSV;
+    mask to 16 bits before decoding.
+    """
+    pos &= 0xFFFF
+    if pos == 0:
+        return []
+    return [name for bit, name in sorted(SLOTS.items()) if pos & bit]
+
+
+def display_name(raw: str) -> str:
+    """Catalog names are Latin-1 with underscores for spaces (`Botas_Douradas(N)`)."""
+    return raw.replace("_", " ").strip()
+
+
+def parse_csv(path: Path) -> dict[int, dict]:
+    """Parse ItemList.csv following BASE_ReadItemListFile (Basedef.cpp:5717).
+
+    Columns: index, name, mesh.texture, lvl.str.int.dex.con, unique, price,
+    pos, extra, grade, then up to 12 `EF_<name>,value` pairs.
+    """
+    items: dict[int, dict] = {}
+    for line in path.read_bytes().splitlines():
+        row = line.decode("latin-1").strip()
+        if not row:
+            continue
+        f = row.split(",")
+        if len(f) < 9:
+            continue
+        try:
+            index = int(f[0])
+        except ValueError:
+            continue
+        if index < 0 or not f[1]:
+            continue
+        mesh, _, texture = f[2].partition(".")
+        req = (f[3].split(".") + ["0"] * 5)[:5]
+
+        def num(s: str) -> int:
+            try:
+                return int(s.strip())
+            except ValueError:
+                return 0
+
+        effects = {}
+        for i in range(9, len(f) - 1):
+            token = f[i].strip()
+            if token.startswith("EF_"):
+                effects[token] = num(f[i + 1])
+
+        pos = num(f[6]) & 0xFFFF
+        items[index] = {
+            "index": index,
+            "name": f[1],
+            "display_name": display_name(f[1]),
+            "mesh": num(mesh),
+            "texture": num(texture),
+            "pos": pos,
+            "slots": slot_names(pos),
+            "grade": num(f[8]),
+            "price": num(f[5]),
+            "req_level": num(req[0]),
+            "class_mask": effects.get("EF_CLASS", 0),
+            "grid": effects.get("EF_GRID", 0),
+            "icon_key": f"m{num(mesh)}_t{num(texture)}_p{pos}",
+        }
+    return items
+
+
+def parse_bin(path: Path) -> dict[int, dict]:
+    """Decode the compiled ItemList.bin (XOR 0x5A, 6500 x 140 bytes, no header)."""
+    raw = path.read_bytes()
+    data = bytes(b ^ BIN_XOR for b in raw)
+    out: dict[int, dict] = {}
+    for i in range(BIN_COUNT):
+        rec = data[i * BIN_RECORD : (i + 1) * BIN_RECORD]
+        if len(rec) < BIN_RECORD:
+            break
+        name = rec[:64].split(b"\x00")[0].decode("latin-1")
+        if not name:
+            continue
+        mesh, texture, _vfx = struct.unpack("<3h", rec[64:70])
+        _unique, pos, _extra, grade = struct.unpack("<4h", rec[132:140])
+        out[i] = {"name": name, "mesh": mesh, "texture": texture, "pos": pos & 0xFFFF, "grade": grade}
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("-o", "--output", type=Path, help="write the manifest here instead of stdout")
+    ap.add_argument("--check-bin", action="store_true", help="diff ItemList.csv against ItemList.bin")
+    args = ap.parse_args()
+
+    items = parse_csv(CSV)
+    keys = {it["icon_key"] for it in items.values()}
+
+    manifest = {
+        "source": "Release/Common/ItemList.csv",
+        "item_count": len(items),
+        "icon_key_count": len(keys),
+        "items": [items[i] for i in sorted(items)],
+    }
+    blob = json.dumps(manifest, ensure_ascii=False, indent=2)
+    if args.output:
+        args.output.write_text(blob, encoding="utf-8")
+    else:
+        print(blob)
+
+    print(f"items: {len(items)}  distinct icon_key: {len(keys)}", file=sys.stderr)
+
+    if args.check_bin:
+        if not BIN.exists():
+            print(f"missing {BIN}", file=sys.stderr)
+            return 1
+        binrows = parse_bin(BIN)
+        drift = [
+            i
+            for i, it in items.items()
+            if i in binrows
+            and (it["mesh"], it["texture"], it["pos"]) != (binrows[i]["mesh"], binrows[i]["texture"], binrows[i]["pos"])
+        ]
+        only_bin = sorted(set(binrows) - set(items))
+        print(
+            f"bin rows: {len(binrows)}  visual drift csv!=bin: {len(drift)}  only in bin: {len(only_bin)}",
+            file=sys.stderr,
+        )
+        for i in drift[:10]:
+            print(
+                f"  #{i} {items[i]['name']}: csv mesh/tex/pos="
+                f"{items[i]['mesh']}/{items[i]['texture']}/{items[i]['pos']} "
+                f"bin={binrows[i]['mesh']}/{binrows[i]['texture']}/{binrows[i]['pos']}",
+                file=sys.stderr,
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## O que é

Plano de viabilidade para mostrar imagem de item no portal web (`docs/migration/item-icons-plan.md`). Só documentação + um script de levantamento — nenhum serviço tocado.

## A resposta curta

O repositório **não tem nenhum pixel de item** e não vai ter: o cliente (`WYD.exe` 7662) é fechado e não faz parte da árvore. O que ele tem, e ninguém estava usando, é a **chave** da imagem.

O cliente lê o **mesmo** `ItemList` que o servidor (`STRUCT_ITEMLIST`, `Basedef.h:1162`). Como ali os únicos campos visuais são `IndexMesh`, `IndexTexture` e `nPos`, a imagem do item só pode ser função desse trio — não do `item_index`. Consequência prática: os **3220 itens nomeados colapsam em 1055 ícones distintos** (614 meshes), então um pacote de ícones precisa cobrir ~1k imagens, não 6,5k.

## O plano

Contrato primeiro, pixels depois: publicar um `icon_key` (`m<mesh>_t<tex>_p<pos>`) + `slot` + `grade` num manifesto estático, com **fallback SVG procedural** por slot/raridade. O front integra uma vez e não muda quando a fonte da imagem mudar. Opções de fonte avaliadas (extrair do cliente oficial, pack comunitário PNG 35×35, render 3D dos meshes, fallback procedural, IA, hotlink) com esforço/risco em tabela.

Fase 1 (~1-2 dias) já entrega telas usáveis sem depender de nada externo. Fase 2 (ícones reais) é a única com risco jurídico — assets são da HanbitSoft/JoyImpact — e por isso o pacote fica **fora deste repo**, e a decisão é de um humano.

## Achados de engenharia reversa (bônus)

- `ItemList.bin` decodificado: **6500 registros × 140 bytes, XOR 0x5A plano, sem cabeçalho**. Os comentários de offset da struct (`Price // 92`) estão desatualizados — com `ITEMNAME_LENGTH=64` o registro real tem 140 B. Incorporado em `data-formats.md` §3.1.
- `nPos` é bitmask sobre `Equip[16]`, decodificado slot a slot conferindo com os nomes reais (bit13 = fada bate com `CMob.cpp:712`; bit14 = montaria bate com `handler/character.go:662`).
- O `.bin` está **23 itens atrás do `.csv`** (Dríade Selado, Sephirot, Pedra/Cupom da Imortalidade). O `.csv` é a fonte de verdade — é o que os serviços Go carregam.

## Verificação

```
$ ./scripts/item-icon-manifest.py -o items.json --check-bin
items: 3220  distinct icon_key: 1055
bin rows: 3216  visual drift csv!=bin: 23  only in bin: 0
```

## Não verificado

A *fórmula exata* que o cliente usa para ir de `(mesh, texture, pos)` até o bitmap (atlas? arquivo por mesh? tabela intermediária?) exige o cliente em mãos — o doc traz o experimento de meio dia que confirma ou derruba isso antes de qualquer trabalho de Fase 2. Se cair, o formato do `icon_key` muda; o resto do plano não.

Dois sites relevantes da pesquisa (WebCheats, wydmisc) estão bloqueados pelo proxy de egress desta sessão e precisam de conferência manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjSkp2P7CnFGbFQkhJGYq7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjSkp2P7CnFGbFQkhJGYq7)_