### PR TITLE
fix(tmserver): support hunting scroll teleports

### DIFF
--- a/openspec/changes/archive/2026-09-02-fix-hunting-scrolls/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-02-fix-hunting-scrolls/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-02

--- a/openspec/changes/archive/2026-09-02-fix-hunting-scrolls/design.md
+++ b/openspec/changes/archive/2026-09-02-fix-hunting-scrolls/design.md
@@ -1,0 +1,56 @@
+## Context
+
+See `proposal.md` for motivation and `specs/hunting-scrolls/spec.md` for observable behavior. The item-use packet already decodes the client's 16-bit `WarpID`, and the handler already owns reusable item-stack and teleport operations. The missing piece is dispatch and routing for `EF_VOLATILE` 195. The legacy server contains the authoritative six-by-ten coordinate table and validates item and destination ranges before mutating state.
+
+All item consumption and player movement must execute in the single-owner world goroutine. No persistence or blocking work is required by this behavior.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve the legacy mapping and its zero-based table calculations without changing the wire format.
+- Make validation precede both inventory mutation and teleportation.
+- Exercise all mapping rows and columns through table-driven tests.
+
+**Non-Goals:**
+
+- Changing scroll item definitions, prices, icons, or acquisition.
+- Introducing destination restrictions not present in the legacy handler.
+- Generalizing unrelated teleport items or replacing the shared teleport path.
+
+## Decisions
+
+### Use an immutable in-process destination table
+
+Port the legacy `HuntingScrolls[6][10][2]` data as a fixed Go table next to the item-use behavior. Select the row with `itemIndex - 3432` and the column with `WarpID - 1`, but only after explicit bounds checks.
+
+This keeps the gameplay data auditable against the legacy source and avoids a new configuration or database dependency for static compatibility data. Loading the coordinates from runtime configuration was rejected because it adds operational failure modes without a current content-management requirement.
+
+### Dispatch by consumable class and validate by item index
+
+Add consumable class 195 to the existing item-use dispatch, then require item indices 3432 through 3437 inside the dedicated behavior. Dispatching by item index alone was rejected because the current architecture and legacy handler classify this family by `EF_VOLATILE` before applying the narrower item-index guard.
+
+### Preserve invalid requests without side effects
+
+Invalid item indices and `WarpID` values perform no teleport and no consumption. The handler should synchronize the unchanged inventory slot to prevent optimistic client state from appearing consumed, while retaining the legacy gameplay result of no mutation.
+
+Silent return was considered for byte-for-byte control-flow parity, but slot synchronization is consistent with the Go server's established rejection behavior and prevents phantom inventory changes.
+
+### Reuse the shared authoritative teleport and stack primitives
+
+Successful use decrements exactly one unit with the existing stack helper, sends the updated slot, and invokes the existing teleport path. This preserves visibility reconciliation and avoids duplicating movement state changes. The sequence will validate first, consume and synchronize second, then teleport, matching other item-triggered teleports in the Go server.
+
+### Test the mapping exhaustively
+
+Use table-driven tests covering all 60 item/`WarpID` combinations, plus focused tests for single-item removal, stacked decrement, and invalid boundaries. Exhaustive data coverage is appropriate because transcription mistakes in a static coordinate table compile successfully but send players to the wrong location.
+
+## Risks / Trade-offs
+
+- [Coordinate transcription error] → Compare every test case against the six legacy table rows and assert both teleport coordinates.
+- [Client sends an unexpected `WarpID`] → Bounds-check before indexing or mutating inventory and re-synchronize the unchanged slot.
+- [Teleport succeeds but inventory appears stale] → Use the established stack mutation and slot synchronization helpers on every successful use.
+- [Minor divergence from legacy invalid-request response] → Limit the divergence to re-sending unchanged authoritative item state; gameplay state remains identical.
+
+## Migration Plan
+
+No data migration is required. Deploy the updated game server normally; existing scroll items immediately become usable because their catalog metadata and packet layout are already supported. Rollback consists of deploying the previous binary, with no persisted schema or data to reverse.

