### PR TITLE
fix(tmserver): permitir separar pilha de Pedra do Sábio

### DIFF
--- a/docs/game.md
+++ b/docs/game.md
@@ -43,7 +43,7 @@
 ✅ /gm goto \<jogador\> (ou /gm ir): teleporta você até o jogador <br/>
 ✅ /gm summon \<jogador\> (ou /gm puxar): puxa o jogador até você <br/>
 ✅ /gm spawn \<id\>: cria uma criatura de teste (índice do roster de summons) na sua posição <br/>
-✅ /gm item \<id\>: coloca um item (por índice) no seu inventário <br/>
+✅ /gm item \<id\> \[qtd\]: coloca um item (por índice) no seu inventário; `qtd` (1–120) cria um stack <br/>
 ✅ /gm setlevel \<n\>: sobe o seu nível para n (apenas sobe — não rebaixa) <br/>
 ✅ /gm setgold \<n\>: define o seu ouro carregado <br/>
 ✅ /gm ban \<jogador|conta\>: bloqueia a conta (via `account.is_blocked`) e derruba se online <br/>

--- a/docs/migration/handlers/lote2-itens-char.md
+++ b/docs/migration/handlers/lote2-itens-char.md
@@ -41,6 +41,10 @@
 - **Status Go (issue #120): ✅** `handler.splitItem` + `setItemAmount`/`isSplittable` (`item.go`).
   Whitelist {412,413,414,416,419,420, 2390–2419}; `EF_AMOUNT` (61) guarda a quantidade; coloca o novo
   stack via `AddToCarry` e envia dois `MsgSendItem`. Sem slot livre → mantém o stack inteiro.
+  **Divergência deliberada (issue #268):** a whitelist inclui também **1774** (Pedra do Sábio), que a
+  loja de NPC do portal vende em pack (`npcconfig.go` grava `EF_AMOUNT` no item vendido) — sem isso o
+  Shift+clique no pack não fazia nada. O merge (`sameStackClass`) usa a mesma lista, então as duas
+  pontas ficam consistentes.
 
 ## `_MSG_UpdateItem` (0x0374) — abrir portões/baús/estado de item no mundo
 - **Gatilho/struct:** `MSG_UpdateItem` (`ItemID`, `State`).

--- a/tmserver/internal/handler/combine.go
+++ b/tmserver/internal/handler/combine.go
@@ -157,7 +157,8 @@ func (d *Dispatcher) combineItem(w *world.World, s *world.Session, h protocol.He
 }
 
 // combineExtracao handles _MSG_CombineItemExtracao (0x02D4): Huntress extraction
-// uses MSG_STANDARDPARM2.Parm2 as the carry slot and consumes one 1774 catalyst.
+// uses MSG_STANDARDPARM2.Parm2 as the carry slot and consumes one Pedra do Sábio
+// catalyst — one unit, not the whole stack: the NPC shop sells it in packs.
 func (d *Dispatcher) combineExtracao(w *world.World, s *world.Session, _ protocol.Header, payload []byte) {
 	e := w.Entity(s.Conn)
 	if e == nil || e.HP <= 0 || s.Mode != world.UserPlay {
@@ -186,7 +187,7 @@ func (d *Dispatcher) combineExtracao(w *world.World, s *world.Session, _ protoco
 	}
 	catalyst := -1
 	for i := 0; i < activeCarryLimit(e); i++ {
-		if e.Carry[i].Index == 1774 {
+		if e.Carry[i].Index == itemPedraDoSabio {
 			catalyst = i
 			break
 		}
@@ -194,7 +195,7 @@ func (d *Dispatcher) combineExtracao(w *world.World, s *world.Session, _ protoco
 	if catalyst < 0 {
 		return
 	}
-	e.Carry[catalyst] = world.Item{}
+	consumeOneItem(&e.Carry[catalyst])
 	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, catalyst, itemToSel(e.Carry[catalyst])))
 
 	roll := w.Rand().Intn(115)

--- a/tmserver/internal/handler/combine_test.go
+++ b/tmserver/internal/handler/combine_test.go
@@ -132,3 +132,42 @@ func TestCombineInvalidRecipe(t *testing.T) {
 		t.Errorf("got %#x parm=%d ok=%v, want CombineComplete(0) with no prior SendItem", ty, parmOf(p), ok)
 	}
 }
+
+// TestCombineExtracaoConsumesOneCatalyst pins the stack behaviour of the Huntress
+// extraction: the Pedra do Sábio is sold in packs, so a run must peel a single unit
+// off the stack instead of wiping the slot.
+func TestCombineExtracaoConsumesOneCatalyst(t *testing.T) {
+	target := world.Item{Index: 1050, Effects: [3]world.Effect{{Effect: efSanc, Value: 9}}}
+	addr, stop := startServerClockItemPos(t,
+		carryDB(target, amountItem(itemPedraDoSabio, 3)),
+		map[int]int{1050: 2})
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	send(t, c, protocol.MsgCombineItemExtracao, protocol.EncodeStandardParm2(0, 0))
+
+	_, slot, index, amount := sendItemSlotAmount(expect(t, c, protocol.MsgSendItem))
+	if slot != 1 || index != itemPedraDoSabio || amount != 2 {
+		t.Errorf("catalyst slot=%d idx=%d amt=%d, want slot 1 idx %d amt 2", slot, index, amount, itemPedraDoSabio)
+	}
+}
+
+// TestCombineExtracaoClearsLastCatalyst is the boundary of the case above: the last
+// unit still empties the slot.
+func TestCombineExtracaoClearsLastCatalyst(t *testing.T) {
+	target := world.Item{Index: 1050, Effects: [3]world.Effect{{Effect: efSanc, Value: 9}}}
+	addr, stop := startServerClockItemPos(t,
+		carryDB(target, world.Item{Index: itemPedraDoSabio}),
+		map[int]int{1050: 2})
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	send(t, c, protocol.MsgCombineItemExtracao, protocol.EncodeStandardParm2(0, 0))
+
+	_, slot, index, _ := sendItemSlotAmount(expect(t, c, protocol.MsgSendItem))
+	if slot != 1 || index != 0 {
+		t.Errorf("catalyst slot=%d idx=%d, want slot 1 cleared", slot, index)
+	}
+}

--- a/tmserver/internal/handler/gm.go
+++ b/tmserver/internal/handler/gm.go
@@ -174,11 +174,31 @@ func (d *Dispatcher) gmSpawn(w *world.World, s *world.Session, rest string) {
 	d.log.Info("gm spawn", "account", s.AccountName, "template", id, "mobConn", newID)
 }
 
-// gmItem grants a test item (by index, no effects) into the caller's inventory.
+// gmItem grants a test item into the caller's inventory: "/gm item <index> [qty]".
+// The optional quantity writes EF_AMOUNT (clamped to [1, maxStackAmount]) so stack
+// paths — split, merge, catalyst consumption — are reachable without configuring an
+// NPC shop pack in the web portal.
 func (d *Dispatcher) gmItem(w *world.World, s *world.Session, rest string) {
-	id, err := strconv.Atoi(firstToken(rest))
+	fields := strings.Fields(rest)
+	if len(fields) == 0 {
+		return
+	}
+	id, err := strconv.Atoi(fields[0])
 	if err != nil || id <= 0 || id >= world.MaxItem {
 		return
+	}
+	qty := 1
+	if len(fields) > 1 {
+		qty, err = strconv.Atoi(fields[1])
+		if err != nil {
+			return
+		}
+		if qty < 1 {
+			qty = 1
+		}
+		if qty > maxStackAmount {
+			qty = maxStackAmount
+		}
 	}
 	e := w.Entity(s.Conn)
 	if e == nil {
@@ -189,9 +209,13 @@ func (d *Dispatcher) gmItem(w *world.World, s *world.Session, rest string) {
 		d.notify(w, s, NoticeNoEmptySlot)
 		return
 	}
-	e.Carry[slot] = world.Item{Index: int16(id)}
+	it := world.Item{Index: int16(id)}
+	if qty > 1 {
+		setItemAmount(&it, qty)
+	}
+	e.Carry[slot] = it
 	w.Send(s, protocol.MsgCNFGetItem, slotPayload(slot))
-	d.log.Info("gm item", "account", s.AccountName, "item", id, "slot", slot)
+	d.log.Info("gm item", "account", s.AccountName, "item", id, "amount", qty, "slot", slot)
 }
 
 // gmSetLevel raises the caller to the given level for testing. It reuses the

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -162,13 +162,21 @@ func (d *Dispatcher) deleteItem(w *world.World, s *world.Session, _ protocol.Hea
 // isSplittable reports whether an item may be divided by _MSG_SplitItem
 // (_MSG_SplitItem.cpp:45-52): a fixed set of currency/stackable specials plus the
 // 2390..2419 range (dusts Vol 4/5 — the hot case, feeds refino, issue #103).
+//
+// itemPedraDoSabio is a deliberate divergence from the legacy list: the NPC shop
+// sells it in packs (npcconfig.go shopEffects writes EF_AMOUNT), so Shift+click
+// must be able to peel units off the stack (issue #268).
 func isSplittable(index int16) bool {
 	switch index {
-	case 412, 413, 414, 416, 419, 420:
+	case 412, 413, 414, 416, 419, 420, itemPedraDoSabio:
 		return true
 	}
 	return index >= 2390 && index <= 2419
 }
+
+// itemPedraDoSabio is the Pedra do Sábio (ItemList.csv:2903), the Huntress
+// extraction catalyst — see combineExtracao.
+const itemPedraDoSabio = 1774
 
 const maxStackAmount = 120
 

--- a/tmserver/internal/handler/itemops_test.go
+++ b/tmserver/internal/handler/itemops_test.go
@@ -84,6 +84,54 @@ func TestSplitItem(t *testing.T) {
 	}
 }
 
+// TestSplitItemPedraDoSabio covers issue #268: the NPC shop sells the Pedra do
+// Sábio in packs, so Shift+click must peel units off it. The shop's extra effects
+// must ride along to the new stack (splitItem copies the item, unlike the legacy).
+func TestSplitItemPedraDoSabio(t *testing.T) {
+	pack := amountItem(itemPedraDoSabio, 10)
+	pack.Effects[1] = world.Effect{Effect: efItemLevel, Value: 3}
+	addr, stop, _ := startServerClock(t, carryDB(pack))
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	send(t, c, protocol.MsgSplitItem, (&protocol.MsgSplitItemBody{Slot: 0, SIndex: itemPedraDoSabio, Num: 3}).Encode())
+
+	newPayload := expect(t, c, protocol.MsgSendItem)
+	_, newSlot, newIdx, newAmt := sendItemSlotAmount(newPayload)
+	_, srcSlot, srcIdx, srcAmt := sendItemSlotAmount(expect(t, c, protocol.MsgSendItem))
+	if newSlot == 0 || newIdx != itemPedraDoSabio || newAmt != 3 {
+		t.Errorf("new stack slot=%d idx=%d amt=%d, want slot!=0 idx %d amt 3", newSlot, newIdx, newAmt, itemPedraDoSabio)
+	}
+	if srcSlot != 0 || srcIdx != itemPedraDoSabio || srcAmt != 7 {
+		t.Errorf("source stack slot=%d idx=%d amt=%d, want slot 0 idx %d amt 7", srcSlot, srcIdx, srcAmt, itemPedraDoSabio)
+	}
+	if newPayload[8] != efItemLevel || newPayload[9] != 3 {
+		t.Errorf("new stack effect1 = (%d,%d), want (%d,3)", newPayload[8], newPayload[9], efItemLevel)
+	}
+}
+
+// TestTradingItemMergePedraDoSabio is the inverse of TestSplitItemPedraDoSabio:
+// dragging one pack onto another must merge instead of swapping.
+func TestTradingItemMergePedraDoSabio(t *testing.T) {
+	addr, stop, _ := startServerClock(t, carryDB(amountItem(itemPedraDoSabio, 3), amountItem(itemPedraDoSabio, 7)))
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	tradeItemFrame(t, c, world.ItemPlaceCarry, 0, world.ItemPlaceCarry, 1, 0)
+	expect(t, c, protocol.MsgTradingItem)
+	_, srcSlot, srcIdx, _ := sendItemSlotAmount(expect(t, c, protocol.MsgSendItem))
+	_, dstSlot, dstIdx, dstAmt := sendItemSlotAmount(expect(t, c, protocol.MsgSendItem))
+
+	if srcSlot != 0 || srcIdx != 0 {
+		t.Errorf("source after merge slot=%d idx=%d, want slot 0 cleared", srcSlot, srcIdx)
+	}
+	if dstSlot != 1 || dstIdx != itemPedraDoSabio || dstAmt != 10 {
+		t.Errorf("dest after merge slot=%d idx=%d amt=%d, want slot 1 idx %d amt 10", dstSlot, dstIdx, dstAmt, itemPedraDoSabio)
+	}
+}
+
 func TestSplitItemRejected(t *testing.T) {
 	cases := []struct {
 		name string
@@ -230,12 +278,14 @@ func TestTradingItemSameSlotNoop(t *testing.T) {
 }
 
 func TestIsSplittable(t *testing.T) {
-	for _, idx := range []int16{412, 413, 414, 416, 419, 420, 2390, 2400, 2419} {
+	for _, idx := range []int16{412, 413, 414, 416, 419, 420, 2390, 2400, 2419, itemPedraDoSabio} {
 		if !isSplittable(idx) {
 			t.Errorf("isSplittable(%d) = false, want true", idx)
 		}
 	}
-	for _, idx := range []int16{0, 411, 415, 417, 418, 421, 2389, 2420, 1100} {
+	// 1745 (Pedra da Sabedoria) and 1773/1775 neighbour the Pedra do Sábio in the
+	// catalog: only 1774 itself is splittable.
+	for _, idx := range []int16{0, 411, 415, 417, 418, 421, 2389, 2420, 1100, 1745, 1773, 1775} {
 		if isSplittable(idx) {
 			t.Errorf("isSplittable(%d) = true, want false", idx)
 		}


### PR DESCRIPTION
Closes #268

## Causa raiz

O split de pilha já estava implementado e roteado (`MsgSplitItem` `0x02E5` → `handler.splitItem`), mas a whitelist `isSplittable` era cópia fiel do legado (`_MSG_SplitItem.cpp:45-52`): `{412, 413, 414, 416, 419, 420}` ∪ `[2390..2419]`. A **Pedra do Sábio é o índice 1774** (`Release/Common/ItemList.csv:2903`) e caía fora, então o handler retornava em silêncio — exatamente o "não acontece nada" do relato.

O "pack" existe porque a loja de NPC configurada pelo portal grava `EF_AMOUNT` no item vendido (`npcconfig.go` `shopEffects`); o template 1774 do `ItemList.csv` não traz `EF_AMOUNT`.

## Mudanças

- **`handler/item.go`** — `isSplittable` passa a aceitar `itemPedraDoSabio` (nova const `1774`), documentado como divergência deliberada do legado. Como `sameStackClass` consulta a mesma lista, o merge (arrastar uma pilha sobre outra) fica consistente com o split.
- **`handler/combine.go`** — bug vizinho do mesmo item: `combineExtracao` zerava o slot do catalisador, então uma extração da Caçadora queimava o pack inteiro. Agora usa `consumeOneItem`, que decrementa `EF_AMOUNT` e só limpa o slot na última unidade.
- **`handler/gm.go`** — `/gm item <id> [qtd]` aceita quantidade opcional (clamp 1–120) e escreve `EF_AMOUNT`. Sem isso, nenhum caminho além da loja do portal criava stacks, e os fluxos de pilha eram intestáveis in-game.
- **Docs** — divergência da whitelist registrada em `docs/migration/handlers/lote2-itens-char.md`; `/gm item` atualizado em `docs/game.md`.

## Testes

Quatro testes novos:

- `TestSplitItemPedraDoSabio` — pack de 10 → 7 + 3, e os efeitos extras da loja acompanham a pilha nova.
- `TestTradingItemMergePedraDoSabio` — o inverso: 3 + 7 funde em 10.
- `TestCombineExtracaoConsumesOneCatalyst` — pack de 3 → sobram 2.
- `TestCombineExtracaoClearsLastCatalyst` — a última unidade ainda esvazia o slot.

`TestIsSplittable` ganhou o 1774 nos positivos e os vizinhos 1745/1773/1775 nos negativos.

Verificação executada (Docker `golang:1.25`): `go build ./...`, `go vet ./tmserver/...` e `go test -race -p 2 ./tmserver/...` limpos; `gofmt` limpo nos arquivos tocados; `golangci-lint` sem achados fora do ruído conhecido de CRLF.

**Não verificado:** o teste com o cliente real. Se o Shift+clique continuar sem efeito, conferir no log do tmserver a linha `recv packet ... type=0x2e5`: se o pacote não chegar, o bloqueio é client-side (a janela de split não abre para o 1774) e a issue muda de natureza.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
