### PR TITLE
fix(tmserver): align kingdom teleport commands

### DIFF
--- a/docs/game.md
+++ b/docs/game.md
@@ -11,10 +11,9 @@
 ✅ /gelo: se teleportará para a cidade de Gelo <br/>
 ✅ /kefra: se teleportará para a cidade de Kefra <br/>
 ✅ /noatun: se teleportará para Noatun <br/>
-✅ /red: se teleportará para o rei de Akelonia <br/>
-✅ /blue: se teleportará para o rei de Hekalotia <br/>
 ✅ /arch: se teleportará para a cidade dos reinos (apenas o teleporte; o destrave do Arch é ⏳) <br/>
-✅ /reino: teleporta de acordo com a capa — capa de Hekalotia (azul) leva ao rei de Hekalotia, capa de Akelonia (vermelha) ao rei de Akelonia, e qualquer capa neutra (sem capa, Capa Branca do Monstro #550, capa verde/Manto do Aprendiz #4006, …) à cidade dos reinos — comando novo, não existe na fonte legada <br/>
+✅ /rei ou /king: teleporta para o rei correspondente à capa equipada — Hekalotia (azul) vai para `(1748,1574)` e Akelonia (vermelha) para `(1748,1880)`; sem capa de reino, o comando não teleporta <br/>
+✅ /reino ou /kingdom: teleporta para a área de comércio correspondente à capa equipada — Hekalotia (azul) vai para `(1690,1618)`, Akelonia (vermelha) para `(1690,1842)`, e qualquer capa neutra (sem capa, Capa Branca do Monstro #550, capa verde/Manto do Aprendiz #4006, …) para o centro dos reinos em `(1702,1726)` <br/>
 ⏳ /crias: se teleportará para o drop de crias (Sleipnir e Svaldfire) — sem coordenada na fonte legada <br/>
 ✅ /destravar40: destrava o level 40 do celestial (seta o gate `QuestInfo.Celestial.Lv40`; efetivo só para chars Celestial) <br/>
 ✅ /destravar90: destrava o level 90 do celestial (gate `Lv90` + dá a FuryStone item 3502) <br/>
@@ -65,7 +64,7 @@ usa Vento (5337). A pedra será consumida, a capa será substituída pela versã
 personagem retornará à seleção para recarregar a progressão.
 
 Faça as quest dos quatros cristais no seu Arch para liberar mais pontos.
-- Dê /red ou /blue para ir direto para o rei desejado.
+- Use /rei ou /king para ir ao rei correspondente à capa equipada.
 • Não precisa transformar o Lac, somente separe 10 que já vai funcionar
 
 Para destravar o lv 40 e 90 do Cele utilize o comando /destravar40 e /destravar90

--- a/openspec/changes/archive/2026-09-08-fix-kingdom-teleport-commands/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-08-fix-kingdom-teleport-commands/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/archive/2026-09-08-fix-kingdom-teleport-commands/design.md
+++ b/openspec/changes/archive/2026-09-08-fix-kingdom-teleport-commands/design.md
@@ -1,0 +1,67 @@
+## Context
+
+See `proposal.md` for motivation. Chat slash commands arrive as whisper packets whose target name contains the command keyword. The current dispatcher handles `/red`, `/blue`, and `/reino`; the first two bypass cape classification, while `/reino` combines king and neutral-center behavior with randomized destinations.
+
+The existing cape classifier already maps every known kingdom cape to Hekalotia or Akelonia, and `doTeleport` already performs authoritative movement and view reconciliation inside the single-owner world loop. The legacy handler provides distinct fixed destinations for `/king` and `/kingdom`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep all command routing synchronous inside the world loop.
+- Centralize the cape-to-destination decision so Portuguese and English aliases cannot drift.
+- Preserve normal whisper fallback for keywords that are no longer commands.
+- Make coordinates deterministic and directly testable against the legacy behavior.
+
+**Non-Goals:**
+
+- Diagnose or repair the broader area-transition client freeze.
+- Change general teleport packet encoding or visibility reconciliation.
+- Introduce command authorization, persistence, or configurable destinations.
+- Change how kingdom capes are classified elsewhere in the game.
+
+## Decisions
+
+### Separate static city teleports from cape-aware kingdom commands
+
+Remove `red` and `blue` from the static teleport-command table and dispatch the four supported aliases through cape-aware handlers. This prevents a generic coordinate lookup from bypassing faction selection.
+
+Alternative considered: retain `/red` and `/blue` but validate the cape. This preserves nonstandard commands that issue #318 explicitly identifies as uncommon and keeps redundant public paths, so it is rejected.
+
+### Reuse equipped-cape classification with a neutral clan input
+
+Both handlers will derive the effective kingdom from the equipped cape while deliberately ignoring the entity's stored guild clan. A character without a kingdom cape is neutral for command routing even if guild state carries a kingdom-like clan value.
+
+Alternative considered: use the entity's stored clan directly, as the legacy local variable did. The current project already treats equipped cape as the externally visible kingdom identity, and the requested behavior is explicitly cape-based.
+
+### Use distinct destination tables and fixed legacy coordinates
+
+The king handler maps Hekalotia to `(1748,1574)` and Akelonia to `(1748,1880)`. The commerce handler maps Hekalotia to `(1690,1618)`, Akelonia to `(1690,1842)`, and neutral to `(1702,1726)`. No random spread is added.
+
+Alternative considered: preserve the existing random offset used by generic city commands. Fixed destinations match the legacy `/king` and `/kingdom` behavior and avoid landing on an adjacent tile with different map or NPC characteristics.
+
+### Consume neutral king commands without teleporting
+
+`/rei` and `/king` remain recognized for neutral characters but produce no movement. This mirrors the legacy handler, which has no neutral destination, and prevents the keyword from falling through to an offline-whisper notice.
+
+Alternative considered: send neutral characters to the kingdom center. That would collapse the distinction between the king and kingdom-commerce commands and contradict the issue's “respectiva capa” rule.
+
+### Let retired color keywords use normal whisper fallback
+
+Once removed from command dispatch, `red` and `blue` follow the existing non-command whisper behavior. If no matching player is online, the caller receives the standard not-connected response. No special deprecation notice is introduced.
+
+Alternative considered: keep them as handled no-ops. Falling through proves they are no longer commands and preserves the dispatcher's established behavior for unknown keywords.
+
+## Risks / Trade-offs
+
+- [Existing users may still type `/red` or `/blue`] -> The change is intentional and covered as a breaking behavior in the proposal; supported PT/EN aliases replace them.
+- [A known kingdom cape could be missing from the shared classifier] -> Exercise the classifier's existing base, elite, and advanced cape families in table-driven tests.
+- [The reported client freeze may still occur after other teleports] -> Do not describe this change as a general disconnect fix; retain the separate freeze investigation and telemetry.
+- [Fixed tiles could differ from server-specific content placement] -> Use coordinates present in the shipped legacy handler and assert them exactly in regression tests.
+
+## Migration Plan
+
+1. Deploy the command routing and regression tests together.
+2. Verify each alias with blue, red, and neutral cape states against the shipped map content.
+3. Monitor existing teleport and session-send telemetry for freezes without changing the broader incident conclusion.
+4. Roll back the command-dispatch commit if the fixed destinations prove incompatible; no stored data or schema rollback is required.

--- a/openspec/changes/archive/2026-09-08-fix-kingdom-teleport-commands/proposal.md
+++ b/openspec/changes/archive/2026-09-08-fix-kingdom-teleport-commands/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The kingdom teleport command set currently exposes nonstandard `/red` and `/blue` shortcuts and gives `/reino` behavior that conflicts with the legacy `/king` and `/kingdom` distinction. This allows a character to teleport directly to the opposing king and provides a known path into the client-freeze symptom reported in issue #318.
+
+## What Changes
+
+- Add `/rei` and `/king` aliases that route a kingdom-caped character to the king associated with the equipped cape.
+- Add `/reino` and `/kingdom` aliases that route a character to the commerce area associated with the equipped kingdom cape, or to the neutral kingdom center for no cape, a white cape, a green cape, or another neutral cape.
+- **BREAKING**: Remove `/red` and `/blue` from the recognized public teleport commands so they fall through as ordinary whisper targets and can no longer bypass cape-based routing.
+- Use the legacy fixed destination coordinates for king and kingdom-commerce commands rather than the existing randomized `/reino` destinations.
+- Treat `/rei` and `/king` as handled no-ops for characters without a kingdom cape, matching the legacy command's lack of a neutral destination.
+- Add command-level regression coverage for aliases, cape classifications, exact destinations, and retired commands.
+- Keep the broader client-freeze investigation out of scope; this change removes the reported invalid command path but does not claim to repair every area-transition freeze.
+
+## Capabilities
+
+### New Capabilities
+
+- `kingdom-teleport-commands`: Defines cape-aware king and kingdom-commerce teleport commands, their aliases, destinations, and retired shortcuts.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affects chat command dispatch and kingdom teleport routing in `tmserver/internal/handler/chat.go`.
+- Affects handler-level protocol tests in `tmserver/internal/handler/chat_test.go`.
+- Reuses the existing equipped-cape classification and authoritative `doTeleport` path inside the single-owner world loop.
+- Does not change wire formats, persistence, external APIs, dependencies, or general disconnect handling.

--- a/openspec/changes/archive/2026-09-08-fix-kingdom-teleport-commands/specs/kingdom-teleport-commands/spec.md
+++ b/openspec/changes/archive/2026-09-08-fix-kingdom-teleport-commands/specs/kingdom-teleport-commands/spec.md
@@ -1,0 +1,53 @@
+## Purpose
+
+Define safe, cape-aware chat commands for travel to a character's kingdom king or commerce area while preventing direct selection of an opposing kingdom.
+
+## ADDED Requirements
+
+### Requirement: King command aliases route by equipped cape
+The server SHALL recognize `/rei` and `/king` as equivalent commands and SHALL determine their destination exclusively from the character's equipped cape.
+
+#### Scenario: Blue kingdom cape travels to the blue king
+- **WHEN** a character wearing a Hekalotia kingdom cape invokes `/rei` or `/king`
+- **THEN** the server teleports the character to exactly `(1748,1574)`
+
+#### Scenario: Red kingdom cape travels to the red king
+- **WHEN** a character wearing an Akelonia kingdom cape invokes `/rei` or `/king`
+- **THEN** the server teleports the character to exactly `(1748,1880)`
+
+#### Scenario: Neutral cape cannot select a king
+- **WHEN** a character with no equipped kingdom cape invokes `/rei` or `/king`
+- **THEN** the server consumes the command without teleporting the character
+
+### Requirement: Kingdom command aliases route to commerce or neutral center
+The server SHALL recognize `/reino` and `/kingdom` as equivalent commands and SHALL route the character according to the kingdom represented by the equipped cape.
+
+#### Scenario: Blue kingdom cape travels to blue commerce
+- **WHEN** a character wearing a Hekalotia kingdom cape invokes `/reino` or `/kingdom`
+- **THEN** the server teleports the character to exactly `(1690,1618)`
+
+#### Scenario: Red kingdom cape travels to red commerce
+- **WHEN** a character wearing an Akelonia kingdom cape invokes `/reino` or `/kingdom`
+- **THEN** the server teleports the character to exactly `(1690,1842)`
+
+#### Scenario: Neutral cape travels to the kingdom center
+- **WHEN** a character with no cape, a white cape, a green cape, or another cape that represents neither kingdom invokes `/reino` or `/kingdom`
+- **THEN** the server teleports the character to exactly `(1702,1726)`
+
+### Requirement: Direct color teleport shortcuts are retired
+The server MUST NOT recognize `/red` or `/blue` as teleport commands.
+
+#### Scenario: Red shortcut is entered
+- **WHEN** a character invokes `/red`
+- **THEN** the server does not teleport the character
+
+#### Scenario: Blue shortcut is entered
+- **WHEN** a character invokes `/blue`
+- **THEN** the server does not teleport the character
+
+### Requirement: Kingdom command teleports preserve world consistency
+Every successful kingdom command teleport SHALL use the server's authoritative teleport behavior so the character position and nearby entity visibility remain consistent within the single-owner world loop.
+
+#### Scenario: Kingdom command teleport completes
+- **WHEN** any recognized king or kingdom command selects a destination
+- **THEN** the server updates the authoritative character position and emits the normal teleport and visibility updates

--- a/openspec/changes/archive/2026-09-08-fix-kingdom-teleport-commands/tasks.md
+++ b/openspec/changes/archive/2026-09-08-fix-kingdom-teleport-commands/tasks.md
@@ -1,0 +1,19 @@
+## 1. Command Routing
+
+- [x] 1.1 Remove `red` and `blue` from the static teleport command table and verify `/red` and `/blue` no longer emit a teleport action.
+- [x] 1.2 Add `/rei` and `/king` dispatch to one cape-aware king handler and verify both aliases select identical behavior.
+- [x] 1.3 Add `/reino` and `/kingdom` dispatch to one cape-aware commerce handler and verify both aliases select identical behavior.
+
+## 2. Cape-Aware Destinations
+
+- [x] 2.1 Define the fixed legacy king and commerce destination coordinates and verify no random offset is applied by the kingdom command handlers.
+- [x] 2.2 Route Hekalotia and Akelonia kingdom capes through the existing cape classifier and verify each cape family reaches its specified king and commerce destinations.
+- [x] 2.3 Route no cape, white cape, green cape, and other neutral capes to `(1702,1726)` for `/reino` and `/kingdom`, and verify `/rei` and `/king` are handled without movement for the same cases.
+- [x] 2.4 Execute every successful route through the authoritative teleport path and verify position plus view reconciliation remain covered by the existing teleport tests.
+
+## 3. Regression Verification
+
+- [x] 3.1 Replace the existing randomized `/reino` test with table-driven coverage for all four aliases, representative blue/red cape families, neutral cape states, and exact coordinates; verify `go test -run 'TestCommand(Rei|King|Reino|Kingdom)' ./tmserver/internal/handler` passes.
+- [x] 3.2 Add regression cases for `/red` and `/blue` normal-whisper fallback, including absence of `MsgAction`, and verify the targeted handler tests pass.
+- [x] 3.3 Run `go test ./tmserver/internal/handler ./tmserver/internal/world` and verify the affected handler and authoritative teleport suites pass.
+- [x] 3.4 Run `make test` and verify the full repository suite passes with race detection and coverage.

--- a/openspec/specs/kingdom-teleport-commands/spec.md
+++ b/openspec/specs/kingdom-teleport-commands/spec.md
@@ -1,0 +1,55 @@
+# Kingdom Teleport Commands Specification
+
+## Purpose
+
+Define safe, cape-aware chat commands for travel to a character's kingdom king or commerce area while preventing direct selection of an opposing kingdom.
+
+## Requirements
+
+### Requirement: King command aliases route by equipped cape
+The server SHALL recognize `/rei` and `/king` as equivalent commands and SHALL determine their destination exclusively from the character's equipped cape.
+
+#### Scenario: Blue kingdom cape travels to the blue king
+- **WHEN** a character wearing a Hekalotia kingdom cape invokes `/rei` or `/king`
+- **THEN** the server teleports the character to exactly `(1748,1574)`
+
+#### Scenario: Red kingdom cape travels to the red king
+- **WHEN** a character wearing an Akelonia kingdom cape invokes `/rei` or `/king`
+- **THEN** the server teleports the character to exactly `(1748,1880)`
+
+#### Scenario: Neutral cape cannot select a king
+- **WHEN** a character with no equipped kingdom cape invokes `/rei` or `/king`
+- **THEN** the server consumes the command without teleporting the character
+
+### Requirement: Kingdom command aliases route to commerce or neutral center
+The server SHALL recognize `/reino` and `/kingdom` as equivalent commands and SHALL route the character according to the kingdom represented by the equipped cape.
+
+#### Scenario: Blue kingdom cape travels to blue commerce
+- **WHEN** a character wearing a Hekalotia kingdom cape invokes `/reino` or `/kingdom`
+- **THEN** the server teleports the character to exactly `(1690,1618)`
+
+#### Scenario: Red kingdom cape travels to red commerce
+- **WHEN** a character wearing an Akelonia kingdom cape invokes `/reino` or `/kingdom`
+- **THEN** the server teleports the character to exactly `(1690,1842)`
+
+#### Scenario: Neutral cape travels to the kingdom center
+- **WHEN** a character with no cape, a white cape, a green cape, or another cape that represents neither kingdom invokes `/reino` or `/kingdom`
+- **THEN** the server teleports the character to exactly `(1702,1726)`
+
+### Requirement: Direct color teleport shortcuts are retired
+The server MUST NOT recognize `/red` or `/blue` as teleport commands.
+
+#### Scenario: Red shortcut is entered
+- **WHEN** a character invokes `/red`
+- **THEN** the server does not teleport the character
+
+#### Scenario: Blue shortcut is entered
+- **WHEN** a character invokes `/blue`
+- **THEN** the server does not teleport the character
+
+### Requirement: Kingdom command teleports preserve world consistency
+Every successful kingdom command teleport SHALL use the server's authoritative teleport behavior so the character position and nearby entity visibility remain consistent within the single-owner world loop.
+
+#### Scenario: Kingdom command teleport completes
+- **WHEN** any recognized king or kingdom command selects a destination
+- **THEN** the server updates the authoritative character position and emits the normal teleport and visibility updates

--- a/tmserver/internal/handler/chat.go
+++ b/tmserver/internal/handler/chat.go
@@ -77,7 +77,7 @@ func (d *Dispatcher) messageWhisper(w *world.World, s *world.Session, _ protocol
 var teleportCmds = map[string][2]int16{
 	"armia": {2100, 2100}, "azran": {2500, 1716}, "erion": {2461, 2003},
 	"gelo": {3650, 3130}, "kefra": {2365, 3884}, "torre": {2506, 1878},
-	"red": {1744, 1880}, "blue": {1745, 1573}, "arch": {1706, 1723},
+	"arch":    {1706, 1723},
 	"selados": {1843, 3652}, "amagos": {3910, 2878}, "agua": {1966, 1770},
 	"noatun": {1052, 1726},
 }
@@ -93,14 +93,15 @@ const reinoCapeSlot = 15
 // "capa branca".
 const capaBrancaDoMonstroIndex = 550
 
-// /reino destinations (issue #208). A kingdom-aligned cape sends the player to their
-// own king — the same tiles as the /blue and /red commands in teleportCmds — while any
-// neutral cape (none at all, the Capa Branca do Monstro #550, the Manto do Aprendiz
-// "capa verde" #4006, …) lands in the kingdom city.
+// Kingdom command destinations remain fixed like the legacy /king and /kingdom
+// handlers. King and commerce destinations are intentionally distinct (issue #318).
 var (
-	reinoDestNeutral   = [2]int16{1706, 1724}
-	reinoDestHekalotia = [2]int16{1745, 1573} // Clan 7 (blue), same tile as /blue
-	reinoDestAkelonia  = [2]int16{1744, 1880} // Clan 8 (red), same tile as /red
+	kingDestHekalotia = [2]int16{1748, 1574}
+	kingDestAkelonia  = [2]int16{1748, 1880}
+
+	kingdomDestNeutral   = [2]int16{1702, 1726}
+	kingdomDestHekalotia = [2]int16{1690, 1618}
+	kingdomDestAkelonia  = [2]int16{1690, 1842}
 )
 
 // runCommand executes a chat slash command delivered as a whisper whose target name is
@@ -118,8 +119,12 @@ func (d *Dispatcher) runCommand(w *world.World, s *world.Session, name string, a
 		}
 		return true
 	}
-	if cmd == "reino" {
-		d.teleportReino(w, s)
+	if cmd == "rei" || cmd == "king" {
+		d.teleportKing(w, s)
+		return true
+	}
+	if cmd == "reino" || cmd == "kingdom" {
+		d.teleportKingdom(w, s)
 		return true
 	}
 	if cmd == "buffs" {
@@ -183,31 +188,36 @@ func (d *Dispatcher) runCommand(w *world.World, s *world.Session, name string, a
 	return false
 }
 
-// teleportReino handles the /reino command: it routes the player by the kingdom their
-// cape belongs to (issue #208). A Hekalotia (blue) cape goes to Hekalotia's king, an
-// Akelonia (red) one to Akelonia's king, and anything else — no cape, capa branca,
-// capa verde, any other neutral cape — to the kingdom city. Nobody is refused.
-//
-// The command itself is not among the 55 legacy command regions enumerated from
-// _MSG_MessageWhisper.cpp (docs/migration/handlers) — a new addition (issue #127), not
-// a ported one. The Clan routing mirrors the legacy /kingdom (_MSG_MessageWhisper.cpp:868-881)
-// but lands on the king tiles instead of the legacy kingdom-city ones.
-func (d *Dispatcher) teleportReino(w *world.World, s *world.Session) {
+// teleportKing routes /rei and /king by the equipped cape. Neutral cape states
+// are handled no-ops because the legacy /king command has no neutral destination.
+func (d *Dispatcher) teleportKing(w *world.World, s *world.Session) {
 	e := w.Entity(s.Conn)
 	if e == nil {
 		return
 	}
-	// Clan 0 is passed on purpose: only the cape decides the destination. e.Clan can
-	// already be 7/8 from the guild/DB while the player wears no cape at all, and a
-	// capeless player belongs to the neutral destination.
-	dest := reinoDestNeutral
 	switch kingClanFromCape(0, e.Equip[reinoCapeSlot].Index) {
 	case clanHekalotia:
-		dest = reinoDestHekalotia
+		d.doTeleport(w, s, kingDestHekalotia[0], kingDestHekalotia[1])
 	case clanAkelonia:
-		dest = reinoDestAkelonia
+		d.doTeleport(w, s, kingDestAkelonia[0], kingDestAkelonia[1])
 	}
-	d.doTeleport(w, s, dest[0]+int16(w.Rand().Intn(3)), dest[1]+int16(w.Rand().Intn(3)))
+}
+
+// teleportKingdom routes /reino and /kingdom by the equipped cape. Kingdom
+// capes land by their commerce NPCs; neutral cape states land between kingdoms.
+func (d *Dispatcher) teleportKingdom(w *world.World, s *world.Session) {
+	e := w.Entity(s.Conn)
+	if e == nil {
+		return
+	}
+	dest := kingdomDestNeutral
+	switch kingClanFromCape(0, e.Equip[reinoCapeSlot].Index) {
+	case clanHekalotia:
+		dest = kingdomDestHekalotia
+	case clanAkelonia:
+		dest = kingdomDestAkelonia
+	}
+	d.doTeleport(w, s, dest[0], dest[1])
 }
 
 // clearBuffs removes every active buff/debuff (the /buffs command), recomputes the score

--- a/tmserver/internal/handler/chat_test.go
+++ b/tmserver/internal/handler/chat_test.go
@@ -78,23 +78,25 @@ func TestCommandNoatunTeleport(t *testing.T) {
 	}
 }
 
-// TestCommandReino verifies /reino routes by the cape's kingdom (issue #208): a
-// Hekalotia/Akelonia cape lands on that kingdom's king, every neutral cape (including
-// none at all) on the kingdom city. No cape is refused any more.
-func TestCommandReino(t *testing.T) {
+// TestCommandKingdomAliases verifies the Portuguese and English commerce commands
+// route by equipped cape to the fixed legacy destinations from issue #318.
+func TestCommandKingdomAliases(t *testing.T) {
 	tests := []struct {
-		name  string
-		cape  int16
-		wantX int16
-		wantY int16
+		name string
+		cmd  string
+		cape int16
+		want [2]int16
 	}{
-		{"no cape", 0, reinoDestNeutral[0], reinoDestNeutral[1]},
-		{"capa branca", capaBrancaDoMonstroIndex, reinoDestNeutral[0], reinoDestNeutral[1]},
-		{"capa verde", greenCapeItem, reinoDestNeutral[0], reinoDestNeutral[1]},
-		{"hekalotia base", 545, reinoDestHekalotia[0], reinoDestHekalotia[1]},
-		{"hekalotia elite", 3191, reinoDestHekalotia[0], reinoDestHekalotia[1]},
-		{"akelonia base", 546, reinoDestAkelonia[0], reinoDestAkelonia[1]},
-		{"akelonia elite", 3192, reinoDestAkelonia[0], reinoDestAkelonia[1]},
+		{"reino no cape", "reino", 0, kingdomDestNeutral},
+		{"kingdom white cape", "kingdom", capaBrancaDoMonstroIndex, kingdomDestNeutral},
+		{"reino green cape", "reino", greenCapeItem, kingdomDestNeutral},
+		{"kingdom other neutral cape", "kingdom", 100, kingdomDestNeutral},
+		{"reino hekalotia base", "reino", 545, kingdomDestHekalotia},
+		{"kingdom hekalotia elite", "kingdom", 3191, kingdomDestHekalotia},
+		{"reino hekalotia advanced", "reino", 3197, kingdomDestHekalotia},
+		{"kingdom akelonia base", "kingdom", 546, kingdomDestAkelonia},
+		{"reino akelonia elite", "reino", 3192, kingdomDestAkelonia},
+		{"kingdom akelonia advanced", "kingdom", 3198, kingdomDestAkelonia},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -108,7 +110,7 @@ func TestCommandReino(t *testing.T) {
 			a := enterWorldAs(t, addr, "tester")
 			defer a.Close()
 
-			whisperFrame(t, a, "reino", "")
+			whisperFrame(t, a, tc.cmd, "")
 			ty, payload, ok := readMaybe(t, a)
 			if !ok || ty != protocol.MsgAction {
 				t.Fatalf("got %#x ok=%v, want MsgAction (teleport)", ty, ok)
@@ -117,11 +119,77 @@ func TestCommandReino(t *testing.T) {
 			if err := body.Decode(payload); err != nil {
 				t.Fatalf("decode MsgAction: %v", err)
 			}
-			// doTeleport spreads the destination by rand%3 on each axis.
-			if body.TargetX < tc.wantX || body.TargetX > tc.wantX+2 ||
-				body.TargetY < tc.wantY || body.TargetY > tc.wantY+2 {
-				t.Errorf("/reino target = %d,%d, want within %d..%d,%d..%d",
-					body.TargetX, body.TargetY, tc.wantX, tc.wantX+2, tc.wantY, tc.wantY+2)
+			if body.TargetX != tc.want[0] || body.TargetY != tc.want[1] {
+				t.Errorf("/%s target = %d,%d, want %d,%d",
+					tc.cmd, body.TargetX, body.TargetY, tc.want[0], tc.want[1])
+			}
+		})
+	}
+}
+
+func TestCommandKingAliases(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      string
+		cape     int16
+		want     [2]int16
+		teleport bool
+	}{
+		{"rei hekalotia base", "rei", 545, kingDestHekalotia, true},
+		{"king hekalotia advanced", "king", 3197, kingDestHekalotia, true},
+		{"rei akelonia base", "rei", 546, kingDestAkelonia, true},
+		{"king akelonia advanced", "king", 3198, kingDestAkelonia, true},
+		{"rei no cape", "rei", 0, [2]int16{}, false},
+		{"king white cape", "king", capaBrancaDoMonstroIndex, [2]int16{}, false},
+		{"rei green cape", "rei", greenCapeItem, [2]int16{}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			db := newDB()
+			db.loads = map[int64]world.CharacterState{
+				7: {Slot: 0, Name: "Hero", X: 5, Y: 5, HP: 1000, MaxHP: 1000,
+					Equip: [world.MaxEquip]world.Item{reinoCapeSlot: {Index: tc.cape}}},
+			}
+			addr, stop, _ := startServerClock(t, db)
+			defer stop()
+			a := enterWorldAs(t, addr, "tester")
+			defer a.Close()
+
+			whisperFrame(t, a, tc.cmd, "")
+			ty, payload, ok := readMaybe(t, a)
+			if !tc.teleport {
+				if ok {
+					t.Fatalf("neutral /%s produced %#x; want handled no-op", tc.cmd, ty)
+				}
+				return
+			}
+			if !ok || ty != protocol.MsgAction {
+				t.Fatalf("got %#x ok=%v, want MsgAction (teleport)", ty, ok)
+			}
+			var body protocol.MsgActionBody
+			if err := body.Decode(payload); err != nil {
+				t.Fatalf("decode MsgAction: %v", err)
+			}
+			if body.TargetX != tc.want[0] || body.TargetY != tc.want[1] {
+				t.Errorf("/%s target = %d,%d, want %d,%d",
+					tc.cmd, body.TargetX, body.TargetY, tc.want[0], tc.want[1])
+			}
+		})
+	}
+}
+
+func TestCommandColorTeleportsRetired(t *testing.T) {
+	for _, cmd := range []string{"red", "blue"} {
+		t.Run(cmd, func(t *testing.T) {
+			addr, stop, _ := startServerClock(t, chatDB())
+			defer stop()
+			a := enterWorldAs(t, addr, "tester")
+			defer a.Close()
+
+			whisperFrame(t, a, cmd, "")
+			ty, payload, ok := readMaybe(t, a)
+			if !ok || ty != protocol.MsgMessageBoxOk || noticeCode(t, payload) != NoticeNotConnected {
+				t.Fatalf("/%s produced %#x ok=%v; want normal offline-whisper response", cmd, ty, ok)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- replace the nonstandard `/red` and `/blue` teleport shortcuts with cape-aware `/rei` and `/king` aliases
- route `/reino` and `/kingdom` to the appropriate kingdom commerce area, with neutral capes sent to the center
- use fixed legacy coordinates and preserve authoritative teleport/view reconciliation
- add regression coverage and archive the completed OpenSpec change

## Tests

- `go test -run 'TestCommand(Rei|King|Color)' ./tmserver/internal/handler`
- `go test ./tmserver/internal/handler ./tmserver/internal/world`
- `make test`
- `openspec validate --specs`

Closes #318