--- a/openspec/changes/archive/2026-09-02-fix-hunting-scrolls/proposal.md
+++ b/openspec/changes/archive/2026-09-02-fix-hunting-scrolls/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Pedidos de Caça (items 3432 through 3437) are rejected as unknown consumables by the Go game server, so the unmodified WYD 7662 client cannot use their destination-selection interface. The complete legacy routing table and handling rules are available in `Source/Code/TMSrv/_MSG_UseItem.cpp`, allowing the missing behavior to be restored with protocol parity.
+
+## What Changes
+
+- Recognize `EF_VOLATILE` 195 as the Pedido de Caça consumable class.
+- Support the six legacy scroll variants for Armia, Dungeon, Submundo, Kult, Kefra, and Nippleheim.
+- Resolve the client's `WarpID` selection to the corresponding legacy destination, teleport the player, and consume one scroll unit.
+- Preserve the item and player position when the item index or `WarpID` is outside the legacy ranges.
+- Add automated coverage for destination routing, stack consumption, and invalid selections.
+
+## Capabilities
+
+### New Capabilities
+
+- `hunting-scrolls`: Defines validation, destination selection, teleportation, and consumption behavior for Pedidos de Caça.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affects `_MSG_UseItem` handling in `tmserver/internal/handler` and its tests.
+- Reuses the existing `MSG_UseItem.WarpID` decoder, authoritative world teleport path, item-stack handling, and structured logging.
+- Introduces no protocol, persistence, database, client-data, or external dependency changes.
+- World-state mutations remain inside the single-owner game loop.

--- a/openspec/changes/archive/2026-09-02-fix-hunting-scrolls/specs/hunting-scrolls/spec.md
+++ b/openspec/changes/archive/2026-09-02-fix-hunting-scrolls/specs/hunting-scrolls/spec.md
@@ -1,0 +1,45 @@
+## Purpose
+
+Defines how the game server validates and executes Pedido de Caça destination selections sent by the unmodified WYD 7662 client.
+
+## ADDED Requirements
+
+### Requirement: Legacy hunting scroll variants
+The system SHALL recognize items 3432 through 3437 with `EF_VOLATILE` 195 as the Armia, Dungeon, Submundo, Kult, Kefra, and Nippleheim Pedidos de Caça, respectively.
+
+#### Scenario: Supported scroll is used
+- **WHEN** a playing, living character uses an inventory item whose index is between 3432 and 3437 and whose consumable class is 195
+- **THEN** the system processes it as the corresponding Pedido de Caça variant
+
+#### Scenario: Consumable class has an unsupported item index
+- **WHEN** a character uses an item with consumable class 195 whose index is outside 3432 through 3437
+- **THEN** the system does not teleport the character or consume the item
+
+### Requirement: Destination selection
+The system SHALL map each supported Pedido de Caça and client-selected `WarpID` from 1 through 10 to the corresponding destination coordinates defined by the legacy `HuntingScrolls` table.
+
+#### Scenario: Valid destination is selected
+- **WHEN** a character uses a supported Pedido de Caça with a `WarpID` from 1 through 10
+- **THEN** the character is teleported to the legacy destination selected by the scroll variant and `WarpID`
+
+#### Scenario: Destination selection is out of range
+- **WHEN** a character uses a supported Pedido de Caça with `WarpID` zero or greater than 10
+- **THEN** the system does not teleport the character or consume the item
+
+### Requirement: Successful scroll consumption
+The system SHALL consume exactly one unit of a Pedido de Caça only after its item index and destination selection have been validated.
+
+#### Scenario: Single scroll is consumed
+- **WHEN** a valid Pedido de Caça destination is executed from an item stack containing one unit
+- **THEN** the inventory slot becomes empty and is synchronized with the client
+
+#### Scenario: One scroll is consumed from a stack
+- **WHEN** a valid Pedido de Caça destination is executed from an item stack containing multiple units
+- **THEN** the stack decreases by exactly one unit and the updated slot is synchronized with the client
+
+### Requirement: Authoritative teleport behavior
+The system SHALL execute Pedido de Caça travel through the authoritative world teleport behavior so that position and entity visibility remain consistent for the player and nearby sessions.
+
+#### Scenario: Hunting scroll teleport completes
+- **WHEN** a valid Pedido de Caça destination is executed
+- **THEN** the server updates the character's authoritative position and emits the normal teleport and visibility updates

