### PR TITLE
feat(tmserver): ganhar Pontos Caos ao subir de nível

### DIFF
--- a/docs/game.md
+++ b/docs/game.md
@@ -23,7 +23,7 @@
 ✅ /sair: sai da sua guild (limpa a guild + atualiza a tag; metadados de guild não modelados) <br/>
 ⏳ /guild: mostra o index (ID) da sua guild — sistema de guild não modelado <br/>
 ✅ /buffs: Remove todos os buffs do personagem <br/>
-✅ /cp: mostra os pontos de caos atuais do personagem <br/>
+✅ /cp: mostra os pontos de caos atuais do personagem (`PKPoint-75`; 0 = nick branco). Recuperam de duas formas: +1 por hora online (gate do `RegenMob` legado) e **+1 por nível subido**, ambas com teto no neutro 75 — o ganho por nível é um desvio consciente do legado, pedido na issue #279 <br/>
 ✅ /nick \<jogador\>: mostra nick, guild (nome/fama, se registrada — `world/guild.go`), cidadania e fama do jogador alvo <br/>
 ✅ /gritar \<mensagem\>: grito global — consome 1 Trombeta Mágica (item 3330) e envia `[Nome]> mensagem` a todos os jogadores online, em verde (`_MSG_MagicTrumpet`). Alias legado: `/spk`. Sem trombeta, avisa e não grita; o alcance é o deste canal (o fan-out entre canais do legado passava pelo DBSrv e não foi portado) <br/>
 

--- a/tmserver/internal/handler/mobkilled.go
+++ b/tmserver/internal/handler/mobkilled.go
@@ -261,7 +261,7 @@ func isCelestialTier(classMaster uint8) bool {
 // /destravar40 and /destravar90 set the flags (CMob.cpp:1107, 1121-1151). Shared by
 // kill EXP, Poeira de Fada, GM setlevel and combat.
 func (d *Dispatcher) applyLevelUps(w *world.World, s *world.Session, e *world.Entity) bool {
-	leveled := false
+	gained := int32(0) // levels actually crossed — the Chaos Point grant below is per level
 	celestial := isCelestialTier(e.ClassMaster)
 	levelCap := level.MaxLevelForTier(e.ClassMaster)
 	for e.Level < levelCap && e.Exp >= level.NextLevelExpTier(e.Level, e.ClassMaster) {
@@ -292,9 +292,9 @@ func (d *Dispatcher) applyLevelUps(w *world.World, s *world.Session, e *world.En
 			}
 			e.SpecialBonus += 2
 		}
-		leveled = true
+		gained++
 	}
-	if !leveled {
+	if gained == 0 {
 		return false
 	}
 	// BASE_GetBonusScorePoint reads the equipment-free BaseScore attributes: it
@@ -317,6 +317,11 @@ func (d *Dispatcher) applyLevelUps(w *world.World, s *world.Session, e *world.En
 		w.Send(s, protocol.MsgMotion, motion)
 	}
 	w.BroadcastInView(e.ID, protocol.MsgMotion, motion)
+
+	// Chaos Points paid back for the levels just gained (issue #279). Last on
+	// purpose: it can emit a CreateMob that recolors the nick, which must land
+	// after the score/etc refresh above, not in the middle of it.
+	d.grantLevelUpPKPoint(w, s, e, gained)
 	return true
 }
 

--- a/tmserver/internal/handler/pkmode.go
+++ b/tmserver/internal/handler/pkmode.go
@@ -34,6 +34,18 @@ const (
 	pkPointChaos   uint8 = 0  // red blinking nick
 )
 
+// pkPointPerLevel is the Chaos Point paid back per level gained (issue #279).
+//
+// DELIBERATE DIVERGENCE FROM THE LEGACY — do not "fix" this back to parity
+// without reading the issue. The original never tied PKPoint to leveling: its
+// only natural recovery is the hourly RegenMob gate (Server.cpp:4872-4881,
+// ported below as pkPointRecoverPeriod), which is why issue #210 was closed
+// without this. Issue #279 reopened it as a design decision for this server:
+// leveling must also pay chaos back, so a character grinding out of chaos sees
+// the nick go white. Same +1 step and same 75 ceiling as the hourly gate, and it
+// stacks with it rather than replacing it.
+const pkPointPerLevel = 1
+
 // pkGuilty reports whether e is currently in the chaotic (red-blinking-nick)
 // state: its Guilty decay counter (GetFunc.cpp KILL_MARK slot) hasn't reached 0.
 func pkGuilty(e *world.Entity) bool {
@@ -91,6 +103,37 @@ func (d *Dispatcher) markGuilty(w *world.World, s *world.Session, e *world.Entit
 	}
 }
 
+// grantLevelUpPKPoint pays levels × pkPointPerLevel back toward the neutral 75
+// after a level-up (issue #279). It never pushes past 75: the 76..150 range only
+// comes from the quest/item paths (_MSG_Quest.cpp:2569-2579, _MSG_UseItem.cpp:3867)
+// and leveling must not top those up — same ceiling the hourly recovery uses.
+//
+// The gain is reported once, not per level, so a multi-level jump (Poeira de
+// Fada, GM /setlevel) produces a single chat line, and the PK state is
+// re-broadcast so the nick recolors without a relog. While Guilty > 0 the visible
+// pkPoint(e) is pinned at 0, so the CreateMob would carry the same byte as before
+// — skip the broadcast then and let the Guilty decay in sweepGuilty do it.
+// s may be nil (the GM/offline applyLevelUps callers).
+func (d *Dispatcher) grantLevelUpPKPoint(w *world.World, s *world.Session, e *world.Entity, levels int32) {
+	if levels <= 0 || e.PKPoint >= pkPointNeutral {
+		return
+	}
+	// int arithmetic first: levels can be in the hundreds (/setlevel), which would
+	// overflow the uint8 counter.
+	gain := int(levels) * pkPointPerLevel
+	if room := int(pkPointNeutral - e.PKPoint); gain > room {
+		gain = room
+	}
+	e.PKPoint += uint8(gain)
+	if s == nil {
+		return
+	}
+	d.sendChatText(w, s, notifyPKPointDelta(e.PKPoint, gain))
+	if !pkGuilty(e) {
+		d.broadcastPKState(w, s, e)
+	}
+}
+
 // pkMode handles _MSG_PKMode (0x0399): the client's K-key Player-Killer consent
 // toggle (Exec_MSG_PKMode, _MSG_PKMode.cpp). Toggling only flips the consent gate
 // checked by attack() — it cancels any active trade (same anti-dup guard as
@@ -136,6 +179,13 @@ func (d *Dispatcher) sweepGuilty(w *world.World) {
 		if pkTick && e.PKPoint < pkPointNeutral {
 			e.PKPoint++
 			d.sendChatText(w, s, notifyPKPointDelta(e.PKPoint, 1))
+			// The recovered point changes MobName[12], so the nick has to be
+			// repainted here too — otherwise it keeps the stale color until the
+			// next CreateMob (a relog, or leaving and re-entering someone's view).
+			// Pinned at 0 while Guilty > 0, so nothing to repaint in that case.
+			if !pkGuilty(e) {
+				d.broadcastPKState(w, s, e)
+			}
 		}
 	})
 }

