### PR TITLE
feat(tmserver): implementar Soul mortal na Kibita

### DIFF
--- a/docs/game.md
+++ b/docs/game.md
@@ -59,6 +59,11 @@
 # Evoluções 
 NPC Evoluções vende poeira, upe o seu Mortal, Arch, Celestial e Sub Celestial com ela.
 
+Para liberar a Soul permanente do Mortal no nível técnico 369+, leve à Kibita a Pedra Secreta da
+classe: TransKnight usa Água (5334), Foema usa Sol (5336), Beastmaster usa Terra (5335) e Huntress
+usa Vento (5337). A pedra será consumida, a capa será substituída pela versão do reino e o
+personagem retornará à seleção para recarregar a progressão.
+
 Faça as quest dos quatros cristais no seu Arch para liberar mais pontos.
 - Dê /red ou /blue para ir direto para o rei desejado.
 • Não precisa transformar o Lac, somente separe 10 que já vai funcionar

--- a/docs/migration/game-rules.md
+++ b/docs/migration/game-rules.md
@@ -527,6 +527,30 @@ soma `Dex*kd + Str*ks` conforme a arma. Ex.: TK (`Class==0`) com skill "Confian�
   stack nova deve usar o mesmo delay efetivo (Delay/4) para não rejeitar ações legítimas do cliente.
 - Efeitos de affect persistidos: `STRUCT_AFFECT[MAX_AFFECT=32]` com `Time` (expiração).
 
+### 5.1. Soul permanente do Mortal — Kibita
+
+O terceiro ramo do `case KIBITA` (`_MSG_Quest.cpp:2518-2558`) é uma progressão permanente, não um
+cast nem o campo elemental `MobExtra.Soul`. O parâmetro `confirm` é ignorado.
+
+```text
+requer ClassMaster == MORTAL
+requer CurrentScore.Level >= 369
+requer LearnedSkill bit 30 ainda zerado
+pedra_por_classe = [5334 Água, 5336 Sol, 5335 Terra, 5337 Vento]
+
+limpa integralmente o primeiro slot com pedra_por_classe[MOB.Class]
+LearnedSkill |= 1 << 30
+Equip[15] = 3194 se Clan==7, 3195 se Clan==8, senão 3196
+CharLogOut(); SendArchEffect(slot do personagem)
+```
+
+O `memset` do legado substitui qualquer capa anterior e apaga todos os efeitos do item consumido;
+não é consumo de uma unidade de stack. O logout é parte da transição: salva antes de o cliente
+reler a skill e a capa na seleção.
+
+Esse bit 30 também não é o gate de `Limite_da_Alma` (skill 102 usa `102%24 == 6`). O affect 29 lê
+`MobExtra.Soul`, que permanece inalterado neste fluxo.
+
 ---
 
 ## 6. Eventos e timers

--- a/docs/migration/handlers/_MSG_Quest-npcs.md
+++ b/docs/migration/handlers/_MSG_Quest-npcs.md
@@ -49,7 +49,7 @@
 | 58 | — | `MOUNT_MASTER` | 170 | curar/ressuscitar montaria (`Equip[14]`) |
 | 62 | — | `ARZAN_DRAGON` | 1397 | dragão de Arzan |
 | 76 | — | `URNAMMU` | 1247 | NPC Urnammu |
-| 74 | — | `KIBITA` | 2430 | NPC Kibita |
+| 74 | — | `KIBITA` | 2430 | cidadania, buff condicional e Soul permanente |
 | 200 | — | `CURANDEIRO` | 2717 | curandeiro |
 
 > **Total:** 38 tipos de NPC → 36 blocos `case`/`#pragma region` (KING cobre Merchant 14 e 15).
@@ -91,6 +91,36 @@ Etapas sequenciais de progressão de nível (rumo ao cap 256/Arch). Cada NPC:
   (teleporte, item inicial, cura, troca). Passo-a-passo fino: abrir a linha do `case` indicada na
   tabela de despacho.
 