--- a/openspec/changes/archive/2026-09-02-fix-hunting-scrolls/tasks.md
+++ b/openspec/changes/archive/2026-09-02-fix-hunting-scrolls/tasks.md
@@ -1,0 +1,12 @@
+## 1. Hunting Scroll Routing
+
+- [x] 1.1 Add the `EF_VOLATILE` 195 constant, supported item-index bounds, and the six-by-ten legacy destination table in the item handler; verify every coordinate matches `Source/Code/TMSrv/_MSG_UseItem.cpp`.
+- [x] 1.2 Add a dedicated hunting-scroll use path that validates item index and `WarpID` before accessing the table, consumes and synchronizes exactly one item on success, and invokes the shared authoritative teleport operation; verify invalid inputs preserve inventory and position.
+- [x] 1.3 Route consumable class 195 from `_MSG_UseItem` to the dedicated hunting-scroll behavior and add structured use logging; verify supported items no longer reach the unknown-consumable rejection path.
+
+## 2. Verification
+
+- [x] 2.1 Add table-driven handler tests for all 60 combinations of six supported scrolls and ten destinations, verifying the emitted teleport target matches the legacy table.
+- [x] 2.2 Add handler tests for single-unit removal and multi-unit stack decrement, verifying the authoritative inventory slot update sent to the client.
+- [x] 2.3 Add boundary tests for item indices outside 3432 through 3437 and `WarpID` values 0 and 11, verifying there is no consumption or teleport and the unchanged slot is synchronized.
+- [x] 2.4 Run `go test -run 'Test.*HuntingScroll' ./tmserver/internal/handler` and `go test ./tmserver/internal/handler ./tmserver/internal/protocol`, verifying both focused and related package tests pass.

--- a/openspec/specs/hunting-scrolls/spec.md
+++ b/openspec/specs/hunting-scrolls/spec.md
@@ -1,0 +1,47 @@
+# Hunting Scrolls Specification
+
+## Purpose
+
+Defines how the game server validates and executes Pedido de Caça destination selections sent by the unmodified WYD 7662 client.
+
+## Requirements
+
+### Requirement: Legacy hunting scroll variants
+The system SHALL recognize items 3432 through 3437 with `EF_VOLATILE` 195 as the Armia, Dungeon, Submundo, Kult, Kefra, and Nippleheim Pedidos de Caça, respectively.
+
+#### Scenario: Supported scroll is used
+- **WHEN** a playing, living character uses an inventory item whose index is between 3432 and 3437 and whose consumable class is 195
+- **THEN** the system processes it as the corresponding Pedido de Caça variant
+
+#### Scenario: Consumable class has an unsupported item index
+- **WHEN** a character uses an item with consumable class 195 whose index is outside 3432 through 3437
+- **THEN** the system does not teleport the character or consume the item
+
+### Requirement: Destination selection
+The system SHALL map each supported Pedido de Caça and client-selected `WarpID` from 1 through 10 to the corresponding destination coordinates defined by the legacy `HuntingScrolls` table.
+
+#### Scenario: Valid destination is selected
+- **WHEN** a character uses a supported Pedido de Caça with a `WarpID` from 1 through 10
+- **THEN** the character is teleported to the legacy destination selected by the scroll variant and `WarpID`
+
+#### Scenario: Destination selection is out of range
+- **WHEN** a character uses a supported Pedido de Caça with `WarpID` zero or greater than 10
+- **THEN** the system does not teleport the character or consume the item
+
+### Requirement: Successful scroll consumption
+The system SHALL consume exactly one unit of a Pedido de Caça only after its item index and destination selection have been validated.
+
+#### Scenario: Single scroll is consumed
+- **WHEN** a valid Pedido de Caça destination is executed from an item stack containing one unit
+- **THEN** the inventory slot becomes empty and is synchronized with the client
+
+#### Scenario: One scroll is consumed from a stack
+- **WHEN** a valid Pedido de Caça destination is executed from an item stack containing multiple units
+- **THEN** the stack decreases by exactly one unit and the updated slot is synchronized with the client
+
+### Requirement: Authoritative teleport behavior
+The system SHALL execute Pedido de Caça travel through the authoritative world teleport behavior so that position and entity visibility remain consistent for the player and nearby sessions.
+
+#### Scenario: Hunting scroll teleport completes
+- **WHEN** a valid Pedido de Caça destination is executed
+- **THEN** the server updates the character's authoritative position and emits the normal teleport and visibility updates

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -341,6 +341,7 @@ const (
 	volMagicBean         = 186
 	volPaint             = volMagicBean
 	volEntradaTerritorio = 188 // Entrada do Território (LAN) ticket (_MSG_UseItem.cpp:4202)
+	volHuntingScroll     = 195 // Pedido de Caça: destination selected by MSG_UseItem.WarpID
 	volExpChest          = 198
 	volBuffKappa20h      = 200
 	volBuffCombat20h     = 201
@@ -381,7 +382,22 @@ const (
 	// distinguished by sIndex: (N)=4111, (M)=4112, (A)=4113. Tier = sIndex - base
 	// (_MSG_UseItem.cpp:4204).
 	itemEntradaTerritorioBase = 4111
+
+	itemHuntingScrollBase = 3432
+	itemHuntingScrollLast = 3437
 )
+
+// huntingScrollDestinations preserves HuntingScrolls[6][10][2] from the
+// legacy _MSG_UseItem.cpp. Rows are item indices 3432..3437 and columns are
+// the client selection WarpID 1..10.
+var huntingScrollDestinations = [6][10][2]int16{
+	{{2370, 2106}, {2508, 2101}, {2526, 2109}, {2529, 1882}, {2126, 1600}, {2005, 1617}, {2241, 1474}, {1858, 1721}, {2250, 1316}, {1989, 1755}},
+	{{290, 3799}, {724, 3781}, {481, 4062}, {876, 4058}, {855, 3922}, {808, 3876}, {959, 3813}, {926, 3750}, {1096, 3730}, {1132, 3800}},
+	{{1242, 4035}, {1264, 4017}, {1333, 3994}, {1358, 4041}, {1462, 4033}, {1326, 3788}, {1493, 3777}, {1437, 3741}, {1389, 3740}, {1422, 3810}},
+	{{1376, 1722}, {1426, 1686}, {1381, 1861}, {1326, 1896}, {1510, 1723}, {1543, 1726}, {1580, 1758}, {1182, 1714}, {1634, 1727}, {1237, 1764}},
+	{{2367, 4024}, {2236, 4044}, {2236, 3993}, {2209, 3989}, {2453, 4067}, {2485, 4043}, {2537, 3897}, {2489, 3919}, {2269, 3910}, {2202, 3866}},
+	{{3664, 3024}, {3582, 3007}, {3514, 3008}, {3819, 2977}, {3517, 2889}, {3745, 2977}, {3639, 2877}, {3650, 2727}, {3660, 2773}, {3746, 2879}},
+}
 
 // volClasses (Classes A-E, _MSG_UseItem.cpp:4959) is handled by useClasseItem
 // (classe.go), NOT rejectUnimplementedConsumable: unlike the water scrolls
@@ -492,6 +508,8 @@ func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header
 		d.useClasseItem(w, s, e, body, src)
 	case vol == volEntradaTerritorio:
 		d.useEntradaTerritorio(w, s, e, src)
+	case vol == volHuntingScroll:
+		d.useHuntingScroll(w, s, e, src, body.WarpID)
 	case vol >= volWaterMLo && vol <= volWaterMHi,
 		vol >= volWaterNLo && vol <= volWaterNHi,
 		vol >= volWaterALo && vol <= volWaterAHi:
@@ -505,6 +523,22 @@ func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header
 		// appears to bring the item back.
 		d.rejectUnimplementedConsumable(w, s, e, src)
 	}
