### PR TITLE
fix(tmserver): restore refinement feedback

### DIFF
--- a/tmserver/internal/handler/classe.go
+++ b/tmserver/internal/handler/classe.go
@@ -44,22 +44,22 @@ func (d *Dispatcher) useClasseItem(w *world.World, s *world.Session, e *world.En
 	// activeCarryLimit(e) <= maxUnlockedCarry == 60 and yields nil above it —
 	// caught by the dst == nil return above.
 	if int(body.DestType) == world.ItemPlaceEquip {
-		// _NN_Only_To_Equips is the string Source sends here (:4972). It reads
-		// backwards for this gate — one of the legacy's many misfiled message
-		// ids — but the client shows it, so it is kept for parity.
-		d.notify(w, s, NoticeOnlyToEquips)
+		// The legacy used the backwards _NN_Only_To_Equips string here. Give the
+		// player an actionable error while preserving the inventory-only rule.
+		d.sendRefineMessage(w, s, classeMessageInventory)
 		d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
 		return
 	}
 
 	mobType := d.itemAbility(*dst, efMobType)
 	if itemSanc(*dst) >= 10 || (mobType != 0 && mobType != 2) {
-		// Source sends no notice on this gate — just resyncs the dragged slot.
+		d.sendRefineMessage(w, s, classeMessageCantRefine)
 		d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
 		return
 	}
 
 	if d.itemAbility(*dst, efItemLevel) != classeTier(e.Carry[src].Index) {
+		d.sendRefineMessage(w, s, classeMessageMismatch)
 		d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
 		return
 	}
@@ -70,11 +70,14 @@ func (d *Dispatcher) useClasseItem(w *world.World, s *world.Session, e *world.En
 	// recorded in "Source/Lista de bugs.txt:6". Refuse and resync instead of
 	// destroying the item.
 	if !refine.ClasseBonus(dst, d.itemPos[int(dst.Index)], func(n int) int { return w.Rand().Intn(n) }, d.itemAbility) {
+		d.sendRefineMessage(w, s, classeMessageCantRefine)
 		d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
 		return
 	}
 
 	d.sendSlot(w, s, int(body.DestType), int(body.DestPos), *dst)
+	d.sendRefineMessage(w, s, refineMessageSuccess)
+	d.sendRefineMotion(w, s, e.ID, refineMotionSuccess, refineMotionSuccessParm)
 	d.log.Info("classe item bonus reroll", "conn", s.Conn, "item", dst.Index, "effects", dst.Effects)
 	consumeOneItem(&e.Carry[src])
 	// The Classe slot is deliberately NOT re-sent on success, mirroring

--- a/tmserver/internal/handler/classe_test.go
+++ b/tmserver/internal/handler/classe_test.go
@@ -119,6 +119,12 @@ func TestClasseBonusHelmRerollsSancAndEffects(t *testing.T) {
 	if got.Effects[1].Effect == 0 || got.Effects[2].Effect == 0 {
 		t.Errorf("bonus effects not set: %+v", got.Effects)
 	}
+	if got := f.w.SentOfType(f.s, protocol.MsgMessagePanel); got != 1 {
+		t.Errorf("message panels = %d, want 1", got)
+	}
+	if got := f.w.SentOfType(f.s, protocol.MsgMotion); got != 1 {
+		t.Errorf("motions = %d, want 1", got)
+	}
 }
 
 // classeSancCapForTest avoids importing the unexported refine.classeSancCap.
@@ -230,6 +236,12 @@ func TestClasseGates(t *testing.T) {
 			if f.e.Carry[0].Empty() {
 				t.Errorf("classe item unexpectedly consumed on a gate failure")
 			}
+			if got := f.w.SentOfType(f.s, protocol.MsgMessagePanel); got != 1 {
+				t.Errorf("message panels = %d, want 1", got)
+			}
+			if got := f.w.SentOfType(f.s, protocol.MsgMotion); got != 0 {
+				t.Errorf("motions = %d, want 0 on rejection", got)
+			}
 		})
 	}
 }
@@ -253,6 +265,12 @@ func TestClasseRejectsEquipDestination(t *testing.T) {
 	}
 	if f.e.Equip[1] != (world.Item{Index: itemChestT1}) {
 		t.Errorf("equipped target mutated: %+v", f.e.Equip[1])
+	}
+	if got := f.w.SentOfType(f.s, protocol.MsgMessagePanel); got != 1 {
+		t.Errorf("message panels = %d, want 1", got)
+	}
+	if got := f.w.SentOfType(f.s, protocol.MsgMotion); got != 0 {
+		t.Errorf("motions = %d, want 0 on rejection", got)
 	}
 }
 