+## Detalhe — `KIBITA` (Merchant 74)
+
+O `case KIBITA` (`_MSG_Quest.cpp:2430-2562`) ignora `confirm` e avalia três serviços nesta ordem:
+
+1. **Cidadania:** se `Citizen==0` e há pelo menos 4.000.000 de gold, cobra o valor, define
+   `Citizen=ServerIndex+1`, atualiza a cidadania da guilda quando o jogador é líder e encerra o case.
+2. **Buff temporário:** existe somente sob `#ifdef KIBITA_SOUL` (não há definição desse macro na
+   árvore versionada). Em dias úteis, às 21h, Mortal abaixo do nível 369 entrega o item 420, recebe
+   affect 29 por `AFFECT_1H` e é teleportado para perto de `(2454,1843)`.
+3. **Soul permanente ✅:** Mortal com `CurrentScore.Level>=369` e sem o bit 30 de `LearnedSkill`
+   entrega a Pedra Secreta da classe. O slot é limpo integralmente, o bit 30 é ativado, `Equip[15]`
+   é substituído pela capa do reino e `CharLogOut` força o reload antes de `_MSG_SendArchEffect`.
+
+| Classe (`MOB.Class`) | Pedra Secreta | Item |
+|---------------------:|----------------|-----:|
+| 0 — TransKnight | Água | 5334 |
+| 1 — Foema | Sol | 5336 |
+| 2 — Beastmaster | Terra | 5335 |
+| 3 — Huntress | Vento | 5337 |
+
+| Reino (`MOB.Clan`) | Capa (`Equip[15]`) |
+|--------------------:|-------------------:|
+| 7 — Hekalotia | 3194 |
+| 8 — Akelonia | 3195 |
+| qualquer outro | 3196 |
+
+O bit 30 é uma flag permanente de progressão. Este ramo não escreve `STRUCT_MOBEXTRA.Soul`; esse
+campo elemental é outro conceito, consumido pelo affect 29. No servidor Go somente o terceiro ramo
+está implementado; cidadania e o bloco condicional continuam pendentes.
+
 ## Notas de migração
 - **Estado de quest** mora em `STRUCT_MOBEXTRA.QuestInfo` (Mortal/Arch/Celestial, Fase 2 §1.5) e em
   `pMob[conn].QuestFlag` (estado volátil da etapa atual) — mapear cada flag no schema novo.
