### PR TITLE
fix(tmserver): support quest reward items

### DIFF
--- a/openspec/changes/archive/2026-09-03-fix-quest-item-rewards/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-03-fix-quest-item-rewards/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-03

--- a/openspec/changes/archive/2026-09-03-fix-quest-item-rewards/design.md
+++ b/openspec/changes/archive/2026-09-03-fix-quest-item-rewards/design.md
@@ -1,0 +1,80 @@
+## Context
+
+See `proposal.md` for motivation and `specs/quest-item-rewards/spec.md` for observable behavior. The legacy server classifies items `4117..4121` with `EF_VOLATILE=191`, maps `itemID - 4117` to five rows in `QuestsRate.txt`, and performs the reward in `_MSG_UseItem.cpp`. The Go server already has content-rate loaders, item dispatch, party state, level progression, EXP notification, slot synchronization, and generic amount helpers, but volatile 191 is not dispatched and the item IDs are absent from the stack whitelist.
+
+All reward and inventory mutations must remain inside the single-owner world loop. No new asynchronous work or world-state locking is needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep quest reward values operator-configurable through the shipped legacy content file.
+- Reuse one tier-aware reward path for the consumer and party recipients so caps, level-ups, and client state remain consistent.
+- Make reward application and single-unit consumption one loop-owned operation.
+- Cover the complete five-item family even though issue #304 directly reports only its first three tiers.
+
+**Non-Goals:**
+
+- Implement or repair the quest arenas, drops, or Hidra second-floor teleport.
+- Change the CPSock protocol, persistence schema, general monster EXP distribution, or general party rules.
+- Reproduce the legacy source's accidental extra 10% award to a solo consumer or consuming leader.
+- Require a fairy or other equipped item before quest rewards can stack.
+
+## Decisions
+
+### Add a typed quest-rate content model
+
+Add a five-row content type and loader alongside the existing `CompRate` and `SancRate` loaders. Start from the defaults compiled in `CReadFiles.cpp`, then overlay valid `Exp`, `Coin`, and `Level` directives from `QuestsRate.txt`, matching the legacy parser's configuration model while validating row indices, numeric bounds, and usable level intervals.
+
+When `-content` is supplied, `loadContent` will treat this shipped settings file like the other required rate files and pass the loaded table into the handler configuration. Without a content tree, the dispatcher will use a default table so tests and no-content development mode remain functional.
+
+Alternative considered: hard-code the shipped `Release` values directly in the handler. This would ignore an existing operator configuration surface and diverge whenever server rates are tuned.
+
+### Dispatch the whole volatile-191 family through one handler
+
+Add a volatile 191 dispatch case, then validate the concrete index is in `4117..4121` before deriving its tier. This avoids indexing malformed or future volatile-191 items outside the configured table.
+
+The handler will select Mortal columns for Mortal and Arch columns for Arch. Other class tiers are not given an invented mapping: they will follow the legacy active selection behavior, which uses the non-Mortal columns, unless later capture evidence establishes a different rule.
+
+Alternative considered: switch on each item ID separately. That duplicates identical behavior and makes tier coverage easier to drift.
+
+### Centralize direct experience award behavior
+
+Introduce or extract a helper for a known direct EXP amount that clamps to the tier's existing experience ceiling, emits the EXP panel for the amount actually applied, invokes the existing multi-level progression routine, and sends the required score/ETC and reward emotion state. Use it for both the consumer and party recipients.
+
+Quest EXP is a fixed configured award, so it must not pass through monster level scaling, equipment/fairy EXP bonuses, or global monster EXP events.
+
+Alternative considered: construct a synthetic monster and call the kill-reward path. That would incorrectly apply PvE scaling and bonuses and would obscure the fixed-reward contract.
+
+### Resolve the party once and exclude the consumer
+
+Normalize the consumer's party leader as follows: a member uses its nonzero `Leader`; a leader is recognized by its nonempty `PartyList`; otherwise the consumer is solo. Award the integer `questExp / 10` share to the active leader and active member entries, deduplicating connection IDs and excluding the consumer.
+
+This deliberately follows the issue's “demais membros” requirement rather than the legacy block that can award an additional share to the consumer. Party membership is enough; no proximity restriction is added because the legacy reward path contains none.
+
+Alternative considered: literal line-for-line legacy behavior. It would grant 110% to a solo character or consuming leader, contradicting the reported expected behavior.
+
+### Extend the existing stack policy
+
+Add `4117..4121` to the same `isSplittable` policy used by inventory merge and split. Reuse `EF_AMOUNT`, the existing compatible-effect comparison, and the current maximum of 120. After a successful reward, call the established single-unit consumption and slot synchronization path; on validation failure, only resynchronize the unchanged slot.
+
+Alternative considered: a quest-only merge implementation. A second stack engine would create inconsistent caps and duplicate anti-duplication logic.
+
+## Risks / Trade-offs
+
+- **Legacy source has contradictory party semantics** -> Follow the issue's explicit “other members” wording, exclude the consumer, and lock this behavior with leader/member/solo tests.
+- **Class tiers beyond Mortal and Arch are underspecified** -> Preserve the active legacy ternary behavior by selecting the non-Mortal configuration columns and add a focused characterization test.
+- **Malformed party lists could award twice** -> Deduplicate recipient connection IDs and require a live entity plus an active playing session.
+- **A partial reward mutation could consume an item incorrectly** -> Validate all use preconditions before mutation and perform rewards plus consumption synchronously in the world loop.
+- **Strict content loading can expose previously unnoticed bad files** -> Return contextual parser errors at startup and retain compiled defaults only for the intentional no-content mode.
+- **Large rewards can cross several levels** -> Reuse the existing loop-based level progression and test multi-level and capped cases.
+
+## Migration Plan
+
+1. Add and test the quest-rate parser and compiled defaults.
+2. Wire the rate table through tmserver startup and dispatcher configuration.
+3. Add direct reward and party distribution behavior with regression tests.
+4. Extend stack merge/split coverage and stacked-use tests.
+5. Run focused handler/content tests, followed by the repository test suite.
+
+Rollback consists of reverting the handler dispatch, stack whitelist, and quest-rate wiring together. No persisted-data or protocol migration is required; existing `EF_AMOUNT` stacks remain valid either way.

