### PR TITLE
Fix production item icon manifest loading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,9 @@ COPY --from=build /out/app /app
 # rejects (crash on entering the world). dbserver/binserver ignore it.
 # The heavy legacy artifacts are stripped by .dockerignore.
 COPY --from=build /src/Release /Release
+# The storage-manager assigns opaque object names, so the validated published
+# manifest is the immutable URL map consumed by webserver. Pinning its digest
+# makes the production build fail instead of silently accepting changed data.
+ADD --checksum=sha256:e6e10d3bac61792d9bae048715ff9bf5f85168c1fe18ec43c5dc900e4d57a4da https://jeanluca-teste.s3.amazonaws.com/602dce1d-bdf1-4ce6-a329-7e1fa630bec6file /item-icons/published-manifest.json
+ENV W2PP_ITEM_ICONS_MANIFEST=/item-icons/published-manifest.json
 ENTRYPOINT ["/app"]

--- a/webserver/cmd/webserver/main.go
+++ b/webserver/cmd/webserver/main.go
@@ -108,6 +108,9 @@ func run(logger *slog.Logger) error {
 		}
 		logger.Info("loaded item icon manifest", "version", iconManifest.PackVersion,
 			"mapped", iconManifest.MappedItems, "icons", iconManifest.DistinctIcons)
+	} else {
+		logger.Warn("item icon manifest not configured; catalog is fallback-only",
+			"configuration", "W2PP_ITEM_ICONS_MANIFEST")
 	}
 	if *contentDir != "" {
 		templates, npcStats, err := npctemplates.Scan(*contentDir, logger)
@@ -125,7 +128,10 @@ func run(logger *slog.Logger) error {
 			if *iconManifestPath != "" {
 				itemcatalog.ApplyIcons(&catalog, iconManifest)
 			}
-			logger.Info("scanned item catalog", "count", len(catalog.Items), "version", catalog.Version)
+			withIconKey, withIconURL := catalog.IconCoverage()
+			logger.Info("scanned item catalog", "count", len(catalog.Items), "version", catalog.Version,
+				"icon_pack_version", catalog.IconPackVersion, "items_with_icon_key", withIconKey,
+				"items_with_icon_url", withIconURL)
 			npcAdmin.SetItemCatalog(catalog)
 			itemCatalog = catalog
 		}

--- a/webserver/internal/itemcatalog/itemcatalog.go
+++ b/webserver/internal/itemcatalog/itemcatalog.go
@@ -67,6 +67,22 @@ type Catalog struct {
 	IconPackVersion string
 }
 
+// IconCoverage reports how many catalog entries have a classic-client mapping
+// and how many of those mappings have a published URL. Keeping these counts on
+// the boot path makes a generated-only manifest distinguishable from a fully
+// published one without logging individual URLs.
+func (c Catalog) IconCoverage() (withKey, withURL int) {
+	for _, item := range c.Items {
+		if item.IconKey != "" {
+			withKey++
+		}
+		if item.IconURL != "" {
+			withURL++
+		}
+	}
+	return withKey, withURL
+}
+
 // ApplyIcons joins a validated classic-client icon manifest onto a catalog.
 // itemicon.bin is indexed directly by item index; mesh, texture and position
 // are fallback metadata and are not an icon lookup key.

--- a/webserver/internal/itemcatalog/itemcatalog_test.go
+++ b/webserver/internal/itemcatalog/itemcatalog_test.go
@@ -215,6 +215,19 @@ func TestApplyIconsUsesItemIndexTable(t *testing.T) {
 	}
 }
 
+func TestIconCoverageDistinguishesMappedAndPublished(t *testing.T) {
+	catalog := Catalog{Items: []Entry{
+		{Index: 1, IconKey: "i0001", IconURL: "https://storage.example/one"},
+		{Index: 2, IconKey: "i0002"},
+		{Index: 3},
+	}}
+
+	withKey, withURL := catalog.IconCoverage()
+	if withKey != 2 || withURL != 1 {
+		t.Fatalf("IconCoverage = %d/%d, want 2/1", withKey, withURL)
+	}
+}
+
 // TestScanVersionFingerprintsContent guards the cache contract the BFF relies
 // on: the same catalog must produce the same version, a changed one must not.
 func TestScanVersionFingerprintsContent(t *testing.T) {


### PR DESCRIPTION
## Causa raiz
O api-server de produção executava o código do PR 300, mas não tinha W2PP_ITEM_ICONS_MANIFEST nem volume/artefato do manifesto. O catálogo iniciava em fallback-only.

## Correção
- incorpora o published-manifest.json na imagem com SHA-256 fixado
- define o caminho do manifesto no runtime
- registra fallback-only explicitamente
- registra versão e cobertura de chaves/URLs no boot
- testa os contadores de cobertura

## Validação
- go test ./...
- go vet ./...
- go build ./...
- docker build --build-arg SVC=webserver

Pack: 3260f9a7065f88ef (2662 itens mapeados, 912 ícones distintos).