@@ -107,7 +137,7 @@ Etapas sequenciais de progressão de nível (rumo ao cap 256/Arch). Cada NPC:
   propósito; desambiguar quebraria a paridade.
 - **UNVERIFIED (passo-a-passo fino):** recompensas/etapas internas exatas dos blocos longos
   (`JEFFI`, `SHAMA`, `KING`, `KINGDOM`, `URNAMMU`, `ARZAN_DRAGON`, `GOLD_DRAGON`, `EXPLOIT_LEADER`,
-  `MESTREHAB`, `KIBITA`, `GODGOVERNMENT`) — o **despacho e o propósito** estão mapeados; abrir a linha
+  `MESTREHAB`, `GODGOVERNMENT`) — o **despacho e o propósito** estão mapeados; abrir a linha
   do `case` ao implementar cada um.
 
 > **Status:** todos os **38 tipos de NPC / 36 `case`** mapeados (gatilho Merchant/grade → modo →

--- a/docs/migration/handlers/npc-map.md
+++ b/docs/migration/handlers/npc-map.md
@@ -46,7 +46,7 @@ O **`Merchant`** do NPC decide o que o clique manda:
 | 64 | 65 | Magician, Imp, Wizard | _MSG_Quest | ❌ |
 | 68 | 17 | Kemi, Aylin, Jasmine | _MSG_Quest (GODGOVERNMENT) | ❌ |
 | 72 | — | Uxmal (ver merchant 104) | _MSG_Quest (UXMAL) | ❌ |
-| 74 | 3 | Kibita, Lindy | CombineItem (Lindy) / _MSG_Quest | ⚠️ parcial (Lindy combine ✅) |
+| 74 | 3 | Kibita, Lindy | CombineItem (Lindy) / _MSG_Quest | ⚠️ Lindy e Soul permanente ✅; cidadania/buff pendentes |
 | 76 | 3 | Urnammu | _MSG_Quest (URNAMMU) | ❌ |
 | 78 | 3 | QuestOffice, Blue/RedOracle | _MSG_Quest (BLACKORACLE) | ❌ |
 | 80/84 | 1/1 | Aaryan, Oraculo_Negro | _MSG_Quest | ❌ |
@@ -88,6 +88,9 @@ quests grade 11–16/24–30) **não**.
 - **Coveiro** (Merchant 100 grade 0): etapa 1 da cadeia Quest 256 ("Defensor da Alma", issue #261) —
   `quest256NPC` em `handler/misc.go` consome a Vela do Coveiro (4038), seta `QuestFlag = 1` e
   teleporta para `(2398,2105)`. Grades 1–4 (Jardineiro/Kaizen/Hidra/Elfos) ainda pendentes.
+- **Kibita** (Merchant 74): o ramo permanente consome a Pedra Secreta da classe, ativa
+  `LearnedSkill` bit 30, troca `Equip[15]` pela capa 3194/3195/3196 e retorna à seleção. A compra de
+  cidadania e o buff compilado por `KIBITA_SOUL` ainda não foram portados.
 - **King Arch** (Merchant 111): cria personagem Arch a partir dos reis canônicos.
 - **Mestre Grifo** (`_MSG_MasterGriff` 0x0AD9): teleporta, após a animação de viagem do cliente, para
   Defensor de Almas `(2372,2099)`, Jardim dos Deuses `(2220,1714)`, Calabouco `(2365,2279)` ou

--- a/docs/migration/npc-generator-inventory.md
+++ b/docs/migration/npc-generator-inventory.md
@@ -18,7 +18,7 @@ Principais grupos que estavam integral ou parcialmente ausentes:
 | 23/24 | 2 | Mestre_Grifo, Alquimista_Odin | quest/combine |
 | 32 | 65 | guardas e cavaleiros | evento/combate |
 | 64 | 178 | Zakum, arqueiros, lanceiros | evento/combate |
-| 74 | 2 | Kibita, Lindy | quest/combine parcial |
+| 74 | 2 | Kibita, Lindy | Lindy + Soul permanente; cidadania/buff da Kibita pendentes |
 | 78 | 2 | BlueOracle, RedOracle | quest |
 | 96 | 43 | guardas, soldados e Lanceiro | evento/combate |
 | 100 | 26 | cadeia Quest 256 e tutoriais | quest parcial |
@@ -27,3 +27,8 @@ Principais grupos que estavam integral ou parcialmente ausentes:
 Casos não classificados com paridade comprovada permanecem `UNVERIFIED` e são
 acompanhados pela issue guarda-chuva. A presença no mundo não implica que a
 interação específica já esteja implementada.
+
+No grupo 74, o generator da Kibita já aciona o ramo permanente documentado em
+`handlers/_MSG_Quest-npcs.md`: Pedra Secreta por classe, bit 30 de `LearnedSkill`, capa por reino e
+retorno à seleção. O grupo continua parcial porque os outros dois serviços do mesmo `case KIBITA`
+(cidadania e o buff protegido por `#ifdef KIBITA_SOUL`) não fazem parte desse port.

--- a/docs/migration/skills/progress.md
+++ b/docs/migration/skills/progress.md
@@ -142,6 +142,9 @@ Itens fechados:
 - Livros Sephira `EF_VOLATILE 31..38` setam bits `24..31`, atualizam `UpdateEtc` e agora consomem apenas uma unidade quando o item esta stackado.
 - Validação de cast shared/extra-class usa a regra viva do legado: `LearnedSkill & (1 << (skillnum % 24))` para `0..247`; `SecLearnedSkill` nao participa.
 - `Poder Superior`/A39 aplica +100 `ExpBonus`; `Limite da Alma`/A29 aplica Soul no score quando `Entity.Soul` esta populado.
+- Kibita agora concede a progressao Soul permanente para Mortal no nivel legado 369+: consome a
+  Pedra Secreta da classe, ativa `LearnedSkill` bit 30, troca a capa e persiste antes do logout. Esse
+  bit nao e o gate da skill 102 e nao altera `Entity.Soul`.
 - `Canhão Guardião` exige item 746 no grid; `Muro de Espinhos` cria Vinha; `Ressureição` revive o personagem morto.
 - Buff Loop recebeu os types 5, 6 e 12 alem dos types 39/42 ja usados por Sephira.
 - `Invocação Final`/InstanceValue 9 foi triada para template de summon id 8 com `pSummonBonus` zero.

--- a/docs/migration/skills/sephira-shared.md
+++ b/docs/migration/skills/sephira-shared.md
@@ -14,6 +14,9 @@ Windows `WIN-SKILL-007/008` fecharam a regra viva deste build:
   isso ainda e preservado como dado de save, mas a promocao/troca de tier nao faz parte desta fase.
 - Affects/ticks `40/41/43/44/45/46/47/48` sao icon-only/no-op no servidor original: entram no slot,
   aparecem no cliente e decaem, mas nao alteram score, dano, resist, regen, target, on-hit ou cooldown.
+- A "Soul permanente" entregue pela Kibita e outra flag: ela ativa diretamente o bit 30 de
+  `LearnedSkill`. Nao ensina a skill 102 (cujo gate vivo e o bit `102%24 == 6`) e nao preenche
+  `MobExtra.Soul`, que continua sendo o atributo lido pelo affect 29 de `Limite_da_Alma`.
 
 Evidencia usa os codigos definidos em `README.md`.
 

--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -582,6 +582,14 @@ func (d *Dispatcher) characterLogout(w *world.World, s *world.Session, _ protoco
 	if s.Mode != world.UserPlay {
 		return
 	}
+	d.returnToCharacterSelection(w, s, nil)
+}
+
+// returnToCharacterSelection performs the world cleanup and durable save shared
+// by ordinary logout and legacy quest transitions that force a character reload.
+// after runs in the world loop after the client has received the logout
+// confirmation, so follow-up selection-screen effects cannot race the save.
+func (d *Dispatcher) returnToCharacterSelection(w *world.World, s *world.Session, after func(*world.World, *world.Session)) {
 	// Leave the party (and reap this character's summons) first, while the session
 	// is still UserPlay — sendRemoveParty/sendAddParty only reach UserPlay
 	// recipients (_MSG_CharacterLogout.cpp:23 calls RemoveParty for the same
@@ -616,6 +624,9 @@ func (d *Dispatcher) characterLogout(w *world.World, s *world.Session, _ protoco
 			s.TradeMode = 0
 			s.Mode = world.UserSelChar
 			w.Send(s, protocol.MsgCNFCharacterLogout, nil)
+			if after != nil {
+				after(w, s)
+			}
 		})
 	})
 }

