### PR TITLE
fix(tmserver): corrigir refino do ataque mágico

### DIFF
--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -1690,6 +1690,31 @@ func (d *Dispatcher) itemAbility(it world.Item, effect uint8) int {
 	return total
 }
 
+// itemScoreAbility mirrors the refine scaling at the end of
+// BASE_GetItemAbility (Basedef.cpp:1849-1858). Levels above +10 use the
+// legacy REF_* score values rather than the displayed refine level; notably,
+// +15 is REF_15 (27), so score effects scale by (27+10)/10.
+func (d *Dispatcher) itemScoreAbility(it world.Item, effect uint8) int32 {
+	v := int32(d.itemAbility(it, effect))
+	if v == 0 {
+		return 0
+	}
+	sanc := itemScoreSanc(itemSanc(it))
+	if sanc == refineThreshold && d.itemPos[int(it.Index)]&accessoryPosMask != 0 {
+		sanc = 10
+	}
+	return v * int32(sanc+10) / 10
+}
+
+// itemScoreSanc converts the true 0..15 level reported by the Go refine
+// package back to BASE_GetItemSanc's REF_* values used in score arithmetic.
+func itemScoreSanc(level int) int {
+	if level <= 10 {
+		return level
+	}
+	return [...]int{11: 12, 12: 15, 13: 18, 14: 22, 15: 27}[level]
+}
+
 // accessoryPosMask marks the four accessory slots (Equip[8..11]) in an item's catalog
 // nPos bitmask — the slots Pedra_Amunra equips into, which is why a player wears four.
 // BASE_GetItemAbility keys the +9 refine promotion off it (Basedef.cpp:1850).
@@ -1717,17 +1742,11 @@ func (d *Dispatcher) itemCritical(it world.Item) int32 {
 	if it.Effects[1].Effect == efCritical2 || it.Effects[2].Effect == efCritical2 {
 		want = efCritical2
 	}
-	v := int32(d.itemAbility(it, want))
+	v := d.itemScoreAbility(it, want)
 	if v == 0 {
 		return 0
 	}
-	// Inherits itemSanc's decoding of the EF_SANC byte (issue #103 is correcting that
-	// decode); crit scales with whatever level it reports, so it improves in step.
-	sanc := itemSanc(it)
-	if sanc == refineThreshold && d.itemPos[int(it.Index)]&accessoryPosMask != 0 {
-		sanc = 10
-	}
-	return v * int32(sanc+10) / 10
+	return v
 }
 
 // resistEffects maps resist index [0..3] to its EF_RESISTn id (CMob.cpp:640-643 assigns
