### PR TITLE
feat(tmserver): implementar quest Defensor da Alma (Coveiro)

### DIFF
--- a/docs/migration/handlers/_MSG_Quest-npcs.md
+++ b/docs/migration/handlers/_MSG_Quest-npcs.md
@@ -71,7 +71,7 @@ Etapas sequenciais de progressão de nível (rumo ao cap 256/Arch). Cada NPC:
 
 | Etapa | NPC (grade) | Faixa de nível | Ticket (`sIndex`) | `QuestFlag` | Teleporte (aprox.) |
 |------:|-------------|----------------|------------------:|------------:|--------------------|
-| 1 | COVEIRO (0) | 39 – 115 | 4038 | 1 | (2398, 2105) |
+| 1 | COVEIRO (0) ✅ | 39 – 115 | 4038 | 1 | (2398, 2105) |
 | 2 | JARDINEIRO (1) | 115 – 190 | 4039 | 2 | (2234, 1714) |
 | 3 | KAIZEN (2) | 190 – 265 | 4040 | 3 | (464, 3902) |
 | 4 | HIDRA (3) | 265 – 320 | 4041 | 4 | (668, 3756) |
@@ -100,6 +100,11 @@ Etapas sequenciais de progressão de nível (rumo ao cap 256/Arch). Cada NPC:
   (open-wyd-scripts) e em game-rules (Fase 4).
 - **Identificação do NPC por `Merchant` + `EF_GRADE0` do item equipado** é um quirk a preservar na
   leitura dos dados de NPC (Fase 2 — `NPCGener`/BaseMob) durante a migração.
+- **Grade 0 é ambíguo — e isso é legado, não bug.** `BASE_GetItemAbilityNosanc` (`:34`) devolve `0`
+  quando o `Equip[0]` não tem efeito `EF_GRADE0`, então templates Merchant-100 sem esse efeito
+  (`FirstTrainer`, `Guarda_`, `Treinador1` em `Release/TMsrv/run/npc/`) caem em `QUEST_COVEIRO`
+  junto com o Coveiro (que tem `EF_GRADE0 0` explícito). A porta do grade 0 no Go reproduz isso de
+  propósito; desambiguar quebraria a paridade.
 - **UNVERIFIED (passo-a-passo fino):** recompensas/etapas internas exatas dos blocos longos
   (`JEFFI`, `SHAMA`, `KING`, `KINGDOM`, `URNAMMU`, `ARZAN_DRAGON`, `GOLD_DRAGON`, `EXPLOIT_LEADER`,
   `MESTREHAB`, `KIBITA`, `GODGOVERNMENT`) — o **despacho e o propósito** estão mapeados; abrir a linha

--- a/docs/migration/handlers/npc-map.md
+++ b/docs/migration/handlers/npc-map.md
@@ -85,6 +85,9 @@ quests grade 11–16/24–30) **não**.
 - **Cargo/banco** (Merchant 2): `reqShopList` → `openCargo`, deposit/withdraw.
 - **Combine/refino**: família `combineItem` (Odin/Lindy/Shany/… via opcodes dedicados).
 - **Perzen** (Merchant 100 grade 7/8/9): troca esfera→montaria.
+- **Coveiro** (Merchant 100 grade 0): etapa 1 da cadeia Quest 256 ("Defensor da Alma", issue #261) —
+  `quest256NPC` em `handler/misc.go` consome a Vela do Coveiro (4038), seta `QuestFlag = 1` e
+  teleporta para `(2398,2105)`. Grades 1–4 (Jardineiro/Kaizen/Hidra/Elfos) ainda pendentes.
 - **King Arch** (Merchant 111): cria personagem Arch a partir dos reis canônicos.
 - **Mestre Grifo** (`_MSG_MasterGriff` 0x0AD9): teleporta, após a animação de viagem do cliente, para
   Defensor de Almas `(2372,2099)`, Jardim dos Deuses `(2220,1714)`, Calabouco `(2365,2279)` ou
@@ -95,8 +98,8 @@ quests grade 11–16/24–30) **não**.
    — alinha com o sistema de montaria (Shire/esfera) que estamos implementando.
 2. **Mestres de skill/classe** (Merchant 3, 31) — progressão.
 3. **Teleportes/guardas** (Merchant 36, 128) — locomoção.
-4. **Cadeia Quest 256** (Merchant 100 grades 0–4) — progressão de level (hardcoded; candidato a
-   tabela data-driven `quest`/`quest_step`).
+4. **Cadeia Quest 256** (Merchant 100 grades 1–4; o grade 0 / Coveiro já está feito) — progressão de
+   level (hardcoded; candidato a tabela data-driven `quest`/`quest_step`).
 5. Restante (reis, oráculos, governo, etc.) — quests pontuais.
 
 > **Nota:** o engine de quest completo é hardcoded (level, tickets, coords) — forte candidato a

