### PR TITLE
Handle content-owned NPC delete refusals

### DIFF
--- a/docs/integrations/npc-admin-nextjs.md
+++ b/docs/integrations/npc-admin-nextjs.md
@@ -73,9 +73,15 @@ Todas as RPCs recebem `moderator_id` (int64). Resultados de negócio viajam **no
 | `ADMIN_RESULT_FORBIDDEN` (2)| chamador não é `moderator`/`admin`             | 403                  |
 | `ADMIN_RESULT_INVALID` (3)  | validação falhou (slot, merchant, campos…)     | 400 / 422            |
 | `ADMIN_RESULT_NOT_FOUND` (4)| NPC alvo não existe                            | 404                  |
+| `ADMIN_RESULT_CONTENT_OWNED` (5)| NPC é conteúdo versionado (`origin = "content"`) — deve ser **escondido**, não apagado (§5.7) | 409 |
 | `ADMIN_RESULT_UNSPECIFIED`(0)| não deve ocorrer                              | 500                  |
 
 Erros gRPC (ex.: `UNAVAILABLE`, `INTERNAL`) = falha de infraestrutura → 502/500 no BFF.
+
+> **Não trate um valor desconhecido como erro genérico.** `ADMIN_RESULT_CONTENT_OWNED` é um resultado
+> *esperado* de `DeleteNpc` na esmagadora maioria dos NPCs; um mapa `AdminResult → HTTP` que não o
+> conheça o joga em 500 e o moderador vê "erro interno" sem saber o que fazer — foi exatamente o bug
+> da issue #257. Ver §5.7.
 
 ### 4.2 RPCs
 