--- a/tmserver/internal/handler/refine.go
+++ b/tmserver/internal/handler/refine.go
@@ -141,25 +141,25 @@ func (d *Dispatcher) refineItem(w *world.World, s *world.Session, e *world.Entit
 	// EF_VOLATILE is a catalog property — no minted item carries it as an instance
 	// effect — so the two agree in practice.
 	if d.itemVolatiles[int(dst.Index)] != 0 {
-		d.refineReject(w, s, e, src, NoticeOnlyToEquips)
+		d.refineDustReject(w, s, e, src, refineMessageOnlyEquipment)
 		return
 	}
 	if d.itemAbility(*dst, efNoSanc) != 0 {
-		d.refineReject(w, s, e, src, NoticeCantRefineMore)
+		d.refineDustReject(w, s, e, src, refineMessageCantMore)
 		return
 	}
 
 	level := refine.Level(*dst)
 	// Ori cannot touch an item already at +6 or above (:203).
 	if vol == volDustOri && level >= oriMaxSanc {
-		d.refineReject(w, s, e, src, NoticeCantRefineMore)
+		d.refineDustReject(w, s, e, src, refineMessageCantMore)
 		return
 	}
 	// +9 is the dust path's wall. +10 is allowed through as the one special case
 	// (it becomes +11); +11 and up are refused (:802, where the legacy compares
 	// against the REF_11 sentinel).
 	if level == lacMaxSanc || level >= sancHardCap || (level >= lacMaxSanc && dst.Index == item769) {
-		d.refineReject(w, s, e, src, NoticeCantRefineMore)
+		d.refineDustReject(w, s, e, src, refineMessageCantMore)
 		return
 	}
 
@@ -171,7 +171,7 @@ func (d *Dispatcher) refineItem(w *world.World, s *world.Session, e *world.Entit
 	// A never-refined item has nowhere to store a level yet. When all three effect
 	// slots hold real effects the legacy refuses to refine the item at all (:814).
 	if level == 0 && !refine.Bootstrap(dst) {
-		d.refineReject(w, s, e, src, NoticeCantRefineMore)
+		d.refineDustReject(w, s, e, src, refineMessageCantMore)
 		return
 	}
 
@@ -181,7 +181,7 @@ func (d *Dispatcher) refineItem(w *world.World, s *world.Session, e *world.Entit
 	// UNVERIFIED: the legacy reads BaseScore.Level here; the Entity only carries
 	// CurrentScore.Level. They differ only via EF_LEVEL gear, never near 999.
 	if isEgg(*dst) && e.Level < incuLevelExempt && itemInstanceAbility(*dst, efIncuDelay) > 0 {
-		d.refineReject(w, s, e, src, NoticeIncuWaitMore)
+		d.refineDustReject(w, s, e, src, refineMessageIncubationWait)
 		return
 	}
 
@@ -214,8 +214,9 @@ func (d *Dispatcher) refineItem(w *world.World, s *world.Session, e *world.Entit
 // game-rules.md §3.6.1); it's a migration design decision, not a port.
 func (d *Dispatcher) refineTintura(w *world.World, s *world.Session, e *world.Entity, dst *world.Item, body protocol.MsgUseItemBody, src int) {
 	dst.Index = int16(magicBeanBase + (int(dst.Index) - tinturaLo))
-	d.notify(w, s, NoticeRefineSuccess)
+	d.sendRefineMessage(w, s, refineMessageSuccess)
 	d.sendSlot(w, s, int(body.DestType), int(body.DestPos), *dst)
+	d.sendRefineMotion(w, s, e.ID, refineMotionSuccess, refineMotionSuccessParm)
 	consumeOneItem(&e.Carry[src])
 }
 
@@ -251,15 +252,14 @@ func (d *Dispatcher) refineSucceed(w *world.World, s *world.Session, e *world.En
 
 	d.refreshScore(e)
 	d.sendScore(w, s, e)
-	d.notify(w, s, NoticeRefineSuccess)
+	d.sendRefineMessage(w, s, refineMessageSuccess)
 
 	if isEgg(*dst) {
 		d.hatchEgg(w, s, t, level)
 	}
 
 	d.sendSlot(w, s, t.place, t.slot, *dst)
-	// SendEmotion(conn, 14, 3) — cosmetic, and no emotion packet exists in this
-	// port yet (_MSG_UseItem.cpp:920).
+	d.sendRefineMotion(w, s, e.ID, refineMotionSuccess, refineMotionSuccessParm)
 	consumeOneItem(&e.Carry[src])
 	// The dust slot is deliberately NOT re-sent: the client already removed the
 	// item it dragged, and the legacy only echoes the source back on the refusal
@@ -269,7 +269,7 @@ func (d *Dispatcher) refineSucceed(w *world.World, s *world.Session, e *world.En
 // refineFail applies a lost roll (_MSG_UseItem.cpp:929-974). The item survives
 // untouched — only the dust is spent and the pity counter grows.
 func (d *Dispatcher) refineFail(w *world.World, s *world.Session, e *world.Entity, t refineTarget, src, anvil, level, pity int) {
-	d.notify(w, s, NoticeFailToRefine)
+	d.sendRefineMessage(w, s, refineMessageFailure)
 	consumeOneItem(&e.Carry[src])
 
 	if w.Rand().Intn(pityRollModulo) <= pityRollMax {
@@ -288,7 +288,7 @@ func (d *Dispatcher) refineFail(w *world.World, s *world.Session, e *world.Entit
 		refine.Set(dst, level, pity)
 	}
 	d.sendSlot(w, s, t.place, t.slot, *dst)
-	// SendEmotion(conn, 15|20, 0) — cosmetic, not ported (:967).
+	d.sendRefineFailureMotion(w, s, e)
 }
 
 // hatchEgg is the mount-egg branch inlined in the refine success
@@ -317,7 +317,7 @@ func (d *Dispatcher) hatchEgg(w *world.World, s *world.Session, t refineTarget, 
 		Value:  uint8(w.Rand().Intn(hatchLifeSpan) + hatchLifeBase),
 	}
 	dst.Effects[2] = world.Effect{Effect: hatchMountFeed, Value: hatchMountKill}
-	d.notify(w, s, NoticeIncubated)
+	d.sendRefineMessage(w, s, refineMessageIncubated)
 	// MountProcess(conn, 0) is a no-op: with a NULL mount its IsEqual stays 1 and
 	// it returns immediately (Server.cpp:4639-4643). Nothing to port.
 	//
@@ -326,8 +326,15 @@ func (d *Dispatcher) hatchEgg(w *world.World, s *world.Session, t refineTarget, 
 	d.sendSlot(w, s, t.place, t.slot, *dst)
 }
 
-// refineReject refuses a refine and re-sends the DUST slot, so the client puts
+// refineDustReject refuses a dust refine and re-sends the DUST slot, so the client puts
 // the item it dragged back where it was (_MSG_UseItem.cpp:805).
+func (d *Dispatcher) refineDustReject(w *world.World, s *world.Session, e *world.Entity, src int, message string) {
+	d.sendRefineMessage(w, s, message)
+	d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])
+}
+
+// refineReject is shared by refinement-like consumables that still use the
+// placeholder Notice system and are outside issue #317.
 func (d *Dispatcher) refineReject(w *world.World, s *world.Session, e *world.Entity, src int, n Notice) {
 	d.notify(w, s, n)
 	d.sendSlot(w, s, world.ItemPlaceCarry, src, e.Carry[src])

--- a/tmserver/internal/handler/refine_feedback.go
+++ b/tmserver/internal/handler/refine_feedback.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+const (
+	refineMessageSuccess        = "Obteve sucesso na refinação."
+	refineMessageFailure        = "Refinação falhou."
+	refineMessageCantMore       = "Este item não pode ser mais refinado."
+	refineMessageOnlyEquipment  = "Possível somente com armas e armaduras."
+	refineMessageIncubated      = "Incubação sucedida."
+	refineMessageIncubationWait = "Incubação não está pronta."
+
+	classeMessageMismatch   = "A Classe não é compatível com este item."
+	classeMessageInventory  = "O item deve estar no inventário."
+	classeMessageCantRefine = "Este item não pode ser refinado."
+)
+
+const (
+	refineMotionSuccess     = 14
+	refineMotionFailureFace = 15
+	refineMotionFailureBase = 20
+	refineMotionSuccessParm = 3
+)
+
+// sendRefineMessage uses the same MSG_MessagePanel wire shape as the legacy
+// SendClientMessage function. Notice's MessageBoxOk body is only a placeholder
+// and is not understood as text by the unmodified 7662 client.
+func (d *Dispatcher) sendRefineMessage(w *world.World, s *world.Session, message string) {
+	w.Send(s, protocol.MsgMessagePanel, protocol.EncodeMessagePanelBody(message))
+}
+
+// sendRefineMotion reproduces SendEmotion: the player and everyone in view see
+// the same motion, identified by the player's entity id in HEADER.ID.
+func (d *Dispatcher) sendRefineMotion(w *world.World, s *world.Session, entityID, motion, parm int) {
+	body := protocol.EncodeMotion(uint16(motion), uint16(parm))
+	w.Send(s, protocol.MsgMotion, body)
+	w.BroadcastInView(entityID, protocol.MsgMotion, body)
+}
+
+func (d *Dispatcher) sendRefineFailureMotion(w *world.World, s *world.Session, e *world.Entity) {
+	d.sendRefineMotion(w, s, e.ID, refineFailureMotion(e), 0)
+}
+
+func refineFailureMotion(e *world.Entity) int {
+	if e.Equip[0].Index/10 != 0 {
+		return refineMotionFailureFace
+	}
+	return refineMotionFailureBase
+}

--- a/tmserver/internal/handler/refine_test.go
+++ b/tmserver/internal/handler/refine_test.go
@@ -105,6 +105,12 @@ func TestRefineSuccessRaisesLevel(t *testing.T) {
 	if f.target().Effects[0] != (world.Effect{Effect: efSanc, Value: 1}) {
 		t.Errorf("Effects[0] = %+v, want {EF_SANC 1}", f.target().Effects[0])
 	}
+	if got := f.w.SentOfType(f.s, protocol.MsgMessagePanel); got != 1 {
+		t.Errorf("message panels = %d, want 1", got)
+	}
+	if got := f.w.SentOfType(f.s, protocol.MsgMotion); got != 1 {
+		t.Errorf("motions = %d, want 1", got)
+	}
 }
 
 // A failed dust refine never destroys or downgrades the item — that only happens
@@ -129,6 +135,12 @@ func TestRefineFailKeepsItemAndAccruesPity(t *testing.T) {
 	// does NOT accrue pity — the roll is 3-in-4.
 	if got := refine.Pity(f.target()); got != 0 {
 		t.Errorf("pity = %d, want 0 (rand()#2%%4 = 3 misses the <=2 window)", got)
+	}
+	if got := f.w.SentOfType(f.s, protocol.MsgMessagePanel); got != 1 {
+		t.Errorf("message panels = %d, want 1", got)
+	}
+	if got := f.w.SentOfType(f.s, protocol.MsgMotion); got != 1 {
+		t.Errorf("motions = %d, want 1", got)
 	}
 }
 
@@ -225,6 +237,12 @@ func TestRefineGates(t *testing.T) {
 			}
 			if f.e.Carry[0].Empty() {
 				t.Error("a refused refine consumed the dust")
+			}
+			if got := f.w.SentOfType(f.s, protocol.MsgMessagePanel); got != 1 {
+				t.Errorf("message panels = %d, want 1", got)
+			}
+			if got := f.w.SentOfType(f.s, protocol.MsgMotion); got != 0 {
+				t.Errorf("motions = %d, want 0 on rejection", got)
 			}
 		})
 	}
@@ -395,6 +413,66 @@ func TestRefineOverTheWire(t *testing.T) {
 			t.Fatalf("SendItem Effects[0] = %+v, want {EF_SANC 1} — the client renders THIS, not the server's copy", eff0)
 		}
 		return
+	}
+}
+
+func TestRefineFailureMotionMatchesLegacyFaceRule(t *testing.T) {
+	if got := refineFailureMotion(&world.Entity{}); got != refineMotionFailureBase {
+		t.Errorf("base-character failure motion = %d, want %d", got, refineMotionFailureBase)
+	}
+	withFace := &world.Entity{}
+	withFace.Equip[0] = world.Item{Index: 10}
+	if got := refineFailureMotion(withFace); got != refineMotionFailureFace {
+		t.Errorf("equipped-face failure motion = %d, want %d", got, refineMotionFailureFace)
+	}
+}
+
+// TestRefineFeedbackOverTheWire guards the issue #317 regression: the 7662
+// client needs a real MessagePanel body and Motion frame, not the placeholder
+// MessageBoxOk notice code previously emitted by the handler.
+func TestRefineFeedbackOverTheWire(t *testing.T) {
+	db := newDB()
+	st := world.CharacterState{Slot: 0, Name: "Hero", X: 5, Y: 5, HP: 1000, MaxHP: 1000}
+	st.Carry[0] = world.Item{Index: itemPoeiraLac}
+	st.Carry[1] = world.Item{Index: itemArmor}
+	db.loadResult = st
+
+	addr, stop := startRefineServer(t, db)
+	defer stop()
+	c := enterWorld(t, addr)
+	defer c.Close()
+
+	body := protocol.MsgUseItemBody{
+		SourType: world.ItemPlaceCarry, SourPos: 0,
+		DestType: world.ItemPlaceCarry, DestPos: 1,
+	}
+	send(t, c, protocol.MsgUseItem, body.Encode())
+
+	var sawPanel, sawMotion bool
+	for i := 0; i < 12 && (!sawPanel || !sawMotion); i++ {
+		ty, payload, ok := readMaybe(t, c)
+		if !ok {
+			t.Fatal("connection closed before refine feedback arrived")
+		}
+		switch ty {
+		case protocol.MsgMessagePanel:
+			if got := cstr(payload); got != refineMessageSuccess {
+				t.Fatalf("panel text = %q, want %q", got, refineMessageSuccess)
+			}
+			sawPanel = true
+		case protocol.MsgMessageBoxOk:
+			t.Fatal("refine feedback used the placeholder MessageBoxOk packet")
+		case protocol.MsgMotion:
+			motion := binary.LittleEndian.Uint16(payload[0:])
+			parm := binary.LittleEndian.Uint16(payload[2:])
+			if motion != refineMotionSuccess || parm != refineMotionSuccessParm {
+				t.Fatalf("motion = %d/%d, want %d/%d", motion, parm, refineMotionSuccess, refineMotionSuccessParm)
+			}
+			sawMotion = true
+		}
+	}
+	if !sawPanel || !sawMotion {
+		t.Fatalf("incomplete refine feedback: panel=%v motion=%v", sawPanel, sawMotion)
 	}
 }
 

--- a/tmserver/internal/protocol/types.go
+++ b/tmserver/internal/protocol/types.go
@@ -12,6 +12,18 @@ type Type uint16
 // 1789): mob action chat and normal public chat are a fixed 96-byte C string.
 const MessageLength = 96
 
+// MessagePanelLength is MSG_MessagePanel.String's fixed-width C string
+// (Basedef.h:1528). Unlike chat messages, client notices reserve 128 bytes.
+const MessagePanelLength = 128
+
+// EncodeMessagePanelBody returns the fixed MSG_MessagePanel.String payload.
+// The zero-filled tail supplies the C-string terminator expected by the client.
+func EncodeMessagePanelBody(text string) []byte {
+	body := make([]byte, MessagePanelLength)
+	copy(body[:MessagePanelLength-1], text)
+	return body
+}
+
 // Direction flag bits (protocol-spec.md §2, Basedef.h:1212-1221).
 const (
 	FlagGame2Client Type = 0x0100 // TMSrv → client

--- a/tmserver/internal/protocol/types_test.go
+++ b/tmserver/internal/protocol/types_test.go
@@ -2,6 +2,37 @@ package protocol
 
 import "testing"
 
+func TestEncodeMessagePanelBody(t *testing.T) {
+	t.Run("pads a short C string", func(t *testing.T) {
+		body := EncodeMessagePanelBody("Refinação falhou.")
+		if len(body) != MessagePanelLength {
+			t.Fatalf("body length = %d, want %d", len(body), MessagePanelLength)
+		}
+		if got := cTrimNUL(body); got != "Refinação falhou." {
+			t.Fatalf("text = %q, want %q", got, "Refinação falhou.")
+		}
+	})
+
+	t.Run("truncates to the legacy field", func(t *testing.T) {
+		text := make([]byte, MessagePanelLength+10)
+		for i := range text {
+			text[i] = 'x'
+		}
+		body := EncodeMessagePanelBody(string(text))
+		if len(body) != MessagePanelLength {
+			t.Fatalf("body length = %d, want %d", len(body), MessagePanelLength)
+		}
+		for i, b := range body[:MessagePanelLength-1] {
+			if b != 'x' {
+				t.Fatalf("body[%d] = %d, want 'x'", i, b)
+			}
+		}
+		if body[MessagePanelLength-1] != 0 {
+			t.Fatal("truncated panel text is not NUL-terminated")
+		}
+	})
+}
+
 // Legacy message-type direction flags (Basedef.h:1212-1221). These bits are
 // part of the value the client matches on, not metadata about it: every wire
 // type is a base number OR'd with its direction flags.


### PR DESCRIPTION
## Summary
- send refinement feedback through the client-compatible `MSG_MessagePanel` packet
- restore legacy success and failure motions for dust refinement and Classe A-E rerolls
- report incompatible Classe tiers and refinement caps without consuming the source item

## Tests
- `go test ./tmserver/internal/protocol ./tmserver/internal/handler`

Closes #317