### PR TITLE
fix: Trajes não atualizam HP/MP conforme os atributos concedidos (#321)

### DIFF
--- a/docs/migration/captura-wyd-levelup.md
+++ b/docs/migration/captura-wyd-levelup.md
@@ -42,6 +42,29 @@ TK {8,4,7,6,80,45}  FM {5,8,5,5,60,65}  BM {6,6,9,5,70,55}  HT {8,9,13,6,75,60}
 `MaxMp = baseMP + (Int-baseInt)*2 + Level*incMp`. (No level-up usamos o incremento
 `MaxHp += incHp[cls]`, equivalente.)
 
+### Recursos concedidos por atributos de equipamento (issue #321)
+
+O recálculo dos jogadores acrescenta `2 * CON do equipamento` ao HP máximo
+e `2 * INT do equipamento` ao MP máximo, após resolver catálogo, efeitos da
+instância e refinamento. Esses termos entram antes dos affects e percentuais.
+Não incluem atributos-base (já contemplados pela distribuição de pontos) nem
+CON dos buffs, que concedem seu próprio HP explicitamente.
+
+Os trajes 4185/4186 sem refinamento acrescentam 500 HP e 500 MP máximos;
+4187 acrescenta 1000 MP e 4188 acrescenta 1000 HP. Equipar não cura recursos
+atuais; remover limita HP/MP aos novos máximos efetivos. A conversão é comum
+aos equipamentos que concedem esses atributos e não se aplica a mobs/summons.
+
+`Basedef.cpp:3152-3163` fundamenta o fator 2, mas também duplica o máximo
+preexistente. Essa duplicação integral não é reproduzida: a correção mantém
+o modelo Go de base mais bônus. `Entity.EquipmentAttributeHP/MP` registra
+somente o novo termo em memória; `CharacterSaveFor` o desconta dos máximos
+salvos. Assim, saves antigos recebem o bônus no login e novos saves mantêm
+a representação anterior, sem migração ou acúmulo nas reconexões. HP/MP atuais
+continuam persistidos separadamente, como nos bônus percentuais existentes.
+A prévia da seleção de personagens mantém os máximos históricos persistidos;
+os pacotes de score dentro do jogo usam os máximos corrigidos.
+
 ## 4. `GetExpApply` (em código: `level.ExpApply`, path MORTAL)
 `GetFunc.cpp:1028`. `mult% = (target+1)*100/(attacker+1)`, teto 200; se `mult<80 && attacker+1>=50`
 → `mult*2-100` (pune killer muito acima do mob); `exp=(exp*mult+1)/100`. ARCH=50% base + quest-gates

--- a/openspec/changes/issue-321/.openspec.yaml
+++ b/openspec/changes/issue-321/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/issue-321/design.md
+++ b/openspec/changes/issue-321/design.md
@@ -1,0 +1,54 @@
+## Context
+
+See proposal.md for motivation. Initial git status/diff were clean; no issue-321 artifacts existed. Planning uses the local spec-driven schema.
+
+Evidence inspected:
+
+- `Release/Common/ItemList.csv:5917-5923`: 4185/4186 have 250 STR/DEX/INT/CON; 4187 has 500 STR/INT; 4188 has 500 DEX/CON. Their position mask is 4096 (equipment slot 12). Values above 255 belong to catalog effects, not byte-sized instance values.
+- `tmserver/internal/handler/item.go`: `equipBonus` already resolves catalog/instance/refinement effects; `refreshScore` adds `b.con`/`b.intel` to attributes but only `b.maxHP`/`b.maxMP` to maxima. `effectiveMaxHP/MP` apply percentages and buffs at read time. `sendScore` uses effective maxima.
+- `Source/Code/Basedef.cpp:3152-3163`: equipment INT/CON deltas are multiplied by two. The same block also adds the entire preexisting maximum a second time. That whole-maximum doubling is not the Go model and is not part of this correction.
+- `docs/migration/captura-wyd-levelup.md` section 3 and `handler/misc.go`: allocation already contributes two resources per INT/CON. `affect_score.go:231+` explicitly adds HP for CON buffs; converting total or effective attributes would double-count them.
+- `handler/character.go:300+` derives bases from saved flat scores and refreshes. `world/world.go:373-374` snapshots live MaxHP/MP directly today. Simply adding the conversion to both refresh and inverse login derivation would cancel the correction on old saves; changing only refresh would accumulate it on every login.
+- Consulted `AGENTS.md`, Go development guidelines, migration game rules, domain model, data formats, protocol score references, item/character handler contracts, project overview, dependency report and Basedef component analysis. Keep world state in the owning loop, preserve explicit wire layouts and RNG call order.
+
+## Goals / Non-Goals
+
+**Goals:** Correct the missing equipment-only conversion through the existing score pipeline and retain compatibility with the old persisted maxima representation.
+
+**Non-Goals:** Costume-specific hardcoded grants, item rebalance, legacy whole-maximum doubling, new soul/buff formulas, base-stat recalculation from level, client changes, expiration-system redesign or database migrations. Existing incidental issues in recovery of attributes/direct bonuses when gear expires are outside this correction; the newly introduced resource term must not survive expiration.
+
+## Decisions
+
+### 1. Convert the existing equipment aggregate for players
+
+During `refreshScore`, compute HP delta as `2 * int32(b.con)` and MP delta as `2 * int32(b.intel)`, gated to players, before affect calculation. Add them to the existing base-plus-direct-equipment maxima. Use consistent player eligibility for both deltas and bookkeeping; mobs/summons receive zero. Keep the existing resolved item/refinement policy, including mount exclusions. Never derive this from total CON/INT or effective affect attributes.
+
+This follows the shared effect semantics and avoids an ID allowlist that would fail for equivalent costumes or other equipment. Do not copy the legacy block's doubling of base and direct resources: it changes characters without costumes and is unrelated private-server tuning. Document this distinction alongside the correction.
+
+### 2. Track and exclude only the new term from saved maxima
+
+Add two narrowly named, runtime-only int32 fields on Entity (for example EquipmentAttributeHP/MP), overwritten on every refresh, zero for non-players and reset on login initialization. Live MaxHP/MP include these deltas so existing affects, transforms, healing limits and score publication naturally use corrected values. Character snapshot construction writes `MaxHP - EquipmentAttributeHP` and `MaxMP - EquipmentAttributeMP`, leaving the old persisted flat representation intact. Preserve current HP/MP verbatim as the existing percent/buff save path already does.
+
+Keep `deriveBaseScore` subtracting direct equipment resource bonuses only, because stored maxima deliberately exclude the new term. After login, refresh adds the current costume delta exactly once. Old saves therefore immediately gain the correction, new saves remain compatible, and expiration before refresh cannot retain the new term. Audit every CharacterSave construction path and entity reuse/reset path, including progression/reset flows, so cached values cannot be stale.
+
+Alternative: changing persistence to equipment-free maxima or adding a versioned migration would address broader historical issues but materially expands scope. Alternative: subtracting the new delta on load assumes historical saves already contained it and cancels this fix. Alternative: applying it only at effectiveMax reads would leave affects and direct MaxHP consumers inconsistent.
+
+### 3. Preserve transitions and existing score transport
+
+Use current trading/equip, login and score refresh paths; no new packet. Existing refresh clamps resources to effective maxima and does not heal when maxima increase. Keep percent order and affect contributions; update the stale comment saying CON feeds nothing to explain equipment conversion versus affect deltas. Verify displayed score bytes through handler packet assertions, not a new serializer.
+
+## Risks / Trade-offs
+
+- Cached delta out of sync with a direct maximum reset → audit resource assignments in login, level-up, rebirth/reset and snapshots; test reset then refresh/save. Keep cache writes paired with flat-score recalculation.
+- Incorrect 500-point fixtures → load the real catalog through existing content test helpers; never encode 500 in an instance effect byte. Include instance and refined items separately.
+- Unintended damage or buff changes → preserve current calculations and assert existing STR/INT damage behavior and explicit CON/HP buffs, plus percent order.
+- Catalog/refinement differences → expected 500/1000 resource deltas apply to unrefined listed costumes; refined expectations use the established resolved attribute values.
+- Persistence previews still use the historical flat representation → this matches existing percentage/buff preview limitations; accurate in-world login/update packets are the acceptance boundary.
+
+## Migration Plan
+
+No schema/data migration or services. Implement runtime bookkeeping, conversion and snapshot exclusion together. Run focused regression and existing automatic Go checks only in the orchestrator's Docker image. Deploy through the orchestrator's normal process. Reverting the cohesive code change restores prior behavior because persisted maxima retain their previous meaning.
+
+## Validation Plan
+
+Add handler tests for real 4185-4188 catalog items, all player classes/tiers, mixed direct and attribute bonuses, percentages/Divine, explicit CON affects, no-gear and non-player controls, equip/swap/unequip packets, rejected moves, repeated refresh, injured/full resources, and allocation/level gains remaining single-counted. Add snapshot/login regressions beginning with pre-fix saved values, at least three save/login cycles, removal and login expiration; assert both runtime and persisted values. Use in-memory persistence mocks and world test harnesses. No external services required. `make test`, `make build` and `make vet` are supplied by the orchestrator; no extra command beyond that suite is necessary. No code tests or builds were run during planning.

--- a/openspec/changes/issue-321/proposal.md
+++ b/openspec/changes/issue-321/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Issue #321 reports that costumes increase attributes and damage but fail to increase HP/MP. The Go equipment recalculation aggregates INT/CON without converting their equipment contribution into resource maxima, including catalog costumes with 250 and 500 points.
+
+## What Changes
+
+- Convert equipment CON into two flat maximum HP per point and equipment INT into two flat maximum MP per point for players, before existing percentage and affect processing.
+- Use the shared equipment calculation, so costumes and other equipment granting the same effects behave consistently; retain current catalog values and damage rules.
+- Preserve current HP/MP on increases and clamp on decreases, publish the recalculated score through existing packets, and prevent bonus accumulation across refresh/save/login.
+- Preserve compatibility with saves made before this correction by keeping the persisted maxima representation unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- `equipment-attribute-resources`: Equipment-derived INT/CON resource maxima, lifecycle updates and persistence compatibility.
+
+### Modified Capabilities
+
+None. Existing item-equip requirements describe eligibility, not derived score.
+
+## Impact
+
+Expected changes during apply: `tmserver/internal/handler/item.go`, score/affect comments and regression tests, runtime score bookkeeping in `tmserver/internal/world/session.go`, and character snapshot construction in `tmserver/internal/world/world.go`. Add focused handler/world tests and document the derivation in migration documentation. No client patch, catalog rebalance, RPC/schema migration, external service or dependency is needed. This change contains planning only.

--- a/openspec/changes/issue-321/specs/equipment-attribute-resources/spec.md
+++ b/openspec/changes/issue-321/specs/equipment-attribute-resources/spec.md
@@ -1,0 +1,58 @@
+## Purpose
+
+Ensure equipment-granted intelligence and constitution consistently contribute to player resource maxima throughout equipment changes and character sessions.
+
+## ADDED Requirements
+
+### Requirement: Equipment attributes contribute to resource maxima
+The server SHALL add two flat maximum HP per equipment CON and two flat maximum MP per equipment INT for players, using the same resolved equipment attributes displayed in their score. These contributions SHALL precede existing resource percentage and affect processing. Base attributes and affect-granted attributes MUST NOT be counted again as equipment attributes. STR and DEX SHALL retain their existing effects without an additional HP/MP conversion.
+
+#### Scenario: Costumes granting 250 attributes
+- **WHEN** a player equips unrefined costume 4185 or 4186 without other resource modifiers
+- **THEN** maximum HP and MP each increase by 500, and the existing attribute and damage bonuses remain
+
+#### Scenario: Costumes granting 500 attributes
+- **WHEN** a player equips unrefined costume 4187 without other resource modifiers
+- **THEN** maximum MP increases by 1000 and maximum HP does not increase from attribute conversion
+- **AND** equipping costume 4188 instead grants 1000 maximum HP and no attribute-derived MP
+
+#### Scenario: Shared equipment effects
+- **WHEN** another valid equipped item grants resolved INT or CON, including catalog, instance and refinement effects
+- **THEN** each resolved point contributes once to the corresponding resource maximum using the same rule as costumes
+
+#### Scenario: Percentages and affects
+- **WHEN** a costume grants 250 CON and 250 INT to a player whose flat maxima without it are 1000 HP and 1000 MP, with 10 percent HP/MP equipment bonuses and Divine active
+- **THEN** each effective maximum is 1980 using the existing percentage order
+- **AND** explicit HP/MP bonuses from other affects are applied once under their existing rules
+
+### Requirement: Equipment transitions update live resources without healing
+The server SHALL recalculate and communicate the corrected maxima through the existing supported client score messages after accepted equipment changes. Current HP/MP SHALL remain unchanged on maximum increases and SHALL be clamped when they exceed the new effective maxima. Rejected changes SHALL leave equipment and score unchanged. Repeated recalculation SHALL be idempotent.
+
+#### Scenario: Equip and unequip while injured
+- **WHEN** an injured player equips a costume and later removes it
+- **THEN** equipping does not heal HP or MP and removing it clamps only resources above the reduced maxima
+- **AND** the client receives score values matching the server's effective maxima
+
+#### Scenario: Replacement and repeated recalculation
+- **WHEN** a player replaces a 250-attribute costume with a 500-attribute costume and score is recalculated repeatedly
+- **THEN** maxima reflect only the currently equipped items without stacking prior contributions
+
+#### Scenario: Invalid equipment move
+- **WHEN** the server rejects an attempted costume equip or removal
+- **THEN** neither resource maxima nor current resources change
+
+### Requirement: Save and login preserve the correction
+The server SHALL grant the correction to existing saved characters and retain stable equipment-free maxima across subsequent saves and logins, without requiring a database migration. Equipment removed before character entry SHALL not retain the new attribute-derived resource contribution. Non-player template resources SHALL retain their current behavior.
+
+#### Scenario: Existing character already wearing a costume
+- **WHEN** a character saved before the correction logs in wearing costume 4185
+- **THEN** flat maxima gain 500 HP and 500 MP over the old behavior
+- **AND** repeated save/login cycles preserve these maxima and unequipping restores the equipment-free maxima
+
+#### Scenario: Costume expires before login
+- **WHEN** a previously equipped costume is discarded as expired during login
+- **THEN** the new attribute-derived HP/MP contribution from that costume is absent
+
+#### Scenario: Non-player regression
+- **WHEN** a mob or summon score is refreshed
+- **THEN** this player equipment correction does not change its template resource maxima

--- a/openspec/changes/issue-321/tasks.md
+++ b/openspec/changes/issue-321/tasks.md
@@ -1,0 +1,18 @@
+## 1. Equipment resource derivation and compatible saves
+
+- [x] 1.1 Add runtime equipment-attribute HP/MP bookkeeping and player-only conversion in refreshScore before affects, preserving direct bonuses and percentages; verify delivered code computes 2 times resolved equipment CON/INT, overwrites deltas on refresh, and excludes base/affect attributes and non-players.
+- [x] 1.2 Exclude the new runtime deltas from CharacterSave maxima while preserving the current persisted representation and deriveBaseScore contract; audit all snapshot construction and login/reset paths, verifying no RPC or database schema change and no stale delta after entity reuse or progression resets.
+
+## 2. Regression coverage
+
+- [x] 2.1 Add real-catalog tests for costumes 4185/4186 (+500 HP/MP), 4187 (+1000 MP only), and 4188 (+1000 HP only), plus resolved instance/refinement and other-equipment contributions; verify assertions cover resources and unchanged attribute/damage behavior across player classes/tiers.
+- [x] 2.2 Add tests for mixed direct resource bonuses, percentage/Divine ordering, explicit CON affects, attribute allocation and level gains, no gear and non-player controls; verify the fixtures independently calculate expected maxima and detect double counting.
+- [x] 2.3 Add handler transition tests for equip, replacement, removal, rejected moves and repeated refresh; verify score packet maxima, no healing on increases and clamps on decreases for injured/full resources.
+- [x] 2.4 Add world snapshot and handler login regressions starting with a pre-fix saved costume, at least three save/login cycles, subsequent removal, expired costume on login and reset/reuse; verify stable persisted maxima, immediate correction of old saves and absence of leaked bonuses using in-memory persistence.
+
+## 3. Documentation and orchestrated validation
+
+- [x] 3.1 Update score/persistence comments and relevant migration documentation to explain the equipment-only 2x conversion, unchanged saved representation and intentional exclusion of legacy whole-maximum doubling; verify documentation matches implemented formulas and lifecycle tests.
+- [x] 3.2 Have the orchestrator execute its automatic make test, make build and make vet inside Docker in /workspace and record results; verify all new regression tests are included and resolve failures without weakening assertions. No additional services or test commands are required.
+
+Implementation, regression tests and documentation are delivered. On 2026-09-10 the orchestrator reported successful Docker execution in /workspace: make test (11:45:22 UTC), make build (11:46:55 UTC) and make vet (11:47:53 UTC), all exit code 0. No host code checks were run. Additional test commands and service requirements remain empty.

--- a/tmserver/internal/handler/affect_score.go
+++ b/tmserver/internal/handler/affect_score.go
@@ -230,10 +230,9 @@ func applyAffectScoreWithItemAbility(e *world.Entity, itemAbility func(world.Ite
 
 // applyConHpBuff is the CON/MaxHP buff shape shared by affect 14 (Possuído,
 // Basedef.cpp:4053 / Buff Loop.txt:127) and affect 24 (Samaritano, by the issue
-// #267 divergence). MaxHP is added EXPLICITLY because Con feeds nothing in this
-// model: refreshScore builds MaxHP from BaseMaxHP + equipment (item.go), never
-// from Con, exactly like the legacy, whose Con→HP derivation runs before the
-// buff loop (Basedef.cpp:3152).
+// #267 divergence). MaxHP is added EXPLICITLY because refreshScore converts only
+// equipment CON to HP before the buff loop (Basedef.cpp:3152). Affect-granted
+// CON must supply its own HP delta without entering that conversion again.
 //
 // Not ported from Basedef.cpp:4056: `if (ClassMaster != MORTAL && != ARCH) value
 // *= 3`, along with that file's *22 / *125% multipliers — those are private-server

--- a/tmserver/internal/handler/character.go
+++ b/tmserver/internal/handler/character.go
@@ -254,6 +254,7 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 		w.SetEntityPos(s.Conn, loginX, loginY)
 		e.HP, e.MaxHP = st.HP, st.MaxHP
 		e.MP, e.MaxMP = st.MP, st.MaxMP
+		e.EquipmentAttributeHP, e.EquipmentAttributeMP = 0, 0
 		// Critical is a save-side cache only: refreshScore below re-derives it from the
 		// equipment (Basedef.cpp:3209), so the stored value never survives login.
 		// Damage and AC are NOT read from the state at all: the DB contract carries
@@ -316,10 +317,9 @@ func (d *Dispatcher) completeCharacterLogin(w *world.World, s *world.Session, st
 				e.Affect[slot] = a
 			}
 		}
-		// Recompute the live score once (idempotent right after deriveBaseScore:
-		// current = base + equip reproduces the loaded values) — this is what fills
-		// the live Special (= BaseSpecial + gear) and the affect caches, which are
-		// not persisted.
+		// Recompute runtime equipment resources, live Special and affect caches.
+		// Saved maxima omit equipment CON/INT resources, so even an old save gains
+		// the issue #321 correction here without accumulating it on later logins.
 		d.refreshScore(e)
 		s.ReqHp, s.ReqMp = e.HP, e.MP
 		s.CriticalProgress = 0

--- a/tmserver/internal/handler/equipment_resources_lifecycle_test.go
+++ b/tmserver/internal/handler/equipment_resources_lifecycle_test.go
@@ -1,0 +1,199 @@
+package handler
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/protocol"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+// resourceRoundTripDB uses actual captured CharacterSave values on the next
+// login. Its lock protects only fake persistence, never live world state.
+type resourceRoundTripDB struct {
+	*fakeDB
+	initial map[int]world.CharacterState
+}
+
+func (f *resourceRoundTripDB) LoadCharacter(_ context.Context, _ int64, slot int) (world.CharacterState, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	st := f.initial[slot]
+	for i := len(f.savedChars) - 1; i >= 0; i-- {
+		save := f.savedChars[i]
+		if save.Slot != slot {
+			continue
+		}
+		st.HP, st.MaxHP, st.MP, st.MaxMP = save.HP, save.MaxHP, save.MP, save.MaxMP
+		st.Str, st.Int, st.Dex, st.Con = save.Str, save.Int, save.Dex, save.Con
+		st.Level, st.Exp, st.ClassMaster = int(save.Level), save.Exp, save.ClassMaster
+		st.ScoreBonus = save.ScoreBonus
+		st.Equip, st.Carry = [world.MaxEquip]world.Item{}, [world.MaxCarry]world.Item{}
+		for _, group := range []struct {
+			saved []world.SavedItem
+			items []world.Item
+		}{{save.Equip, st.Equip[:]}, {save.Carry, st.Carry[:]}} {
+			for _, it := range group.saved {
+				group.items[it.Slot] = world.Item{Index: it.Index, ExpiresAt: it.ExpiresAt, Effects: [3]world.Effect{
+					{Effect: it.Eff1, Value: it.EffV1}, {Effect: it.Eff2, Value: it.EffV2}, {Effect: it.Eff3, Value: it.EffV3},
+				}}
+			}
+		}
+		break
+	}
+	return st, nil
+}
+
+func resourceCharacterState() world.CharacterState {
+	st := world.CharacterState{
+		Slot: 0, Name: "Hero", Class: 0, ClassMaster: classMasterMortal, Level: 10, X: 5, Y: 5,
+		HP: 400, MaxHP: 1000, MP: 300, MaxMP: 1000,
+		Str: 100, Int: 100, Dex: 100, Con: 100, ScoreBonus: 2,
+	}
+	st.Equip[0] = world.Item{Index: 1} // avoid starter-gear seeding
+	return st
+}
+
+func startEquipmentResourcesServer(t *testing.T, persist world.Persistence) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cfg := equipmentResourcesConfig(t)
+	cfg.Log = log
+	d := New(cfg)
+	w := world.New(world.Config{GridDim: 16}, log, persist, d.Handle)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- w.Serve(ctx, ln) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil && err != context.Canceled {
+				t.Errorf("serve: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Error("server did not stop")
+		}
+	})
+	return ln.Addr().String()
+}
+
+func assertResourceScore(t *testing.T, payload []byte, hp, maxHP, mp, maxMP int32) {
+	t.Helper()
+	if len(payload) != 140 {
+		t.Fatalf("score payload length = %d", len(payload))
+	}
+	for _, tt := range []struct {
+		offset int
+		want   int32
+	}{{16, maxHP}, {20, maxMP}, {24, hp}, {28, mp}, {124, hp}, {128, mp}} {
+		if got := int32(binary.LittleEndian.Uint32(payload[tt.offset:])); got != tt.want {
+			t.Fatalf("score offset %d = %d, want %d", tt.offset, got, tt.want)
+		}
+	}
+}
+
+func selectResourceCharacter(t *testing.T, c net.Conn, slot int32) []byte {
+	t.Helper()
+	body := protocol.MsgCharacterLoginBody{Slot: slot}
+	send(t, c, protocol.MsgCharacterLogin, body.Encode())
+	expect(t, c, protocol.MsgCNFCharacterLogin)
+	return expect(t, c, protocol.MsgUpdateScore)
+}
+
+func logoutResourceCharacter(t *testing.T, c net.Conn) {
+	t.Helper()
+	send(t, c, protocol.MsgCharacterLogout, nil)
+	expect(t, c, protocol.MsgCNFCharacterLogout)
+}
+
+func TestEquipmentResourcesTradingAndAllocation(t *testing.T) {
+	db := newDB()
+	db.loadResult = resourceCharacterState()
+	db.loadResult.Carry[0] = world.Item{Index: 4185}
+	db.loadResult.Carry[1] = world.Item{Index: 4187}
+	c := enterWorld(t, startEquipmentResourcesServer(t, db))
+	defer c.Close()
+	tradeItemFrame(t, c, world.ItemPlaceCarry, 0, world.ItemPlaceEquip, 12, 0)
+	assertResourceScore(t, expect(t, c, protocol.MsgUpdateScore), 400, 1500, 300, 1500)
+	// Wrong slot rejects the replacement. The next valid allocation is also a
+	// response barrier: its score proves the costume and maxima did not change.
+	tradeItemFrame(t, c, world.ItemPlaceCarry, 1, world.ItemPlaceEquip, 2, 0)
+	for _, detail := range []int16{protocol.DetailCon, protocol.DetailInt} {
+		body := protocol.MsgApplyBonusBody{BonusType: protocol.BonusScore, Detail: detail}
+		send(t, c, protocol.MsgApplyBonus, body.Encode())
+		maxMP := int32(1500)
+		if detail == protocol.DetailInt {
+			maxMP = 1502
+		}
+		assertResourceScore(t, expect(t, c, protocol.MsgUpdateScore), 400, 1502, 300, maxMP)
+	}
+	tradeItemFrame(t, c, world.ItemPlaceCarry, 1, world.ItemPlaceEquip, 12, 0)
+	assertResourceScore(t, expect(t, c, protocol.MsgUpdateScore), 400, 1002, 300, 2002)
+	tradeItemFrame(t, c, world.ItemPlaceEquip, 12, world.ItemPlaceCarry, 2, 0)
+	assertResourceScore(t, expect(t, c, protocol.MsgUpdateScore), 400, 1002, 300, 1002)
+	logoutResourceCharacter(t, c)
+	save, _ := db.lastSavedChar()
+	if save.MaxHP != 1002 || save.MaxMP != 1002 || hasItem(save.Equip, 4185) || hasItem(save.Equip, 4187) {
+		t.Fatal("transition save retained costume resources")
+	}
+}
+
+func TestEquipmentResourcesSaveLoginAndExpiration(t *testing.T) {
+	st := resourceCharacterState()
+	st.Equip[12] = world.Item{Index: 4185}
+	st.Str, st.Int, st.Dex, st.Con = 350, 350, 350, 350
+	// A pre-fix save has these attributes but only 1000 flat HP/MP maxima.
+	expired := st
+	expired.Slot = 1
+	expired.Equip[12].ExpiresAt = time.Now().Add(-time.Hour).Unix()
+	db := &resourceRoundTripDB{fakeDB: newDB(), initial: map[int]world.CharacterState{0: st, 1: expired}}
+	c := loginAndSelect(t, startEquipmentResourcesServer(t, db))
+	defer c.Close()
+	for range 3 {
+		assertResourceScore(t, selectResourceCharacter(t, c, 0), 400, 1500, 300, 1500)
+		logoutResourceCharacter(t, c)
+		save, _ := db.lastSavedChar()
+		if save.MaxHP != 1000 || save.MaxMP != 1000 || save.Int != 350 || save.Con != 350 {
+			t.Fatalf("save drift: maxima %d/%d attributes %d/%d", save.MaxHP, save.MaxMP, save.Int, save.Con)
+		}
+	}
+	// Same session/entity, different character with expired gear: cached
+	// resources from the previous character must not survive initialization.
+	assertResourceScore(t, selectResourceCharacter(t, c, 1), 400, 1000, 300, 1000)
+	logoutResourceCharacter(t, c)
+	expiredSave, _ := db.lastSavedChar()
+	if expiredSave.MaxHP != 1000 || expiredSave.MaxMP != 1000 || hasItem(expiredSave.Equip, 4185) {
+		t.Fatal("expired costume leaked into the save")
+	}
+	assertResourceScore(t, selectResourceCharacter(t, c, 0), 400, 1500, 300, 1500)
+	tradeItemFrame(t, c, world.ItemPlaceEquip, 12, world.ItemPlaceCarry, 0, 0)
+	assertResourceScore(t, expect(t, c, protocol.MsgUpdateScore), 400, 1000, 300, 1000)
+	logoutResourceCharacter(t, c)
+	assertResourceScore(t, selectResourceCharacter(t, c, 0), 400, 1000, 300, 1000)
+}
+
+func TestEquipmentResourcesFullBarsClampOnUnequip(t *testing.T) {
+	db := newDB()
+	db.loadResult = resourceCharacterState()
+	db.loadResult.Equip[12] = world.Item{Index: 4185}
+	db.loadResult.Str, db.loadResult.Int, db.loadResult.Dex, db.loadResult.Con = 350, 350, 350, 350
+	// Current resources persist independently from the historical flat maxima.
+	db.loadResult.HP, db.loadResult.MP = 1500, 1500
+	c := loginAndSelect(t, startEquipmentResourcesServer(t, db))
+	defer c.Close()
+	assertResourceScore(t, selectResourceCharacter(t, c, 0), 1500, 1500, 1500, 1500)
+	tradeItemFrame(t, c, world.ItemPlaceEquip, 12, world.ItemPlaceCarry, 0, 0)
+	assertResourceScore(t, expect(t, c, protocol.MsgUpdateScore), 1000, 1000, 1000, 1000)
+	tradeItemFrame(t, c, world.ItemPlaceCarry, 0, world.ItemPlaceEquip, 12, 0)
+	assertResourceScore(t, expect(t, c, protocol.MsgUpdateScore), 1000, 1500, 1000, 1500)
+}

