### PR TITLE
fix: Diálogo do Rei exibe o nome do jogador no lugar do NPC (#316)

### DIFF
--- a/openspec/changes/issue-316/.openspec.yaml
+++ b/openspec/changes/issue-316/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/issue-316/design.md
+++ b/openspec/changes/issue-316/design.md
@@ -1,0 +1,34 @@
+## Context
+
+See proposal.md for motivation. Initial inspection found a clean working tree and no existing issue-316 artifacts. The change uses the repository's spec-driven schema.
+
+Evidence:
+- `tmserver/internal/handler/misc.go:263-320`: `kingCapeService` uses `sendChatText` for already-complete, quote, and exact-payment feedback. Requirement and persistence failures use `notify`; success emits equipment/inventory/score updates.
+- `tmserver/internal/handler/chat.go:411-414`: `sendChatText` explicitly sets `Header.ID` to `s.Conn`, explaining player attribution.
+- `Source/Code/TMSrv/SendFunc.cpp:1779`: `SendSay` uses the mob identifier in chat. Its grid multicast is separate from speaker identity. `SendClientMessage` at line 27 instead emits a panel with ID zero; the legacy KING branch also uses panel messages. We do not claim every legacy cape reply was NPC chat.
+- `docs/migration/handlers/_MSG_Quest-npcs.md`: NPC index and confirmation contract; `docs/migration/protocol-spec.md`: 12-byte header and chat/panel opcodes. The header table's generic player-ID description must be interpreted with the message-specific `SendSay` evidence.
+- `openspec/specs/kingdom-cape-service/spec.md`: existing pricing, payment, transitions, and persistence contracts.
+- `tmserver/internal/handler/quest_test.go`: packet harnesses, `questNPCTemplate`, `startServerQuestNPC`, and supported King forms; `kingdom_cape_test.go`: payment and target tests.
+
+## Goals / Non-Goals
+
+**Goals:** Separate recipient session from NPC speaker in these three replies while retaining the existing wire body encoding and single-owner loop.
+
+**Non-Goals:** Global chat refactoring, NPC renaming, broadcast parity, conversion to panel messages, Arch changes, new purchase acknowledgement, economic or persistence fixes.
+
+## Decisions
+
+1. Add a small handler-local NPC reply helper accepting an explicit runtime NPC identifier, recipient session, and text. Send `MsgMessageChat` with that identifier and the same null-terminated body convention as the current helper. Replace only the three cape-service calls. Do not change `sendChatText` globally: its other callers rely on player attribution. Do not prefix NPC names in text: the client resolves the speaker through the header.
+2. Preserve unicast via `World.SendTo`. Copying legacy `SendSay` multicast would expose individual purchase feedback to bystanders and expand this issue's behavior.
+3. Capture the interacted NPC's runtime ID inside the owner loop before starting the quote operation, and carry that value into its completion callback. Use the actual entity index, never Merchant, Clan, generator index, a fixed King ID, or the connection ID. Keep blocking persistence under `World.Go`; sending still occurs in the loop callback. Preserve existing session-lifetime handling.
+4. Reuse handler packet harnesses with fake persistence; add table-driven cases named under `TestKingCapeDialogue`. Cover quote, insufficient/exact-payment rejection, and complete mode for both clans, including canonical Merchant 111 and legacy 14/15. Ensure player and NPC IDs differ; assert decoded opcode, header ID, text, recipient isolation, and unchanged state/no purchase on these branches. Add a control for ordinary player-attributed replies and retain existing purchase/Arch tests. No external database is needed for this packet attribution change.
+
+## Risks / Trade-offs
+
+- Client rendering is inferred from packet identity and legacy `SendSay`; no client capture was executed or screenshot inspected. Mitigation: decoded packet regressions are the automated oracle; manually interact with both Kings on unmodified build 7662 when available to confirm displayed names.
+- Async quote completion could accidentally revert to the session ID. Mitigation: test the asynchronous quote and rejection paths, not only the synchronous complete branch.
+- Broad helper edits could affect unrelated dialogue. Mitigation: keep replacements scoped to `kingCapeService` and include the player-chat control.
+
+## Migration Plan
+
+Apply handler and regression-test changes together. The orchestrator runs `make test`, `make build`, and `make vet` in Docker; no host checks are authorized. Existing automatic tests cover the added cases, so no additional command or compose service is required. Deploy with the normal tmserver release; rollback restores the prior handler. No data migration is needed.

--- a/openspec/changes/issue-316/proposal.md
+++ b/openspec/changes/issue-316/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Issue #316 reports that King cape-service messages appear under the player's name. The Go handler sends those replies through player-attributed chat, so the client receives the player's identifier as the speaker.
+
+## What Changes
+
+- Attribute the three existing textual cape-service replies (price, exact-payment rejection, and already-complete cape) to the interacted King.
+- Preserve private delivery to the requesting session, existing text, notices, prices, eligibility, payment, persistence, and Arch dispatch.
+- Add packet-level regression coverage for both kingdoms and all supported King merchant shapes.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `kingdom-cape-service`: Require King dialogue to carry the interacted NPC's runtime speaker identifier.
+
+## Impact
+
+Changes are limited to tmserver handler reply construction and handler tests. No client patch, protocol opcode/layout change, database migration, external dependency, or service is required. This change contains planning artifacts only; implementation follows in apply.

--- a/openspec/changes/issue-316/specs/kingdom-cape-service/spec.md
+++ b/openspec/changes/issue-316/specs/kingdom-cape-service/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Cape dialogue identifies the interacted King
+The server SHALL send existing cape price, exact-payment rejection, and already-complete dialogue with the interacted King's runtime entity identifier as the speaker of `MsgMessageChat` (0x0333), never the requesting player's identifier. This MUST apply to both kingdoms and supported King merchant forms 14, 15, and 111. Delivery SHALL remain private to the requesting session, with existing text and cape-service state transitions preserved.
+
+#### Scenario: Player requests a quote
+- **WHEN** an eligible player asks either King for a cape price without confirming
+- **THEN** the reply identifies that King and includes the current price, without charging or changing cape or balance state
+
+#### Scenario: Exact payment is unavailable
+- **WHEN** a player confirms but cannot provide the required exact sapphire payment
+- **THEN** the rejection identifies the interacted King and preserves inventory, cape, and balance
+
+#### Scenario: Cape is already complete
+- **WHEN** a player presents a completed cape of the interacted King's kingdom
+- **THEN** the acknowledgement identifies that King without charging or altering balance
+
+#### Scenario: Another player is nearby
+- **WHEN** the requesting player receives one of these replies while another player is nearby
+- **THEN** only the requesting player receives the reply and its speaker remains the interacted King
+
+#### Scenario: Other messages retain their semantics
+- **WHEN** ordinary player-attributed chat, a requirement notice, or a successful cape purchase is emitted
+- **THEN** its existing attribution, delivery, and state effects remain unchanged

--- a/openspec/changes/issue-316/tasks.md
+++ b/openspec/changes/issue-316/tasks.md
@@ -1,0 +1,16 @@
+## 1. Correct cape dialogue attribution
+
+- [x] 1.1 Add a handler-local NPC chat reply helper and replace the three `kingCapeService` text replies, capturing the runtime NPC ID before asynchronous quote work. Verify by reviewing the diff that opcode/body/text and recipient remain unchanged, `sendChatText` and notices retain their semantics, and all sends remain inside the owner loop.
+
+## 2. Add regression coverage
+
+- [x] 2.1 Add `TestKingCapeDialogue` packet cases for quote, exact-payment rejection, and already-complete replies across both clans and supported Merchant 14/15/111 shapes using fake persistence. Verify the delivered tests assert NPC header ID distinct from player ID, expected text, no purchase, and unchanged inventory/cape/balance for those branches.
+- [x] 2.2 Add recipient-isolation and ordinary player-chat controls using the existing harness. Verify the tests assert no cape dialogue reaches a nearby second session and ordinary chat still carries the player's ID; preserve all existing assertions and purchase/Arch tests.
+
+## 3. Orchestrator verification
+
+- [x] 3.1 Obtain Docker results for the orchestrator's automatic `make test`, `make build`, and `make vet` in `/workspace`; verify all succeed and record results. No host execution, additional test commands, or compose services are required.
+
+Implementation and 16 packet regression cases are delivered in the apply phase. No tests, builds, or code checks were executed on the host; task 3 is complete based on the successful Docker results returned by the orchestrator. Optional client follow-up: inspect the displayed speaker for all three replies with both Kings on unmodified build 7662.
+
+Repair round 1: the orchestrator reported successful `make build` and `make vet`, but all 16 dialogue cases received requirement notices. The King fixture inherited a misplaced clan byte from the generic quest template helper (CurrentScore.Damage rather than STRUCT_MOB byte 16). The issue-specific fixture now writes the documented clan offset and asserts the parsed clan and merchant before starting the server. All dialogue, recipient-isolation, player-chat, and saved-state assertions remain intact. After this repair, the orchestrator reported all three Docker commands passing (exit 0) on 2026-09-09: make test at 11:40:37.411Z (test-1788953827080-0.log), make build at 11:41:32.890Z (test-1788954037525-1.log), and make vet at 11:42:16.991Z (test-1788954092963-2.log). Logs are under .loop/logs/issue-316 in the orchestrator workspace.

--- a/tmserver/internal/handler/chat.go
+++ b/tmserver/internal/handler/chat.go
@@ -413,6 +413,13 @@ func (d *Dispatcher) sendChatText(w *world.World, s *world.Session, text string)
 	w.SendTo(s, protocol.Header{Type: protocol.MsgMessageChat, ID: uint16(s.Conn)}, payload)
 }
 
