### PR TITLE
fix: unlock Vale portal with equipped fairy

### DIFF
--- a/docs/migration/handlers/lote2-quest-ranking-cash.md
+++ b/docs/migration/handlers/lote2-quest-ranking-cash.md
@@ -22,6 +22,12 @@
   data-driven (tabela de quests). Passo-a-passo fino de alguns NPCs longos fica como UNVERIFIED no
   doc dedicado.
 
+## `_MSG_ReqTeleport` (0x0290) — acesso ao Vale
+- O portal de Azran na origem `(2548..2551, 1740..1743)` leva a `(2281..2283, 3688..3690)`.
+- Como em `GetTeleportPosition` (`Source/Code/TMSrv/GetFunc.cpp`), o acesso exige a **Fada do Vale**,
+  item `3916`, equipada em `Equip[13]`. O item não é consumido e a rota é gratuita.
+- Sem a fada equipada, o servidor ignora o pedido sem alterar posição, gold ou estado do item.
+
 ## `_MSG_ReqRanking` (0x039F) — duelo / ranking PvP
 - **Gatilho/struct:** `MSG_STANDARDPARM2` (`Parm1 = tDuel`, `Parm2 = DuelParm` 0..4).
 - **Validações:** `DuelParm` em `[0,4]`; `tDuel` em `(0,MAX_USER)`; alvo não pode ter `Whisper`

--- a/tmserver/internal/handler/movement.go
+++ b/tmserver/internal/handler/movement.go
@@ -225,7 +225,10 @@ func (d *Dispatcher) reqTeleport(w *world.World, s *world.Session, _ protocol.He
 	if e == nil || e.HP == 0 {
 		return
 	}
-	destX, destY, cost, ok := world.TeleportDest(e.X, e.Y)
+	// GetTeleportPosition only opens the Azran→Vale portal for the equipped
+	// Valley Fairy (item 3916 in Equip[13]); preserve that legacy gate.
+	hasValleyFairy := e.Equip[fairyEquipSlot].Index == 3916
+	destX, destY, cost, ok := world.TeleportDestWithAccess(e.X, e.Y, hasValleyFairy, w.Rand())
 	if !ok {
 		return // no teleport tile here
 	}

--- a/tmserver/internal/world/teleport.go
+++ b/tmserver/internal/world/teleport.go
@@ -1,6 +1,10 @@
 package world
 
-import "math/rand"
+import (
+	"math/rand"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/rng"
+)
 
 type teleRoute struct {
 	dx, dy int16
@@ -19,6 +23,7 @@ var teleportTable = map[[2]int16]teleRoute{
 	{1044, 1724}: {2116, 2100, 0},   // Noatum → Armia
 	{1044, 1716}: {2480, 1716, 0},   // Noatum → Azran
 	{1044, 1708}: {2456, 2016, 0},   // Noatum → Erion
+	{2548, 1740}: {2281, 3688, 0},   // Azran → Vale (Fada do Vale, item 3916)
 	{1052, 1708}: {3650, 3110, 0},   // Noatum → Nippleheim
 	{3648, 3108}: {1054, 1710, 0},   // Nippleheim → Noatum
 	// Fields / dungeons (subset of GetTeleportPosition).
@@ -43,9 +48,25 @@ var teleportTable = map[[2]int16]teleRoute{
 // the route, and returns the destination (+rand%3 spread) and gold cost. ok is
 // false when there is no teleport tile at that position.
 func TeleportDest(x, y int16) (destX, destY int16, cost int32, ok bool) {
+	return teleportDest(x, y, false, nil)
+}
+
+// TeleportDestWithAccess resolves routes whose access can depend on equipped items.
+// The legacy Vale portal requires item 3916 in Equip[13].
+func TeleportDestWithAccess(x, y int16, hasFairy bool, random *rng.MSVC) (destX, destY int16, cost int32, ok bool) {
+	return teleportDest(x, y, hasFairy, random)
+}
+
+func teleportDest(x, y int16, hasFairy bool, random *rng.MSVC) (destX, destY int16, cost int32, ok bool) {
 	r, found := teleportTable[[2]int16{x &^ 3, y &^ 3}] // round down to a multiple of 4
-	if !found {
+	if !found || (x&^3 == 2548 && y&^3 == 1740 && !hasFairy) {
 		return 0, 0, 0, false
 	}
-	return r.dx + int16(rand.Intn(3)), r.dy + int16(rand.Intn(3)), r.cost, true
+	spread := func() int { return rand.Intn(3) }
+	// Keep existing route randomness unchanged; the Vale branch is the one
+	// newly ported from the legacy path and uses the world's MSVC stream.
+	if random != nil && x&^3 == 2548 && y&^3 == 1740 {
+		spread = func() int { return random.Intn(3) }
+	}
+	return r.dx + int16(spread()), r.dy + int16(spread()), r.cost, true
 }

--- a/tmserver/internal/world/teleport_test.go
+++ b/tmserver/internal/world/teleport_test.go
@@ -3,6 +3,8 @@ package world
 import (
 	"fmt"
 	"testing"
+
+	"github.com/jeanluca/w2pp-openwyd/tmserver/internal/rng"
 )
 
 func TestTeleportDestDungeon(t *testing.T) {
@@ -61,5 +63,20 @@ func TestTeleportDest(t *testing.T) {
 	// Non-teleport position.
 	if _, _, _, ok := TeleportDest(2096, 2096); ok {
 		t.Errorf("non-tile position reported a teleport")
+	}
+}
+
+func TestTeleportDestValeRequiresEquippedFairy(t *testing.T) {
+	for _, hasFairy := range []bool{false, true} {
+		x, y, cost, ok := TeleportDestWithAccess(2548, 1740, hasFairy, rng.NewSeeded(1))
+		if !hasFairy {
+			if ok {
+				t.Fatal("Vale portal resolved without the Valley Fairy")
+			}
+			continue
+		}
+		if !ok || cost != 0 || x < 2281 || x > 2283 || y < 3688 || y > 3690 {
+			t.Fatalf("Vale portal = (%d,%d), cost=%d, ok=%v", x, y, cost, ok)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- add the Azran to Vale teleport route from the legacy server
- require Valley Fairy item 3916 equipped in slot 13
- add access tests and migration documentation

## Validation

- docker: go test ./tmserver/internal/world ./tmserver/internal/handler
- docker: go test ./...

Closes #324