--- a/tmserver/internal/handler/equipment_resources_test.go
+++ b/tmserver/internal/handler/equipment_resources_test.go
@@ -1,0 +1,189 @@
+package handler
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/content"
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/world"
+)
+
+func equipmentResourcesConfig(t *testing.T) Config {
+	t.Helper()
+	items, err := content.LoadItemList(filepath.Join("..", "..", "..", "Release", "Common", "ItemList.csv"))
+	if err != nil {
+		t.Fatalf("load regression catalog: %v", err)
+	}
+	return Config{ItemEffects: items.BaseEffects(), ItemPos: items.Positions(), ItemUnique: items.Uniques(), ItemReqs: items.Requirements()}
+}
+
+func resourcePlayer() *world.Entity {
+	return &world.Entity{
+		ID: 1, ClassMaster: classMasterMortal, Level: 10,
+		BaseStr: 100, BaseInt: 100, BaseDex: 100, BaseCon: 100,
+		BaseMaxHP: 1000, BaseMaxMP: 1000, HP: 400, MP: 300,
+	}
+}
+
+func TestEquipmentResourcesCostumeCatalog(t *testing.T) {
+	d := New(equipmentResourcesConfig(t))
+	for cls := uint8(0); cls < 4; cls++ {
+		for tier := uint8(0); tier <= classMasterSCelestial; tier++ {
+			for _, tt := range []struct {
+				item                int16
+				str, intel, dex, con int16
+				hp, mp              int32
+			}{
+				{4185, 250, 250, 250, 250, 1500, 1500},
+				{4186, 250, 250, 250, 250, 1500, 1500},
+				{4187, 500, 500, 0, 0, 1000, 2000},
+				{4188, 0, 0, 500, 500, 2000, 1000},
+			} {
+				t.Run(fmt.Sprintf("class%d/tier%d/item%d", cls, tier, tt.item), func(t *testing.T) {
+					e := resourcePlayer()
+					e.Class, e.ClassMaster = cls, tier
+					e.Equip[12] = world.Item{Index: tt.item}
+					for range 3 {
+						d.refreshScore(e)
+						if e.MaxHP != tt.hp || e.MaxMP != tt.mp || e.HP != 400 || e.MP != 300 {
+							t.Fatalf("resources = %d/%d %d/%d", e.HP, e.MaxHP, e.MP, e.MaxMP)
+						}
+						if e.Str != 100+tt.str || e.Int != 100+tt.intel || e.Dex != 100+tt.dex || e.Con != 100+tt.con {
+							t.Fatalf("attributes = %d/%d/%d/%d", e.Str, e.Int, e.Dex, e.Con)
+						}
+						levelTerm := int32(409)
+						if tier == classMasterMortal || tier == classMasterArch {
+							levelTerm = 10
+						}
+						if want := int32(100+tt.str)/2 + int32(100+tt.dex)/3 + levelTerm; e.Damage != want {
+							t.Fatalf("damage = %d, want %d", e.Damage, want)
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestEquipmentResourcesRefinedAndInstance(t *testing.T) {
+	d := New(equipmentResourcesConfig(t))
+	e := resourcePlayer()
+	// Costume +9 is not an accessory: (250+5)*19/10 = 484 CON,
+	// 250*19/10 = 475 INT. Instance and catalog must be summed before rounding.
+	e.Equip[12] = world.Item{Index: 4185, Effects: [3]world.Effect{sancEffect(9), {Effect: efCon, Value: 5}}}
+	// A non-costume grants the same conversion; no catalog bonus on this fixture.
+	e.Equip[2] = world.Item{Index: 30000, Effects: [3]world.Effect{{Effect: efInt, Value: 7}}}
+	d.refreshScore(e)
+	if e.Con != 584 || e.Int != 582 || e.MaxHP != 1968 || e.MaxMP != 1964 {
+		t.Fatalf("CON/INT/HP/MP = %d/%d/%d/%d", e.Con, e.Int, e.MaxHP, e.MaxMP)
+	}
+}
+
+func TestEquipmentResourcesPreserveWeaponMagic(t *testing.T) {
+	cfg := equipmentResourcesConfig(t)
+	// Isolate the Foema staff category from flat weapon catalog effects.
+	cfg.ItemUnique[30000] = 47
+	d := New(cfg)
+	e := resourcePlayer()
+	e.Class, e.LearnedSkill = 1, 1<<7
+	e.Equip[weaponSlotR] = world.Item{Index: 30000}
+	d.refreshScore(e)
+	if e.Magic != 10 { // (100*6.3 + 100*4.2)/100, truncated
+		t.Fatalf("base weapon magic = %d, want 10", e.Magic)
+	}
+	e.Equip[12] = world.Item{Index: 4187}
+	d.refreshScore(e)
+	if e.Magic != 31 || e.MaxMP != 2000 { // (100*6.3 + 600*4.2)/100
+		t.Fatalf("costume magic/MP = %d/%d, want 31/2000", e.Magic, e.MaxMP)
+	}
+}
+
+func TestEquipmentResourcesModifiers(t *testing.T) {
+	d := New(equipmentResourcesConfig(t))
+	e := resourcePlayer()
+	e.Equip[12] = world.Item{Index: 4185}
+	e.Equip[2] = world.Item{Index: 30000, Effects: [3]world.Effect{{Effect: efHpAdd, Value: 10}, {Effect: efMpAdd, Value: 10}}}
+	e.Affect[0] = world.Affect{Type: world.AffectDivine, Time: 100}
+	d.refreshScore(e)
+	if effectiveMaxHP(e) != 1980 || effectiveMaxMP(e) != 1980 {
+		t.Fatalf("percent maxima = %d/%d, want 1980/1980", effectiveMaxHP(e), effectiveMaxMP(e))
+	}
+	e.Equip[3] = world.Item{Index: 30001, Effects: [3]world.Effect{{Effect: efHp, Value: 100}, {Effect: efMp, Value: 50}}}
+	e.Affect[1] = world.Affect{Type: 24, Level: 0, Value: 10, Time: 100}
+	for range 3 {
+		d.refreshScore(e)
+		// Samaritano adds 10 CON and its own 20 HP, not another equipment grant.
+		if e.AffCon != 10 || e.AffMaxHP != 20 || e.MaxHP != 1600 || e.MaxMP != 1550 {
+			t.Fatalf("flat/affect resources = %d/%d, CON/HP affect = %d/%d", e.MaxHP, e.MaxMP, e.AffCon, e.AffMaxHP)
+		}
+		if effectiveMaxHP(e) != 2138 || effectiveMaxMP(e) != 2046 {
+			t.Fatalf("modified maxima = %d/%d", effectiveMaxHP(e), effectiveMaxMP(e))
+		}
+	}
+}
+
+func TestEquipmentResourcesControlsAndClamps(t *testing.T) {
+	d := New(equipmentResourcesConfig(t))
+	for _, id := range []int{1, world.MaxUser, world.MaxUser + 1} {
+		e := resourcePlayer()
+		e.ID = id
+		d.refreshScore(e)
+		if e.MaxHP != 1000 || e.MaxMP != 1000 {
+			t.Fatal("base attributes counted again without equipment")
+		}
+		e.Equip[12] = world.Item{Index: 4185}
+		d.refreshScore(e)
+		want := int32(1000)
+		if id == 1 {
+			want = 1500
+		}
+		if e.MaxHP != want || e.MaxMP != want {
+			t.Fatalf("entity %d maxima = %d/%d, want %d", id, e.MaxHP, e.MaxMP, want)
+		}
+		e.HP, e.MP = want, 300
+		e.Equip[12] = world.Item{}
+		d.refreshScore(e)
+		if e.HP != 1000 || e.MP != 300 || e.EquipmentAttributeHP != 0 || e.EquipmentAttributeMP != 0 {
+			t.Fatal("removal did not clamp/reset equipment resources")
+		}
+	}
+}
+
+func TestEquipmentResourcesLevelUp(t *testing.T) {
+	_, w, e := mobKilledWorld(t)
+	d := New(equipmentResourcesConfig(t))
+	e.Equip[12] = world.Item{Index: 4185}
+	d.refreshScore(e)
+	e.Exp = 1124 // exactly level 2
+	if !d.applyLevelUps(w, nil, e) {
+		t.Fatal("expected level-up")
+	}
+	if e.BaseMaxHP != 83 || e.BaseMaxMP != 46 || e.MaxHP != 583 || e.MaxMP != 546 {
+		t.Fatalf("level maxima = base %d/%d live %d/%d", e.BaseMaxHP, e.BaseMaxMP, e.MaxHP, e.MaxMP)
+	}
+}
+
+func TestEquipmentResourcesCelestialReset(t *testing.T) {
+	d := New(equipmentResourcesConfig(t))
+	e := resourcePlayer()
+	e.ClassMaster, e.Level = classMasterArch, 399
+	e.Equip[0] = world.Item{Index: 1}
+	e.Equip[12] = world.Item{Index: 4185}
+	e.Carry[0] = world.Item{Index: idealStoneItem}
+	d.refreshScore(e)
+	d.buildCelestialSnapshot(e, 0)
+	// Compare against the same reset equipment without the costume so catalog
+	// effects on the newly issued body/cape remain part of the baseline.
+	naked := *e
+	naked.Equip[12] = world.Item{}
+	d.refreshScore(&naked)
+	if e.MaxHP != naked.MaxHP+500 || e.MaxMP != naked.MaxMP+500 || e.BaseMaxHP != 80 || e.BaseMaxMP != 45 {
+		t.Fatalf("reset retained previous resources: %d/%d", e.MaxHP, e.MaxMP)
+	}
+	_, w, _ := mobKilledWorld(t)
+	save := w.CharacterSaveFor(&world.Session{}, e)
+	if save.MaxHP != naked.MaxHP-naked.EquipmentAttributeHP || save.MaxMP != naked.MaxMP-naked.EquipmentAttributeMP {
+		t.Fatalf("reset save includes attribute resources: %d/%d", save.MaxHP, save.MaxMP)
+	}
+}

--- a/tmserver/internal/handler/item.go
+++ b/tmserver/internal/handler/item.go
@@ -2179,9 +2179,9 @@ func (d *Dispatcher) equipBonus(e *world.Entity) equipBonus {
 }
 
 // deriveBaseScore captures the equipment-free BaseScore on login. Persisted
-// Attributes, MaxHP/MaxMP and Magic recover their base by subtracting equipment;
-// after this,
-// refreshScore reproduces the loaded CurrentScore exactly until gear changes.
+// attributes and MaxHP/MaxMP recover their base by subtracting equipment;
+// saved maxima exclude equipment CON/INT resources (issue #321). refreshScore
+// adds those runtime-only contributions after this historical base derivation.
 //
 // AC and Damage are reconstructed because the DB contract omits them.
 // WeaponDamage remains separate.
@@ -2217,8 +2217,16 @@ func (d *Dispatcher) refreshScore(e *world.Entity) {
 	flatAC := e.BaseAC + b.ac
 	e.AC = flatAC + skillDerivedACBonus(e, flatAC)
 	e.Damage = e.BaseDamage + b.damage + d.derivedDamageBeforeAffects(e)
-	e.MaxHP = e.BaseMaxHP + b.maxHP
-	e.MaxMP = e.BaseMaxMP + b.maxMP
+	e.EquipmentAttributeHP, e.EquipmentAttributeMP = 0, 0
+	if world.IsPlayer(e.ID) {
+		// Basedef.cpp:3152-3156 converts equipment-only CON/INT at 2 resources
+		// per point. Do not copy that block's additional doubling of the whole
+		// maximum, or count allocated/buff attributes again (issue #321).
+		e.EquipmentAttributeHP = 2 * int32(b.con)
+		e.EquipmentAttributeMP = 2 * int32(b.intel)
+	}
+	e.MaxHP = e.BaseMaxHP + b.maxHP + e.EquipmentAttributeHP
+	e.MaxMP = e.BaseMaxMP + b.maxMP + e.EquipmentAttributeMP
 	e.HpAddPct = b.hpAddPct
 	e.MpAddPct = b.mpAddPct
 	e.RunSpeedBonus = b.runSpeed

--- a/tmserver/internal/world/equipment_resources_test.go
+++ b/tmserver/internal/world/equipment_resources_test.go
@@ -1,0 +1,31 @@
+package world
+
+import "testing"
+
+func TestCharacterSaveExcludesEquipmentAttributeResources(t *testing.T) {
+	w := New(Config{GridDim: 16}, slogDiscard(), nil, nil)
+	e := &Entity{
+		MaxHP: 1700, MaxMP: 2650, HP: 1600, MP: 2500,
+		EquipmentAttributeHP: 500, EquipmentAttributeMP: 1000,
+		Str: 350, Int: 600, Dex: 350, Con: 350,
+	}
+	e.Equip[12] = Item{Index: 4185}
+	s := &Session{Conn: 1, AccountID: 7, Slot: 0}
+	w.entities[1] = e
+	for range 3 {
+		// Both staged operations and the ordinary logout/shutdown path must use
+		// the same representation. Current resources can exceed stored maxima,
+		// just as with the existing read-time percentage/buff bonuses.
+		for _, save := range []CharacterSave{w.CharacterSaveFor(s, e), w.characterSave(s)} {
+			if save.MaxHP != 1200 || save.MaxMP != 1650 || save.HP != 1600 || save.MP != 2500 {
+				t.Fatalf("saved resources = %d/%d %d/%d", save.HP, save.MaxHP, save.MP, save.MaxMP)
+			}
+			if save.Int != 600 || save.Con != 350 || len(save.Equip) != 1 || save.Equip[0].Index != 4185 {
+				t.Fatal("snapshot altered attributes or equipment")
+			}
+		}
+		if e.MaxHP != 1700 || e.MaxMP != 2650 {
+			t.Fatal("snapshot mutated live maxima")
+		}
+	}
+}

--- a/tmserver/internal/world/session.go
+++ b/tmserver/internal/world/session.go
@@ -294,6 +294,10 @@ type Entity struct {
 	BaseStr, BaseInt, BaseDex, BaseCon int16
 	BaseAC, BaseDamage                 int32
 	BaseMaxHP, BaseMaxMP               int32
+	// EquipmentAttributeHP/MP are the equipment CON/INT resource contributions
+	// included in live maxima but excluded from saves for compatibility with
+	// characters saved before issue #321. Replaced on every score refresh.
+	EquipmentAttributeHP, EquipmentAttributeMP int32
 	// Magic, Parry (evasion) and Resist have NO base term: the legacy has none either.
 	// BASE_GetCurrentScore seeds a fresh local `magic` from equipment (Basedef.cpp:3194),
 	// accumulates the derived terms and stores it at :4729 — there is no BaseScore.Magic

--- a/tmserver/internal/world/world.go
+++ b/tmserver/internal/world/world.go
@@ -370,8 +370,11 @@ func (w *World) CharacterSaveFor(s *Session, e *Entity) CharacterSave {
 	cs.SaveX, cs.SaveY = e.SaveX, e.SaveY
 	cs.Level, cs.Exp, cs.Coin = e.Level, e.Exp, e.Coin
 	cs.Str, cs.Int, cs.Dex, cs.Con = e.Str, e.Int, e.Dex, e.Con
-	cs.HP, cs.MaxHP = e.HP, e.MaxHP
-	cs.MP, cs.MaxMP = e.MP, e.MaxMP
+	// Keep the historical flat save representation: old saves lack equipment
+	// CON/INT resources. Login derives the base from this value, then adds the
+	// current equipment contribution once, including for pre-issue-321 saves.
+	cs.HP, cs.MaxHP = e.HP, e.MaxHP-e.EquipmentAttributeHP
+	cs.MP, cs.MaxMP = e.MP, e.MaxMP-e.EquipmentAttributeMP
 	cs.DivineEnd = e.DivineEnd // 0 once the buff has expired (cleared by the tick sweep)
 	cs.ScoreBonus, cs.SpecialBonus = e.ScoreBonus, e.SpecialBonus
 	cs.LearnedSkill, cs.SecLearnedSkill, cs.BaseSpecial = e.LearnedSkill, e.SecLearnedSkill, e.BaseSpecial


### PR DESCRIPTION
<!-- loop-engineering:2026-09-08T22-23-17-292Z-91635ef9:321 -->

Closes #321

## Resumo

### Problema
Os equipamentos somavam INT/CON aos atributos, mas esses bônus não contribuíam para HP/MP máximos.

### Alterações
O recálculo dos jogadores acrescenta 2 HP máximos por CON e 2 MP máximos por INT de equipamento, antes dos buffs e percentuais. Trajes com 250 INT/CON passam a conceder 500 HP/MP máximos. Equipar não cura; remover limita os recursos aos novos máximos.

O bônus é excluído dos máximos persistidos para preservar saves antigos e evitar acúmulo nas reconexões, sem migração de banco. A conversão usa os efeitos de equipamento existentes, preservando catálogo e fórmulas de dano, sem aplicá-la a mobs.

### Cobertura e limitações
Adicionados testes para os trajes 4185–4188, classes e evoluções, refinamento, efeitos de instância, dano físico/mágico, buffs, percentuais, distribuição de pontos, level-up, troca/remoção e movimentos rejeitados. Também cobrem snapshots, ciclos de save/login, expiração, reutilização da sessão e reset Celestial.

O orquestrador informou sucesso nos testes, build e vet em Docker. Todas as oito tarefas estão concluídas; nenhuma verificação de código foi executada no host.

A seleção de personagens continua usando os máximos históricos persistidos; os valores corrigidos são enviados dentro do jogo.

## Validação

Comandos executados em Docker com a imagem ` golang:1.26-bookworm `:

- Aprovado: ` make test ` (exit 0).
- Aprovado: ` make build ` (exit 0).
- Aprovado: ` make vet ` (exit 0).

## OpenSpec

Proposta, especificações e tarefas: [issue-321](openspec/changes/issue-321/).