--- a/openspec/changes/archive/2026-09-03-fix-quest-item-rewards/proposal.md
+++ b/openspec/changes/archive/2026-09-03-fix-quest-item-rewards/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Quest reward items with `EF_VOLATILE=191` currently fall through the Go item-use dispatcher, so using them grants neither their configured experience and gold nor the party experience share. The same item family is also absent from the stack policy, causing a second player-visible parity failure reported in issue #304.
+
+## What Changes
+
+- Support using all five legacy quest reward items, IDs `4117` through `4121`, rather than limiting the fix to the three items already tested by the reporter.
+- Load their level ranges, experience rewards, and gold rewards from `Common/Settings/QuestsRate.txt`, preserving the legacy content configuration.
+- Grant the user the full configured reward and grant 10% of its experience to each other connected member of the user's party.
+- Apply normal experience caps, gold caps, level progression, client notifications, and item persistence/synchronization.
+- Reject use outside the configured level range without consuming the item.
+- Allow these quest items to merge and split using the existing maximum stack size, and consume exactly one unit after a successful use.
+
+## Capabilities
+
+### New Capabilities
+
+- `quest-item-rewards`: Defines configuration, use, party distribution, consumption, and stacking behavior for the five `EF_VOLATILE=191` quest reward items.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affects quest-rate content loading and tmserver startup wiring.
+- Affects the single-owner item-use and inventory merge/split paths in `tmserver/internal/handler`.
+- Reuses the existing level-up, score/ETC synchronization, EXP notification, and persistence mechanisms; no wire-format or database-schema changes are expected.
+- Requires regression coverage for all five item tiers, boundary levels, party roles, caps, rejected use, and stacked consumption.

--- a/openspec/changes/archive/2026-09-03-fix-quest-item-rewards/specs/quest-item-rewards/spec.md
+++ b/openspec/changes/archive/2026-09-03-fix-quest-item-rewards/specs/quest-item-rewards/spec.md
@@ -1,0 +1,99 @@
+## Purpose
+
+Define legacy-compatible rewards, party sharing, validation, consumption, and inventory stacking for the quest reward item family.
+
+## ADDED Requirements
+
+### Requirement: Quest reward configuration
+The system SHALL associate item IDs `4117` through `4121`, in ascending order, with quest tiers `0` through `4` and SHALL obtain each tier's Mortal and Arch experience reward, gold reward, and Mortal and Arch level range from `Common/Settings/QuestsRate.txt` when a content tree is configured.
+
+#### Scenario: Configured quest rates are loaded
+- **WHEN** the server starts with a content tree containing a valid `Common/Settings/QuestsRate.txt`
+- **THEN** uses of items `4117` through `4121` use the corresponding configured `Exp`, `Coin`, and `Level` values
+
+#### Scenario: Configured quest rates are unavailable
+- **WHEN** the server starts without a configured content tree
+- **THEN** the system uses the legacy compiled default quest rates
+
+#### Scenario: Configured quest rates are invalid
+- **WHEN** the server starts with a configured content tree whose `QuestsRate.txt` is missing or invalid
+- **THEN** startup fails with an error identifying the quest-rate content problem
+
+### Requirement: Eligible quest item use
+The system SHALL allow a living, actively playing character to use a quest reward item only when the character's class tier and current level select a configured range whose minimum is inclusive and maximum is exclusive.
+
+#### Scenario: Mortal uses an item inside its level range
+- **WHEN** a Mortal uses item `4117` through `4121` at a level greater than or equal to that tier's Mortal minimum and less than its Mortal maximum
+- **THEN** the use succeeds with the tier's Mortal reward
+
+#### Scenario: Arch uses an item inside its level range
+- **WHEN** an Arch uses item `4117` through `4121` at a level greater than or equal to that tier's Arch minimum and less than its Arch maximum
+- **THEN** the use succeeds with the tier's Arch reward
+
+#### Scenario: Character is outside the item level range
+- **WHEN** a character uses a quest reward item below the applicable minimum or at or above the applicable maximum
+- **THEN** the system refuses the use, informs the character of the level restriction, synchronizes the unchanged inventory slot, and grants no reward
+
+### Requirement: Successful quest item reward
+On a successful quest item use, the system SHALL add the tier's full configured experience and gold reward to the consuming character, subject to the existing experience and carried-gold ceilings, SHALL apply all resulting level progression, and SHALL synchronize the character's visible reward and state.
+
+#### Scenario: Reward does not reach a ceiling
+- **WHEN** an eligible character successfully uses a quest reward item and both rewards fit below their respective ceilings
+- **THEN** the character receives the full configured experience and gold and receives the corresponding EXP notice, reward emotion, level-up updates when applicable, and current character state
+
+#### Scenario: Reward reaches a ceiling
+- **WHEN** adding a quest item reward would exceed the experience or carried-gold ceiling
+- **THEN** the affected total is capped at that ceiling and the synchronized state reports the capped total
+
+#### Scenario: Reward crosses multiple level thresholds
+- **WHEN** the granted experience crosses one or more level thresholds permitted by the character's tier and quest gates
+- **THEN** the system applies every permitted level-up through the existing level progression rules
+
+### Requirement: Quest experience party share
+After a successful use, the system SHALL grant experience equal to integer division of the consumer's configured experience reward by 10 to each other actively playing character in the same party. The consumer SHALL NOT receive this party share in addition to the full reward, and gold SHALL NOT be shared.
+
+#### Scenario: Party leader consumes an item
+- **WHEN** a party leader successfully uses a quest reward item
+- **THEN** each connected active party member other than the leader receives the 10% experience share exactly once
+
+#### Scenario: Party member consumes an item
+- **WHEN** a non-leader party member successfully uses a quest reward item
+- **THEN** the leader and every other connected active party member receive the 10% experience share exactly once, while the consumer receives only the full configured reward
+
+#### Scenario: Character uses an item without a party
+- **WHEN** a character who is not in a party successfully uses a quest reward item
+- **THEN** no party experience share is granted
+
+#### Scenario: Party contains inactive entries
+- **WHEN** party state contains disconnected, missing, or non-playing characters
+- **THEN** those entries receive no experience share and do not prevent eligible active members from receiving theirs
+
+#### Scenario: Party share causes level progression
+- **WHEN** a party recipient's 10% experience share crosses a permitted level threshold
+- **THEN** the system applies the recipient's normal level progression and synchronizes the recipient's EXP notice, reward emotion, and character state
+
+### Requirement: Quest item stack behavior
+The system SHALL allow each item ID `4117` through `4121` to merge with an otherwise compatible item of the same ID, split into separate stacks, and hold no more than the existing maximum stack amount.
+
+#### Scenario: Compatible quest item stacks are merged
+- **WHEN** a player moves one quest item stack onto a compatible stack with the same item ID
+- **THEN** the system transfers as many units as fit up to the existing stack limit and preserves any remainder
+
+#### Scenario: Quest item stack is split
+- **WHEN** a player requests a valid split amount smaller than the source quest item stack and has an empty inventory slot
+- **THEN** the system reduces the source by that amount and creates a second stack containing the requested amount
+
+### Requirement: Quest item consumption
+The system SHALL consume exactly one unit from a quest item stack only after the reward use succeeds and SHALL synchronize and persist the remaining stack or empty slot.
+
+#### Scenario: Successful use from a multi-item stack
+- **WHEN** an eligible character successfully uses one quest reward item from a stack containing more than one unit
+- **THEN** the stack remains in its slot with its amount reduced by exactly one
+
+#### Scenario: Successful use of the final unit
+- **WHEN** an eligible character successfully uses a quest reward item whose effective amount is one
+- **THEN** the inventory slot becomes empty
+
+#### Scenario: Rejected use preserves the stack
+- **WHEN** use of a quest reward item is rejected
+- **THEN** no unit is consumed and the authoritative unchanged stack is sent back to the client