--- a/tmserver/internal/handler/misc.go
+++ b/tmserver/internal/handler/misc.go
@@ -153,6 +153,17 @@ func (d *Dispatcher) quest(w *world.World, s *world.Session, _ protocol.Header, 
 	if npc == nil || npc.Mode == world.MobEmpty {
 		return
 	}
+	// QUEST_COVEIRO (Merchant 100, EF_GRADE0 0): step 1 of the Quest 256 chain
+	// (_MSG_Quest.cpp:53/293, Basedef.h:331). Grade is 0 both for the Coveiro —
+	// which carries an explicit EF_GRADE0 0 — and for Merchant-100 templates with
+	// no EF_GRADE0 effect at all (FirstTrainer, Guarda_, Treinador1). That is the
+	// legacy behaviour, not an accident: BASE_GetItemAbilityNosanc returns 0 for a
+	// missing effect (_MSG_Quest.cpp:34), so those templates fall into
+	// QUEST_COVEIRO on the original server too. Disambiguating would break parity.
+	if npc.Merchant == 100 && npc.Grade == 0 {
+		d.quest256NPC(w, s, e, quest256Steps[0], itemVelaDoCoveiro)
+		return
+	}
 	// PERZEN (Merchant 100, EF_GRADE0 ∈ {7,8,9}): the item exchange.
 	if npc.Merchant == 100 && npc.Grade >= 7 && npc.Grade <= 9 {
 		d.perzenExchange(w, s, npc)
@@ -578,6 +589,48 @@ var quest256Steps = []quest256Step{
 	{flag: 3, minLevel: 190, maxLevel: 265, x: 464, y: 3902, area: questArea{x1: 459, y1: 3887, x2: 497, y2: 3916}},
 	{flag: 4, minLevel: 265, maxLevel: 320, x: 668, y: 3756, area: questArea{x1: 658, y1: 3728, x2: 703, y2: 3762}},
 	{flag: 5, minLevel: 320, maxLevel: 350, x: 1322, y: 4041, area: questArea{x1: 1312, y1: 4027, x2: 1348, y2: 4055}},
+}
+
+// itemVelaDoCoveiro is the Quest 256 step-1 ticket handed to the Coveiro
+// (ItemList.csv:5703, "Vela_do_Coveiro"; _MSG_Quest.cpp:315).
+const itemVelaDoCoveiro int16 = 4038
+
+// quest256NPC handles the item hand-in performed by the five legacy Quest 256
+// NPC cases (_MSG_Quest.cpp:293/338/382/426/470). The Coveiro route is the first
+// one exposed here; keeping the step and ticket explicit avoids accidentally
+// enabling the other unfinished quest NPC routes.
+func (d *Dispatcher) quest256NPC(w *world.World, s *world.Session, e *world.Entity, step quest256Step, ticket int16) {
+	// Legacy answers each rejection with SendSay on the NPC; this fork uses the
+	// same NoticeReqNotMet message box as the other quest NPCs (perzenExchange,
+	// capaverdeTeleport, molarGargula, useQuest256Ticket).
+	if e.ClassMaster != classMasterMortal && e.ClassMaster != classMasterArch {
+		d.notify(w, s, NoticeReqNotMet) // _NN_Level_Limit2
+		return
+	}
+	if e.Level < step.minLevel || e.Level >= step.maxLevel {
+		d.notify(w, s, NoticeReqNotMet) // _NN_Level_limit
+		return
+	}
+
+	slot := -1
+	for i := 0; i < activeCarryLimit(e); i++ {
+		if e.Carry[i].Index == ticket {
+			slot = i
+			break
+		}
+	}
+	if slot < 0 {
+		d.notify(w, s, NoticeReqNotMet) // _SN_BRINGITEM
+		return
+	}
+
+	// BASE_ClearItem clears the whole legacy slot (_MSG_Quest.cpp:316); Quest 256
+	// tickets are not a stack consumption path (issue #259) even if a malformed
+	// item carries EF_AMOUNT.
+	e.Carry[slot] = world.Item{}
+	d.sendSlot(w, s, world.ItemPlaceCarry, slot, e.Carry[slot])
+	d.teleportQuest256Step(w, s, e, step)
+	d.log.Info("quest256 NPC teleport", "conn", s.Conn, "item", ticket, "level", e.Level, "quest_flag", step.flag)
 }
 
 var masterGriffTravelDelay = 9500 * time.Millisecond

--- a/tmserver/internal/handler/quest_test.go
+++ b/tmserver/internal/handler/quest_test.go
@@ -186,6 +186,87 @@ func baseMortalState(level int) world.CharacterState {
 	}
 }
 
+// TestCoveiroStartsQuest256WithRealTemplate locks the Merchant/EF_GRADE0 pair
+// against the shipped content: the real Coveiro template must route to step 1 of
+// the Quest 256 chain (issue #261, _MSG_Quest.cpp:293).
+func TestCoveiroStartsQuest256WithRealTemplate(t *testing.T) {
+	tmpl, err := os.ReadFile(filepath.Join("..", "..", "..", "Release", "TMsrv", "run", "npc", "Coveiro"))
+	if err != nil {
+		t.Fatalf("read real Coveiro template: %v", err)
+	}
+	db := newDB()
+	st := baseMortalState(39)
+	st.Carry[7] = world.Item{Index: itemVelaDoCoveiro}
+	db.loadResult = st
+	addr, stop, npcID := startServerQuestNPC(t, db, tmpl)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	questFrame(t, c, npcID)
+	item := expect(t, c, protocol.MsgSendItem)
+	if slot, idx := le16(item[2:4]), le16(item[4:6]); slot != 7 || idx != 0 {
+		t.Fatalf("Coveiro consume slot=%d idx=%d, want slot 7 cleared", slot, idx)
+	}
+	action := expectAction(t, c)
+	if action.Effect != 1 || !inRange(action.TargetX, 2398) || !inRange(action.TargetY, 2105) {
+		t.Fatalf("Coveiro teleport effect=%d target=%d,%d, want effect 1 around 2398,2105", action.Effect, action.TargetX, action.TargetY)
+	}
+}
+
+func TestCoveiroAcceptsArch(t *testing.T) {
+	tmpl := questNPCTemplate("Coveiro", 100, 0, 0)
+	db := newDB()
+	st := baseMortalState(114)
+	st.ClassMaster = classMasterArch
+	st.Carry[0] = world.Item{Index: itemVelaDoCoveiro}
+	db.loadResult = st
+	addr, stop, npcID := startServerQuestNPC(t, db, tmpl)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	questFrame(t, c, npcID)
+	expect(t, c, protocol.MsgSendItem)
+	expectAction(t, c)
+}
+
+func TestCoveiroRejectsInvalidRequirements(t *testing.T) {
+	tests := []struct {
+		name        string
+		level       int
+		classMaster uint8
+		item        int16
+	}{
+		{name: "below level", level: 38, classMaster: classMasterMortal, item: itemVelaDoCoveiro},
+		{name: "at upper bound", level: 115, classMaster: classMasterMortal, item: itemVelaDoCoveiro},
+		{name: "wrong class", level: 50, classMaster: classMasterCelestial, item: itemVelaDoCoveiro},
+		{name: "missing ticket", level: 50, classMaster: classMasterMortal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl := questNPCTemplate("Coveiro", 100, 0, 0)
+			db := newDB()
+			st := baseMortalState(tt.level)
+			st.ClassMaster = tt.classMaster
+			st.Carry[0] = world.Item{Index: tt.item}
+			db.loadResult = st
+			addr, stop, npcID := startServerQuestNPC(t, db, tmpl)
+			defer stop()
+			c := enterWorld(t, addr)
+			defer c.Close()
+
+			questFrame(t, c, npcID)
+			if code := noticeCode(t, expect(t, c, protocol.MsgMessageBoxOk)); code != NoticeReqNotMet {
+				t.Fatalf("notice = %d, want NoticeReqNotMet", code)
+			}
+			if ty, _, ok := readMaybe(t, c); ok {
+				t.Fatalf("rejected Coveiro interaction produced %#x after notice", ty)
+			}
+		})
+	}
+}
+
 func TestCapaverdeTeleport(t *testing.T) {
 	tmpl := questNPCTemplate("Treinador_Aprendiz", 100, 14, 0)
 	db := newDB()


### PR DESCRIPTION
## Resumo
- roteia o NPC Coveiro (Merchant 100, `EF_GRADE0` 0) para a etapa 1 da Quest 256
- valida classe, faixa de nível e a Vela do Coveiro antes de consumir o ticket
- define `QuestFlag = 1` e teleporta para o Defensor da Alma com a dispersão legada
- cobre o fluxo com o template real e os cenários de rejeição

## Contexto

Clicar no Coveiro com a Vela do Coveiro no inventário não fazia nada: o dispatcher `quest()`
(`handler/misc.go`) só tratava Merchant 100 nos grades 7/8/9 (Perzen), 14 (Capaverde) e 15
(Molar Gárgula) — o grade 0 caía no `log.Debug("quest NPC not implemented")`, um no-op silencioso.

Toda a infraestrutura em volta já existia: `quest256Steps[0]` já carregava a etapa exata
(`flag 1, nível 39–115, destino (2398, 2105)`), `teleportQuest256Step` já fazia o jitter legado, e
`guardQuest256Areas` já expulsa quem entra na arena sem o `QuestFlag`. O Coveiro também já nasce no
mundo, pelo bloco `# [3445]` do `NPCGener.txt`, em (2375, 2104). Faltava só a rota do clique.

A implementação segue a ordem exata do `case QUEST_COVEIRO`
(`Source/Code/TMSrv/_MSG_Quest.cpp:293-336`): gate de classe (`:296`) → gate de nível (`:303`) →
varredura do inventário pelo item 4038 (`:313`) → `BASE_ClearItem` do slot inteiro (`:316`) →
`QuestFlag = 1` + `DoTeleport` (`:330-332`).

Os níveis internos são `nível de tela - 1`, então `[39, 115)` é exatamente a faixa "40 ao 116"
pedida na issue.

## Decisões

- **Helper com `step` e `ticket` explícitos.** `quest256NPC` não deriva a etapa do NPC: recebe as
  duas coisas de fora, para não habilitar por acidente as rotas das quests irmãs (grades 1–4) que
  ainda não estão implementadas.
- **Grade 0 é ambíguo — de propósito.** Vale também para templates Merchant-100 sem efeito
  `EF_GRADE0` (`FirstTrainer`, `Guarda_`, `Treinador1`). Isso é o legado, não um descuido:
  `BASE_GetItemAbilityNosanc` devolve `0` para efeito ausente (`_MSG_Quest.cpp:34`), então esses
  NPCs também caem em `QUEST_COVEIRO` no servidor original. Desambiguar quebraria a paridade.
  Documentado em `_MSG_Quest-npcs.md`.
- **Slot inteiro, não decremento de stack.** O legado usa `BASE_ClearItem`; tickets Quest 256 não
  são caminho de `consumeOneItem` (#259).
- **Rejeições via `NoticeReqNotMet`**, como `perzenExchange`/`capaverdeTeleport`/`molarGargula`/
  `useQuest256Ticket`. O `SendSay` fiel ao legado (fala do NPC com o nome do item) é um gap
  transversal de todos os NPCs de quest, não desta issue.
- **Nada persistido.** `QuestFlag` é volátil, igual ao `CMob.QuestFlag` legado — sem migration,
  sem proto, sem dbserver.

## Testes

```
docker run --rm --memory=6g -v "${PWD}:/src" -w /src golang:1.25 \
  go test -race -run Coveiro ./tmserver/internal/handler -count=1 -v   # 6/6 PASS
docker run --rm --memory=6g -v "${PWD}:/src" -w /src golang:1.25 \
  go test -race -p 2 ./tmserver/... -count=1                           # tudo ok
```

`go build ./...`, `go vet ./...` e `gofmt` limpos. `golangci-lint` não acusa nada nos arquivos
tocados (os achados restantes são o ruído de CRLF conhecido em `affect_*.go`/`area.go` e o `SA5011`
pré-existente em `npcconfig_test.go`).

`TestCoveiroStartsQuest256WithRealTemplate` carrega o template real
`Release/TMsrv/run/npc/Coveiro`, então trava o par Merchant/`EF_GRADE0` contra o conteúdo publicado —
se alguém reeditar o NPC, o teste quebra.

**Não rodei o fim a fim com o client 7662** (exige subir o `make run-local` e conectar o client
Windows na mão). Roteiro: `/gm level 50` + `/gm item 4038`, ir até o Coveiro em (2375, 2104), clicar
→ o item some e o char vai para ~(2398, 2105) sem ser expulso pelo `guardQuest256Areas`.

## Pontos de atenção

1. **Conflito previsto com o #288** (Jardim do Deus, ainda aberto): ele cria um `quest256NPC`
   idêntico. Quem mergear por último resolve — o corpo do helper é o mesmo, só sobra a linha de
   roteamento de cada quest.
2. **A quest é testável mas não farmável hoje.** Uma varredura binária do `Release/` não acha o item
   4038 em nenhum `Carry[]` de template, nem em `ItemDropList.txt`/`LevelItem.txt`/`QuestDiaria.txt`
   — a Vela do Coveiro só sai de `/gm item 4038`. Dar uma fonte a ela é assunto da #266 / #287.
3. **`-npc-editing`** está *off* por padrão e não é ativado em nenhum compose/deploy deste repo. Se
   um dia virar padrão, todo bloco `Merchant != 0` é pulado do `NPCGener.txt` e o Coveiro **não**
   está no seed `0006_default_npc_seed.up.sql` — ele sumiria do mundo e precisaria entrar no roster.

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)