+}
+
+// useHuntingScroll ports the legacy Pedidos de Caça block. The item selects
+// one of six map rows and WarpID selects one of ten destinations within it.
+func (d *Dispatcher) useHuntingScroll(w *world.World, s *world.Session, e *world.Entity, src int, warpID uint16) {
+	itemIndex := int(e.Carry[src].Index)
+	if itemIndex < itemHuntingScrollBase || itemIndex > itemHuntingScrollLast || warpID == 0 || warpID > 10 {
+		d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
+		return
+	}
+
+	dest := huntingScrollDestinations[itemIndex-itemHuntingScrollBase][int(warpID)-1]
+	consumeOneItem(&e.Carry[src])
+	d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
+	d.doTeleport(w, s, dest[0], dest[1])
+	d.log.Info("hunting scroll used", "conn", s.Conn, "item", itemIndex, "warp_id", warpID, "to_x", dest[0], "to_y", dest[1])
 }
 
 func isLegacyBuffConsumableVol(vol int) bool {

--- a/tmserver/internal/handler/item_test.go
+++ b/tmserver/internal/handler/item_test.go
@@ -2734,6 +2734,105 @@ func useItemFrame(t *testing.T, c net.Conn, slot int) {
 	send(t, c, protocol.MsgUseItem, body.Encode())
 }
 
+func useItemWarpFrame(t *testing.T, c net.Conn, slot int, warpID uint16) {
+	t.Helper()
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: int32(slot), WarpID: warpID}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+}
+
+func TestHuntingScrollDestinations(t *testing.T) {
+	carry := make([]world.Item, len(huntingScrollDestinations))
+	vols := make(map[int]int, len(huntingScrollDestinations))
+	for row := range huntingScrollDestinations {
+		index := itemHuntingScrollBase + row
+		carry[row] = world.Item{Index: int16(index), Effects: [3]world.Effect{{Effect: efAmount, Value: 10}}}
+		vols[index] = volHuntingScroll
+	}
+	db := recallScrollDB(0, 1000, 500, carry...)
+	addr, stop := startServerClockVolGrid(t, db, vols, world.DefaultGridDim)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	for row, destinations := range huntingScrollDestinations {
+		for col, want := range destinations {
+			warpID := uint16(col + 1)
+			useItemWarpFrame(t, c, row, warpID)
+			expect(t, c, protocol.MsgSendItem)
+			action := expectAction(t, c)
+			if action.TargetX != want[0] || action.TargetY != want[1] {
+				t.Errorf("item %d WarpID %d target = (%d,%d), want (%d,%d)",
+					itemHuntingScrollBase+row, warpID, action.TargetX, action.TargetY, want[0], want[1])
+			}
+		}
+	}
+}
+
+func TestHuntingScrollConsumesSingleAndStackedItems(t *testing.T) {
+	const stackedAmount = 3
+	items := []world.Item{
+		{Index: itemHuntingScrollBase},
+		{Index: itemHuntingScrollBase + 1, Effects: [3]world.Effect{{Effect: efAmount, Value: stackedAmount}}},
+	}
+	vols := map[int]int{
+		itemHuntingScrollBase:     volHuntingScroll,
+		itemHuntingScrollBase + 1: volHuntingScroll,
+	}
+	db := recallScrollDB(0, 1000, 500, items...)
+	addr, stop := startServerClockVolGrid(t, db, vols, world.DefaultGridDim)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	useItemWarpFrame(t, c, 0, 1)
+	single := expect(t, c, protocol.MsgSendItem)
+	if got := le16(single[4:6]); got != 0 {
+		t.Errorf("single scroll slot item = %d, want empty", got)
+	}
+	expectAction(t, c)
+
+	useItemWarpFrame(t, c, 1, 1)
+	stacked := expect(t, c, protocol.MsgSendItem)
+	if got := le16(stacked[4:6]); got != itemHuntingScrollBase+1 {
+		t.Fatalf("stacked scroll slot item = %d, want %d", got, itemHuntingScrollBase+1)
+	}
+	if stacked[6] != efAmount || stacked[7] != stackedAmount-1 {
+		t.Errorf("stacked scroll amount effect = %d.%d, want %d.%d", stacked[6], stacked[7], efAmount, stackedAmount-1)
+	}
+	expectAction(t, c)
+}
+
+func TestHuntingScrollRejectsInvalidItemAndWarpID(t *testing.T) {
+	tests := []struct {
+		name   string
+		item   int16
+		warpID uint16
+	}{
+		{name: "item below range", item: itemHuntingScrollBase - 1, warpID: 1},
+		{name: "item above range", item: itemHuntingScrollLast + 1, warpID: 1},
+		{name: "WarpID zero", item: itemHuntingScrollBase, warpID: 0},
+		{name: "WarpID eleven", item: itemHuntingScrollBase, warpID: 11},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := recallScrollDB(0, 1000, 500, world.Item{Index: tt.item})
+			addr, stop := startServerClockVolGrid(t, db, map[int]int{int(tt.item): volHuntingScroll}, 16)
+			defer stop()
+			c := enterWorld(t, addr)
+			defer c.Close()
+
+			useItemWarpFrame(t, c, 0, tt.warpID)
+			item := expect(t, c, protocol.MsgSendItem)
+			if got := int16(le16(item[4:6])); got != tt.item {
+				t.Errorf("rejected slot item = %d, want preserved item %d", got, tt.item)
+			}
+			if ty, _, ok := readMaybe(t, c); ok {
+				t.Errorf("rejected hunting scroll produced unexpected frame %#x", ty)
+			}
+		})
+	}
+}
+
 // TestUseRecallScrollConsumesAndRecalls ports _MSG_UseItem.cpp's "Retorno" block:
 // EF_VOLATILE 11 calls DoRecall and consumes one Pergaminho_Retorno.
 func TestUseRecallScrollConsumesAndRecalls(t *testing.T) {


### PR DESCRIPTION
## Summary

- port the six legacy Pedido de Caça destination tables for items 3432-3437
- validate WarpID, consume one scroll, synchronize inventory, and use the authoritative teleport path
- cover all 60 destinations, stack consumption, and invalid selections
- sync and archive the OpenSpec change

## Tests

- `go test -run 'Test.*HuntingScroll' ./tmserver/internal/handler`
- `go test ./tmserver/internal/handler ./tmserver/internal/protocol`
- `openspec validate --specs`

Closes #311