--- a/openspec/changes/archive/2026-09-03-fix-quest-item-rewards/tasks.md
+++ b/openspec/changes/archive/2026-09-03-fix-quest-item-rewards/tasks.md
@@ -1,0 +1,26 @@
+## 1. Quest Rate Content
+
+- [x] 1.1 Add the typed five-tier quest-rate model with legacy compiled defaults and verify unit tests cover the default EXP, coin, and Mortal/Arch level values.
+- [x] 1.2 Implement strict `QuestsRate.txt` parsing and overlays for `Exp`, `Coin`, and `Level`, and verify parser tests cover valid shipped content, case handling, missing rows that retain defaults, invalid indices, invalid numeric bounds, malformed directives, and unusable ranges.
+- [x] 1.3 Load `Common/Settings/QuestsRate.txt` with the required content tree, expose the rates through tmserver and dispatcher configuration, retain defaults in no-content mode, and verify startup/content tests cover configured, missing, malformed, and fallback cases.
+
+## 2. Reward Application
+
+- [x] 2.1 Add a reusable direct-EXP award path that clamps the applied amount, runs existing multi-level progression, and emits the required EXP, score/ETC, and emotion updates; verify focused tests cover ordinary gain, multiple level-ups, tier gates, and the EXP ceiling.
+- [x] 2.2 Dispatch `EF_VOLATILE=191` to a quest-item handler that safely maps only IDs `4117..4121` to tiers, selects the applicable configured class columns, validates the inclusive-minimum/exclusive-maximum level range, and verify table-driven tests cover every tier and both boundaries.
+- [x] 2.3 Grant the successful consumer's configured EXP and coin with existing ceilings and state synchronization, and verify tests cover configured values, gold capping, EXP capping, and rejection with no mutation.
+
+## 3. Party Distribution
+
+- [x] 3.1 Resolve leader/member/solo party membership inside the world loop, distribute `questExp / 10` to each distinct active recipient except the consumer, and verify tests cover leader use, member use, solo use, duplicate entries, disconnected entries, and the absence of shared gold.
+- [x] 3.2 Apply level progression and client notifications to each party recipient, and verify a party-share regression test covers a recipient crossing a level threshold.
+
+## 4. Stacking and Consumption
+
+- [x] 4.1 Add item IDs `4117..4121` to the existing merge/split policy and verify table-driven inventory tests cover every ID, compatible merges, the 120-unit cap with remainder, valid splits, and invalid split preservation.
+- [x] 4.2 Consume and synchronize exactly one unit only after a successful quest reward, and verify handler tests cover multi-unit stacks, the final unit, rejected use, and a subsequent inventory move preserving the authoritative reduced amount.
+
+## 5. Verification
+
+- [x] 5.1 Run `go test -run 'Test.*Quest(Item|Rate|Reward)' ./tmserver/internal/content ./tmserver/internal/handler` (adjusting the focused pattern to the implemented test names) and verify all focused tests pass.
+- [x] 5.2 Run `make test` and verify the repository test suite, race detection, and coverage complete without regressions.