@@ -108,6 +114,8 @@ message AdminNpc {
   int32  route_type    = 9;  // 0 = parado
   int32  merchant      = 10; // ver §5.1
   repeated AdminNpcShopItem shop = 11; // preenchido em GetNpc/ListNpcs
+  string origin          = 12; // "content" (veio do NPCGener.txt) | "custom" (criado por moderador) — ver §5.7
+  int32  generator_index = 13; // linha de origem no NPCGener.txt; -1 quando não aplicável
 }
 
 message AdminNpcShopItem {
@@ -278,6 +286,40 @@ Ambas as RPCs seguem exatamente o mesmo contrato de `ListMerchantTemplates`:
 - `ListMapZones`: **não depende de `-content`** — é uma tabela fixa de 5 zonas (`0 Armia … 4 Noatum`),
   sempre retornada (nunca vazia). Simples `<select>` de 5 opções, sem necessidade de busca.
 
+### 5.7 `origin` — NPC de conteúdo **não pode ser apagado**, só escondido
+
+Cada definição carrega um `origin` (§4.3, campo 12):
+
+| `origin` | de onde veio | `DeleteNpc` |
+|----------|--------------|-------------|
+| `"content"` | importado do `NPCGener.txt` por `dbserver import-npcs` — é conteúdo versionado do jogo | **sempre recusado** com `ADMIN_RESULT_CONTENT_OWNED` |
+| `"custom"`  | criado pelo moderador no painel (`UpsertNpc`) | permitido |
+
+A regra é intencional: apagar um NPC do `NPCGener.txt` no banco não o remove do conteúdo — o próximo
+`import-npcs` o traria de volta, e nesse meio-tempo o banco e o `Release/` ficariam divergentes. A
+saída pretendida é **desabilitar**: `SetNpcVisibility(npc_id, enabled=false)` tira o NPC do mundo
+mantendo a definição.
+
+**Isso não é um caso de canto.** Na base atual são **567 de 572 definições** com `origin = "content"`
+(~99%). Um painel que mostra o botão de excluir para todos convida a uma ação que falha em quase
+todos os cliques.
+
+Duas coisas a fazer na UI:
+
+1. **Não oferecer a ação impossível.** `origin` já vem no payload de `ListNpcs`/`GetNpc` — esconda ou
+   desabilite o botão de excluir quando `npc.origin === "content"`, deixando só o toggle de
+   visibilidade. É decisão puramente de UI, sem round-trip extra.
+2. **Explicar quando acontecer mesmo assim** (link direto, chamada por script, corrida com outro
+   moderador): traduza `ADMIN_RESULT_CONTENT_OWNED` (5) numa mensagem que aponte a saída, não num
+   erro genérico. Texto sugerido:
+
+   > Este NPC faz parte do conteúdo do jogo e não pode ser excluído. Desabilite-o para removê-lo do mundo.
+
+Do lado do servidor, uma recusa dessas é registrada como
+`delete npc refused: content-owned npc_id=… moderator_id=…` no log do `webserver` — útil para
+confirmar que a rejeição chegou ao backend (ela não deixa linha de auditoria, porque nada foi
+escrito).
+
 ## 6. Camada BFF (Next.js) — como implementar
 
 O browser fala com **rotas REST do próprio Next.js**; essas rotas (server-side) chamam o `web-api` por
@@ -341,7 +383,9 @@ import { NextResponse } from "next/server";
 import { npcAdmin } from "@/lib/npcAdminClient";
 import { getSession } from "@/lib/session"; // lê o cookie httpOnly → { accountId }
 
-const httpFor = (r: number) => ({ 1: 200, 2: 403, 3: 422, 4: 404 } as const)[r] ?? 500;
+// Cobre TODOS os valores do enum (§4.1) — um valor faltando aqui vira 500 e a UI
+// perde o motivo real da recusa (foi o bug da #257 com o 5).
+const httpFor = (r: number) => ({ 1: 200, 2: 403, 3: 422, 4: 404, 5: 409 } as const)[r] ?? 500;
 
 export async function GET() {
   const session = await getSession();
@@ -356,6 +400,33 @@ export async function GET() {
   const status = httpFor(resp.result);
   if (status !== 200) return NextResponse.json({ result: resp.result }, { status });
   return NextResponse.json({ npcs: resp.npcs });
+}
+```
+
+```ts
+// app/api/admin/npcs/[id]/route.ts — DELETE, com o caso content-owned (§5.7)
+import { NextResponse } from "next/server";
+import { npcAdmin } from "@/lib/npcAdminClient";
+import { getSession } from "@/lib/session";
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+
+  const resp = await new Promise<any>((resolve, reject) =>
+    npcAdmin.deleteNpc({ moderatorId: session.accountId, npcId: Number(params.id) }, (err: unknown, r: unknown) =>
+      err ? reject(err) : resolve(r)),
+  ).catch(() => null);
+
+  if (!resp) return NextResponse.json({ error: "upstream" }, { status: 502 });
+  if (resp.result === 5 /* ADMIN_RESULT_CONTENT_OWNED */) {
+    // Não é falha do servidor: o NPC veio do NPCGener.txt. A UI deve mostrar a
+    // mensagem e oferecer o toggle de visibilidade no lugar (§5.7).
+    return NextResponse.json({ result: resp.result, error: "content_owned" }, { status: 409 });
+  }
+  const status = httpFor(resp.result);
+  if (status !== 200) return NextResponse.json({ result: resp.result }, { status });
+  return NextResponse.json({ ok: true });
 }
 ```
 
@@ -393,7 +464,9 @@ export async function GET() {
 Pontos importantes do BFF:
 
 - **`moderatorId` vem SEMPRE da sessão** (`session.accountId`), nunca do corpo do request.
-- Mapear `AdminResult` → HTTP (tabela §4.1). Rejeição de gRPC (promise reject) = falha de infra → 502.
+- Mapear `AdminResult` → HTTP (tabela §4.1), **incluindo o `5` (`CONTENT_OWNED` → 409)**, que a UI
+  precisa traduzir numa mensagem específica e não num erro genérico (§5.7). Rejeição de gRPC
+  (promise reject) = falha de infra → 502.
 - Cliente gRPC é **singleton server-side**; nunca exposto ao browser.
 - Cookie de sessão `httpOnly` + proteção CSRF nas rotas mutantes (POST/PUT/PATCH/DELETE).
 
@@ -426,7 +499,12 @@ feature). Ferramentas usuais: `@grpc/grpc-js` + `grpc-tools`/`ts-proto`, ou `buf
 - [ ] Login via `AccountWebService.VerifyCredentials` → cookie `httpOnly` guardando `account_id` **e** `role`.
 - [ ] Gate da página/menu de NPC por `role ∈ { moderator, admin }` (só UX — o web-api reautoriza).
 - [ ] Toda rota admin deriva `moderator_id` da sessão (nunca do corpo).
-- [ ] Mapear `AdminResult` → HTTP; tratar reject de gRPC como 502.
+- [ ] Mapear `AdminResult` → HTTP (os **6** valores, incluindo `ADMIN_RESULT_CONTENT_OWNED` = 5 → 409);
+      tratar reject de gRPC como 502.
+- [ ] Botão de excluir escondido/desabilitado quando `npc.origin === "content"` (§5.7) — sobra só o
+      toggle de visibilidade, que é a ação suportada para ~99% dos NPCs.
+- [ ] `ADMIN_RESULT_CONTENT_OWNED` traduzido em mensagem específica ("faz parte do conteúdo do jogo…
+      desabilite-o", §5.7), nunca em "erro interno".
 - [ ] UI da loja em 3 abas de 9 (slots 0..8 / 9..17 / 18..26); `SetNpcShop` envia a loja inteira.
 - [ ] Cada item da loja tem um controle de remover (ex.: botão "x" por slot) que, ao salvar, tira aquele
       slot do array de `items` antes de chamar `SetNpcShop` (§5.2) — sem isso não há como excluir um item

--- a/internal/store/npc_integration_test.go
+++ b/internal/store/npc_integration_test.go
@@ -8,6 +8,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -147,6 +148,84 @@ func TestSeedNPCDefinitionsIdempotent(t *testing.T) {
 	}
 	if shopRows != 1 {
 		t.Errorf("shop items for seed-int-1 = %d, want 1", shopRows)
+	}
+}
+
+// contentGenIndex keeps TestDeleteNPCDefinitionContentOwned's generator index
+// clear of the ones the other tests in this package use (generator_index is
+// globally unique).
+const contentGenIndex = 200000
+
+// TestDeleteNPCDefinitionContentOwned checks a definition imported from
+// NPCGener.txt (origin = 'content', written by SeedNPCDefinitions) is refused
+// rather than deleted, and that the refusal leaves nothing behind: no audit row
+// and no config-version bump, since it returns before auditAndBump.
+func TestDeleteNPCDefinitionContentOwned(t *testing.T) {
+	ctx := context.Background()
+	pool := testPool(t)
+	if err := Migrate(ctx, pool); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	_, _ = pool.Exec(ctx, `DELETE FROM npc_shop_item; DELETE FROM npc_definition WHERE slug LIKE 'content-int-%'`)
+
+	s := New(pool)
+
+	var modID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO account (name, pass_hash, role) VALUES ('mod_npc_content_test','x','moderator') RETURNING id`).
+		Scan(&modID); err != nil {
+		t.Fatalf("seed moderator: %v", err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM account WHERE id = $1`, modID) })
+
+	if _, err := s.SeedNPCDefinitions(ctx, []domain.NPCDefinition{
+		{Slug: "content-int-1", TemplateName: "Set_BM_2", Enabled: true, GeneratorIndex: contentGenIndex},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM npc_definition WHERE slug = 'content-int-1'`) })
+
+	var npcID int64
+	if err := pool.QueryRow(ctx, `SELECT id FROM npc_definition WHERE slug = 'content-int-1'`).Scan(&npcID); err != nil {
+		t.Fatalf("read seeded id: %v", err)
+	}
+
+	v0, err := s.NPCConfigVersion(ctx)
+	if err != nil {
+		t.Fatalf("version: %v", err)
+	}
+
+	if err := s.DeleteNPCDefinition(ctx, npcID, modID); !errors.Is(err, ErrContentOwned) {
+		t.Fatalf("delete = %v, want ErrContentOwned", err)
+	}
+
+	var still int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM npc_definition WHERE id = $1`, npcID).Scan(&still); err != nil {
+		t.Fatalf("count definition: %v", err)
+	}
+	if still != 1 {
+		t.Errorf("definition rows after refused delete = %d, want 1 (untouched)", still)
+	}
+
+	var audits int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM npc_audit WHERE npc_id = $1`, npcID).Scan(&audits); err != nil {
+		t.Fatalf("count audit: %v", err)
+	}
+	if audits != 0 {
+		t.Errorf("audit rows = %d, want 0 (refusal returns before auditAndBump)", audits)
+	}
+
+	vN, err := s.NPCConfigVersion(ctx)
+	if err != nil {
+		t.Fatalf("version: %v", err)
+	}
+	if vN != v0 {
+		t.Errorf("version = %d, want %d (refused write must not bump)", vN, v0)
+	}
+
+	// Hiding it is the supported alternative and must still work.
+	if err := s.SetNPCVisibility(ctx, npcID, false, modID); err != nil {
+		t.Errorf("set visibility on content NPC: %v", err)
 	}
 }
 

--- a/webserver/cmd/webserver/main.go
+++ b/webserver/cmd/webserver/main.go
@@ -87,6 +87,7 @@ func run(logger *slog.Logger) error {
 	srv := grpc.NewServer(grpc.Creds(creds))
 	st := store.New(pool)
 	npcAdmin := npcadmin.New(st)
+	npcAdmin.SetLogger(logger)
 	mobTemplateAdmin := mobtemplateadmin.New(st)
 	donate := donateshop.New(st)
 	dailyRwd := dailyreward.New(st)

--- a/webserver/internal/grpcsrv/npcadmin_test.go
+++ b/webserver/internal/grpcsrv/npcadmin_test.go
@@ -44,6 +44,10 @@ type fakeNpcAdmin struct {
 	listZones    []mapzones.Zone
 	listZonesErr error
 
+	deleteRes npcadmin.Result
+	deleteErr error
+	lastNpcID int64
+
 	setShopItems []domain.NPCShopItem
 }
 
@@ -66,8 +70,10 @@ func (f *fakeNpcAdmin) SetShop(_ context.Context, _ int64, _ int64, items []doma
 func (f *fakeNpcAdmin) SetItemPrice(context.Context, int64, int32, int64) (npcadmin.Result, error) {
 	return npcadmin.OK, nil
 }
-func (f *fakeNpcAdmin) Delete(context.Context, int64, int64) (npcadmin.Result, error) {
-	return npcadmin.OK, nil
+func (f *fakeNpcAdmin) Delete(_ context.Context, moderatorID, npcID int64) (npcadmin.Result, error) {
+	f.lastModeratorID = moderatorID
+	f.lastNpcID = npcID
+	return f.deleteRes, f.deleteErr
 }
 func (f *fakeNpcAdmin) ListMerchantTemplates(_ context.Context, moderatorID int64) (npcadmin.Result, []npctemplates.Template, error) {
 	f.lastModeratorID = moderatorID
@@ -458,6 +464,48 @@ func TestListMapZonesInfraError(t *testing.T) {
 	s := NewNpcAdmin(fake)
 
 	if _, err := s.ListMapZones(context.Background(), &webv1.ListMapZonesRequest{}); err == nil {
+		t.Fatal("expected gRPC error on infra failure")
+	}
+}
+
+// TestDeleteNpcContentOwned checks the refusal of a content-owned definition
+// reaches the portal as ADMIN_RESULT_CONTENT_OWNED (5) rather than a generic
+// error — the enum value is the only thing telling the UI to say "hide it
+// instead of deleting it" (#257).
+func TestDeleteNpcContentOwned(t *testing.T) {
+	fake := &fakeNpcAdmin{deleteRes: npcadmin.ContentOwned}
+	s := NewNpcAdmin(fake)
+
+	resp, err := s.DeleteNpc(context.Background(), &webv1.DeleteNpcRequest{ModeratorId: 1, NpcId: 766})
+	if err != nil {
+		t.Fatalf("DeleteNpc: %v", err)
+	}
+	if resp.GetResult() != webv1.AdminResult_ADMIN_RESULT_CONTENT_OWNED {
+		t.Errorf("result = %v, want CONTENT_OWNED", resp.GetResult())
+	}
+	if fake.lastModeratorID != 1 || fake.lastNpcID != 766 {
+		t.Errorf("forwarded (moderator, npc) = (%d, %d), want (1, 766)", fake.lastModeratorID, fake.lastNpcID)
+	}
+}
+
+func TestDeleteNpcForbidden(t *testing.T) {
+	fake := &fakeNpcAdmin{deleteRes: npcadmin.Forbidden}
+	s := NewNpcAdmin(fake)
+
+	resp, err := s.DeleteNpc(context.Background(), &webv1.DeleteNpcRequest{ModeratorId: 3, NpcId: 10})
+	if err != nil {
+		t.Fatalf("DeleteNpc: %v", err)
+	}
+	if resp.GetResult() != webv1.AdminResult_ADMIN_RESULT_FORBIDDEN {
+		t.Errorf("result = %v, want FORBIDDEN", resp.GetResult())
+	}
+}
+
+func TestDeleteNpcInfraError(t *testing.T) {
+	fake := &fakeNpcAdmin{deleteErr: errors.New("pool exhausted")}
+	s := NewNpcAdmin(fake)
+
+	if _, err := s.DeleteNpc(context.Background(), &webv1.DeleteNpcRequest{}); err == nil {
 		t.Fatal("expected gRPC error on infra failure")
 	}
 }

--- a/webserver/internal/npcadmin/service.go
+++ b/webserver/internal/npcadmin/service.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/jeanluca/w2pp-openwyd/internal/domain"
 	"github.com/jeanluca/w2pp-openwyd/internal/store"
@@ -63,6 +64,7 @@ type Service struct {
 	templates   []npctemplates.Template
 	items       []itemcatalog.Entry
 	dropCatalog droptool.Catalog
+	logger      *slog.Logger
 }
 
 // New builds the service over the given store.
@@ -84,6 +86,12 @@ func (s *Service) SetItems(items []itemcatalog.Entry) { s.items = items }
 // ListMobDrops serve. Called once at boot after scanning the content tree; left
 // as a zero-value catalog when -content/W2PP_CONTENT wasn't configured.
 func (s *Service) SetDropCatalog(catalog droptool.Catalog) { s.dropCatalog = catalog }
+
+// SetLogger installs the logger used to record business refusals that leave no
+// audit trail (a content-owned delete returns before the store's audit write, so
+// without this a rejected delete is indistinguishable from "nothing happened" on
+// the server side — issue #257). Left nil in tests, which silences the logging.
+func (s *Service) SetLogger(logger *slog.Logger) { s.logger = logger }
 
 // List returns every NPC definition, after authorizing the caller.
 func (s *Service) List(ctx context.Context, moderatorID int64) (Result, []domain.NPCDefinition, error) {
@@ -243,13 +251,21 @@ func (s *Service) ListItemPrices(ctx context.Context, moderatorID int64) (Result
 	return OK, prices, nil
 }
 
-// Delete removes a definition.
+// Delete removes a definition. Content-owned definitions (origin = "content",
+// ~99% of the catalog) are refused with ContentOwned — the moderator is meant to
+// hide them via SetVisibility instead.
 func (s *Service) Delete(ctx context.Context, moderatorID, npcID int64) (Result, error) {
 	if r, err := s.authorize(ctx, moderatorID); r != OK || err != nil {
 		return r, err
 	}
 	err := s.store.DeleteNPCDefinition(ctx, npcID, moderatorID)
-	return classifyWrite(err, "delete")
+	res, cerr := classifyWrite(err, "delete")
+	// The store rejects before writing the audit row, so this refusal would
+	// otherwise be invisible on the server (issue #257).
+	if res == ContentOwned && s.logger != nil {
+		s.logger.Info("delete npc refused: content-owned", "npc_id", npcID, "moderator_id", moderatorID)
+	}
+	return res, cerr
 }
 
 // authorize checks the caller has a moderator/admin role. A missing account or a

--- a/webserver/internal/npcadmin/service_test.go
+++ b/webserver/internal/npcadmin/service_test.go
@@ -1,8 +1,11 @@
 package npcadmin
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/jeanluca/w2pp-openwyd/internal/domain"
@@ -75,8 +78,13 @@ func (f *fakeStore) ItemPriceOverrides(context.Context) ([]domain.ItemPriceOverr
 	return f.itemPrices, nil
 }
 func (f *fakeStore) DeleteNPCDefinition(_ context.Context, id int64, _ int64) error {
-	if _, ok := f.defs[id]; !ok {
+	d, ok := f.defs[id]
+	if !ok {
 		return store.ErrNotFound
+	}
+	// Mirrors the real store: versioned content is hidden, never deleted.
+	if d.Origin == "content" {
+		return store.ErrContentOwned
 	}
 	f.deletedID = id
 	return nil
@@ -85,7 +93,10 @@ func (f *fakeStore) DeleteNPCDefinition(_ context.Context, id int64, _ int64) er
 func newFake() *fakeStore {
 	return &fakeStore{
 		roles: map[int64]string{1: "moderator", 2: "admin", 3: "player"},
-		defs:  map[int64]domain.NPCDefinition{10: {ID: 10, Slug: "shop-10", Merchant: 1}},
+		defs: map[int64]domain.NPCDefinition{
+			10: {ID: 10, Slug: "shop-10", Merchant: 1},
+			11: {ID: 11, Slug: "Set_BM-6079", Origin: "content"},
+		},
 	}
 }
 
@@ -213,6 +224,43 @@ func TestDeleteNotFound(t *testing.T) {
 	}
 	if got != NotFound {
 		t.Errorf("Delete result = %v, want NotFound", got)
+	}
+}
+
+// TestDeleteContentOwned checks a definition that came from NPCGener.txt is
+// refused rather than deleted, and that the refusal is logged: the store rejects
+// before writing its audit row, so the log is the only server-side trace (#257).
+func TestDeleteContentOwned(t *testing.T) {
+	fs := newFake()
+	s := New(fs)
+	var logs bytes.Buffer
+	s.SetLogger(slog.New(slog.NewTextHandler(&logs, nil)))
+
+	got, err := s.Delete(context.Background(), 1, 11)
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if got != ContentOwned {
+		t.Errorf("Delete result = %v, want ContentOwned", got)
+	}
+	if fs.deletedID != 0 {
+		t.Errorf("deleted id = %d, want none deleted", fs.deletedID)
+	}
+	if !strings.Contains(logs.String(), "content-owned") || !strings.Contains(logs.String(), "npc_id=11") {
+		t.Errorf("log = %q, want a content-owned refusal naming npc_id=11", logs.String())
+	}
+}
+
+// TestDeleteContentOwnedWithoutLogger checks the logger is optional — the
+// refusal still classifies correctly when SetLogger was never called.
+func TestDeleteContentOwnedWithoutLogger(t *testing.T) {
+	s := New(newFake())
+	got, err := s.Delete(context.Background(), 1, 11)
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if got != ContentOwned {
+		t.Errorf("Delete result = %v, want ContentOwned", got)
 	}
 }
 


### PR DESCRIPTION
## Problem
Moderators could try to delete NPCs that come from game content. Those NPCs are not supposed to be deleted; they should be hidden instead. The backend returned the right business result, but the behavior was easy to miss and hard to diagnose because the refusal left no audit row and the portal integration docs did not explain how to show a useful message.

## Solution
Document `ADMIN_RESULT_CONTENT_OWNED` as the expected result for deleting content-owned NPCs and map it to HTTP 409 for the portal/BFF.

Add guidance that the UI should hide or disable delete for `origin = "content"` NPCs and show a specific message telling moderators to disable the NPC instead.

Log content-owned delete refusals in the webserver so rejected deletes are visible server-side even though no audit row is written.

Add tests covering store refusal behavior, npcadmin service classification/logging, and gRPC propagation of `ADMIN_RESULT_CONTENT_OWNED`.

Refs #257

## Testing
- Added integration test for refusing deletion of content-owned NPC definitions without audit/version changes.
- Added npcadmin service tests for content-owned delete handling with and without a logger.
- Added gRPC tests for `DeleteNpc` content-owned, forbidden, and infrastructure-error paths.