--- a/tmserver/internal/handler/misc.go
+++ b/tmserver/internal/handler/misc.go
@@ -209,6 +209,12 @@ func (d *Dispatcher) quest(w *world.World, s *world.Session, _ protocol.Header, 
 		d.compSephi(w, s, e, npc, int(confirm))
 		return
 	}
+	// KIBITA (Merchant 74): permanently unlocks Mortal Soul with the
+	// class-specific Secreta stone (_MSG_Quest.cpp:2518-2558).
+	if npc.Merchant == 74 {
+		d.kibitaSoul(w, s, e)
+		return
+	}
 	if isKingQuestNPC(npc) {
 		d.kingArch(w, s, e, npc, int(confirm))
 		return
@@ -227,6 +233,65 @@ const (
 	capeEquipSlot        = 15
 	pedraIdealsCraftCoin = 30_000_000
 )
+
+const (
+	kibitaSoulMinLevel  = 369
+	kibitaSoulSkillBit  = int32(1 << 30)
+	kibitaCapeHekalotia = int16(3194)
+	kibitaCapeAkelonia  = int16(3195)
+	kibitaCapeNeutral   = int16(3196)
+)
+
+var kibitaSoulStones = [...]int16{5334, 5336, 5335, 5337}
+
+// kibitaSoul ports the permanent Soul branch of KIBITA. The citizenship branch
+// and the compile-time KIBITA_SOUL event buff are separate legacy services and
+// intentionally remain disabled until their own state and scheduling are ported.
+func (d *Dispatcher) kibitaSoul(w *world.World, s *world.Session, e *world.Entity) {
+	if e.ClassMaster != classMasterMortal || e.Level < kibitaSoulMinLevel || e.LearnedSkill&kibitaSoulSkillBit != 0 {
+		d.notify(w, s, NoticeReqNotMet)
+		return
+	}
+	if int(e.Class) >= len(kibitaSoulStones) {
+		d.notify(w, s, NoticeReqNotMet)
+		return
+	}
+
+	stone := kibitaSoulStones[e.Class]
+	slot := -1
+	for i := 0; i < activeCarryLimit(e); i++ {
+		if e.Carry[i].Index == stone {
+			slot = i
+			break
+		}
+	}
+	if slot < 0 {
+		d.notify(w, s, NoticeReqNotMet)
+		return
+	}
+
+	e.Carry[slot] = world.Item{}
+	e.LearnedSkill |= kibitaSoulSkillBit
+	cape := kibitaCapeNeutral
+	switch e.Clan {
+	case clanHekalotia:
+		cape = kibitaCapeHekalotia
+	case clanAkelonia:
+		cape = kibitaCapeAkelonia
+	}
+	e.Equip[capeEquipSlot] = world.Item{Index: cape}
+	d.sendSlot(w, s, world.ItemPlaceCarry, slot, e.Carry[slot])
+	d.sendSlot(w, s, world.ItemPlaceEquip, capeEquipSlot, e.Equip[capeEquipSlot])
+	d.refreshScore(e)
+	d.sendScore(w, s, e)
+	d.sendEtc(w, s, e)
+
+	d.log.Info("mortal soul learned", "conn", s.Conn, "name", e.Name, "class", e.Class, "stone", stone, "cape", cape)
+	d.returnToCharacterSelection(w, s, func(w *world.World, s *world.Session) {
+		w.SendTo(s, protocol.Header{Type: protocol.MsgSendArchEffect, ID: protocol.IDScene},
+			protocol.EncodeStandardParm(int32(s.Slot)))
+	})
+}
 
 func isKingQuestNPC(npc *world.Entity) bool {
 	if npc == nil {

--- a/tmserver/internal/handler/quest_test.go
+++ b/tmserver/internal/handler/quest_test.go
@@ -186,6 +186,136 @@ func baseMortalState(level int) world.CharacterState {
 	}
 }
 
+func TestKibitaSoulWithRealTemplate(t *testing.T) {
+	tmpl, err := os.ReadFile(filepath.Join("..", "..", "..", "Release", "TMsrv", "run", "npc", "Kibita"))
+	if err != nil {
+		t.Fatalf("read real Kibita template: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		class int
+		clan  uint8
+		stone int16
+		cape  int16
+	}{
+		{name: "TransKnight water Hekalotia", class: 0, clan: clanHekalotia, stone: 5334, cape: 3194},
+		{name: "Foema sun Akelonia", class: 1, clan: clanAkelonia, stone: 5336, cape: 3195},
+		{name: "Beastmaster earth neutral", class: 2, stone: 5335, cape: 3196},
+		{name: "Huntress wind other clan", class: 3, clan: 2, stone: 5337, cape: 3196},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := newDB()
+			st := baseMortalState(kibitaSoulMinLevel)
+			st.Class = tt.class
+			st.Clan = tt.clan
+			st.Carry[7] = world.Item{Index: tt.stone, Effects: [3]world.Effect{{Effect: 61, Value: 9}}}
+			st.Equip[capeEquipSlot] = world.Item{Index: 4006}
+			db.loadResult = st
+			addr, stop, npcID := startServerQuestNPC(t, db, tmpl)
+			defer stop()
+			c := enterWorld(t, addr)
+			defer c.Close()
+
+			questFrame(t, c, npcID)
+			carry := expect(t, c, protocol.MsgSendItem)
+			if place, slot, idx := le16(carry[0:2]), le16(carry[2:4]), le16(carry[4:6]); place != world.ItemPlaceCarry || slot != 7 || idx != 0 {
+				t.Fatalf("carry update place=%d slot=%d idx=%d, want carry slot 7 cleared", place, slot, idx)
+			}
+			equip := expect(t, c, protocol.MsgSendItem)
+			if place, slot, idx := le16(equip[0:2]), le16(equip[2:4]), le16(equip[4:6]); place != world.ItemPlaceEquip || slot != capeEquipSlot || int16(idx) != tt.cape {
+				t.Fatalf("cape update place=%d slot=%d idx=%d, want equip slot %d item %d", place, slot, idx, capeEquipSlot, tt.cape)
+			}
+			expect(t, c, protocol.MsgUpdateScore)
+			expect(t, c, protocol.MsgUpdateEtc)
+			expect(t, c, protocol.MsgCNFCharacterLogout)
+			effect := expect(t, c, protocol.MsgSendArchEffect)
+			if parm, ok := protocol.StandardParm(effect); !ok || parm != int32(st.Slot) {
+				t.Fatalf("SendArchEffect parm=%d ok=%v, want slot %d", parm, ok, st.Slot)
+			}
+
+			save, n := db.lastSavedChar()
+			if n == 0 {
+				t.Fatal("Kibita Soul character was not saved before logout")
+			}
+			if save.LearnedSkill&kibitaSoulSkillBit == 0 {
+				t.Fatalf("saved LearnedSkill=%#x, want Soul bit %#x", save.LearnedSkill, kibitaSoulSkillBit)
+			}
+			if _, ok := savedItemAt(save.Carry, 7); ok {
+				t.Fatal("saved carry still contains the consumed Secreta stone")
+			}
+			cape, ok := savedItemAt(save.Equip, capeEquipSlot)
+			if !ok || cape.Index != tt.cape {
+				t.Fatalf("saved cape=%+v ok=%v, want item %d", cape, ok, tt.cape)
+			}
+		})
+	}
+}
+
+func TestKibitaSoulRejectsInvalidRequirementsWithoutMutation(t *testing.T) {
+	tests := []struct {
+		name         string
+		level        int
+		class        int
+		classMaster  uint8
+		learnedSkill int32
+		stone        int16
+	}{
+		{name: "below legacy level", level: 368, classMaster: classMasterMortal, stone: 5334},
+		{name: "not Mortal", level: 369, classMaster: classMasterArch, stone: 5334},
+		{name: "invalid class", level: 369, class: 4, classMaster: classMasterMortal, stone: 5334},
+		{name: "already learned", level: 369, classMaster: classMasterMortal, learnedSkill: kibitaSoulSkillBit, stone: 5334},
+		{name: "missing stone", level: 369, classMaster: classMasterMortal},
+		{name: "wrong class stone", level: 369, classMaster: classMasterMortal, stone: 5337},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl := questNPCTemplate("Kibita", 74, 0, 0)
+			db := newDB()
+			st := baseMortalState(tt.level)
+			st.Class = tt.class
+			st.ClassMaster = tt.classMaster
+			st.LearnedSkill = tt.learnedSkill
+			st.Carry[0] = world.Item{Index: tt.stone}
+			st.Equip[capeEquipSlot] = world.Item{Index: 4006}
+			db.loadResult = st
+			addr, stop, npcID := startServerQuestNPC(t, db, tmpl)
+			defer stop()
+			c := enterWorld(t, addr)
+			defer c.Close()
+
+			questFrame(t, c, npcID)
+			if code := noticeCode(t, expect(t, c, protocol.MsgMessageBoxOk)); code != NoticeReqNotMet {
+				t.Fatalf("notice=%d, want NoticeReqNotMet", code)
+			}
+			if ty, _, ok := readMaybe(t, c); ok {
+				t.Fatalf("rejected Kibita interaction produced %#x after notice", ty)
+			}
+
+			send(t, c, protocol.MsgCharacterLogout, nil)
+			expect(t, c, protocol.MsgCNFCharacterLogout)
+			save, n := db.lastSavedChar()
+			if n == 0 {
+				t.Fatal("character was not saved on explicit logout")
+			}
+			if save.LearnedSkill != tt.learnedSkill {
+				t.Fatalf("saved LearnedSkill=%#x, want unchanged %#x", save.LearnedSkill, tt.learnedSkill)
+			}
+			cape, ok := savedItemAt(save.Equip, capeEquipSlot)
+			if !ok || cape.Index != 4006 {
+				t.Fatalf("saved cape=%+v ok=%v, want original item 4006", cape, ok)
+			}
+			if tt.stone != 0 {
+				item, ok := savedItemAt(save.Carry, 0)
+				if !ok || item.Index != tt.stone {
+					t.Fatalf("saved stone=%+v ok=%v, want unchanged item %d", item, ok, tt.stone)
+				}
+			}
+		})
+	}
+}
+
 func TestJardineiroStartsQuest256WithRealTemplate(t *testing.T) {
 	tmpl, err := os.ReadFile(filepath.Join("..", "..", "..", "Release", "TMsrv", "run", "npc", "Jardineiro"))
 	if err != nil {


### PR DESCRIPTION
## Resumo

- implementa o ramo permanente de Soul da Kibita (`Merchant=74`)
- consome a Pedra Secreta correspondente à classe e ativa o bit 30 de `LearnedSkill`
- troca a capa conforme Hekalotia, Akelonia ou reino neutro
- persiste o personagem antes do retorno à seleção e envia o efeito legado
- documenta o `case KIBITA` completo, incluindo os ramos ainda pendentes

## Paridade

- requisito literal do legado: `CurrentScore.Level >= 369`
- TransKnight/Água `5334`, Foema/Sol `5336`, Beastmaster/Terra `5335`, Huntress/Vento `5337`
- capas `3194`, `3195` e `3196` conforme o clã
- `MobExtra.Soul` permanece inalterado; a progressão usa somente `LearnedSkill` bit 30

## Testes

- `go test ./tmserver/internal/handler -count=1`
- `go vet ./tmserver/internal/handler`
- `git diff --check`

Closes #283