### PR TITLE
Complete Quest 256 NPC chain routing

### DIFF
--- a/docs/migration/handlers/_MSG_Quest-npcs.md
+++ b/docs/migration/handlers/_MSG_Quest-npcs.md
@@ -72,10 +72,20 @@ Etapas sequenciais de progressão de nível (rumo ao cap 256/Arch). Cada NPC:
 | Etapa | NPC (grade) | Faixa de nível | Ticket (`sIndex`) | `QuestFlag` | Teleporte (aprox.) |
 |------:|-------------|----------------|------------------:|------------:|--------------------|
 | 1 | COVEIRO (0) ✅ | 39 – 115 | 4038 | 1 | (2398, 2105) |
-| 2 | JARDINEIRO (1) | 115 – 190 | 4039 | 2 | (2234, 1714) |
-| 3 | KAIZEN (2) | 190 – 265 | 4040 | 3 | (464, 3902) |
-| 4 | HIDRA (3) | 265 – 320 | 4041 | 4 | (668, 3756) |
-| 5 | ELFOS (4) | (ver `:470`) | (ver fonte) | 5 | (ver fonte) |
+| 2 | JARDINEIRO (1) ✅ | 115 – 190 | 4039 | 2 | (2234, 1714) |
+| 3 | KAIZEN (2) ✅ | 190 – 265 | 4040 | 3 | (464, 3902) |
+| 4 | HIDRA (3) ✅ | 265 – 320 | 4041 | 4 | (668, 3756) |
+| 5 | ELFOS (4) ✅ | 320 – 350 | 4042 | 5 | (1322, 4041) |
+
+> **Nomes in-game** (a fonte legada só usa os apelidos internos acima; estes são os nomes que o
+> cliente mostra na tooltip do ticket, levantados nas issues #261/#263/#264/#265):
+> 1 Coveiro = *Defensor da Alma* · 3 Kaizen = *Ressureição do Cavaleiro Negro* (NPC "Patrulha", na
+> Dungeon Negro) · 4 Hidra = *Hidra Imortal* (mesmo NPC "Patrulha") · 5 Elfos =
+> *Início da Infelicidade* (NPC "Guarda", no Submundo).
+>
+> A tooltip mostra a faixa **1-based** (ex.: "Mortal 321~350" para o passo 5), enquanto a checagem
+> legada usa o nível armazenado 0-based `[min, max)` — por isso os títulos das issues citam o limite
+> superior +1. Os valores da tabela são os do `_MSG_Quest.cpp`, e batem com a tooltip.
 
 ## Exemplos de NPCs não-cadeia (amostra detalhada)
 - **`MOUNT_MASTER` (Merchant 58, `:170`):** cura/ressuscita a montaria (`Equip[14]`, `sIndex`

--- a/docs/migration/handlers/npc-map.md
+++ b/docs/migration/handlers/npc-map.md
@@ -53,7 +53,7 @@ O **`Merchant`** do NPC decide o que o clique manda:
 | 96 | 23 | King_Harabard, Lanceiro | _MSG_Quest | ❌ |
 | 97 | 2 | Armeiro_Odalac | _MSG_Quest | ❌ |
 | 99/116 | 2/2 | God_Government | _MSG_Quest (GODGOVERNMENT) | ❌ |
-| 100 | 34 | **Perzen**, Treinador1, Guarda_da_Sorte | _MSG_Quest (por grade) | ⚠️ **Perzen (grade 7/8/9) ✅**; resto ❌ |
+| 100 | 34 | **Perzen**, Coveiro, Jardineiro, Patrulha, Guarda | _MSG_Quest (por grade) | ⚠️ **cadeia Quest 256 (grades 0–4) e Perzen (7/8/9) ✅**; resto ❌ |
 | 101 | 8 | Cecilia, U_Ni_Corn | _MSG_Quest | ❌ montaria unicórnio? |
 | 104/105/107 | 4/2/1 | Uxmal, Treinador2/3, TrainerChief | _MSG_Quest (tutoriais) | ❌ |
 | 110 | 1 | Unicornio_Puro | _MSG_Quest | ❌ |
@@ -71,7 +71,8 @@ O **`Merchant`** do NPC decide o que o clique manda:
 ## Merchant==100 — sub-tipos por `EF_GRADE0`
 Ver a tabela completa em [_MSG_Quest-npcs.md](./_MSG_Quest-npcs.md). Resumo dos grades presentes
 no conteúdo: 0–16, 24, 26–30. **Implementado:** grade **7/8/9 = PERZEN** (troca esfera→montaria,
-data-driven por `npc.Carry[0]→[1]`). Os demais (cadeia Quest 256 grades 0–4, líder grade 5,
+data-driven por `npc.Carry[0]→[1]`) e a **cadeia Quest 256 inteira, grades 0–4**
+(Coveiro/Jardineiro/Patrulha_/Patrulha/Guarda). Os demais (líder grade 5,
 quests grade 11–16/24–30) **não**.
 
 ### Perzen — pares item→recompensa (data-driven, do template do NPC)
@@ -91,9 +92,19 @@ quests grade 11–16/24–30) **não**.
 - **Combine/refino**: `combineItem` (Anct), `combineItemOdin` e os handlers dedicados
   `combineItemAilyn/Ehre/Tiny/Shany/Agatha/Lindy/Alquimia`.
 - **Perzen** (Merchant 100 grade 7/8/9): troca esfera→montaria.
-- **Coveiro** (Merchant 100 grade 0): etapa 1 da cadeia Quest 256 ("Defensor da Alma", issue #261) —
-  `quest256NPC` em `handler/misc.go` consome a Vela do Coveiro (4038), seta `QuestFlag = 1` e
-  teleporta para `(2398,2105)`. Grades 1–4 (Jardineiro/Kaizen/Hidra/Elfos) ainda pendentes.
+- **Cadeia Quest 256 (completa)** — o helper `quest256NPC` em `handler/misc.go` cobre os cinco
+  grades; cada um consome o ticket da etapa, seta o `QuestFlag` e teleporta para a arena:
+
+  | grade | NPC | quest in-game | ticket | `QuestFlag` | arena | issue |
+  |------:|-----|---------------|-------:|------------:|-------|-------|
+  | 0 | Coveiro | Defensor da Alma | 4038 | 1 | (2398,2105) | #261 |
+  | 1 | Jardineiro | — | 4039 | 2 | (2234,1714) | — |
+  | 2 | Patrulha_ | Ressureição do Cavaleiro Negro | 4040 | 3 | (464,3902) | #263 |
+  | 3 | Patrulha | Hidra Imortal | 4041 | 4 | (668,3756) | #264 |
+  | 4 | Guarda | Início da Infelicidade | 4042 | 5 | (1322,4041) | #265 |
+
+  O mesmo ticket também funciona por clique-direito (`useQuest256Ticket`, `handler/item.go`), e
+  `guardQuest256Areas` (`handler/mobai.go`) expulsa quem entra na arena sem o `QuestFlag` da etapa.
 - **Kibita** (Merchant 74): o ramo permanente consome a Pedra Secreta da classe, ativa
   `LearnedSkill` bit 30, troca `Equip[15]` pela capa 3194/3195/3196 e retorna à seleção. A compra de
   cidadania e o buff compilado por `KIBITA_SOUL` ainda não foram portados.
@@ -107,9 +118,7 @@ quests grade 11–16/24–30) **não**.
    — alinha com o sistema de montaria (Shire/esfera) que estamos implementando.
 2. **Mestres de skill/classe** (Merchant 3, 31) — progressão.
 3. **Teleportes/guardas** (Merchant 36, 128) — locomoção.
-4. **Cadeia Quest 256** (Merchant 100 grades 1–4; o grade 0 / Coveiro já está feito) — progressão de
-   level (hardcoded; candidato a tabela data-driven `quest`/`quest_step`).
-5. Restante (reis, oráculos, governo, etc.) — quests pontuais.
+4. Restante (reis, oráculos, governo, etc.) — quests pontuais.
 
 > **Nota:** o engine de quest completo é hardcoded (level, tickets, coords) — forte candidato a
 > **conteúdo data-driven** (ver game-rules.md Fase 4). A troca Perzen já é data-driven (pelo Carry

--- a/tmserver/internal/handler/misc.go
+++ b/tmserver/internal/handler/misc.go
@@ -133,10 +133,11 @@ func (d *Dispatcher) completeAccountSecure(w *world.World, s *world.Session, ok 
 // MSG_STANDARDPARM2 (Parm1 = npcIndex, Parm2 = confirm). The NPC sub-type comes
 // from MOB.Merchant (+ EF_GRADE0 for Merchant==100), see _MSG_Quest-npcs.md.
 //
-// This batch implements the PERZEN item-exchange NPCs (Merchant 100, grade 7/8/9)
-// and Mestre Grifo (Merchant 23), a server-content shortcut into the Quest 256
-// arenas, plus the King Arch creation path. The remaining quest NPC types (level
-// chains, tutorials, teleports) are UNVERIFIED and not yet routed.
+// Routed so far: the whole Quest 256 chain (grade 0-4), the PERZEN item-exchange
+// NPCs (grade 7/8/9), Mestre Grifo (Merchant 23) — a server-content shortcut into
+// the Quest 256 arenas — and the King Arch creation path, plus the standalone
+// service NPCs below. The remaining quest NPC types (tutorials, teleports) are
+// not routed yet.
 func (d *Dispatcher) quest(w *world.World, s *world.Session, _ protocol.Header, payload []byte) {
 	e := w.Entity(s.Conn)
 	if e == nil || e.HP <= 0 || s.Mode != world.UserPlay {
@@ -162,7 +163,28 @@ func (d *Dispatcher) quest(w *world.World, s *world.Session, _ protocol.Header, 
 	}
 	// QUEST_JARDINEIRO (Merchant 100, EF_GRADE0 1): second Quest 256 arena.
 	if npc.Merchant == 100 && npc.Grade == 1 {
-		d.quest256NPC(w, s, e, quest256Steps[1], 4039)
+		d.quest256NPC(w, s, e, quest256Steps[1], itemColheitaDoJardineiro)
+		return
+	}
+	// QUEST_KAIZEN (Merchant 100, EF_GRADE0 2): third Quest 256 arena, the
+	// "Ressureicao do Cavaleiro Negro" quest (_MSG_Quest.cpp:382). The Patrulha of
+	// the Dungeon Negro asks for the Cura do Batedor.
+	if npc.Merchant == 100 && npc.Grade == 2 {
+		d.quest256NPC(w, s, e, quest256Steps[2], itemCuraDoBatedor)
+		return
+	}
+	// QUEST_HIDRA (Merchant 100, EF_GRADE0 3): fourth Quest 256 arena, the
+	// "Hidra Imortal" quest (_MSG_Quest.cpp:426). Same Patrulha NPC name as the
+	// Kaizen step, one tier up: it asks for the Mana do Batedor.
+	if npc.Merchant == 100 && npc.Grade == 3 {
+		d.quest256NPC(w, s, e, quest256Steps[3], itemManaDoBatedor)
+		return
+	}
+	// QUEST_ELFOS (Merchant 100, EF_GRADE0 4): fifth and last Quest 256 arena, the
+	// "Inicio da Infelicidade" quest (_MSG_Quest.cpp:470). The Guarda of the
+	// Submundo asks for the Emblema do Guarda.
+	if npc.Merchant == 100 && npc.Grade == 4 {
+		d.quest256NPC(w, s, e, quest256Steps[4], itemEmblemaDoGuarda)
 		return
 	}
 	// PERZEN (Merchant 100, EF_GRADE0 ∈ {7,8,9}): the item exchange.
@@ -657,9 +679,17 @@ var quest256Steps = []quest256Step{
 	{flag: 5, minLevel: 320, maxLevel: 350, x: 1322, y: 4041, area: questArea{x1: 1312, y1: 4027, x2: 1348, y2: 4055}},
 }
 
-// itemVelaDoCoveiro is the Quest 256 step-1 ticket handed to the Coveiro
-// (ItemList.csv:5703, "Vela_do_Coveiro"; _MSG_Quest.cpp:315).
-const itemVelaDoCoveiro int16 = 4038
+// The Quest 256 tickets, one per chain step: the NPC of that step only opens its
+// arena for the player carrying the matching item (_MSG_Quest.cpp:315/360/404/448/492).
+// They are consecutive in ItemList.csv (:5703-5711), which is what lets
+// quest256StepForTicket map a right-clicked ticket back to its step.
+const (
+	itemVelaDoCoveiro        int16 = 4038 // "Vela_do_Coveiro"
+	itemColheitaDoJardineiro int16 = 4039 // "Colheita_do_Jardineiro"
+	itemCuraDoBatedor        int16 = 4040 // "Cura_do_Batedor"
+	itemManaDoBatedor        int16 = 4041 // "Mana_do_Batedor"
+	itemEmblemaDoGuarda      int16 = 4042 // "Emblema_do_Guarda"
+)
 
 // quest256NPC handles the item hand-in performed by the five legacy Quest 256
 // NPC cases (_MSG_Quest.cpp:293/338/382/426/470). Keeping the step and ticket

--- a/tmserver/internal/handler/quest_test.go
+++ b/tmserver/internal/handler/quest_test.go
@@ -1273,3 +1273,242 @@ func TestQuest256TicketSecondUseOnEmptySlotIsNoop(t *testing.T) {
 		t.Fatalf("second use on empty slot produced %#x; want no-op", ty)
 	}
 }
+
+func TestGuardaStartsQuest256WithRealTemplate(t *testing.T) {
+	tmpl, err := os.ReadFile(filepath.Join("..", "..", "..", "Release", "TMsrv", "run", "npc", "Guarda"))
+	if err != nil {
+		t.Fatalf("read real Guarda template: %v", err)
+	}
+	db := newDB()
+	st := baseMortalState(320)
+	st.Carry[7] = world.Item{Index: itemEmblemaDoGuarda}
+	db.loadResult = st
+	addr, stop, npcID := startServerQuestNPC(t, db, tmpl)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	questFrame(t, c, npcID)
+	item := expect(t, c, protocol.MsgSendItem)
+	if slot, idx := le16(item[2:4]), le16(item[4:6]); slot != 7 || idx != 0 {
+		t.Fatalf("Guarda consume slot=%d idx=%d, want slot 7 cleared", slot, idx)
+	}
+	action := expectAction(t, c)
+	if action.Effect != 1 || !inRange(action.TargetX, 1322) || !inRange(action.TargetY, 4041) {
+		t.Fatalf("Guarda teleport effect=%d target=%d,%d, want effect 1 around 1322,4041", action.Effect, action.TargetX, action.TargetY)
+	}
+}
+
+func TestGuardaAcceptsArch(t *testing.T) {
+	tmpl := questNPCTemplate("Guarda", 100, 4, 0)
+	db := newDB()
+	st := baseMortalState(349)
+	st.ClassMaster = classMasterArch
+	st.Carry[0] = world.Item{Index: itemEmblemaDoGuarda}
+	db.loadResult = st
+	addr, stop, npcID := startServerQuestNPC(t, db, tmpl)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	questFrame(t, c, npcID)
+	expect(t, c, protocol.MsgSendItem)
+	expectAction(t, c)
+}
+
+func TestGuardaRejectsInvalidRequirements(t *testing.T) {
+	tests := []struct {
+		name        string
+		level       int
+		classMaster uint8
+		item        int16
+	}{
+		{name: "below level", level: 319, classMaster: classMasterMortal, item: itemEmblemaDoGuarda},
+		{name: "at upper bound", level: 350, classMaster: classMasterMortal, item: itemEmblemaDoGuarda},
+		{name: "wrong class", level: 330, classMaster: classMasterCelestial, item: itemEmblemaDoGuarda},
+		{name: "missing ticket", level: 330, classMaster: classMasterMortal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl := questNPCTemplate("Guarda", 100, 4, 0)
+			db := newDB()
+			st := baseMortalState(tt.level)
+			st.ClassMaster = tt.classMaster
+			st.Carry[0] = world.Item{Index: tt.item}
+			db.loadResult = st
+			addr, stop, npcID := startServerQuestNPC(t, db, tmpl)
+			defer stop()
+			c := enterWorld(t, addr)
+			defer c.Close()
+
+			questFrame(t, c, npcID)
+			if code := noticeCode(t, expect(t, c, protocol.MsgMessageBoxOk)); code != NoticeReqNotMet {
+				t.Fatalf("notice = %d, want NoticeReqNotMet", code)
+			}
+			if ty, _, ok := readMaybe(t, c); ok {
+				t.Fatalf("rejected Guarda interaction produced %#x after notice", ty)
+			}
+		})
+	}
+}
+
+// The Kaizen and Hidra steps share the "Patrulha" NPC name in the content tree;
+// only EF_GRADE0 (2 vs 3) and the ticket tell them apart, so both load the real
+// template to prove the pair resolves to different steps.
+func TestPatrulhaKaizenStartsQuest256WithRealTemplate(t *testing.T) {
+	tmpl, err := os.ReadFile(filepath.Join("..", "..", "..", "Release", "TMsrv", "run", "npc", "Patrulha_"))
+	if err != nil {
+		t.Fatalf("read real Patrulha_ template: %v", err)
+	}
+	db := newDB()
+	st := baseMortalState(190)
+	st.Carry[7] = world.Item{Index: itemCuraDoBatedor}
+	db.loadResult = st
+	addr, stop, npcID := startServerQuestNPC(t, db, tmpl)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	questFrame(t, c, npcID)
+	item := expect(t, c, protocol.MsgSendItem)
+	if slot, idx := le16(item[2:4]), le16(item[4:6]); slot != 7 || idx != 0 {
+		t.Fatalf("Kaizen consume slot=%d idx=%d, want slot 7 cleared", slot, idx)
+	}
+	action := expectAction(t, c)
+	if action.Effect != 1 || !inRange(action.TargetX, 464) || !inRange(action.TargetY, 3902) {
+		t.Fatalf("Kaizen teleport effect=%d target=%d,%d, want effect 1 around 464,3902", action.Effect, action.TargetX, action.TargetY)
+	}
+}
+
+func TestPatrulhaKaizenAcceptsArch(t *testing.T) {
+	tmpl := questNPCTemplate("Patrulha_", 100, 2, 0)
+	db := newDB()
+	st := baseMortalState(264)
+	st.ClassMaster = classMasterArch
+	st.Carry[0] = world.Item{Index: itemCuraDoBatedor}
+	db.loadResult = st
+	addr, stop, npcID := startServerQuestNPC(t, db, tmpl)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	questFrame(t, c, npcID)
+	expect(t, c, protocol.MsgSendItem)
+	expectAction(t, c)
+}
+
+func TestPatrulhaKaizenRejectsInvalidRequirements(t *testing.T) {
+	tests := []struct {
+		name        string
+		level       int
+		classMaster uint8
+		item        int16
+	}{
+		{name: "below level", level: 189, classMaster: classMasterMortal, item: itemCuraDoBatedor},
+		{name: "at upper bound", level: 265, classMaster: classMasterMortal, item: itemCuraDoBatedor},
+		{name: "wrong class", level: 200, classMaster: classMasterCelestial, item: itemCuraDoBatedor},
+		{name: "missing ticket", level: 200, classMaster: classMasterMortal},
+		{name: "next step ticket", level: 200, classMaster: classMasterMortal, item: itemManaDoBatedor},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl := questNPCTemplate("Patrulha_", 100, 2, 0)
+			db := newDB()
+			st := baseMortalState(tt.level)
+			st.ClassMaster = tt.classMaster
+			st.Carry[0] = world.Item{Index: tt.item}
+			db.loadResult = st
+			addr, stop, npcID := startServerQuestNPC(t, db, tmpl)
+			defer stop()
+			c := enterWorld(t, addr)
+			defer c.Close()
+
+			questFrame(t, c, npcID)
+			if code := noticeCode(t, expect(t, c, protocol.MsgMessageBoxOk)); code != NoticeReqNotMet {
+				t.Fatalf("notice = %d, want NoticeReqNotMet", code)
+			}
+			if ty, _, ok := readMaybe(t, c); ok {
+				t.Fatalf("rejected Kaizen interaction produced %#x after notice", ty)
+			}
+		})
+	}
+}
+
+func TestPatrulhaHidraStartsQuest256WithRealTemplate(t *testing.T) {
+	tmpl, err := os.ReadFile(filepath.Join("..", "..", "..", "Release", "TMsrv", "run", "npc", "Patrulha"))
+	if err != nil {
+		t.Fatalf("read real Patrulha template: %v", err)
+	}
+	db := newDB()
+	st := baseMortalState(265)
+	st.Carry[7] = world.Item{Index: itemManaDoBatedor}
+	db.loadResult = st
+	addr, stop, npcID := startServerQuestNPC(t, db, tmpl)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	questFrame(t, c, npcID)
+	item := expect(t, c, protocol.MsgSendItem)
+	if slot, idx := le16(item[2:4]), le16(item[4:6]); slot != 7 || idx != 0 {
+		t.Fatalf("Hidra consume slot=%d idx=%d, want slot 7 cleared", slot, idx)
+	}
+	action := expectAction(t, c)
+	if action.Effect != 1 || !inRange(action.TargetX, 668) || !inRange(action.TargetY, 3756) {
+		t.Fatalf("Hidra teleport effect=%d target=%d,%d, want effect 1 around 668,3756", action.Effect, action.TargetX, action.TargetY)
+	}
+}
+
+func TestPatrulhaHidraAcceptsArch(t *testing.T) {
+	tmpl := questNPCTemplate("Patrulha", 100, 3, 0)
+	db := newDB()
+	st := baseMortalState(319)
+	st.ClassMaster = classMasterArch
+	st.Carry[0] = world.Item{Index: itemManaDoBatedor}
+	db.loadResult = st
+	addr, stop, npcID := startServerQuestNPC(t, db, tmpl)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	questFrame(t, c, npcID)
+	expect(t, c, protocol.MsgSendItem)
+	expectAction(t, c)
+}
+
+func TestPatrulhaHidraRejectsInvalidRequirements(t *testing.T) {
+	tests := []struct {
+		name        string
+		level       int
+		classMaster uint8
+		item        int16
+	}{
+		{name: "below level", level: 264, classMaster: classMasterMortal, item: itemManaDoBatedor},
+		{name: "at upper bound", level: 320, classMaster: classMasterMortal, item: itemManaDoBatedor},
+		{name: "wrong class", level: 300, classMaster: classMasterCelestial, item: itemManaDoBatedor},
+		{name: "missing ticket", level: 300, classMaster: classMasterMortal},
+		{name: "previous step ticket", level: 300, classMaster: classMasterMortal, item: itemCuraDoBatedor},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl := questNPCTemplate("Patrulha", 100, 3, 0)
+			db := newDB()
+			st := baseMortalState(tt.level)
+			st.ClassMaster = tt.classMaster
+			st.Carry[0] = world.Item{Index: tt.item}
+			db.loadResult = st
+			addr, stop, npcID := startServerQuestNPC(t, db, tmpl)
+			defer stop()
+			c := enterWorld(t, addr)
+			defer c.Close()
+
+			questFrame(t, c, npcID)
+			if code := noticeCode(t, expect(t, c, protocol.MsgMessageBoxOk)); code != NoticeReqNotMet {
+				t.Fatalf("notice = %d, want NoticeReqNotMet", code)
+			}
+			if ty, _, ok := readMaybe(t, c); ok {
+				t.Fatalf("rejected Hidra interaction produced %#x after notice", ty)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem
Players with the Guarda emblem could click the Guarda NPC, but the server did not route that NPC to the Início da Infelicidade quest. That meant the quest could not start from the normal NPC path.

## Solution
Route all remaining Quest 256 NPC grades, including Guarda for Início da Infelicidade. The handler now checks the correct ticket for each step, consumes it, sets the quest flag, and teleports the player to the matching arena.

Details:
- Added Quest 256 ticket constants for Jardineiro, Kaizen, Hidra, and Guarda steps.
- Routed Merchant 100 grades 1-4 through `quest256NPC`.
- Added coverage for Guarda, Patrulha_/Kaizen, and Patrulha/Hidra success and rejection cases.
- Updated migration docs to mark the full Quest 256 chain as implemented.

Testing notes:
- Added quest handler tests for real NPC templates and invalid requirement cases.

Fixes #265