--- a/tmserver/internal/handler/pkpoint_levelup_test.go
+++ b/tmserver/internal/handler/pkpoint_levelup_test.go
@@ -1,0 +1,144 @@
+package handler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/level"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// TestLevelUpGrantsPKPoint is the issue #279 core: every level crossed pays one
+// Chaos Point back, capped at the neutral 75 and never touching a character
+// already at or past it (the quest/item 76..150 range).
+func TestLevelUpGrantsPKPoint(t *testing.T) {
+	cases := []struct {
+		name       string
+		pkPoint    uint8
+		guilty     uint8
+		toLevel    int32 // Exp is set to NextLevelExp(toLevel-1), so levels gained = toLevel-1
+		wantPoint  uint8
+		wantLevels int32
+	}{
+		{name: "one level, one point", pkPoint: 70, toLevel: 2, wantPoint: 71, wantLevels: 1},
+		{name: "five levels, five points", pkPoint: 60, toLevel: 6, wantPoint: 65, wantLevels: 5},
+		{name: "caps at neutral", pkPoint: 74, toLevel: 11, wantPoint: pkPointNeutral, wantLevels: 10},
+		{name: "no-op at neutral", pkPoint: pkPointNeutral, toLevel: 6, wantPoint: pkPointNeutral, wantLevels: 5},
+		{name: "no-op above neutral (quest/item range)", pkPoint: 150, toLevel: 6, wantPoint: 150, wantLevels: 5},
+		// Guilty pins the *displayed* pkPoint at 0, but the counter underneath must
+		// still accrue — otherwise a chaotic player's grind would be wasted.
+		{name: "accrues while guilty", pkPoint: 70, guilty: 5, toLevel: 3, wantPoint: 72, wantLevels: 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d, w, e := mobKilledWorld(t) // mortal, level 1
+			e.PKPoint, e.Guilty = c.pkPoint, c.guilty
+			e.Exp = level.NextLevelExp(c.toLevel - 1)
+
+			d.applyLevelUps(w, nil, e)
+
+			if e.Level != c.toLevel {
+				t.Fatalf("level = %d, want %d (%d levels gained)", e.Level, c.toLevel, c.wantLevels)
+			}
+			if e.PKPoint != c.wantPoint {
+				t.Errorf("PKPoint = %d, want %d", e.PKPoint, c.wantPoint)
+			}
+		})
+	}
+}
+
+// TestLevelUpPKPointNoLevelNoGrant: applyLevelUps returning false (not enough Exp)
+// must not move the counter — the grant hangs off levels crossed, not off calls.
+func TestLevelUpPKPointNoLevelNoGrant(t *testing.T) {
+	d, w, e := mobKilledWorld(t)
+	e.PKPoint = 70
+	e.Exp = level.NextLevelExp(1) - 1
+
+	if d.applyLevelUps(w, nil, e) {
+		t.Fatal("applyLevelUps = true, want false (one Exp short of level 2)")
+	}
+	if e.PKPoint != 70 {
+		t.Errorf("PKPoint = %d, want 70 (unchanged without a level-up)", e.PKPoint)
+	}
+}
+
+// pkLevelUpDB seeds a moderator (for /gm setlevel) at level 10 sitting one point
+// below neutral, so a single level-up crosses to 75 = white nick.
+func pkLevelUpDB(pkPoint uint8) *fakeDB {
+	db := &fakeDB{accounts: map[string]*fakeAccount{
+		"mod": {id: 20, pass: "secret", role: "moderator", chars: []world.CharSummary{{Slot: 0, Name: "Mod"}}},
+	}}
+	db.loads = map[int64]world.CharacterState{
+		20: {Slot: 0, Name: "Mod", Class: 0, Level: 10, X: 5, Y: 5, HP: 1000, MaxHP: 1000, PKPoint: pkPoint},
+	}
+	return db
+}
+
+// TestLevelUpPKPointNotifiesAndRecolorsNick is the wire half of issue #279: the
+// level-up must tell the player ("Pontos Caos atual: 0 (+1)") and repaint the nick
+// via a fresh CreateMob carrying MobName[12] = 75, without waiting for a relog.
+// A multi-level jump reports the capped gain ONCE, not one line per level.
+func TestLevelUpPKPointNotifiesAndRecolorsNick(t *testing.T) {
+	addr, stop, _ := startServerClock(t, pkLevelUpDB(74))
+	defer stop()
+
+	c := enterWorldAs(t, addr, "mod") // conn 1
+	defer c.Close()
+	drainRaw(t, c)
+
+	gmFrame(t, c, "setlevel 15") // 5 levels, but only 1 point of room left
+
+	chatLines, sawWhiteNick := []string{}, false
+	for i := 0; i < 40; i++ {
+		ty, payload, ok := readMaybeRaw(t, c)
+		if !ok {
+			break
+		}
+		switch ty {
+		case protocol.MsgMessageChat:
+			chatLines = append(chatLines, cstr(payload))
+		case protocol.MsgCreateMob:
+			if _, _, id := createMobFields(t, payload); id == 1 {
+				if payload[6+12] != pkPointNeutral {
+					t.Errorf("self-CreateMob MobName[12] = %d, want %d (white nick)", payload[6+12], pkPointNeutral)
+				}
+				sawWhiteNick = true
+			}
+		}
+	}
+
+	if len(chatLines) != 1 {
+		t.Fatalf("chat lines = %q, want exactly one Chaos Point notice for a multi-level jump", chatLines)
+	}
+	// PKPoint 74 → 75 (capped): displayed Chaos Points 75-75 = 0, gained +1.
+	if want := "Pontos Caos atual: 0 (+1)"; !strings.HasPrefix(chatLines[0], want) {
+		t.Errorf("chat line = %q, want prefix %q", chatLines[0], want)
+	}
+	if !sawWhiteNick {
+		t.Error("nick was not recolored (no self-CreateMob after the level-up)")
+	}
+}
+
+// TestLevelUpPKPointSilentAtNeutral: a clean character gets no Chaos Point chat
+// spam on every level-up — the notice only fires when there is chaos to pay back.
+func TestLevelUpPKPointSilentAtNeutral(t *testing.T) {
+	addr, stop, _ := startServerClock(t, pkLevelUpDB(pkPointNeutral))
+	defer stop()
+
+	c := enterWorldAs(t, addr, "mod")
+	defer c.Close()
+	drainRaw(t, c)
+
+	gmFrame(t, c, "setlevel 15")
+
+	for i := 0; i < 40; i++ {
+		ty, payload, ok := readMaybeRaw(t, c)
+		if !ok {
+			break
+		}
+		if ty == protocol.MsgMessageChat {
+			t.Errorf("unexpected chat line %q on a level-up at neutral PKPoint", cstr(payload))
+		}
+	}
+}