@@ -1749,7 +1768,7 @@ func (d *Dispatcher) itemResist(it world.Item, i int) int32 {
 	if v == 0 {
 		return 0
 	}
-	sanc := itemSanc(it)
+	sanc := itemScoreSanc(itemSanc(it))
 	if sanc == refineThreshold && d.itemPos[int(it.Index)]&accessoryPosMask != 0 {
 		sanc = 10
 	}
@@ -1815,10 +1834,10 @@ type equipBonus struct {
 func (d *Dispatcher) equipBonus(e *world.Entity) equipBonus {
 	var b equipBonus
 	// add folds one effect/value pair into the bonus. weaponSlot excludes weapon-hand
-	// EF_DAMAGE; dmgJewel gates EF_DAMAGEADD/EF_MAGICADD to the jewel items (nUnique
-	// 41-50); offHand excludes EF_MAGIC on the off-hand weapon slot only (Basedef.cpp:
-	// 2447 — unlike EF_DAMAGE, the right-hand weapon still counts toward magic).
-	add := func(eff uint8, val int32, weaponSlot, dmgJewel, offHand bool) {
+	// EF_DAMAGE; dmgJewel gates EF_DAMAGEADD to nUnique 41-50 items. Magic is handled
+	// per item below because BASE_GetItemAbility applies refine scaling to the combined
+	// catalog and instance values before BASE_GetMobAbility sums the equipment.
+	add := func(eff uint8, val int32, weaponSlot, dmgJewel bool) {
 		switch eff {
 		case efStr:
 			b.str += int16(val)
@@ -1849,14 +1868,6 @@ func (d *Dispatcher) equipBonus(e *world.Entity) equipBonus {
 		case efDamageAdd:
 			if dmgJewel { // only jewels (nUnique 41-50) contribute EF_DAMAGEADD
 				b.damage += val
-			}
-		case efMagic:
-			if !offHand { // BASE_GetMobAbility excludes only the off-hand weapon slot
-				b.magicRaw += val
-			}
-		case efMagicAdd:
-			if dmgJewel { // only jewels (nUnique 41-50) contribute EF_MAGICADD
-				b.magicRaw += val
 			}
 		case efHp:
 			b.maxHP += val
@@ -1898,11 +1909,21 @@ func (d *Dispatcher) equipBonus(e *world.Entity) equipBonus {
 		offHand := slot == weaponSlotL
 		nUnique := d.itemUnique[int(it.Index)]
 		dmgJewel := nUnique >= 41 && nUnique <= 50
+		// Magic is queried per item through BASE_GetItemAbility, which applies
+		// the item's refine multiplier after combining catalog and instance
+		// effects. EF_MAGIC is excluded only from the off-hand; EF_MAGICADD is
+		// independently queried and gated by nUnique 41..50.
+		if !offHand {
+			b.magicRaw += d.itemScoreAbility(it, efMagic)
+		}
+		if dmgJewel {
+			b.magicRaw += d.itemScoreAbility(it, efMagicAdd)
+		}
 		for _, be := range d.itemEffects[int(it.Index)] { // catalog base effects
-			add(be.Eff, int32(be.Val), weaponSlot, dmgJewel, offHand)
+			add(be.Eff, int32(be.Val), weaponSlot, dmgJewel)
 		}
 		for _, ef := range it.Effects { // per-item instance refines/divines
-			add(ef.Effect, int32(ef.Value), weaponSlot, dmgJewel, offHand)
+			add(ef.Effect, int32(ef.Value), weaponSlot, dmgJewel)
 		}
 		// Refine (+9) threshold: defense pieces gain +25 AC (weapons' +40 is in
 		// weaponDamage). captura §E.

--- a/tmserver/internal/handler/magic_test.go
+++ b/tmserver/internal/handler/magic_test.go
@@ -3,17 +3,19 @@ package handler
 import (
 	"testing"
 
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/combat"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
 	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
 )
 
 // Item indices used by the magic tests, synthetic, mirroring resist_test.go's convention.
 const (
-	magicFlat        = 620 // flat EF_MAGIC on an ordinary (non-weapon) slot
-	magicOffHand     = 621 // EF_MAGIC on the off-hand weapon slot (7) — excluded
-	magicRightHand   = 622 // EF_MAGIC on the right-hand weapon slot (6) — still counts
-	magicAddJewel    = 623 // EF_MAGICADD, registered as a jewel (nUnique 41-50) in magicConfig
-	magicAddNonJewel = 624 // EF_MAGICADD, no nUnique entry — must NOT count
+	magicFlat        = 620  // flat EF_MAGIC on an ordinary (non-weapon) slot
+	magicOffHand     = 621  // EF_MAGIC on the off-hand weapon slot (7) — excluded
+	magicRightHand   = 622  // EF_MAGIC on the right-hand weapon slot (6) — still counts
+	magicAddJewel    = 623  // EF_MAGICADD, registered as a jewel (nUnique 41-50) in magicConfig
+	magicAddNonJewel = 624  // EF_MAGICADD, no nUnique entry — must NOT count
+	magicChaoticAnct = 3725 // Cajado_Caotico(Anct), the real issue #223 reproduction
 )
 
 // magicConfig is the catalog the magic tests read: static effects and the nUnique each
@@ -26,9 +28,14 @@ func magicConfig() Config {
 			magicRightHand:   {{Eff: efMagic, Val: 40}},
 			magicAddJewel:    {{Eff: efMagicAdd, Val: 20}},
 			magicAddNonJewel: {{Eff: efMagicAdd, Val: 20}},
+			magicChaoticAnct: {{Eff: efMagic, Val: 63}},
 		},
 		ItemUnique: map[int]int{
-			magicAddJewel: 45, // jewel range 41-50
+			magicAddJewel:    45, // nUnique range 41-50
+			magicChaoticAnct: 47,
+		},
+		ItemPos: map[int]int{
+			magicChaoticAnct: nPosWeapon1,
 		},
 	}
 }
@@ -69,6 +76,20 @@ func TestMagicFromEquipment(t *testing.T) {
 			want:  0,
 		},
 		{
+			// ItemList[3725] has EF_MAGIC 63; the instance carries another
+			// EF_MAGIC 8 and packed +15 (250). BASE_GetItemSanc maps +15 to
+			// REF_15=27: (63+8)*37/10 = 262, then (262+1)/4 = 65.
+			name: "Cajado Caotico Anct +15 applies refined magic",
+			equip: map[int]world.Item{weaponSlotR: {
+				Index: magicChaoticAnct,
+				Effects: [3]world.Effect{
+					{Effect: efSanc, Value: 250},
+					{Effect: efMagic, Value: 8},
+				},
+			}},
+			want: 65,
+		},
+		{
 			// Mount magicRaw (Thoroughbred 30D: 110, mountBonusTable row {750,110,80,32,6})
 			// and item magicRaw (40) combine BEFORE the single (x+1)/4 scaling: (110+40+1)/4.
 			name: "mount magic and item magic combine under one scaling",
@@ -97,6 +118,15 @@ func TestMagicFromEquipment(t *testing.T) {
 				t.Errorf("e.Magic = %d, want %d", e.Magic, tt.want)
 			}
 		})
+	}
+}
+
+func TestItemScoreSancUsesLegacyRefValues(t *testing.T) {
+	want := map[int]int{10: 10, 11: 12, 12: 15, 13: 18, 14: 22, 15: 27}
+	for level, scoreSanc := range want {
+		if got := itemScoreSanc(level); got != scoreSanc {
+			t.Errorf("itemScoreSanc(%d) = %d, want %d", level, got, scoreSanc)
+		}
 	}
 }
 
@@ -173,5 +203,31 @@ func TestMagicEquipChangesAreMonotonic(t *testing.T) {
 	d.refreshScore(e)
 	if e.Magic < 0 || e.Magic >= withGear {
 		t.Fatalf("Magic after unequip = %d, want [0,%d)", e.Magic, withGear)
+	}
+}
+
+func TestRefinedMagicItemRaisesSkillDamage(t *testing.T) {
+	d := New(magicConfig())
+	e := &world.Entity{ID: 1, Class: 1, Level: 200, BaseInt: 1000, Int: 1000}
+	e.Equip[weaponSlotR] = world.Item{
+		Index: magicChaoticAnct,
+		Effects: [3]world.Effect{
+			{Effect: efSanc, Value: 250},
+			{Effect: efMagic, Value: 8},
+		},
+	}
+	d.refreshScore(e)
+	withItem := combat.SkillBaseDamage(16, combat.SkillSpell{InstanceType: 1, InstanceValue: 100}, combat.SkillCaster{
+		Class: int(e.Class), Level: int(e.Level), Int: int(e.Int), Magic: int(effectiveMagic(e)),
+	}, 0, 0)
+
+	e.Equip[weaponSlotR] = world.Item{}
+	d.refreshScore(e)
+	withoutItem := combat.SkillBaseDamage(16, combat.SkillSpell{InstanceType: 1, InstanceValue: 100}, combat.SkillCaster{
+		Class: int(e.Class), Level: int(e.Level), Int: int(e.Int), Magic: int(effectiveMagic(e)),
+	}, 0, 0)
+
+	if withItem <= withoutItem {
+		t.Fatalf("skill damage with refined magic item = %d, without = %d", withItem, withoutItem)
 	}
 }


### PR DESCRIPTION
## Causa raiz

As correções anteriores passaram a ler `EF_MAGIC`/`EF_MAGICADD` e reconstruíram a parcela de classe/arma, mas `equipBonus` ainda somava os valores brutos. O legado aplica `BASE_GetItemAbility` por item antes de acumular a magia, incluindo o multiplicador de refino e os valores especiais `REF_*` de +11 a +15.

Em +15, por exemplo, o legado usa `REF_15=27`, portanto a escala é `(27+10)/10`, e não `(15+10)/10`.

## Correção

- centraliza a escala de score compatível com `BASE_GetItemAbility`;
- combina efeitos estáticos e da instância antes de aplicar o refino;
- preserva exclusão de `EF_MAGIC` na mão esquerda, gate de `EF_MAGICADD`, promoção de acessórios +9 e tabelas próprias de montaria;
- aplica a mesma conversão `REF_*` aos caminhos já refinados de crítico e resistência;
- adiciona regressão com o Cajado Caótico (Anct) +15 da issue e comprova aumento do dano de habilidade.

## Testes

- `go test ./...`