--- a/openspec/specs/quest-item-rewards/spec.md
+++ b/openspec/specs/quest-item-rewards/spec.md
@@ -1,0 +1,102 @@
+# Quest Item Rewards Specification
+
+## Purpose
+
+Define legacy-compatible rewards, party sharing, validation, consumption, and inventory stacking for the quest reward item family.
+
+## Requirements
+
+### Requirement: Quest reward configuration
+The system SHALL associate item IDs `4117` through `4121`, in ascending order, with quest tiers `0` through `4` and SHALL obtain each tier's Mortal and Arch experience reward, gold reward, and Mortal and Arch level range from `Common/Settings/QuestsRate.txt` when a content tree is configured.
+
+#### Scenario: Configured quest rates are loaded
+- **WHEN** the server starts with a content tree containing a valid `Common/Settings/QuestsRate.txt`
+- **THEN** uses of items `4117` through `4121` use the corresponding configured `Exp`, `Coin`, and `Level` values
+
+#### Scenario: Configured quest rates are unavailable
+- **WHEN** the server starts without a configured content tree
+- **THEN** the system uses the legacy compiled default quest rates
+
+#### Scenario: Configured quest rates are invalid
+- **WHEN** the server starts with a configured content tree whose `QuestsRate.txt` is missing or invalid
+- **THEN** startup fails with an error identifying the quest-rate content problem
+
+### Requirement: Eligible quest item use
+The system SHALL allow a living, actively playing character to use a quest reward item only when the character's class tier and current level select a configured range whose minimum is inclusive and maximum is exclusive.
+
+#### Scenario: Mortal uses an item inside its level range
+- **WHEN** a Mortal uses item `4117` through `4121` at a level greater than or equal to that tier's Mortal minimum and less than its Mortal maximum
+- **THEN** the use succeeds with the tier's Mortal reward
+
+#### Scenario: Arch uses an item inside its level range
+- **WHEN** an Arch uses item `4117` through `4121` at a level greater than or equal to that tier's Arch minimum and less than its Arch maximum
+- **THEN** the use succeeds with the tier's Arch reward
+
+#### Scenario: Character is outside the item level range
+- **WHEN** a character uses a quest reward item below the applicable minimum or at or above the applicable maximum
+- **THEN** the system refuses the use, informs the character of the level restriction, synchronizes the unchanged inventory slot, and grants no reward
+
+### Requirement: Successful quest item reward
+On a successful quest item use, the system SHALL add the tier's full configured experience and gold reward to the consuming character, subject to the existing experience and carried-gold ceilings, SHALL apply all resulting level progression, and SHALL synchronize the character's visible reward and state.
+
+#### Scenario: Reward does not reach a ceiling
+- **WHEN** an eligible character successfully uses a quest reward item and both rewards fit below their respective ceilings
+- **THEN** the character receives the full configured experience and gold and receives the corresponding EXP notice, reward emotion, level-up updates when applicable, and current character state
+
+#### Scenario: Reward reaches a ceiling
+- **WHEN** adding a quest item reward would exceed the experience or carried-gold ceiling
+- **THEN** the affected total is capped at that ceiling and the synchronized state reports the capped total
+
+#### Scenario: Reward crosses multiple level thresholds
+- **WHEN** the granted experience crosses one or more level thresholds permitted by the character's tier and quest gates
+- **THEN** the system applies every permitted level-up through the existing level progression rules
+
+### Requirement: Quest experience party share
+After a successful use, the system SHALL grant experience equal to integer division of the consumer's configured experience reward by 10 to each other actively playing character in the same party. The consumer SHALL NOT receive this party share in addition to the full reward, and gold SHALL NOT be shared.
+
+#### Scenario: Party leader consumes an item
+- **WHEN** a party leader successfully uses a quest reward item
+- **THEN** each connected active party member other than the leader receives the 10% experience share exactly once
+
+#### Scenario: Party member consumes an item
+- **WHEN** a non-leader party member successfully uses a quest reward item
+- **THEN** the leader and every other connected active party member receive the 10% experience share exactly once, while the consumer receives only the full configured reward
+
+#### Scenario: Character uses an item without a party
+- **WHEN** a character who is not in a party successfully uses a quest reward item
+- **THEN** no party experience share is granted
+
+#### Scenario: Party contains inactive entries
+- **WHEN** party state contains disconnected, missing, or non-playing characters
+- **THEN** those entries receive no experience share and do not prevent eligible active members from receiving theirs
+
+#### Scenario: Party share causes level progression
+- **WHEN** a party recipient's 10% experience share crosses a permitted level threshold
+- **THEN** the system applies the recipient's normal level progression and synchronizes the recipient's EXP notice, reward emotion, and character state
+
+### Requirement: Quest item stack behavior
+The system SHALL allow each item ID `4117` through `4121` to merge with an otherwise compatible item of the same ID, split into separate stacks, and hold no more than the existing maximum stack amount.
+
+#### Scenario: Compatible quest item stacks are merged
+- **WHEN** a player moves one quest item stack onto a compatible stack with the same item ID
+- **THEN** the system transfers as many units as fit up to the existing stack limit and preserves any remainder
+
+#### Scenario: Quest item stack is split
+- **WHEN** a player requests a valid split amount smaller than the source quest item stack and has an empty inventory slot
+- **THEN** the system reduces the source by that amount and creates a second stack containing the requested amount
+
+### Requirement: Quest item consumption
+The system SHALL consume exactly one unit from a quest item stack only after the reward use succeeds and SHALL synchronize and persist the remaining stack or empty slot.
+
+#### Scenario: Successful use from a multi-item stack
+- **WHEN** an eligible character successfully uses one quest reward item from a stack containing more than one unit
+- **THEN** the stack remains in its slot with its amount reduced by exactly one
+
+#### Scenario: Successful use of the final unit
+- **WHEN** an eligible character successfully uses a quest reward item whose effective amount is one
+- **THEN** the inventory slot becomes empty
+
+#### Scenario: Rejected use preserves the stack
+- **WHEN** use of a quest reward item is rejected
+- **THEN** no unit is consumed and the authoritative unchanged stack is sent back to the client
+

