### PR TITLE
fix: Teleporte ao segundo andar da Dungeon não funciona (#309)

### DIFF
--- a/openspec/changes/issue-309/.openspec.yaml
+++ b/openspec/changes/issue-309/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/issue-309/design.md
+++ b/openspec/changes/issue-309/design.md
@@ -1,0 +1,36 @@
+## Context
+
+See proposal.md for motivation. The initial working tree and diff were clean and no issue-309 artifacts existed; the change was scaffolded without replacing prior work.
+
+Evidence consulted:
+- `Source/Code/TMSrv/GetFunc.cpp:782`, especially the five floor 1/2 branches around lines 871–900: exact origins, destinations, default zero Charge and two `rand()%3` calls.
+- `Source/Code/TMSrv/_MSG_ReqTeleport.cpp`: routing uses authoritative TargetX/Y.
+- `tmserver/internal/world/teleport.go`: only a subset of the legacy table exists; none of those five branches is represented. Lookup rounds each coordinate down to a multiple of four.
+- `tmserver/internal/handler/movement.go`: `reqTeleport` already handles play/liveness, lookup and charging; `doTeleport` updates position and reconciles visibility.
+- `docs/migration/handlers/lote2-movimento.md`, existing kingdom teleport spec, project overview, dependency report, TMSrv-Core analysis, AGENTS.md and Go guidelines establish protocol and ownership constraints. Kingdom chat travel is a separate capability.
+
+The issue attachment could not be fetched through either the web reader or HTTP download. No screenshot coordinates or reproduced client symptoms are claimed. Missing routes are a concrete static defect sufficient to plan this bounded correction; the reported intermittency is not established by inspection.
+
+## Goals / Non-Goals
+
+**Goals:** Restore the five routes through the existing lookup and teleport pipeline; prevent partial coverage of adjacent blocks and verify wire-visible results.
+
+**Non-Goals:** Broader table completion (including floor 3 and Underworld), new movement rules, tax fixes, client patches, map editing, timers, retries, or RNG migration. The existing alternate Armia entrance uses a spread differing from legacy; that separate discrepancy is excluded.
+
+## Decisions
+
+1. Add five explicit `teleRoute` entries in `world/teleport.go`, grouped and attributed to the legacy floor branches. Preserve the exact asymmetric return to (148,3780). A larger proximity rectangle could activate unrelated tiles; porting every omitted route would expand scope.
+2. Reuse `TeleportDest`, `reqTeleport` and `doTeleport` unchanged unless a new focused regression demonstrates a necessary correction. No locks or asynchronous world mutation are introduced. No new protocol representation is needed.
+3. Preserve the existing two destination draws (X then Y) and +0..2 spread. The current resolver uses math/rand; this change does not claim deterministic MSVC RNG parity and does not refactor other callers or consume extra random draws.
+4. Add independent expected-coordinate tests, not expectations derived from the production table. World tests cover the Cartesian product of offsets 0..3 for all five blocks, landing bounds, zero cost, and nearby unregistered blocks. In particular, (147,3780) and (148,3780) both work; X 143 and 152 at Y 3780 do not become portals.
+5. Handler tests dispatch opcode 0x0290 with empty payload in a world large enough for coordinates near 4096 (do not reuse the 16-tile movement fixture). Use existing in-memory fixtures, execute mutations under the established single-owner test pattern, and decode the outgoing jump to compare against authoritative position. Cover all five routes, zero and positive gold, dead/non-play rejection, unregistered position, and an explicit entry/return/re-entry sequence. Include old/new view observers to verify normal visibility reconciliation. Do not require exact random samples or probabilistic distribution checks.
+
+## Risks / Trade-offs
+
+- Unobserved screenshot/client behavior may involve another failure → keep the confirmed route defect distinct from the unproven intermittent symptom; optionally confirm the passages with the unmodified client after apply.
+- Adjacent origins and randomized landings can conceal incomplete mappings → exhaustively test origin offsets and assert bounds for each landing; every landing remains inside a valid return block.
+- Overly broad cleanup can affect other travel or RNG consumers → only add the five entries and focused tests; retain existing city route tests.
+
+## Migration Plan
+
+No schema, configuration or data migration is needed. After explicit apply, the orchestrator runs `make test`, `make build`, and `make vet` inside Docker. An additional focused repeated race run is specified in tasks.md. No external services or credentials are needed. Publication and deployment belong to the orchestrator; reverting the five route additions restores previous behavior if rollback is needed.

--- a/openspec/changes/issue-309/proposal.md
+++ b/openspec/changes/issue-309/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Issue #309 reports that travel to Dungeon floor 2 fails. Static inspection finds that the Go teleport table omits all five legacy routes connecting floors 1 and 2, so requests at those origins are silently ignored.
+
+## What Changes
+
+- Restore both adjacent entrance blocks, the alternate entrance, and their two return routes using legacy coordinates, zero cost, and destination spread.
+- Cover every tile of each 4-by-4 origin block and verify the request-to-jump behavior, including rejection and unchanged gold.
+- Keep this change limited to Dungeon floors 1 and 2; do not port other missing teleport routes, change guild taxation, refactor RNG, or modify the client.
+
+## Capabilities
+
+### New Capabilities
+
+- `dungeon-floor-teleports`: Position-based travel between Dungeon floors 1 and 2 compatible with the 7662 client.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+Implementation will affect `tmserver/internal/world/teleport.go`, its tests, and handler regression tests using the existing `reqTeleport` / `doTeleport` pipeline. No new packets, persistence, dependencies, external services, or content assets are required. This change contains planning artifacts only.

--- a/openspec/changes/issue-309/specs/dungeon-floor-teleports/spec.md
+++ b/openspec/changes/issue-309/specs/dungeon-floor-teleports/spec.md
@@ -1,0 +1,49 @@
+## Purpose
+
+Provide reliable, position-authoritative travel between Dungeon floors 1 and 2 for the unmodified WYD 7662 client.
+
+## ADDED Requirements
+
+### Requirement: Dungeon floor routes match legacy entrances and returns
+
+The server SHALL resolve each of the following origin blocks to its destination base at zero gold cost. Each origin includes all 16 integer positions from the base through base plus 3 on each axis. Each destination SHALL add an offset in the inclusive range 0 through 2 independently on each axis.
+
+| Origin base | Destination base | Direction |
+|---|---|---|
+| (144,3780) | (1004,4028) | Floor 1 to floor 2 |
+| (148,3780) | (1004,4028) | Floor 1 to floor 2 |
+| (1004,4028) | (148,3780) | Floor 2 to floor 1 |
+| (408,4072) | (1004,4064) | Alternate floor 1 to floor 2 |
+| (1004,4064) | (408,4072) | Alternate floor 2 to floor 1 |
+
+#### Scenario: Enter through either adjacent block
+- **WHEN** a living character in play requests teleport from any tile of (144,3780) or (148,3780)
+- **THEN** the character arrives within X 1004..1006 and Y 4028..4030 without losing gold
+
+#### Scenario: Return from the first landing
+- **WHEN** a living character in play requests teleport from any tile of (1004,4028)
+- **THEN** the character arrives within X 148..150 and Y 3780..3782 without losing gold
+
+#### Scenario: Use the alternate passage in both directions
+- **WHEN** a living character in play requests teleport from any tile of (408,4072) or (1004,4064)
+- **THEN** the character arrives within base plus 0..2 on each axis of the corresponding destination in the table without losing gold
+
+### Requirement: Requests preserve authoritative movement and client compatibility
+
+The server SHALL use its current character position to resolve opcode 0x0290, including requests with no body, and SHALL retain existing in-play and liveness guards. Successful travel SHALL update authoritative position and send the existing 0x036C jump with Effect 1 and the corresponding destination, reconciling visibility through the normal teleport flow. These routes SHALL require no gold, items, guild membership, or event activation.
+
+#### Scenario: Zero-gold character travels
+- **WHEN** a living character in play with zero gold sends a header-only teleport request on a listed origin
+- **THEN** its authoritative position and client jump destination agree within the specified landing area and gold remains zero
+
+#### Scenario: Invalid character state
+- **WHEN** a dead character or a session outside play requests one of these teleports
+- **THEN** no teleport or gold mutation occurs
+
+#### Scenario: Position outside a portal
+- **WHEN** a character requests teleport from a nearby position outside all registered portal blocks
+- **THEN** no teleport or gold mutation occurs
+
+#### Scenario: Return and re-enter
+- **WHEN** an eligible character travels to floor 2, explicitly requests the return, and explicitly requests entry again
+- **THEN** each request follows the table without requiring a reconnect or server restart

--- a/openspec/changes/issue-309/tasks.md
+++ b/openspec/changes/issue-309/tasks.md
@@ -1,0 +1,16 @@
+## 1. Restore Dungeon floor routes
+
+- [x] 1.1 Add the five floor 1/floor 2 entries specified in `specs/dungeon-floor-teleports/spec.md` to `tmserver/internal/world/teleport.go`, with legacy attribution; verify the delivered diff matches the five origin/destination pairs and zero costs, preserves the existing resolver and other entries, and contains no unrelated code changes.
+- [x] 1.2 Add `TestTeleportDestDungeon` coverage in `tmserver/internal/world/teleport_test.go` with independent expected coordinates for all 16 tiles of each origin block, zero cost, destination bounds and adjacent non-portals; verify the test cases cover both sides of the 147/148 boundary and preserve existing city regressions. Execution belongs to section 3.
+
+## 2. Verify request-to-jump behavior
+
+- [x] 2.1 Add handler tests named with the `TestReqTeleportDungeon` prefix using an in-memory world supporting the real coordinates and the established single-owner fixture pattern; verify coverage dispatches header-only 0x0290 for all five routes and compares decoded 0x036C Effect=1 destinations with authoritative position, with zero and positive gold unchanged. Execution belongs to section 3.
+- [x] 2.2 Extend those handler regressions for dead/non-play sessions, unregistered origins, entry/return/re-entry and old/new view observers; verify the delivered assertions reject invalid travel without mutation and check normal visibility reconciliation without requiring exact random samples. Execution belongs to section 3.
+
+## 3. Orchestrator validation in Docker
+
+- [x] 3.1 After apply, have the orchestrator execute its automatic `make test`, `make build` and `make vet` checks in the Go image at `/workspace`; record results and address actual failures without weakening tests.
+- [x] 3.2 After apply, have the orchestrator run `go test -race -count=20 -run 'TestTeleportDestDungeon|TestReqTeleportDungeon' ./tmserver/internal/world ./tmserver/internal/handler` from `/workspace`; verify both new test groups run and pass repeatedly. No compose services or environment variables are required.
+
+Implementation and regression coverage are delivered. All six tasks are complete. On 2026-09-09, the orchestrator reported exit code 0 for make test (11:13:40 UTC), make build (11:14:46 UTC), make vet (11:15:28 UTC), and the focused race test with count=20 (11:16:02 UTC), all inside Docker. No tests, builds or code checks were executed on the host. The additional test command and empty service configuration are preserved for the publication rerun.

--- a/tmserver/internal/handler/dungeon_teleport_test.go
+++ b/tmserver/internal/handler/dungeon_teleport_test.go
@@ -1,0 +1,163 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// The real dungeon coordinates require a full-sized grid. All fixture changes
+// and dispatcher calls run on the owner loop, including rejected requests.
+func TestReqTeleportDungeon(t *testing.T) {
+	db := newDB()
+	db.accounts["observer"] = &fakeAccount{id: 12, pass: "secret", chars: []world.CharSummary{{Slot: 0, Name: "Observer"}}}
+	db.loads = map[int64]world.CharacterState{
+		7:  {Slot: 0, Name: "Hero", X: 20, Y: 20, HP: 1000, MaxHP: 1000},
+		11: {Slot: 0, Name: "HeroB", X: 50, Y: 50, HP: 1000, MaxHP: 1000},
+		12: {Slot: 0, Name: "Observer", X: 80, Y: 80, HP: 1000, MaxHP: 1000},
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := slog.New(slog.DiscardHandler)
+	d := New(Config{Log: log})
+	w := world.New(world.Config{GridDim: 4096}, log, db, d.Handle)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := w.Serve(ctx, ln); err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("serve: %v", err)
+		}
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("server did not stop")
+		}
+	})
+	c := enterWorldAs(t, ln.Addr().String(), "tester")
+	defer c.Close()
+	var s *world.Session
+	runInLoop(t, w, func() { s, _ = w.SessionByName("Hero") })
+	if s == nil {
+		t.Fatal("missing player session")
+	}
+
+	request := func(t *testing.T, dx, dy int16) {
+		t.Helper()
+		var oldX, oldY, x, y int16
+		var coinBefore, coinAfter int32
+		runInLoop(t, w, func() {
+			e := w.Entity(s.Conn)
+			oldX, oldY, coinBefore = e.X, e.Y, e.Coin
+			d.Handle(w, s, protocol.Header{Type: protocol.MsgReqTeleport, ID: uint16(s.Conn)}, nil)
+			x, y, coinAfter = e.X, e.Y, e.Coin
+		})
+		ty, payload := read(t, c)
+		if ty != protocol.MsgAction {
+			t.Fatalf("got %#x, want teleport action", ty)
+		}
+		var jump protocol.MsgActionBody
+		if err := jump.Decode(payload); err != nil {
+			t.Fatal(err)
+		}
+		if jump.Effect != 1 || jump.PosX != oldX || jump.PosY != oldY || jump.TargetX != x || jump.TargetY != y {
+			t.Errorf("jump %+v disagrees with (%d,%d) -> (%d,%d)", jump, oldX, oldY, x, y)
+		}
+		if x < dx || x > dx+2 || y < dy || y > dy+2 || coinAfter != coinBefore {
+			t.Errorf("landed (%d,%d), gold %d -> %d; want (%d..%d,%d..%d), unchanged gold", x, y, coinBefore, coinAfter, dx, dx+2, dy, dy+2)
+		}
+	}
+
+	for _, r := range []struct{ x, y, dx, dy int16 }{
+		{147, 3783, 1004, 4028}, {148, 3780, 1004, 4028},
+		{1007, 4031, 148, 3780}, {411, 4075, 1004, 4064},
+		{1007, 4067, 408, 4072},
+	} {
+		for _, coin := range []int32{0, 700} {
+			t.Run(fmt.Sprintf("%d,%d/gold%d", r.x, r.y, coin), func(t *testing.T) {
+				runInLoop(t, w, func() {
+					w.SetEntityPos(s.Conn, r.x, r.y)
+					w.Entity(s.Conn).Coin = coin
+				})
+				request(t, r.dx, r.dy)
+			})
+		}
+	}
+	t.Run("return-and-reenter", func(t *testing.T) {
+		runInLoop(t, w, func() { w.SetEntityPos(s.Conn, 144, 3780) })
+		request(t, 1004, 4028)
+		request(t, 148, 3780)
+		request(t, 1004, 4028)
+	})
+	for _, name := range []string{"dead", "not-playing", "outside-portal"} {
+		t.Run(name, func(t *testing.T) {
+			var changed bool
+			runInLoop(t, w, func() {
+				e := w.Entity(s.Conn)
+				w.SetEntityPos(s.Conn, 144, 3780)
+				mode, hp := s.Mode, e.HP
+				switch name {
+				case "dead":
+					e.HP = 0
+				case "not-playing":
+					s.Mode = world.UserSelChar
+				case "outside-portal":
+					w.SetEntityPos(s.Conn, 152, 3780)
+				}
+				x, y, coin := e.X, e.Y, e.Coin
+				jumps := w.SentOfType(s, protocol.MsgAction)
+				d.Handle(w, s, protocol.Header{Type: protocol.MsgReqTeleport}, nil)
+				changed = e.X != x || e.Y != y || e.Coin != coin || w.SentOfType(s, protocol.MsgAction) != jumps
+				s.Mode, e.HP = mode, hp
+			})
+			if changed {
+				t.Fatal("rejected request changed position/gold or sent a jump")
+			}
+		})
+	}
+
+	t.Run("visibility", func(t *testing.T) {
+		oldClient := enterWorldAs(t, ln.Addr().String(), "tradeb")
+		defer oldClient.Close()
+		newClient := enterWorldAs(t, ln.Addr().String(), "observer")
+		defer newClient.Close()
+		var oldS, newS *world.Session
+		var oldRemoves, newCreates, moverRemoves, moverCreates uint32
+		runInLoop(t, w, func() {
+			oldS, _ = w.SessionByName("HeroB")
+			newS, _ = w.SessionByName("Observer")
+			w.SetEntityPos(s.Conn, 148, 3780)
+			w.SetEntityPos(oldS.Conn, 155, 3780)
+			w.SetEntityPos(newS.Conn, 1012, 4028)
+			w.MarkSeen(s, oldS.Conn)
+			w.MarkSeen(oldS, s.Conn)
+			oldRemoves = w.SentOfType(oldS, protocol.MsgRemoveMob)
+			newCreates = w.SentOfType(newS, protocol.MsgCreateMob)
+			moverRemoves = w.SentOfType(s, protocol.MsgRemoveMob)
+			moverCreates = w.SentOfType(s, protocol.MsgCreateMob)
+		})
+		request(t, 1004, 4028)
+		var reconciled bool
+		runInLoop(t, w, func() {
+			reconciled = w.SentOfType(oldS, protocol.MsgRemoveMob) == oldRemoves+1 &&
+				w.SentOfType(newS, protocol.MsgCreateMob) == newCreates+1 &&
+				w.SentOfType(s, protocol.MsgRemoveMob) == moverRemoves+1 &&
+				w.SentOfType(s, protocol.MsgCreateMob) == moverCreates+1
+		})
+		if !reconciled {
+			t.Error("teleport did not remove old and reveal new observers in both directions")
+		}
+	})
+}