### PR DESCRIPTION
## Contexto

A issue #279 é a **reabertura da #210** (mesmo autor, mesmo pedido). O trabalho relacionado já existia: o PR #218 portou o sistema de karma inteiro — `PKPoint`/`Guilty`/`CurKill`/`TotKill` persistidos, decaimento de `Guilty`, recuperação horária, gate `PKPoint<=10` no combate, `pvpKilled` e `/cp`.

O que o #218 **não** fez, de propósito: amarrar ganho de CP ao level-up. E ele estava certo quanto ao legado — a única recuperação natural do original é o gate horário do `RegenMob` (`Source/Code/TMSrv/Server.cpp:4872-4881`), não existe `SetPKPoint` em nenhum caminho de level-up. Como o autor reabriu, isto entra como **desvio consciente do legado / decisão de design do servidor**, e está documentado como tal no código para não ser "consertado" numa auditoria de paridade futura.

## Mudanças

**`tmserver/internal/handler/pkmode.go`**
- `pkPointPerLevel = 1` + `grantLevelUpPKPoint`: paga `levels × 1` até o teto neutro 75, nunca acima — a faixa 76..150 só vem de quest/item (`_MSG_Quest.cpp:2569`, `_MSG_UseItem.cpp:3867`) e leveling não pode inflá-la. Aritmética em `int` antes do `uint8`, então `/setlevel` saltando centenas de níveis não estoura o contador. Uma linha de chat por salto, não uma por nível, e re-broadcast do `MSG_CreateMob` para o nick recolorir sem relog.
- `sweepGuilty`: **bug adjacente corrigido** — a recuperação horária incrementava o `PKPoint` e avisava no chat, mas nunca reenviava `CreateMob`. O nick ficava com a cor velha até relogar (ou sair e voltar da view de alguém), o que sozinho já quebrava o critério "até o nome ficar branco" da issue.