--- a/tmserver/cmd/tmserver/main.go
+++ b/tmserver/cmd/tmserver/main.go
@@ -151,6 +151,7 @@ func run(logger *slog.Logger) error {
 	var heights *content.Grid
 	var sancRate *content.SancRate
 	var compRate *content.CompRate
+	var questRates *content.QuestRates
 	if *contentDir != "" {
 		c, err := loadContent(*contentDir, logger)
 		if err != nil {
@@ -168,6 +169,7 @@ func run(logger *slog.Logger) error {
 		heights = c.heights
 		sancRate = c.sanc
 		compRate = c.comp
+		questRates = c.quests
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -301,6 +303,7 @@ func run(logger *slog.Logger) error {
 		OdinCatalog:     odinCatalog,
 		CombineCatalog:  odinCatalog,
 		CompRate:        compRate,
+		QuestRates:      questRates,
 		NpcConfig:       npcConfig,
 		WorldEvents:     worldEvents,
 		CastleQuests:    castleQuests,
@@ -597,6 +600,10 @@ func loadContent(dir string, logger *slog.Logger) (*loadedContent, error) {
 	if err != nil {
 		return nil, err
 	}
+	quests, err := content.LoadQuestRates(filepath.Join(dir, "Common", "Settings", "QuestsRate.txt"))
+	if err != nil {
+		return nil, err
+	}
 	items, err := content.LoadItemList(filepath.Join(dir, "Common", "ItemList.csv"))
 	if err != nil {
 		return nil, err
@@ -633,7 +640,7 @@ func loadContent(dir string, logger *slog.Logger) (*loadedContent, error) {
 	} else if hm != nil || attr != nil {
 		logger.Warn("mob pathfinding disabled: need BOTH HeightMap.dat and AttributeMap.dat")
 	}
-	return &loadedContent{items: items, comp: comp, sanc: sanc, skills: skills, heights: heights}, nil
+	return &loadedContent{items: items, comp: comp, sanc: sanc, quests: quests, skills: skills, heights: heights}, nil
 }
 
 // loadedContent is what a mounted Release/ tree yields. It is a struct rather
@@ -642,6 +649,7 @@ type loadedContent struct {
 	items   *content.ItemList
 	comp    *content.CompRate
 	sanc    *content.SancRate
+	quests  *content.QuestRates
 	skills  *content.SkillData
 	heights *content.Grid
 }

--- a/tmserver/internal/content/content_test.go
+++ b/tmserver/internal/content/content_test.go
@@ -103,6 +103,54 @@ func TestLoadSancRate(t *testing.T) {
 	}
 }
 
+func TestQuestRateDefaults(t *testing.T) {
+	q := DefaultQuestRates()
+	want := []QuestTierRate{
+		{1000, 500, 2000, 39, 115, 39, 115},
+		{2000, 1000, 4000, 115, 190, 115, 190},
+		{3000, 1500, 6000, 190, 265, 190, 265},
+		{4000, 2000, 8000, 265, 320, 265, 320},
+		{5000, 2500, 10000, 320, 350, 320, 350},
+	}
+	for i := range want {
+		if got, ok := q.Tier(i); !ok || got != want[i] {
+			t.Errorf("Tier(%d) = %+v,%v, want %+v,true", i, got, ok, want[i])
+		}
+	}
+	if _, ok := q.Tier(-1); ok {
+		t.Error("Tier(-1) succeeded")
+	}
+}
+
+func TestLoadQuestRates(t *testing.T) {
+	q, err := LoadQuestRates(release(t, "Common", "Settings", "QuestsRate.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := q.Tier(2); got != (QuestTierRate{200000, 200000, 100000, 190, 265, 190, 265}) {
+		t.Errorf("Tier(2) = %+v", got)
+	}
+}
+
+func TestParseQuestRatesOverlayAndValidation(t *testing.T) {
+	q, err := parseQuestRates(strings.NewReader("exp 0 30 20\nCoin 0 40\nLEVEL 0 1 2 3 4\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := q.Tier(0); got != (QuestTierRate{30, 20, 40, 1, 2, 3, 4}) {
+		t.Errorf("Tier(0) = %+v", got)
+	}
+	if got, _ := q.Tier(1); got != questRateDefaults[1] {
+		t.Errorf("missing Tier(1) override changed default: %+v", got)
+	}
+	bad := []string{"EXP 5 1 1", "EXP 0 nope 1", "COIN 0 -1", "LEVEL 0 4 4 1 2", "LEVEL 0 0 400 1 2", "wat 0 1"}
+	for _, input := range bad {
+		if _, err := parseQuestRates(strings.NewReader(input)); err == nil {
+			t.Errorf("parseQuestRates(%q) succeeded", input)
+		}
+	}
+}
+
 func TestSancRateOutOfRange(t *testing.T) {
 	s := DefaultSancRate()
 	for _, tt := range []struct{ anvil, idx int }{{-1, 0}, {3, 0}, {0, -1}, {0, 12}} {

--- a/tmserver/internal/content/rates.go
+++ b/tmserver/internal/content/rates.go
@@ -12,6 +12,111 @@ import (
 	"strings"
 )
 
+const questTierCount = 5
+
+// QuestTierRate is one QuestsRate.txt row. Level minima are inclusive and
+// maxima exclusive, matching _MSG_UseItem.cpp's Vol-191 gate.
+type QuestTierRate struct {
+	MortalExp, ArchExp                     int64
+	Coin                                   int32
+	MortalMin, MortalMax, ArchMin, ArchMax int32
+}
+
+// QuestRates holds the five quest-item reward tiers (item 4117 + tier).
+type QuestRates struct {
+	tiers [questTierCount]QuestTierRate
+}
+
+var questRateDefaults = [questTierCount]QuestTierRate{
+	{MortalExp: 1000, ArchExp: 500, Coin: 2000, MortalMin: 39, MortalMax: 115, ArchMin: 39, ArchMax: 115},
+	{MortalExp: 2000, ArchExp: 1000, Coin: 4000, MortalMin: 115, MortalMax: 190, ArchMin: 115, ArchMax: 190},
+	{MortalExp: 3000, ArchExp: 1500, Coin: 6000, MortalMin: 190, MortalMax: 265, ArchMin: 190, ArchMax: 265},
+	{MortalExp: 4000, ArchExp: 2000, Coin: 8000, MortalMin: 265, MortalMax: 320, ArchMin: 265, ArchMax: 320},
+	{MortalExp: 5000, ArchExp: 2500, Coin: 10000, MortalMin: 320, MortalMax: 350, ArchMin: 320, ArchMax: 350},
+}
+
+// DefaultQuestRates returns the CReadFiles.cpp defaults used without -content.
+func DefaultQuestRates() *QuestRates { return &QuestRates{tiers: questRateDefaults} }
+
+// Tier returns a quest tier and whether the index is valid.
+func (q *QuestRates) Tier(tier int) (QuestTierRate, bool) {
+	if q == nil || tier < 0 || tier >= len(q.tiers) {
+		return QuestTierRate{}, false
+	}
+	return q.tiers[tier], true
+}
+
+// LoadQuestRates reads Common/Settings/QuestsRate.txt over legacy defaults.
+func LoadQuestRates(path string) (*QuestRates, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("content: open QuestsRate: %w", err)
+	}
+	defer f.Close()
+	return parseQuestRates(f)
+}
+
+func parseQuestRates(r io.Reader) (*QuestRates, error) {
+	q := DefaultQuestRates()
+	sc := bufio.NewScanner(r)
+	for line := 1; sc.Scan(); line++ {
+		fields := strings.Fields(sc.Text())
+		if len(fields) == 0 || strings.HasPrefix(fields[0], "#") {
+			continue
+		}
+		kind := asciiUpper(fields[0])
+		want := 4
+		if kind == "COIN" {
+			want = 3
+		} else if kind == "LEVEL" {
+			want = 6
+		}
+		if (kind != "EXP" && kind != "COIN" && kind != "LEVEL") || len(fields) != want {
+			return nil, fmt.Errorf("content: QuestsRate line %d: malformed directive", line)
+		}
+		values := make([]int64, len(fields)-1)
+		for i := 1; i < len(fields); i++ {
+			v, err := strconv.ParseInt(fields[i], 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("content: QuestsRate line %d: invalid integer %q", line, fields[i])
+			}
+			values[i-1] = v
+		}
+		tier := int(values[0])
+		if tier < 0 || tier >= questTierCount {
+			return nil, fmt.Errorf("content: QuestsRate line %d: tier %d out of range", line, tier)
+		}
+		r := &q.tiers[tier]
+		switch kind {
+		case "EXP":
+			if values[1] < 0 || values[1] >= 2_000_000_000 || values[2] < 0 || values[2] >= 2_000_000_000 {
+				return nil, fmt.Errorf("content: QuestsRate line %d: experience out of range", line)
+			}
+			r.MortalExp, r.ArchExp = values[1], values[2]
+		case "COIN":
+			if values[1] < 0 || values[1] > 2_000_000_000 {
+				return nil, fmt.Errorf("content: QuestsRate line %d: coin out of range", line)
+			}
+			r.Coin = int32(values[1])
+		case "LEVEL":
+			for _, v := range values[1:] {
+				if v < 0 || v >= 400 {
+					return nil, fmt.Errorf("content: QuestsRate line %d: level out of range", line)
+				}
+			}
+			if values[1] >= values[2] || values[3] >= values[4] {
+				return nil, fmt.Errorf("content: QuestsRate line %d: empty level range", line)
+			}
+			r.MortalMin, r.MortalMax = int32(values[1]), int32(values[2])
+			r.ArchMin, r.ArchMax = int32(values[3]), int32(values[4])
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("content: read QuestsRate: %w", err)
+	}
+	return q, nil
+}
+
 // CompRate holds the combine-recipe success rates (Common/Settings/CompRate.txt,
 // CReadFiles::ReadCompRate, game-rules.md §3.2). Lines are "Family Key Rate".
 type CompRate struct {

--- a/tmserver/internal/content/rates.go
+++ b/tmserver/internal/content/rates.go
@@ -65,13 +65,18 @@ func parseQuestRates(r io.Reader) (*QuestRates, error) {
 			continue
 		}
 		kind := asciiUpper(fields[0])
-		want := 4
-		if kind == "COIN" {
+		var want int
+		switch kind {
+		case "EXP":
+			want = 4
+		case "COIN":
 			want = 3
-		} else if kind == "LEVEL" {
+		case "LEVEL":
 			want = 6
+		default:
+			return nil, fmt.Errorf("content: QuestsRate line %d: malformed directive", line)
 		}
-		if (kind != "EXP" && kind != "COIN" && kind != "LEVEL") || len(fields) != want {
+		if len(fields) != want {
 			return nil, fmt.Errorf("content: QuestsRate line %d: malformed directive", line)
 		}
 		values := make([]int64, len(fields)-1)

--- a/tmserver/internal/handler/dispatch.go
+++ b/tmserver/internal/handler/dispatch.go
@@ -51,6 +51,7 @@ type Config struct {
 	OdinCatalog    combine.Catalog
 	CombineCatalog combine.Catalog
 	CompRate       *content.CompRate
+	QuestRates     *content.QuestRates
 
 	// BaseMobs are the per-class STRUCT_MOB templates (class index → raw 816 bytes,
 	// content.LoadBaseMobs). Used to render a character on entering the world with
@@ -151,6 +152,7 @@ type Dispatcher struct {
 	odinCatalog     combine.Catalog
 	combineCatalog  combine.Catalog
 	compRate        *content.CompRate
+	questRates      *content.QuestRates
 	baseMobs        map[int][]byte               // per-class STRUCT_MOB templates
 	summonMobs      [][]byte                     // BM evocation templates (summon id → STRUCT_MOB)
 	vineMob         []byte                       // Sephira Muro de Espinhos template
@@ -276,6 +278,7 @@ func New(cfg Config) *Dispatcher {
 		odinCatalog:      cfg.OdinCatalog,
 		combineCatalog:   cfg.CombineCatalog,
 		compRate:         cfg.CompRate,
+		questRates:       cfg.QuestRates,
 		baseMobs:         cfg.BaseMobs,
 		summonMobs:       cfg.SummonMobs,
 		vineMob:          cfg.VineMob,
@@ -316,6 +319,9 @@ func New(cfg Config) *Dispatcher {
 		// No content tree: fall back to the compiled g_pSancRate, like the original
 		// server before it reads SancRate.txt over it.
 		d.sancRate = content.DefaultSancRate()
+	}
+	if d.questRates == nil {
+		d.questRates = content.DefaultQuestRates()
 	}
 	if d.combineFamilies == nil {
 		d.combineFamilies = make(map[protocol.Type]CombineFamily)

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -171,7 +171,7 @@ func isSplittable(index int16) bool {
 	case 412, 413, 414, 416, 419, 420, itemPedraDoSabio:
 		return true
 	}
-	return index >= 2390 && index <= 2419
+	return index >= 2390 && index <= 2419 || index >= itemQuestRewardBase && index <= itemQuestRewardLast
 }
 
 // itemPedraDoSabio is the Pedra do Sábio (ItemList.csv:2903), the Huntress
@@ -341,6 +341,7 @@ const (
 	volMagicBean         = 186
 	volPaint             = volMagicBean
 	volEntradaTerritorio = 188 // Entrada do Território (LAN) ticket (_MSG_UseItem.cpp:4202)
+	volQuestReward       = 191 // quest reward items 4117..4121 (_MSG_UseItem.cpp:2344)
 	volHuntingScroll     = 195 // Pedido de Caça: destination selected by MSG_UseItem.WarpID
 	volExpChest          = 198
 	volBuffKappa20h      = 200
@@ -382,6 +383,8 @@ const (
 	// distinguished by sIndex: (N)=4111, (M)=4112, (A)=4113. Tier = sIndex - base
 	// (_MSG_UseItem.cpp:4204).
 	itemEntradaTerritorioBase = 4111
+	itemQuestRewardBase       = 4117
+	itemQuestRewardLast       = 4121
 
 	itemHuntingScrollBase = 3432
 	itemHuntingScrollLast = 3437
@@ -508,6 +511,8 @@ func (d *Dispatcher) useItem(w *world.World, s *world.Session, _ protocol.Header
 		d.useClasseItem(w, s, e, body, src)
 	case vol == volEntradaTerritorio:
 		d.useEntradaTerritorio(w, s, e, src)
+	case vol == volQuestReward:
+		d.useQuestReward(w, s, e, src)
 	case vol == volHuntingScroll:
 		d.useHuntingScroll(w, s, e, src, body.WarpID)
 	case vol >= volWaterMLo && vol <= volWaterMHi,
@@ -924,6 +929,75 @@ func (d *Dispatcher) useEntradaTerritorio(w *world.World, s *world.Session, e *w
 	consumeOneItem(&e.Carry[src])
 	w.Send(s, protocol.MsgSendItem, protocol.EncodeSendItemBody(protocol.ItemPlaceCarry, src, itemToSel(e.Carry[src])))
 	d.doTeleport(w, s, x, y)
+}
+
+// useQuestReward handles the five Vol-191 quest trophies. Their row is the
+// contiguous item offset, and QuestsRate.txt supplies tier-specific rewards and
+// half-open level ranges. All mutation stays in the world loop.
+func (d *Dispatcher) useQuestReward(w *world.World, s *world.Session, e *world.Entity, src int) {
+	tier := int(e.Carry[src].Index) - itemQuestRewardBase
+	rate, ok := d.questRates.Tier(tier)
+	if !ok {
+		d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
+		return
+	}
+
+	questExp := rate.ArchExp
+	minLevel, maxLevel := rate.ArchMin, rate.ArchMax
+	if e.ClassMaster == classMasterMortal {
+		questExp = rate.MortalExp
+		minLevel, maxLevel = rate.MortalMin, rate.MortalMax
+	}
+	if e.Level < minLevel || e.Level >= maxLevel {
+		d.notify(w, s, NoticeReqNotMet)
+		d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
+		return
+	}
+
+	if int64(e.Coin)+int64(rate.Coin) > maxCoin {
+		e.Coin = maxCoin
+	} else {
+		e.Coin += rate.Coin
+	}
+	d.grantDirectExp(w, s, e, questExp)
+	d.grantQuestPartyExp(w, e, questExp/10)
+
+	consumeOneItem(&e.Carry[src])
+	d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
+	d.sendEtc(w, s, e) // coin changed even when EXP was already at its ceiling
+}
+
+func (d *Dispatcher) grantQuestPartyExp(w *world.World, consumer *world.Entity, share int64) {
+	if share <= 0 {
+		return
+	}
+	leaderID := consumer.Leader
+	if leaderID == 0 {
+		if partyMemberCount(consumer) == 0 {
+			return
+		}
+		leaderID = consumer.ID
+	}
+	leader := w.Entity(leaderID)
+	if leader == nil {
+		return
+	}
+
+	seen := map[int]bool{consumer.ID: true}
+	recipients := make([]int, 0, world.MaxParty+1)
+	recipients = append(recipients, leaderID)
+	recipients = append(recipients, leader.PartyList[:]...)
+	for _, conn := range recipients {
+		if conn <= 0 || conn >= world.MaxUser || seen[conn] {
+			continue
+		}
+		seen[conn] = true
+		rs, re := w.Session(conn), w.Entity(conn)
+		if rs == nil || rs.Mode != world.UserPlay || re == nil {
+			continue
+		}
+		d.grantDirectExp(w, rs, re, share)
+	}
 }
 
 // useHealPotion consumes an HP/MP potion (EF_VOLATILE 1), porting

--- a/tmserver/internal/handler/itemops_test.go
+++ b/tmserver/internal/handler/itemops_test.go
@@ -278,7 +278,7 @@ func TestTradingItemSameSlotNoop(t *testing.T) {
 }
 
 func TestIsSplittable(t *testing.T) {
-	for _, idx := range []int16{412, 413, 414, 416, 419, 420, 2390, 2400, 2419, itemPedraDoSabio} {
+	for _, idx := range []int16{412, 413, 414, 416, 419, 420, 2390, 2400, 2419, itemPedraDoSabio, 4117, 4118, 4119, 4120, 4121} {
 		if !isSplittable(idx) {
 			t.Errorf("isSplittable(%d) = false, want true", idx)
 		}

--- a/tmserver/internal/handler/mobkilled.go
+++ b/tmserver/internal/handler/mobkilled.go
@@ -246,6 +246,31 @@ func (d *Dispatcher) grantExp(w *world.World, ks *world.Session, killer, mob *wo
 	d.applyLevelUps(w, ks, killer)
 }
 
+// grantDirectExp awards a fixed, already-calculated amount. Quest rewards must
+// not pass through monster level scaling, equipment bonuses, or EXP events.
+func (d *Dispatcher) grantDirectExp(w *world.World, s *world.Session, e *world.Entity, gain int64) int64 {
+	if gain <= 0 {
+		return 0
+	}
+	previous := e.Exp
+	e.Exp += gain
+	if e.Exp > level.MaxExp {
+		e.Exp = level.MaxExp
+	}
+	applied := e.Exp - previous
+	if applied <= 0 || s == nil {
+		return applied
+	}
+	w.Send(s, protocol.MsgExpPanel, protocol.EncodeExpPanelBody(fmt.Sprintf("+%d de EXP", applied), expPanelDefaultColor))
+	if !d.applyLevelUps(w, s, e) {
+		d.sendEtc(w, s, e)
+	}
+	motion := protocol.EncodeMotion(motionLevelUp, motionLevelUpParm)
+	w.Send(s, protocol.MsgMotion, motion)
+	w.BroadcastInView(e.ID, protocol.MsgMotion, motion)
+	return applied
+}
+
 // isCelestialTier reports whether the tier rides the Celestial curve (g_pNextLevel_2)
 // and cap (MAX_CLEVEL): CELESTIAL/CELESTIALCS/SCELESTIAL (CMob.cpp:1085).
 func isCelestialTier(classMaster uint8) bool {

--- a/tmserver/internal/handler/quest_item_test.go
+++ b/tmserver/internal/handler/quest_item_test.go
@@ -1,0 +1,149 @@
+package handler
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/level"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+func questRewardDB(item int16, lvl int, amount uint8) *fakeDB {
+	db := newDB()
+	st := world.CharacterState{
+		Slot: 0, Name: "Hero", ClassMaster: classMasterMortal, Level: lvl,
+		X: 5, Y: 5, HP: 1000, MaxHP: 1000,
+	}
+	st.Carry[0] = world.Item{Index: item}
+	if amount > 1 {
+		st.Carry[0].Effects[0] = world.Effect{Effect: efAmount, Value: amount}
+	}
+	db.loadResult = st
+	return db
+}
+
+func useQuestItem(t *testing.T, c net.Conn) {
+	t.Helper()
+	body := protocol.MsgUseItemBody{SourType: world.ItemPlaceCarry, SourPos: 0}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+}
+
+func collectQuestResult(t *testing.T, c net.Conn, max int) (exp int64, coin int32, item []byte, sawPanel bool) {
+	t.Helper()
+	for range max {
+		ty, payload, ok := readMaybe(t, c)
+		if !ok {
+			break
+		}
+		switch ty {
+		case protocol.MsgExpPanel:
+			sawPanel = true
+		case protocol.MsgUpdateEtc:
+			exp = int64(binary.LittleEndian.Uint64(payload[4:12]))
+			coin = int32(binary.LittleEndian.Uint32(payload[28:32]))
+		case protocol.MsgSendItem:
+			item = payload
+		}
+	}
+	return
+}
+
+func TestQuestItemRewardAllTiersAndStackConsumption(t *testing.T) {
+	tiers := []struct {
+		item int16
+		lvl  int
+		exp  int64
+		coin int32
+	}{{4117, 39, 1000, 2000}, {4118, 115, 2000, 4000}, {4119, 190, 3000, 6000}, {4120, 265, 4000, 8000}, {4121, 320, 5000, 10000}}
+	for _, tc := range tiers {
+		t.Run(fmt.Sprintf("item-%d", tc.item), func(t *testing.T) {
+			addr, stop := startServerClockVol(t, questRewardDB(tc.item, tc.lvl, 3), map[int]int{int(tc.item): volQuestReward})
+			defer stop()
+			c := enterWorld(t, addr)
+			defer c.Close()
+			useQuestItem(t, c)
+			exp, coin, item, panel := collectQuestResult(t, c, 10)
+			if exp != tc.exp || coin != tc.coin || !panel {
+				t.Errorf("reward = exp %d coin %d panel %v, want %d %d true", exp, coin, panel, tc.exp, tc.coin)
+			}
+			if len(item) < 8 || le16(item[4:6]) != uint16(tc.item) || item[6] != efAmount || item[7] != 2 {
+				t.Errorf("remaining stack = %v, want item %d amount 2", item, tc.item)
+			}
+		})
+	}
+}
+
+func TestQuestItemRewardLevelBoundariesRejectWithoutConsumption(t *testing.T) {
+	for _, lvl := range []int{38, 115} {
+		addr, stop := startServerClockVol(t, questRewardDB(4117, lvl, 3), map[int]int{4117: volQuestReward})
+		c := enterWorld(t, addr)
+		useQuestItem(t, c)
+		if notice := expect(t, c, protocol.MsgMessageBoxOk); noticeCode(t, notice) != NoticeReqNotMet {
+			t.Errorf("level %d notice = %d", lvl, noticeCode(t, notice))
+		}
+		item := expect(t, c, protocol.MsgSendItem)
+		if le16(item[4:6]) != 4117 || item[7] != 3 {
+			t.Errorf("level %d changed rejected stack: %v", lvl, item)
+		}
+		c.Close()
+		stop()
+	}
+}
+
+func TestQuestItemRewardCaps(t *testing.T) {
+	db := questRewardDB(4117, 39, 1)
+	db.loadResult.Exp = level.MaxExp - 10
+	db.loadResult.Coin = maxCoin - 10
+	addr, stop := startServerClockVol(t, db, map[int]int{4117: volQuestReward})
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+	useQuestItem(t, c)
+	exp, coin, item, _ := collectQuestResult(t, c, 10)
+	if exp != level.MaxExp || coin != maxCoin {
+		t.Errorf("capped reward = exp %d coin %d, want %d %d", exp, coin, level.MaxExp, maxCoin)
+	}
+	if len(item) < 6 || le16(item[4:6]) != 0 {
+		t.Errorf("final unit not consumed: %v", item)
+	}
+}
+
+func TestQuestItemRewardPartyMemberGetsTenPercent(t *testing.T) {
+	db := partyDB()
+	leader := db.loads[7]
+	leader.Carry[0] = world.Item{Index: 4117}
+	db.loads[7] = leader
+	addr, stop := startServerClockVol(t, db, map[int]int{4117: volQuestReward})
+	defer stop()
+	a := enterWorldAs(t, addr, "tester")
+	defer a.Close()
+	b := enterWorldAs(t, addr, "tradeb")
+	defer b.Close()
+
+	reqPartyFrame(t, a, 1, 2)
+	expectPartyFrame(t, b, protocol.MsgSendReqParty)
+	acceptPartyFrame(t, b, 1, "Hero")
+	for {
+		if _, _, ok := readMaybe(t, a); !ok {
+			break
+		}
+	}
+	for {
+		if _, _, ok := readMaybe(t, b); !ok {
+			break
+		}
+	}
+
+	useQuestItem(t, a)
+	leaderExp, _, _, _ := collectQuestResult(t, a, 10)
+	memberExp, memberCoin, _, panel := collectQuestResult(t, b, 8)
+	if leaderExp != 1000 {
+		t.Errorf("consumer exp = %d, want 1000 (no self share)", leaderExp)
+	}
+	if memberExp != 100 || memberCoin != 0 || !panel {
+		t.Errorf("member reward = exp %d coin %d panel %v, want 100 0 true", memberExp, memberCoin, panel)
+	}
+}

--- a/tmserver/internal/handler/quest_item_test.go
+++ b/tmserver/internal/handler/quest_item_test.go
@@ -31,9 +31,9 @@ func useQuestItem(t *testing.T, c net.Conn) {
 	send(t, c, protocol.MsgUseItem, body.Encode())
 }
 
-func collectQuestResult(t *testing.T, c net.Conn, max int) (exp int64, coin int32, item []byte, sawPanel bool) {
+func collectQuestResult(t *testing.T, c net.Conn, limit int) (exp int64, coin int32, item []byte, sawPanel bool) {
 	t.Helper()
-	for range max {
+	for range limit {
 		ty, payload, ok := readMaybe(t, c)
 		if !ok {
 			break


### PR DESCRIPTION
## Summary

- load the five quest reward tiers from Common/Settings/QuestsRate.txt, with legacy defaults for no-content mode
- grant configured EXP/gold for items 4117-4121 and distribute a 10% EXP share to other active party members
- support merging, splitting, and single-unit consumption of quest item stacks
- add regression coverage and archive the completed OpenSpec change

## Validation

- go test -run 'Test.*Quest(Item|Rate|Reward)' ./tmserver/internal/content ./tmserver/internal/handler
- make test (go test -race -cover ./...)
- openspec validate --strict
- openspec validate --specs
- git diff --check

Closes #304