### PR TITLE
Ativar drops comuns de itens dos mobs

### DIFF
--- a/tmserver/internal/handler/mobkilled.go
+++ b/tmserver/internal/handler/mobkilled.go
@@ -83,7 +83,9 @@ func (d *Dispatcher) mobKilled(w *world.World, killer, mob *world.Entity) {
 	// Item drop: each occupied loot slot rolls against its g_pDropRate odds.
 	for slot := range mob.Carry {
 		it := mob.Carry[slot]
-		if it.Empty() {
+		// MobKilled.cpp only admits real droppable catalog entries here. Low
+		// indices are internal/legacy objects and 454 is explicitly suppressed.
+		if it.Index <= 390 || int(it.Index) >= maxItemList || it.Index == 454 {
 			continue
 		}
 		// UNVERIFIED: killer.DropBonus (item/event bonus) → 0 placeholder.
@@ -92,7 +94,10 @@ func (d *Dispatcher) mobKilled(w *world.World, killer, mob *world.Entity) {
 			if d.castleKeyDrop(w, reward, it) {
 				continue
 			}
-			w.CreateGroundItem(it, mob.X, mob.Y)
+			// Ordinary legacy mob loot goes through PutItem: it is delivered
+			// directly to the killer's Carry and synchronized with SendItem. It is
+			// not a floor object and therefore must not use CreateGroundItem.
+			d.putMobDrop(w, reward, it)
 		}
 	}
 
@@ -102,6 +107,27 @@ func (d *Dispatcher) mobKilled(w *world.World, killer, mob *world.Entity) {
 	// free its grid cell + entity slot, so the corpse disappears and it can't be
 	// retargeted. Without this the client keeps rendering the dead mob.
 	w.DespawnMob(mob.ID, 1)
+}
+
+// putMobDrop mirrors legacy PutItem for common mob loot. A full accessible Carry
+// loses the rolled item and receives the same no-space notification; there is no
+// fallback to the ground.
+func (d *Dispatcher) putMobDrop(w *world.World, reward *world.Entity, it world.Item) bool {
+	if reward == nil {
+		return false
+	}
+	slot := firstEmptyAccessibleCarry(reward)
+	if slot < 0 {
+		if s := w.Session(reward.ID); s != nil {
+			d.notify(w, s, NoticeNoSpaceToTrade)
+		}
+		return false
+	}
+	reward.Carry[slot] = it
+	if s := w.Session(reward.ID); s != nil {
+		d.sendSlot(w, s, world.ItemPlaceCarry, slot, it)
+	}
+	return true
 }
 
 func (d *Dispatcher) growBabyMountOnKill(w *world.World, killer, mob *world.Entity) {

--- a/tmserver/internal/handler/mobkilled_test.go
+++ b/tmserver/internal/handler/mobkilled_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"log/slog"
 	"net"
@@ -49,6 +50,17 @@ func expMobTemplate(lvl int32, exp int64, clan uint8) []byte {
 	binary.LittleEndian.PutUint32(b[cs+0:], uint32(lvl))
 	binary.LittleEndian.PutUint32(b[cs+16:], 100) // MaxHp
 	binary.LittleEndian.PutUint32(b[cs+24:], 100) // Hp
+	return b
+}
+
+func mobTemplateWithDrop(slot int, item world.Item) []byte {
+	b := expMobTemplate(100, 0, 0)
+	o := 268 + slot*8 // STRUCT_MOB.Carry[64]
+	binary.LittleEndian.PutUint16(b[o:], uint16(item.Index))
+	for i, ef := range item.Effects {
+		b[o+2+i*2] = ef.Effect
+		b[o+3+i*2] = ef.Value
+	}
 	return b
 }
 
@@ -169,6 +181,59 @@ func TestMobKilledClan4NoExp(t *testing.T) {
 	d.mobKilled(w, killer, w.Entity(mobID))
 	if killer.Exp != 0 {
 		t.Errorf("killer.Exp = %d, want 0 for a clan-4 mob", killer.Exp)
+	}
+}
+
+func TestMobKilledDeliversCommonDropToCarry(t *testing.T) {
+	d, w, killer := mobKilledWorld(t)
+	want := world.Item{Index: 777, Effects: [3]world.Effect{
+		{Effect: 43, Value: 7},
+		{Effect: 2, Value: 20},
+		{Effect: 3, Value: 5},
+	}}
+	mobID := w.SpawnMob(mobTemplateWithDrop(11, want), 6, 5) // slot 11 always drops
+
+	d.mobKilled(w, killer, w.Entity(mobID))
+
+	if got := killer.Carry[0]; got != want {
+		t.Fatalf("killer.Carry[0] = %+v, want %+v", got, want)
+	}
+	if gi := w.GroundItemAt(6, 5); gi != nil {
+		t.Fatalf("common mob drop was incorrectly placed on the ground: %+v", gi)
+	}
+}
+
+func TestMobKilledFullCarryLosesCommonDrop(t *testing.T) {
+	d, w, killer := mobKilledWorld(t)
+	for i := 0; i < baseCarrySlots; i++ {
+		killer.Carry[i] = world.Item{Index: int16(1000 + i)}
+	}
+	mobID := w.SpawnMob(mobTemplateWithDrop(11, world.Item{Index: 777}), 6, 5)
+
+	d.mobKilled(w, killer, w.Entity(mobID))
+
+	for i := 0; i < baseCarrySlots; i++ {
+		if killer.Carry[i].Index != int16(1000+i) {
+			t.Fatalf("full Carry slot %d changed to %+v", i, killer.Carry[i])
+		}
+	}
+	if gi := w.GroundItemAt(6, 5); gi != nil {
+		t.Fatalf("full Carry fell back to ground: %+v", gi)
+	}
+}
+
+func TestMobKilledRejectsNonDroppableCatalogEntries(t *testing.T) {
+	for _, index := range []int16{390, 454, 30000} {
+		t.Run(fmt.Sprintf("item_%d", index), func(t *testing.T) {
+			d, w, killer := mobKilledWorld(t)
+			mobID := w.SpawnMob(mobTemplateWithDrop(11, world.Item{Index: index}), 6, 5)
+
+			d.mobKilled(w, killer, w.Entity(mobID))
+
+			if !killer.Carry[0].Empty() {
+				t.Fatalf("non-droppable item %d delivered as %+v", index, killer.Carry[0])
+			}
+		})
 	}
 }
 
@@ -476,4 +541,42 @@ func TestKillWorldEventDropSendsCarrySlot(t *testing.T) {
 		return
 	}
 	t.Fatal("never received world event SendItem")
+}
+
+func TestKillCommonMobDropSendsCarrySlot(t *testing.T) {
+	want := world.Item{Index: 777, Effects: [3]world.Effect{
+		{Effect: 43, Value: 7},
+		{Effect: 2, Value: 20},
+		{Effect: 3, Value: 5},
+	}}
+	mob := mobTemplateWithDrop(11, want) // slot 11 is the legacy guaranteed slot
+	binary.LittleEndian.PutUint32(mob[92+16:], 1)
+	binary.LittleEndian.PutUint32(mob[92+24:], 1)
+	addr, stop := startServerExpMob(t, skillCombatDB(0), mob)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	skillAttackFrame(t, c, serverTime, world.MaxUser, -1, -2)
+
+	for i := 0; i < 12; i++ {
+		ty, payload, ok := readMaybe(t, c)
+		if !ok {
+			t.Fatal("no MsgSendItem after common mob drop")
+		}
+		if ty != protocol.MsgSendItem {
+			continue
+		}
+		if place, slot, idx := le16(payload[0:2]), le16(payload[2:4]), le16(payload[4:6]); place != world.ItemPlaceCarry || slot != 0 || idx != uint16(want.Index) {
+			t.Fatalf("common drop SendItem = place %d slot %d index %d, want carry/0/%d", place, slot, idx, want.Index)
+		}
+		for i, effect := range want.Effects {
+			o := 6 + i*2
+			if payload[o] != effect.Effect || payload[o+1] != effect.Value {
+				t.Fatalf("common drop effect %d = %d:%d, want %d:%d", i, payload[o], payload[o+1], effect.Effect, effect.Value)
+			}
+		}
+		return
+	}
+	t.Fatal("never received MsgSendItem for common mob drop")
 }

--- a/tmserver/internal/loot/loot.go
+++ b/tmserver/internal/loot/loot.go
@@ -42,8 +42,6 @@ func init() {
 // bonus and the target-level adjustment (game-rules.md §2.2). A larger result is
 // rarer. killerBonus is the killer's DropBonus (0 = none).
 //
-// UNVERIFIED: only the level<10 adjustment is documented in full
-// (MobKilled.cpp:2779+ is truncated); higher level bands are not yet applied.
 func EffectiveDropRate(slot, killerBonus, mobLevel int) int {
 	droprate := DropRate[slot]
 	dropbonus := DropBonus[slot] + killerBonus
@@ -52,12 +50,50 @@ func EffectiveDropRate(slot, killerBonus, mobLevel int) int {
 		droprate = dropbonus * droprate / 100
 	}
 	if slot < 60 {
-		switch pos := slot / 8; pos {
+		switch slot / 8 {
 		case 0, 1, 2:
-			if mobLevel < 10 {
+			switch {
+			case mobLevel < 10:
 				droprate = 4 * droprate / 100
+			case mobLevel < 20:
+				droprate = 5 * droprate / 100
+			case mobLevel < 30:
+				droprate = 6 * droprate / 100
+			case mobLevel < 40:
+				droprate = 7 * droprate / 100
+			case mobLevel < 60:
+				droprate = 8 * droprate / 100
+			default:
+				droprate = 99 * droprate / 100
 			}
 		}
+	} else {
+		switch {
+		case mobLevel < 170:
+			droprate = 90 * droprate / 100
+		case mobLevel < 200:
+			droprate = 60 * droprate / 100
+		case mobLevel < 230:
+			droprate = 50 * droprate / 100
+		case mobLevel < 255:
+			droprate = 43 * droprate / 100
+		case mobLevel < 320:
+			droprate = 38 * droprate / 100
+		default:
+			droprate = 50 * droprate / 100
+		}
+	}
+
+	// These four Carry positions are hard overrides applied after every level
+	// adjustment in MobKilled.cpp. Slot 11 is therefore guaranteed.
+	switch slot {
+	case 8, 9, 10:
+		droprate = 4
+	case 11:
+		droprate = 1
+	}
+	if droprate > 32000 {
+		droprate = 32000
 	}
 	return droprate
 }

--- a/tmserver/internal/loot/loot.go
+++ b/tmserver/internal/loot/loot.go
@@ -41,7 +41,6 @@ func init() {
 // EffectiveDropRate computes the per-slot drop odds after the killer's drop
 // bonus and the target-level adjustment (game-rules.md §2.2). A larger result is
 // rarer. killerBonus is the killer's DropBonus (0 = none).
-//
 func EffectiveDropRate(slot, killerBonus, mobLevel int) int {
 	droprate := DropRate[slot]
 	dropbonus := DropBonus[slot] + killerBonus

--- a/tmserver/internal/loot/loot_test.go
+++ b/tmserver/internal/loot/loot_test.go
@@ -32,18 +32,57 @@ func TestDropRateTable(t *testing.T) {
 }
 
 func TestEffectiveDropRate(t *testing.T) {
-	// No killer bonus, level >= 10 ⇒ raw table value.
-	if got := EffectiveDropRate(0, 0, 100); got != 900 {
-		t.Errorf("slot 0 = %d, want 900", got)
+	// Level >= 60 on the first three groups receives the legacy 99% scaling.
+	if got := EffectiveDropRate(0, 0, 100); got != 891 {
+		t.Errorf("slot 0 = %d, want 891", got)
 	}
 	// Level < 10 on a low slot (pos 0) ⇒ 4*rate/100.
 	if got := EffectiveDropRate(0, 0, 5); got != 4*900/100 {
 		t.Errorf("slot 0 low level = %d, want %d", got, 4*900/100)
 	}
 	// Killer bonus changes the divisor: dropbonus=10000/(100+50+1) ⇒ rate scaled.
-	want := (10000 / (151)) * 900 / 100
+	want := 99 * ((10000 / 151) * 900 / 100) / 100
 	if got := EffectiveDropRate(0, 50, 100); got != want {
 		t.Errorf("slot 0 with bonus = %d, want %d", got, want)
+	}
+}
+
+func TestEffectiveDropRateLevelBandsAndOverrides(t *testing.T) {
+	tests := []struct {
+		name        string
+		slot, level int
+		want        int
+	}{
+		{"under 20", 0, 10, 45},
+		{"under 30", 0, 20, 54},
+		{"under 40", 0, 30, 63},
+		{"under 60", 0, 40, 72},
+		{"slot 8 override", 8, 1, 4},
+		{"slot 11 guaranteed", 11, 1, 1},
+		{"high slot under 170", 63, 100, 18000},
+		{"high slot under 200", 63, 170, 12000},
+		{"high slot under 230", 63, 200, 10000},
+		{"high slot under 255", 63, 230, 8600},
+		{"high slot under 320", 63, 255, 7600},
+		{"high slot 320 plus", 63, 320, 10000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EffectiveDropRate(tt.slot, 0, tt.level); got != tt.want {
+				t.Errorf("EffectiveDropRate(%d, 0, %d) = %d, want %d", tt.slot, tt.level, got, tt.want)
+			}
+		})
+	}
+
+	old := DropRate[63]
+	DropRate[63] = 50000
+	t.Cleanup(func() { DropRate[63] = old })
+	if got := EffectiveDropRate(63, 0, 320); got != 25000 {
+		t.Errorf("scaled capped rate = %d, want 25000", got)
+	}
+	DropRate[63] = 100000
+	if got := EffectiveDropRate(63, 0, 320); got != 32000 {
+		t.Errorf("rate cap = %d, want 32000", got)
 	}
 }
 


### PR DESCRIPTION
## Resumo

- entrega drops comuns diretamente no `Carry` do jogador, reproduzindo o `PutItem` legado
- completa as faixas de nível, os overrides dos slots 8–11 e o teto do divisor de drop
- rejeita entradas não dropáveis e trata inventário cheio sem criar item invisível no chão
- adiciona cobertura unitária e ponta a ponta para estado e `MsgSendItem`

## Motivo

O sorteio já existia, mas o resultado era enviado para `CreateGroundItem`. Além de divergir do `MobKilled.cpp`, o servidor ainda não publica `_MSG_CreateItem`, então o item permanecia apenas no estado interno e nunca aparecia para o cliente.

## Testes

```text
go test ./tmserver/internal/loot ./tmserver/internal/world ./tmserver/internal/handler
```

Closes #266