+// sendNPCChatText uses the speaker ID like legacy SendSay, but keeps personal
+// service replies private to the requesting session instead of multicasting.
+func (d *Dispatcher) sendNPCChatText(w *world.World, s *world.Session, npcID int, text string) {
+	payload := append([]byte(text), 0)
+	w.SendTo(s, protocol.Header{Type: protocol.MsgMessageChat, ID: uint16(npcID)}, payload)
+}
+
 // notifyPKPointDelta formats the _DD_PKPointPlus/_DD_PKPointMinus chat line:
 // the player's new displayed Chaos Points (PKPoint-75) plus the signed change
 // that just happened. Exact legacy string-table text isn't available in this

--- a/tmserver/internal/handler/king_cape_dialogue_test.go
+++ b/tmserver/internal/handler/king_cape_dialogue_test.go
@@ -1,0 +1,129 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sync/atomic"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+type kingDialogueDB struct {
+	*fakeDB
+	quote     world.KingdomCapeQuote
+	purchases atomic.Int32
+}
+
+func (db *kingDialogueDB) QuoteKingdomCape(context.Context) (world.KingdomCapeQuote, error) {
+	return db.quote, nil
+}
+
+func (db *kingDialogueDB) PurchaseKingdomCape(context.Context, int64, uint8, world.CharacterSave) (world.KingdomCapeQuote, bool, error) {
+	db.purchases.Add(1)
+	return db.quote, false, nil
+}
+
+func TestKingCapeDialogue(t *testing.T) {
+	kings := []struct {
+		name     string
+		merchant uint8
+		clan     uint8
+		cape     int16
+		cost     int
+	}{
+		{"Harabard legacy", 14, clanHekalotia, 543, 8},
+		{"Glantuar legacy", 15, clanAkelonia, 544, 6},
+		{"Harabard canonical", 111, clanHekalotia, 543, 8},
+		{"Glantuar canonical", 111, clanAkelonia, 544, 6},
+	}
+	for _, king := range kings {
+		for _, branch := range []string{"quote", "insufficient", "inexact", "complete"} {
+			t.Run(king.name+"/"+branch, func(t *testing.T) {
+				st := baseMortalState(255)
+				st.Carry[0] = world.Item{Index: 697}
+				wantCarry := []world.SavedItem{{Slot: 0, Index: 697}}
+				confirm := int32(0)
+				wantText := fmt.Sprintf("Sao necessarias %d safiras.", king.cost)
+				switch branch {
+				case "insufficient", "inexact":
+					confirm = 1
+					wantText = fmt.Sprintf("Sao necessarias %d safiras em pagamento exato.", king.cost)
+					if branch == "inexact" {
+						st.Carry[1] = world.Item{Index: 4131}
+						wantCarry = append(wantCarry, world.SavedItem{Slot: 1, Index: 4131})
+					}
+				case "complete":
+					st.Clan = king.clan
+					st.Equip[capeEquipSlot] = world.Item{Index: king.cape}
+					wantText = "A capa deste reino ja esta completa."
+				}
+				db := &kingDialogueDB{
+					fakeDB: newDB(),
+					quote:  world.KingdomCapeQuote{Revision: 7, HekalotiaCost: 8, AkeloniaCost: 6},
+				}
+				watcherState := baseMortalState(255)
+				watcherState.Name = "Watcher"
+				db.loads = map[int64]world.CharacterState{7: st, 11: watcherState}
+				// STRUCT_MOB.Clan is at byte 16; the generic quest fixture's
+				// clan argument writes CurrentScore.Damage instead.
+				tmpl := questNPCTemplate(king.name, king.merchant, 0, 0)
+				tmpl[16] = king.clan
+				if got := protocol.ParseMobBasics(tmpl); got.Clan != king.clan || got.Merchant != king.merchant {
+					t.Fatalf("King fixture decoded clan=%d merchant=%d, want %d/%d", got.Clan, got.Merchant, king.clan, king.merchant)
+				}
+				addr, stop, npcID := startServerQuestNPC(t, db, tmpl)
+				defer stop()
+				player := enterWorldAs(t, addr, "tester") // First connection is player slot 1.
+				defer player.Close()
+				watcher := enterWorldAs(t, addr, "tradeb")
+				defer watcher.Close()
+				drainRaw(t, player)
+				drainRaw(t, watcher)
+				if npcID == 1 {
+					t.Fatal("fixture must distinguish NPC and player identifiers")
+				}
+
+				send(t, player, protocol.MsgQuest, protocol.EncodeStandardParm2(int32(npcID), confirm))
+				h, body, ok := readMaybeHeader(t, player)
+				if !ok || h.Type != protocol.MsgMessageChat || h.ID != uint16(npcID) {
+					t.Fatalf("dialogue header = %+v, received=%v; want chat from NPC %d", h, ok, npcID)
+				}
+				if string(body) != wantText+"\x00" {
+					t.Fatalf("dialogue body = %q, want %q with null terminator", body, wantText)
+				}
+				if h, _, ok := readMaybeHeader(t, watcher); ok {
+					t.Fatalf("private dialogue leaked to watcher: %+v", h)
+				}
+
+				// Exercise the original player-attributed helper after NPC dialogue.
+				whisperFrame(t, player, "cp", "")
+				h, body, ok = readMaybeHeader(t, player)
+				if !ok || h.Type != protocol.MsgMessageChat || h.ID != 1 || string(body) != "Pontos Caos atual: 0\x00" {
+					t.Fatalf("player reply = %+v %q received=%v", h, body, ok)
+				}
+
+				// Logout acknowledgement is a barrier after the authoritative save.
+				send(t, player, protocol.MsgCharacterLogout, nil)
+				expect(t, player, protocol.MsgCNFCharacterLogout)
+				save, n := db.lastSavedChar()
+				if n == 0 || !reflect.DeepEqual(save.Carry, wantCarry) || save.Clan != st.Clan {
+					t.Fatalf("dialogue changed inventory/clan: saves=%d carry=%+v clan=%d", n, save.Carry, save.Clan)
+				}
+				cape, present := savedSlot(save.Equip, capeEquipSlot)
+				if branch == "complete" {
+					if !present || cape != (world.SavedItem{Slot: capeEquipSlot, Index: king.cape}) {
+						t.Fatalf("completed cape changed: %+v present=%v", cape, present)
+					}
+				} else if present {
+					t.Fatalf("dialogue granted a cape: %+v", cape)
+				}
+				if got := db.purchases.Load(); got != 0 {
+					t.Fatalf("dialogue attempted %d purchases/balance changes", got)
+				}
+			})
+		}
+	}
+}