**`tmserver/internal/handler/mobkilled.go`**
- `applyLevelUps` passa a contar os níveis cruzados (`leveled bool` → `gained int32`) e chama o helper por último, depois do `sendScore`/`sendEtc`/`MsgMotion`: o `CreateMob` do recolor precisa chegar depois do refresh de score, não no meio dele. Cobre de graça todos os caminhos de level-up (EXP de kill, EXP de cura, Poeira de Fada, GM `/setlevel`), já que esse é o único ponto de level-up do servidor.

**`docs/game.md`** — a entrada do `/cp` passa a explicar como os pontos recuperam e marca o ganho por nível como desvio do legado.

Nada de migration/proto/store: `PKPoint` já fazia round-trip save→load desde o #218.

## Decisões de escopo (confirmadas com o autor)

- **+1 por nível**, o mesmo passo do gate horário legado.
- **A recuperação horária continua** — o level-up é fonte adicional, não substituto.

Vale notar o alcance prático: com +1/nível, um char no fundo do poço (CP -74) precisa de 74 níveis para ficar branco. É lento em nível alto, mas soma com a recuperação horária. Se ficar lento demais na prática, o ajuste é uma constante só (`pkPointPerLevel`).

## Testes

`tmserver/internal/handler/pkpoint_levelup_test.go` (novo):
- Tabela de unidade: 1 nível → +1; 5 níveis → +5; teto em 75; no-op em 75 e em 150; acúmulo sob `Guilty` (o contador sobe mesmo com o valor exibido preso em 0); sem level-up = sem ganho.
- Wire: num salto de 5 níveis a partir de 74, sai **uma** linha `Pontos Caos atual: 0 (+1)` e um `CreateMob` com `MobName[12] = 75`; e nenhum spam de chat para quem já está neutro.

Verificação (via Docker `golang:1.25` — não há toolchain Go na máquina):
- [x] `go build ./...` e `go vet ./tmserver/...` limpos
- [x] `go test -race -p 2 ./...` — suíte inteira passa
- [x] `gofmt` limpo nos arquivos tocados (checado com CRLF normalizado)
- [x] `golangci-lint run ./tmserver/internal/handler/...` — os achados restantes são pré-existentes, em arquivos não tocados (ruído de CRLF no gofmt + `SA5011` em `npcconfig_test.go`)

**Não testado no cliente real.** Roteiro E2E: `make run-local`, forçar caos (nick vermelho piscando), subir de nível, conferir a linha no chat + `/cp`, ver o nick ficar branco ao chegar em 75 sem relogar, e relogar para confirmar a persistência.

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)