--- a/tmserver/internal/world/teleport.go
+++ b/tmserver/internal/world/teleport.go
@@ -30,6 +30,13 @@ var teleportTable = map[[2]int16]teleRoute{
 	{144, 3772}:  {2668, 2156, 0}, // Dungeon 1 → Armia Field (alt)
 	{1824, 1772}: {1172, 4080, 0}, // Azran Field → Underworld
 	{1172, 4080}: {1824, 1772, 0}, // Underworld → Azran Field
+	// GetFunc.cpp: both adjacent entrance blocks lead to floor 2; the return
+	// deliberately lands in the eastern block, not the western entrance.
+	{144, 3780}:  {1004, 4028, 0}, // Dungeon 1 → Dungeon 2
+	{148, 3780}:  {1004, 4028, 0}, // Dungeon 1 → Dungeon 2
+	{1004, 4028}: {148, 3780, 0},  // Dungeon 2 → Dungeon 1
+	{408, 4072}:  {1004, 4064, 0}, // Dungeon 1 → Dungeon 2 (alt)
+	{1004, 4064}: {408, 4072, 0},  // Dungeon 2 → Dungeon 1 (alt)
 }
 
 // TeleportDest resolves a teleport from (x,y): it rounds to the tile, looks up

--- a/tmserver/internal/world/teleport_test.go
+++ b/tmserver/internal/world/teleport_test.go
@@ -1,6 +1,43 @@
 package world
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
+
+func TestTeleportDestDungeon(t *testing.T) {
+	// Independent legacy coordinates catch omissions as well as misrouting.
+	routes := []struct{ x, y, dx, dy int16 }{
+		{144, 3780, 1004, 4028},
+		{148, 3780, 1004, 4028},
+		{1004, 4028, 148, 3780},
+		{408, 4072, 1004, 4064},
+		{1004, 4064, 408, 4072},
+	}
+	for _, r := range routes {
+		for ox := int16(0); ox < 4; ox++ {
+			for oy := int16(0); oy < 4; oy++ {
+				x, y := r.x+ox, r.y+oy
+				t.Run(fmt.Sprintf("%d,%d", x, y), func(t *testing.T) {
+					dx, dy, cost, ok := TeleportDest(x, y)
+					if !ok || cost != 0 || dx < r.dx || dx > r.dx+2 || dy < r.dy || dy > r.dy+2 {
+						t.Fatalf("got (%d,%d), cost=%d ok=%v; want (%d..%d,%d..%d), free", dx, dy, cost, ok, r.dx, r.dx+2, r.dy, r.dy+2)
+					}
+				})
+			}
+		}
+	}
+	for _, p := range [][2]int16{
+		{143, 3780}, {152, 3780}, {144, 3779}, {148, 3784},
+		{407, 4072}, {412, 4072}, {408, 4071}, {408, 4076},
+		{1003, 4028}, {1008, 4028}, {1004, 4027}, {1004, 4032},
+		{1003, 4064}, {1008, 4064}, {1004, 4063}, {1004, 4068},
+	} {
+		if _, _, _, ok := TeleportDest(p[0], p[1]); ok {
+			t.Errorf("non-portal %v resolved a route", p)
+		}
+	}
+}
 
 func TestTeleportDest(t *testing.T) {
 	// Armia teleport tile → Noatum, cost 700 (rounds the position to the tile and


### PR DESCRIPTION
<!-- loop-engineering:2026-09-08T22-23-17-292Z-91635ef9:309 -->

Issue-309 concluída: 6/6 tarefas marcadas. Registrados os resultados Docker aprovados de make test, make build, make vet e das 20 repetições com race detector. Comando adicional e configuração de serviços preservados.

Closes #309

OpenSpec: `openspec/changes/issue-309/`

Validação em Docker (`golang:1.26-bookworm`):
- ["make","test"] — exit 0
- ["make","build"] — exit 0
- ["make","vet"] — exit 0
- ["sh","-eu","-c","go test -race -count=20 -run 'TestTeleportDestDungeon|TestReqTeleportDungeon' ./tmserver/internal/world ./tmserver/internal/handler"] — exit 0