--- a/tmserver/internal/handler/misc.go
+++ b/tmserver/internal/handler/misc.go
@@ -261,13 +261,14 @@ func (d *Dispatcher) kingQuest(w *world.World, s *world.Session, e, npc *world.E
 }
 
 func (d *Dispatcher) kingCapeService(w *world.World, s *world.Session, e, npc *world.Entity, confirm int) {
+	npcID := npc.ID
 	kingdom, mode := capeKingdomMode(e.Equip[capeEquipSlot].Index)
 	if kingdom != 0 && kingdom != npc.Clan {
 		d.notify(w, s, NoticeReqNotMet)
 		return
 	}
 	if mode >= 2 {
-		d.sendChatText(w, s, "A capa deste reino ja esta completa.")
+		d.sendNPCChatText(w, s, npcID, "A capa deste reino ja esta completa.")
 		return
 	}
 	target, ok := kingdomCapeTarget(e.ClassMaster, e.Level, e.Equip[capeEquipSlot].Index, npc.Clan)
@@ -288,13 +289,13 @@ func (d *Dispatcher) kingCapeService(w *world.World, s *world.Session, e, npc *w
 				cost = quote.AkeloniaCost
 			}
 			if confirm == 0 {
-				d.sendChatText(w, s, fmt.Sprintf("Sao necessarias %d safiras.", cost))
+				d.sendNPCChatText(w, s, npcID, fmt.Sprintf("Sao necessarias %d safiras.", cost))
 				return
 			}
 			staged := *e
 			changed, exact := sapphirePaymentPlan(&staged, cost)
 			if !exact {
-				d.sendChatText(w, s, fmt.Sprintf("Sao necessarias %d safiras em pagamento exato.", cost))
+				d.sendNPCChatText(w, s, npcID, fmt.Sprintf("Sao necessarias %d safiras em pagamento exato.", cost))
 				return
 			}
 			staged.Equip[capeEquipSlot] = world.Item{Index: target}


### PR DESCRIPTION
<!-- loop-engineering:2026-09-08T22-23-17-292Z-91635ef9:316 -->

Issue-316 concluída: 4/4 tarefas marcadas. Validação registrada com make test, make build e make vet aprovados no Docker pelo orquestrador. Comandos e serviços preservados; nenhuma execução no host.

Closes #316

OpenSpec: `openspec/changes/issue-316/`

Validação em Docker (`golang:1.26-bookworm`):
- ["make","test"] — exit 0
- ["make","build"] — exit 0
- ["make","vet"] — exit 0